### PR TITLE
Fix flaky cron E2E test (#15)

### DIFF
--- a/awa-worker/src/client.rs
+++ b/awa-worker/src/client.rs
@@ -71,6 +71,7 @@ pub struct ClientBuilder {
     heartbeat_interval: Duration,
     periodic_jobs: Vec<PeriodicJob>,
     global_max_workers: Option<u32>,
+    leader_election_interval: Option<Duration>,
 }
 
 impl ClientBuilder {
@@ -83,6 +84,7 @@ impl ClientBuilder {
             heartbeat_interval: Duration::from_secs(30),
             periodic_jobs: Vec::new(),
             global_max_workers: None,
+            leader_election_interval: None,
         }
     }
 
@@ -128,6 +130,15 @@ impl ClientBuilder {
     /// Set the heartbeat interval (default: 30s).
     pub fn heartbeat_interval(mut self, interval: Duration) -> Self {
         self.heartbeat_interval = interval;
+        self
+    }
+
+    /// Set the leader election retry interval (default: 10s).
+    ///
+    /// Controls how often a non-leader instance retries acquiring the maintenance
+    /// advisory lock. Lower values are useful in tests.
+    pub fn leader_election_interval(mut self, interval: Duration) -> Self {
+        self.leader_election_interval = Some(interval);
         self
     }
 
@@ -220,6 +231,7 @@ impl ClientBuilder {
             leader: Arc::new(AtomicBool::new(false)),
             overflow_pool,
             metrics,
+            leader_election_interval: self.leader_election_interval,
         })
     }
 }
@@ -286,6 +298,7 @@ pub struct Client {
     /// Shared overflow pool for weighted mode (None in hard-reserved mode).
     overflow_pool: Option<Arc<OverflowPool>>,
     metrics: crate::metrics::AwaMetrics,
+    leader_election_interval: Option<Duration>,
 }
 
 impl Client {
@@ -327,13 +340,16 @@ impl Client {
         }));
 
         // Start maintenance service (uses service_cancel — stays alive during drain)
-        let maintenance = MaintenanceService::new(
+        let mut maintenance = MaintenanceService::new(
             self.pool.clone(),
             self.leader.clone(),
             self.service_cancel.clone(),
             self.periodic_jobs.clone(),
             self.in_flight.clone(),
         );
+        if let Some(interval) = self.leader_election_interval {
+            maintenance = maintenance.leader_election_interval(interval);
+        }
         service_handles.push(tokio::spawn(async move {
             maintenance.run().await;
         }));

--- a/awa-worker/src/maintenance.rs
+++ b/awa-worker/src/maintenance.rs
@@ -32,6 +32,7 @@ pub struct MaintenanceService {
     cron_sync_interval: Duration,
     cron_eval_interval: Duration,
     leader_check_interval: Duration,
+    leader_election_interval: Duration,
     heartbeat_staleness: Duration,
     completed_retention: Duration,
     failed_retention: Duration,
@@ -59,10 +60,20 @@ impl MaintenanceService {
             cron_sync_interval: Duration::from_secs(60),
             cron_eval_interval: Duration::from_secs(1),
             leader_check_interval: Duration::from_secs(30),
+            leader_election_interval: Duration::from_secs(10),
             heartbeat_staleness: Duration::from_secs(90),
             completed_retention: Duration::from_secs(86400), // 24h
             failed_retention: Duration::from_secs(259200),   // 72h
         }
+    }
+
+    /// Set the leader election retry interval (default: 10s).
+    ///
+    /// Controls how often a non-leader instance retries acquiring the
+    /// advisory lock. Lower values speed up leader election in tests.
+    pub fn leader_election_interval(mut self, interval: Duration) -> Self {
+        self.leader_election_interval = interval;
+        self
     }
 
     /// Run the maintenance loop. Attempts leader election first.
@@ -83,7 +94,7 @@ impl MaintenanceService {
                             self.leader.store(false, Ordering::SeqCst);
                             return;
                         }
-                        _ = tokio::time::sleep(Duration::from_secs(10)) => continue,
+                        _ = tokio::time::sleep(self.leader_election_interval) => continue,
                     }
                 }
                 Err(err) => {
@@ -94,7 +105,7 @@ impl MaintenanceService {
                             self.leader.store(false, Ordering::SeqCst);
                             return;
                         }
-                        _ = tokio::time::sleep(Duration::from_secs(10)) => continue,
+                        _ = tokio::time::sleep(self.leader_election_interval) => continue,
                     }
                 }
             };

--- a/awa/tests/cron_test.rs
+++ b/awa/tests/cron_test.rs
@@ -333,9 +333,12 @@ async fn test_end_to_end_periodic_job_enqueued() {
     let queue = "cron_e2e";
     clean_queue(&pool, queue).await;
 
-    // Build a client with a periodic job that fires every minute
+    // Build a client with a periodic job that fires every minute.
+    // Use a 1s leader election interval so the test doesn't wait 10s per
+    // retry when another test binary holds the advisory lock.
     let client = Client::builder(pool.clone())
         .queue(queue, QueueConfig::default())
+        .leader_election_interval(std::time::Duration::from_secs(1))
         .register::<DailyReport, _, _>(|_args: DailyReport, _ctx: &JobContext| async move {
             Ok(JobResult::Completed)
         })
@@ -353,13 +356,9 @@ async fn test_end_to_end_periodic_job_enqueued() {
     client.start().await.unwrap();
 
     // Poll until the cron evaluator fires, or timeout.
-    // The maintenance service needs to: win leader election, sync schedules, then evaluate.
-    // If another test binary's maintenance service holds the advisory lock,
-    // leader election retries every 10s, so we need a generous timeout.
+    // Timing budget: leader election (1s retries) + cron eval (1s tick) +
+    // wait for next minute boundary (up to ~60s) = ~62s worst case.
     let start = std::time::Instant::now();
-    // The cron fires "* * * * *" (every minute). If we start late in a minute,
-    // we may need to wait almost a full minute for the next fire plus leader
-    // election time (up to 10s). Use 90s to avoid flaky failures.
     let timeout = std::time::Duration::from_secs(90);
     let jobs = loop {
         let found: Vec<awa::JobRow> =


### PR DESCRIPTION
## Summary

- Adds `ClientBuilder::leader_election_interval()` to configure how often a non-leader instance retries the maintenance advisory lock (default: 10s)
- Threads the setting through `Client` → `MaintenanceService`
- The flaky `test_end_to_end_periodic_job_enqueued` now uses 1s retries instead of the default 10s, making leader acquisition fast regardless of lock contention from other test binaries

## Test plan

- [x] `test_end_to_end_periodic_job_enqueued` passes reliably (17s locally vs previously timing out at 30s)
- [x] All 12 cron tests pass
- [x] `cargo fmt`, `cargo clippy --all-features` clean
- [x] No production behavior change (default remains 10s)

Closes #15