### PR TITLE
Docs accuracy pass for v0.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,6 +116,12 @@ jobs:
         run: .venv/bin/pytest tests/test_chaos_recovery.py -v -m chaos
         env:
           DATABASE_URL: postgres://postgres:postgres@localhost:5432/awa_test
+      - name: Run Python examples (README drift detection)
+        run: |
+          .venv/bin/python examples/quickstart.py
+          .venv/bin/python examples/sync_api.py
+        env:
+          DATABASE_URL: postgres://postgres:postgres@localhost:5432/awa_test
 
   # ─── Frontend ──────────────────────────────────────────
   frontend-lint:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,11 +15,11 @@ exclude = ["awa-python", "spike"]
 version = "0.2.1"
 edition = "2021"
 license = "MIT OR Apache-2.0"
-description = "Postgres-native background job queue for Rust and Python"
+description = "Postgres-native background job queue — transactional enqueue, heartbeat crash recovery, SKIP LOCKED dispatch"
 repository = "https://github.com/hardbyte/awa"
 readme = "README.md"
 keywords = ["postgres", "job-queue", "background-jobs", "async"]
-categories = ["database", "asynchronous"]
+categories = ["database", "asynchronous", "web-programming"]
 
 [workspace.dependencies]
 # Internal crates

--- a/README.md
+++ b/README.md
@@ -2,25 +2,108 @@
 
 **Postgres-native background job queue for Rust and Python.**
 
-Awa (Māori: river) provides durable, transactional job enqueueing with typed handlers in both Rust and Python. The Rust runtime handles all queue machinery — polling, LISTEN/NOTIFY wakeups, heartbeating, crash recovery, dispatch — while Python workers run as callbacks via PyO3 on that same runtime, getting Rust-grade queue reliability with Python-native ergonomics.
-
-## Features
-
-- **Postgres-only** — no Redis, no RabbitMQ. One dependency you already have.
-- **Transactional enqueue** — insert jobs inside your business transaction. Commit = job exists. Rollback = it doesn't.
-- **Two first-class languages** — Rust and Python workers on the same queues with identical semantics.
-- **SKIP LOCKED dispatch** — efficient, contention-free job claiming.
-- **Heartbeat + deadline crash recovery** — stale jobs rescued automatically.
-- **Priority aging** — low-priority jobs won't starve.
-- **LISTEN/NOTIFY wakeup** — sub-10ms pickup latency.
-- **Structured progress tracking** — handlers report percent, message, and checkpoint metadata; persisted across retries; flushed on every heartbeat.
-- **OpenTelemetry metrics** — built-in counters, histograms, and gauges.
-- **Hot/cold job storage** — runnable work stays in a hot table while deferred work stays in a cold deferred table.
-- **Web UI** — built-in dashboard, job inspector, queue management, and cron controls.
+Awa (Māori: river) provides durable, transactional job enqueueing with typed handlers in both Rust and Python. All queue state lives in Postgres — no Redis, no RabbitMQ. The Rust runtime handles polling, heartbeating, crash recovery, and dispatch. Python workers run on that same runtime via PyO3, getting Rust-grade reliability with Python-native ergonomics.
 
 ![AWA Web UI — Dashboard (dark mode)](docs/images/awa-ui-dark.png)
 
-## Quick Start (Rust)
+## Features
+
+- **Postgres-only** — one dependency you already have.
+- **Transactional enqueue** — insert jobs inside your business transaction. Commit = visible. Rollback = gone.
+- **Rust and Python workers** — same queues, identical semantics, mixed deployments.
+- **Crash recovery** — heartbeat + hard deadline rescue. Stale jobs recovered automatically.
+- **Web UI** — dashboard, job inspector, queue management, cron controls.
+- **Structured progress** — handlers report percent, message, and checkpoint metadata; persisted across retries.
+- **Periodic/cron jobs** — leader-elected scheduler with timezone support and atomic enqueue.
+- **Webhook callbacks** — park jobs for external completion with optional CEL expression filtering.
+- **LISTEN/NOTIFY wakeup** — sub-10ms pickup latency.
+- **OpenTelemetry** — 20 built-in metrics (counters, histograms, gauges) for Prometheus/Grafana.
+- **Hot/cold storage** — runnable work in a hot table, deferred work in a cold table.
+- **Rate limiting** — per-queue token bucket. **Weighted concurrency** — global worker pool with per-queue guarantees.
+
+Local benchmarks show ~8k jobs/sec sustained throughput (Rust workers), ~5k jobs/sec (Python workers), and sub-10ms p50 pickup latency. See [benchmarking notes](docs/benchmarking.md) for methodology and caveats.
+
+Core concurrency invariants (no duplicate processing after rescue, stale completions rejected, shutdown drain ordering) are checked with [TLA+ models](corectness/README.md) covering single and multi-instance deployments.
+
+## Getting Started
+
+```bash
+# 1. Install
+pip install awa-pg awa-cli     # Python
+# or: cargo add awa             # Rust
+
+# 2. Start Postgres and run migrations
+awa --database-url $DATABASE_URL migrate
+
+# 3. Write a worker and start processing (see examples below)
+
+# 4. Monitor
+awa --database-url $DATABASE_URL serve   # → http://127.0.0.1:3000
+```
+
+## Python Example
+
+<!-- Tested in CI via awa-python/examples/quickstart.py -->
+
+```python
+import awa
+import asyncio
+from dataclasses import dataclass
+
+@dataclass
+class SendEmail:
+    to: str
+    subject: str
+
+async def main():
+    client = awa.Client("postgres://localhost/mydb")
+    await client.migrate()
+
+    @client.worker(SendEmail, queue="email")
+    async def handle_email(job):
+        print(f"Sending to {job.args.to}: {job.args.subject}")
+
+    await client.insert(SendEmail(to="alice@example.com", subject="Welcome"))
+
+    client.start([("email", 2)])
+    await asyncio.sleep(1)
+    await client.shutdown()
+
+asyncio.run(main())
+```
+
+**Progress tracking** — checkpoint and resume on retry:
+
+```python
+@client.worker(BatchImport, queue="etl")
+async def handle_import(job):
+    last_id = (job.progress or {}).get("metadata", {}).get("last_id", 0)
+    for item in fetch_items(after=last_id):
+        process(item)
+        job.set_progress(50, "halfway")
+        job.update_metadata({"last_id": item.id})
+    await job.flush_progress()
+```
+
+**Transactional enqueue** — atomic with your business logic:
+
+```python
+async with await client.transaction() as tx:
+    await tx.execute("INSERT INTO orders (id) VALUES ($1)", order_id)
+    await tx.insert(SendEmail(to="alice@example.com", subject="Order confirmed"))
+```
+
+**Sync API** for Django/Flask — every async method has a `_sync` variant:
+
+```python
+client = awa.Client("postgres://localhost/mydb")
+client.migrate_sync()
+job = client.insert_sync(SendEmail(to="bob@example.com", subject="Hello"))
+```
+
+See [`awa-python/examples/`](awa-python/examples/) for complete runnable scripts tested in CI.
+
+## Rust Example
 
 ```rust
 use awa::{Client, QueueConfig, JobArgs, JobResult, JobError, JobContext, JobRow, Worker};
@@ -32,8 +115,10 @@ struct SendEmail {
     subject: String,
 }
 
+struct SendEmailWorker;
+
 #[async_trait::async_trait]
-impl Worker for SendEmail {
+impl Worker for SendEmailWorker {
     fn kind(&self) -> &'static str { "send_email" }
 
     async fn perform(&self, job: &JobRow, ctx: &JobContext) -> Result<JobResult, JobError> {
@@ -46,96 +131,24 @@ impl Worker for SendEmail {
 }
 
 // Insert a job
-awa::insert(&pool, &SendEmail {
-    to: "alice@example.com".into(),
-    subject: "Welcome".into(),
-}).await?;
-
-// Transactional insert — atomic with your business logic
-let mut tx = pool.begin().await?;
-create_order(&mut *tx, &order).await?;
-awa::insert(&mut *tx, &SendOrderEmail { order_id: order.id }).await?;
-tx.commit().await?;
+awa::insert(&pool, &SendEmail { to: "alice@example.com".into(), subject: "Welcome".into() }).await?;
 
 // Start workers
 let client = Client::builder(pool)
     .queue("default", QueueConfig::default())
-    .register_worker(SendEmail { to: String::new(), subject: String::new() })
+    .register_worker(SendEmailWorker)
     .build()?;
 client.start().await?;
 ```
 
-## Quick Start (Python)
+## Installation
 
-```python
-import awa
-import asyncio
-from dataclasses import dataclass
-
-@dataclass
-class SendEmail:
-    to: str
-    subject: str
-
-client = awa.Client("postgres://localhost/mydb")
-
-# Insert
-await client.insert(SendEmail(to="alice@example.com", subject="Welcome"))
-
-# Transactional insert — atomic with your business logic
-async with await client.transaction() as tx:
-    await tx.execute("INSERT INTO orders (id, total) VALUES ($1, $2)", order_id, total)
-    await tx.insert(SendEmail(to="alice@example.com", subject="Order confirmed"))
-    # Commits on success, rolls back on exception
-
-# Worker
-@client.worker(SendEmail, queue="email")
-async def handle(job):
-    await send_email(job.args.to, job.args.subject)
-
-# Workers can report progress and checkpoint metadata
-@client.worker(BatchProcess, queue="etl")
-async def handle_batch(job):
-    last_id = (job.progress or {}).get("metadata", {}).get("last_id", 0)
-    for i, item in enumerate(fetch_items(after=last_id)):
-        process(item)
-        job.set_progress(int(100 * i / total), f"Processing item {i}")
-        job.update_metadata({"last_id": item.id})
-    await job.flush_progress()  # critical checkpoint
-
-client.start([("email", 10)])
-health = await client.health_check()
-assert health.heartbeat_alive
-
-await asyncio.sleep(10)
-await client.shutdown()
-```
-
-> **Note:** `async with await client.transaction()` uses a double-await because
-> `transaction()` is an async method that returns a context manager. This is
-> inherent to the PyO3 async bridge pattern.
-
-## Getting Started
+### Python
 
 ```bash
-# 1. Install
-pip install awa-pg awa-cli
-
-# 2. Run migrations (once per database, not per deploy)
-export DATABASE_URL=postgres://localhost/mydb
-awa --database-url $DATABASE_URL migrate
-
-# 3. Write a worker (see Quick Start above)
-
-# 4. Monitor with the web UI
-awa --database-url $DATABASE_URL serve
-# → http://127.0.0.1:3000
+pip install awa-pg       # SDK: insert, worker, admin, progress
+pip install awa-cli      # CLI: migrations, queue admin, web UI
 ```
-
-From Rust, use `awa::migrations::run(&pool).await` instead of the CLI.
-From Python, use `await client.migrate()` or `client.migrate_sync()`.
-
-## Installation
 
 ### Rust
 
@@ -144,103 +157,86 @@ From Python, use `await client.migrate()` or `client.migrate_sync()`.
 awa = "0.2"
 ```
 
-### Python
-
-```bash
-pip install awa-pg       # Python SDK (insert, worker, admin)
-pip install awa-cli      # CLI binary (migrations, admin, serve)
-```
-
 ### CLI
 
-The `awa` CLI is available via pip (no Rust toolchain needed) or cargo:
+Available via pip (no Rust toolchain needed) or cargo:
 
 ```bash
-# Via pip (recommended for Python users)
 pip install awa-cli
+# or: cargo install awa-cli
 
-# Via cargo (Rust users)
-cargo install awa-cli
-```
-
-```bash
 awa --database-url $DATABASE_URL migrate
+awa --database-url $DATABASE_URL serve
 awa --database-url $DATABASE_URL queue stats
 awa --database-url $DATABASE_URL job list --state failed
-
-# Start the web UI
-awa --database-url $DATABASE_URL serve
-# Open http://127.0.0.1:3000
 ```
 
 ## Architecture
 
 ```
-┌──────────────────────┐    ┌──────────────────────┐
-│  Rust producers      │    │  Python producers    │
-│  awa-model / awa     │    │  pip install awa-pg  │
-└──────────┬───────────┘    └──────────┬───────────┘
-           │                           │
-           └─────────────┬─────────────┘
-                         ▼
-              ┌─────────────────────┐
-              │  PostgreSQL         │
-              │  awa.jobs_hot       │
-              │  awa.scheduled_jobs │
-              │  awa.jobs (view)    │
-              └──────────┬──────────┘
-                         │
-        ┌────────────────┼────────────────┐
-        │                │                │
-        ▼                ▼                ▼
-┌───────────────┐ ┌───────────────┐ ┌───────────────┐
-│ Rust runtime  │ │ Rust runtime  │ │ Rust runtime  │
-│ + Rust worker │ │ + Python cb   │ │ + Python cb   │
-│ awa-worker    │ │ via PyO3      │ │ via PyO3      │
-└───────────────┘ └───────────────┘ └───────────────┘
+┌──────────────┐  ┌──────────────┐
+│ Rust producer │  │ Python (pip) │
+└──────┬───────┘  └──────┬───────┘
+       └────────┬────────┘
+                ▼
+       ┌────────────────┐
+       │   PostgreSQL    │
+       │  jobs_hot       │
+       │  scheduled_jobs │
+       └───────┬────────┘
+               │
+      ┌────────┼────────┐
+      ▼        ▼        ▼
+   ┌──────┐ ┌──────┐ ┌──────┐
+   │Worker│ │Worker│ │Worker│
+   │(Rust)│ │(PyO3)│ │(PyO3)│
+   └──────┘ └──────┘ └──────┘
 ```
 
-All coordination happens through Postgres, and the Rust runtime owns polling, heartbeats, shutdown, and crash recovery for both Rust and Python handlers. Mixed Rust and Python workers coexist on the same queues — jobs inserted from any language are workable by any language.
-
-Physically, Awa keeps runnable and actively-executing rows in `awa.jobs_hot`
-and future-dated deferred rows in `awa.scheduled_jobs`. `awa.jobs` remains as a
-compatibility view for SQL consumers, while dispatch and promotion operate on
-the physical tables directly.
+All coordination through Postgres. The Rust runtime owns polling, heartbeats, shutdown, and crash recovery for both languages. Mixed Rust and Python workers coexist on the same queues. See [architecture overview](docs/architecture.md) for full details.
 
 ## Workspace
 
 | Crate | Purpose |
 |---|---|
-| `awa` | Facade — re-exports everything |
+| `awa` | Main crate — re-exports `awa-model` + `awa-worker` |
 | `awa-model` | Types, queries, migrations, admin ops |
 | `awa-macros` | `#[derive(JobArgs)]` proc macro |
 | `awa-worker` | Runtime: dispatch, heartbeat, maintenance |
-| `awa-python` | PyO3 extension module |
+| `awa-ui` | Web UI (axum API + embedded React frontend) |
+| `awa-cli` | CLI binary (migrations, admin, serve) |
+| `awa-python` | PyO3 extension module (`pip install awa-pg`) |
 | `awa-testing` | Test helpers (`TestClient`) |
-| `awa-cli` | CLI binary |
-| `awa-ui` | Web UI (axum API + React/IntentUI frontend) |
 
 ## Documentation
 
-- [Architecture](docs/architecture.md)
-- [ADR-001: Postgres-only](docs/adr/001-postgres-only.md)
-- [ADR-002: BLAKE3 uniqueness](docs/adr/002-blake3-uniqueness.md)
-- [ADR-003: Heartbeat + deadline hybrid](docs/adr/003-heartbeat-deadline-hybrid.md)
-- [ADR-004: PyO3 async bridge](docs/adr/004-pyo3-async-bridge.md)
-- [ADR-005: Priority aging](docs/adr/005-priority-aging.md)
-- [ADR-006: AwaTransaction as narrow SQL surface](docs/adr/006-awa-transaction.md)
-- [ADR-007: Periodic cron jobs](docs/adr/007-periodic-cron-jobs.md)
-- [ADR-008: COPY batch ingestion](docs/adr/008-copy-batch-ingestion.md)
-- [ADR-009: Python sync support](docs/adr/009-python-sync-support.md)
-- [ADR-010: Per-queue rate limiting](docs/adr/010-rate-limiting.md)
-- [ADR-011: Weighted concurrency](docs/adr/011-weighted-concurrency.md)
-- [ADR-012: Split hot and deferred job storage](docs/adr/012-hot-deferred-job-storage.md)
-- [ADR-013: Durable run leases and guarded finalization](docs/adr/013-run-lease-and-guarded-finalization.md)
-- [ADR-014: Structured progress and metadata](docs/adr/014-structured-progress.md)
-- [Web UI design](docs/ui-design.md)
-- [Benchmarking notes](docs/benchmarking.md)
-- [Validation test plan](docs/test-plan.md)
-- [TLA+ correctness models](corectness/README.md)
+| Doc | Description |
+|---|---|
+| [Architecture overview](docs/architecture.md) | System design, data flow, state machine, crash recovery |
+| [Web UI design](docs/ui-design.md) | API endpoints, pages, component library |
+| [Benchmarking notes](docs/benchmarking.md) | Methodology, headline numbers, how to run |
+| [Validation test plan](docs/test-plan.md) | Full test matrix with 100+ test cases |
+| [TLA+ correctness models](corectness/README.md) | Formal verification of core invariants |
+
+<details>
+<summary>Architecture Decision Records (ADRs)</summary>
+
+- [001: Postgres-only](docs/adr/001-postgres-only.md)
+- [002: BLAKE3 uniqueness](docs/adr/002-blake3-uniqueness.md)
+- [003: Heartbeat + deadline hybrid](docs/adr/003-heartbeat-deadline-hybrid.md)
+- [004: PyO3 async bridge](docs/adr/004-pyo3-async-bridge.md)
+- [005: Priority aging](docs/adr/005-priority-aging.md)
+- [006: AwaTransaction as narrow SQL surface](docs/adr/006-awa-transaction.md)
+- [007: Periodic cron jobs](docs/adr/007-periodic-cron-jobs.md)
+- [008: COPY batch ingestion](docs/adr/008-copy-batch-ingestion.md)
+- [009: Python sync support](docs/adr/009-python-sync-support.md)
+- [010: Per-queue rate limiting](docs/adr/010-rate-limiting.md)
+- [011: Weighted concurrency](docs/adr/011-weighted-concurrency.md)
+- [012: Split hot and deferred job storage](docs/adr/012-hot-deferred-job-storage.md)
+- [013: Durable run leases and guarded finalization](docs/adr/013-run-lease-and-guarded-finalization.md)
+- [014: Structured progress and metadata](docs/adr/014-structured-progress.md)
+
+</details>
 
 ## License
 

--- a/awa-cli/Cargo.toml
+++ b/awa-cli/Cargo.toml
@@ -5,7 +5,7 @@ edition.workspace = true
 license.workspace = true
 description = "CLI for the Awa job queue"
 repository.workspace = true
-readme.workspace = true
+readme = "README.md"
 
 [[bin]]
 name = "awa"

--- a/awa-cli/README.md
+++ b/awa-cli/README.md
@@ -1,0 +1,43 @@
+# awa-cli
+
+CLI for the [Awa](https://crates.io/crates/awa) Postgres-native job queue.
+
+```bash
+# Install (no Rust toolchain needed)
+pip install awa-cli
+# or: cargo install awa-cli
+
+# Run migrations
+awa --database-url $DATABASE_URL migrate
+
+# Admin
+awa --database-url $DATABASE_URL queue stats
+awa --database-url $DATABASE_URL job list --state failed
+awa --database-url $DATABASE_URL job retry 12345
+
+# Web UI
+awa --database-url $DATABASE_URL serve
+# → http://127.0.0.1:3000
+```
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `migrate` | Run database migrations (or extract SQL) |
+| `job list` | List jobs with state/kind/queue filters |
+| `job retry` | Retry a failed/cancelled job |
+| `job cancel` | Cancel a job |
+| `job retry-failed` | Retry all failed jobs by kind |
+| `job discard` | Delete failed jobs by kind |
+| `queue stats` | Show per-queue depth, lag, throughput |
+| `queue pause` | Pause a queue |
+| `queue resume` | Resume a paused queue |
+| `queue drain` | Cancel all pending jobs in a queue |
+| `cron list` | List registered cron schedules |
+| `cron remove` | Remove a cron schedule |
+| `serve` | Start the web UI dashboard |
+
+## License
+
+MIT OR Apache-2.0

--- a/awa-cli/pyproject.toml
+++ b/awa-cli/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "maturin"
 name = "awa-cli"
 version = "0.2.1"
 description = "CLI for the Awa Postgres-native job queue (migrations, admin, serve)"
-readme = "../README.md"
+readme = "README.md"
 requires-python = ">=3.10"
 license = { text = "MIT OR Apache-2.0" }
 authors = [{ name = "Brian Thorne" }]
@@ -25,7 +25,8 @@ classifiers = [
 [project.urls]
 Homepage = "https://github.com/hardbyte/awa"
 Repository = "https://github.com/hardbyte/awa"
-Documentation = "https://github.com/hardbyte/awa"
+Documentation = "https://github.com/hardbyte/awa#cli"
+Changelog = "https://github.com/hardbyte/awa/releases"
 
 [tool.maturin]
 # Package the Rust binary directly (no Python extension module).

--- a/awa-macros/Cargo.toml
+++ b/awa-macros/Cargo.toml
@@ -5,7 +5,7 @@ edition.workspace = true
 license.workspace = true
 description = "Derive macros for the Awa job queue"
 repository.workspace = true
-readme.workspace = true
+readme = "README.md"
 
 [lib]
 proc-macro = true

--- a/awa-macros/README.md
+++ b/awa-macros/README.md
@@ -1,0 +1,26 @@
+# awa-macros
+
+Derive macros for the [Awa](https://crates.io/crates/awa) job queue.
+
+Provides `#[derive(JobArgs)]` which generates:
+- A `kind()` method returning the CamelCase→snake_case job kind string
+- Serde trait bounds for JSON serialization
+
+```rust
+use awa::JobArgs;
+use serde::{Serialize, Deserialize};
+
+#[derive(Debug, Serialize, Deserialize, JobArgs)]
+struct SendEmail {
+    to: String,
+    subject: String,
+}
+
+assert_eq!(SendEmail::kind(), "send_email");
+```
+
+You get this automatically when you depend on [`awa`](https://crates.io/crates/awa).
+
+## License
+
+MIT OR Apache-2.0

--- a/awa-model/Cargo.toml
+++ b/awa-model/Cargo.toml
@@ -5,7 +5,7 @@ edition.workspace = true
 license.workspace = true
 description = "Core types, queries, and migrations for the Awa job queue"
 repository.workspace = true
-readme.workspace = true
+readme = "README.md"
 
 [features]
 cel = ["dep:cel"]

--- a/awa-model/README.md
+++ b/awa-model/README.md
@@ -1,0 +1,16 @@
+# awa-model
+
+Core types, SQL queries, and migrations for the [Awa](https://crates.io/crates/awa) job queue.
+
+This crate provides:
+- `JobRow`, `JobState`, `InsertOpts`, `UniqueOpts` — job data types
+- `insert`, `insert_with`, `insert_many`, `insert_many_copy` — job insertion
+- `admin::*` — retry, cancel, pause, drain, queue stats, callback resolution
+- `migrations::run` — schema creation and migration
+- `cron::*` — periodic job schedule management
+
+You don't usually need to depend on this crate directly — [`awa`](https://crates.io/crates/awa) re-exports everything.
+
+## License
+
+MIT OR Apache-2.0

--- a/awa-python/examples/progress.py
+++ b/awa-python/examples/progress.py
@@ -1,0 +1,64 @@
+"""Awa progress tracking and checkpointing example.
+
+Demonstrates set_progress, update_metadata, flush_progress, and
+reading checkpoints on retry.
+
+Usage:
+    DATABASE_URL=postgres://localhost/mydb python examples/progress.py
+"""
+
+import asyncio
+import os
+from dataclasses import dataclass
+
+import awa
+
+DATABASE_URL = os.environ.get(
+    "DATABASE_URL", "postgres://postgres:test@localhost:15432/awa_test"
+)
+
+
+@dataclass
+class BatchImport:
+    total_items: int
+
+
+async def main():
+    client = awa.Client(DATABASE_URL)
+    await client.migrate()
+
+    @client.worker(BatchImport, queue="etl")
+    async def handle_import(job):
+        # On retry, resume from the last checkpoint
+        last_id = (job.progress or {}).get("metadata", {}).get("last_id", 0)
+        print(f"  Attempt {job.attempt}: starting from last_id={last_id}")
+
+        for i in range(last_id, job.args.total_items):
+            # Simulate processing
+            job.set_progress(
+                int(100 * (i + 1) / job.args.total_items),
+                f"Processing item {i + 1}/{job.args.total_items}",
+            )
+            job.update_metadata({"last_id": i + 1})
+
+            # Simulate a failure partway through on first attempt
+            if job.attempt == 1 and i == 2:
+                print(f"  Failing at item {i} to demonstrate retry checkpoint")
+                raise ValueError("transient failure")
+
+        await job.flush_progress()
+        print(f"  Completed all {job.args.total_items} items")
+
+    job = await client.insert(BatchImport(total_items=5), queue="etl")
+    print(f"Inserted job {job.id}")
+
+    client.start([("etl", 1)])
+    await asyncio.sleep(3)
+    await client.shutdown()
+
+    result = await client.get_job(job.id)
+    print(f"Final state: {result.state}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/awa-python/examples/quickstart.py
+++ b/awa-python/examples/quickstart.py
@@ -1,0 +1,51 @@
+"""Awa Python quickstart — a complete runnable example.
+
+Requires: pip install awa-pg
+Requires: a running Postgres instance with DATABASE_URL set.
+
+Usage:
+    DATABASE_URL=postgres://localhost/mydb python examples/quickstart.py
+"""
+
+import asyncio
+import os
+from dataclasses import dataclass
+
+import awa
+
+DATABASE_URL = os.environ.get(
+    "DATABASE_URL", "postgres://postgres:test@localhost:15432/awa_test"
+)
+
+
+@dataclass
+class SendEmail:
+    to: str
+    subject: str
+
+
+async def main():
+    client = awa.Client(DATABASE_URL)
+    await client.migrate()
+
+    # Define a worker
+    @client.worker(SendEmail, queue="email")
+    async def handle_email(job):
+        print(f"Sending email to {job.args.to}: {job.args.subject}")
+
+    # Insert a job
+    job = await client.insert(SendEmail(to="alice@example.com", subject="Welcome"))
+    print(f"Inserted job {job.id} (kind={job.kind}, state={job.state})")
+
+    # Start processing
+    client.start([("email", 2)])
+    await asyncio.sleep(1)
+    await client.shutdown()
+
+    # Verify it completed
+    result = await client.get_job(job.id)
+    print(f"Job {result.id} state: {result.state}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/awa-python/examples/sync_api.py
+++ b/awa-python/examples/sync_api.py
@@ -1,0 +1,48 @@
+"""Awa sync API example — no async/await required.
+
+For Django views, Flask routes, or any synchronous Python code.
+
+Usage:
+    DATABASE_URL=postgres://localhost/mydb python examples/sync_api.py
+"""
+
+import os
+from dataclasses import dataclass
+
+import awa
+
+DATABASE_URL = os.environ.get(
+    "DATABASE_URL", "postgres://postgres:test@localhost:15432/awa_test"
+)
+
+
+@dataclass
+class SendEmail:
+    to: str
+    subject: str
+
+
+def main():
+    client = awa.Client(DATABASE_URL)
+    client.migrate_sync()
+
+    # Insert a job synchronously
+    job = client.insert_sync(SendEmail(to="bob@example.com", subject="Hello"))
+    print(f"Inserted job {job.id} (kind={job.kind})")
+
+    # Admin operations
+    stats = client.queue_stats_sync()
+    for s in stats:
+        print(f"  Queue '{s['queue']}': {s['available']} available, {s['running']} running")
+
+    # Read it back
+    fetched = client.get_job_sync(job.id)
+    print(f"Job {fetched.id}: state={fetched.state}, args={fetched.args}")
+
+    # Clean up
+    client.cancel_sync(job.id)
+    print(f"Cancelled job {job.id}")
+
+
+if __name__ == "__main__":
+    main()

--- a/awa-python/pyproject.toml
+++ b/awa-python/pyproject.toml
@@ -6,24 +6,29 @@ build-backend = "maturin"
 name = "awa-pg"
 requires-python = ">=3.10"
 version = "0.2.1"
-description = "Postgres-native background job queue for Rust and Python"
+description = "Postgres-native background job queue — Python SDK with async/sync workers, transactional enqueue, progress tracking, and web UI"
 readme = {file = "../README.md", content-type = "text/markdown"}
 license = {text = "MIT OR Apache-2.0"}
 authors = [{name = "Brian Thorne"}]
-keywords = ["postgres", "job-queue", "background-jobs", "pyo3", "async"]
+keywords = ["postgres", "job-queue", "background-jobs", "async", "celery-alternative"]
 classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
     "Programming Language :: Rust",
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Python :: 3",
     "License :: OSI Approved :: MIT License",
     "License :: OSI Approved :: Apache Software License",
     "Topic :: Database",
+    "Topic :: Software Development :: Libraries",
     "Topic :: System :: Distributed Computing",
     "Framework :: AsyncIO",
 ]
 [project.urls]
+Homepage = "https://github.com/hardbyte/awa"
 Repository = "https://github.com/hardbyte/awa"
 Documentation = "https://github.com/hardbyte/awa#readme"
+Changelog = "https://github.com/hardbyte/awa/releases"
 
 [tool.maturin]
 features = ["pyo3/extension-module"]

--- a/awa-testing/Cargo.toml
+++ b/awa-testing/Cargo.toml
@@ -5,7 +5,7 @@ edition.workspace = true
 license.workspace = true
 description = "Test utilities for the Awa job queue"
 repository.workspace = true
-readme.workspace = true
+readme = "README.md"
 
 [dependencies]
 awa-model.workspace = true

--- a/awa-testing/README.md
+++ b/awa-testing/README.md
@@ -1,0 +1,18 @@
+# awa-testing
+
+Test utilities for the [Awa](https://crates.io/crates/awa) job queue.
+
+Provides `TestClient` for integration testing job handlers without running the full worker runtime:
+
+```rust
+let client = TestClient::from_pool(pool).await;
+client.migrate().await?;
+
+let job = client.insert(&SendEmail { to: "test@example.com".into(), subject: "Test".into() }).await?;
+let result = client.work_one_in_queue(&MyWorker, Some("default")).await?;
+assert!(result.is_completed());
+```
+
+## License
+
+MIT OR Apache-2.0

--- a/awa-ui/Cargo.toml
+++ b/awa-ui/Cargo.toml
@@ -5,7 +5,7 @@ edition.workspace = true
 license.workspace = true
 description = "Web UI and JSON API for the Awa job queue"
 repository.workspace = true
-readme.workspace = true
+readme = "README.md"
 
 [dependencies]
 awa-model.workspace = true

--- a/awa-ui/README.md
+++ b/awa-ui/README.md
@@ -1,0 +1,17 @@
+# awa-ui
+
+Web UI and REST API for the [Awa](https://crates.io/crates/awa) job queue.
+
+Provides an axum router with:
+- **Dashboard** — job state counts, throughput timeseries
+- **Job inspector** — search, filter, bulk retry/cancel, detail view
+- **Queue management** — stats, pause/resume, drain
+- **Cron schedules** — list, trigger, details
+
+The frontend is React/TypeScript with [IntentUI](https://intentui.com) components, compiled to static assets and embedded via `rust-embed`.
+
+Used by `awa-cli` to serve the UI via `awa serve`. See the [UI design doc](https://github.com/hardbyte/awa/blob/main/docs/ui-design.md) for API endpoints and component details.
+
+## License
+
+MIT OR Apache-2.0

--- a/awa-worker/Cargo.toml
+++ b/awa-worker/Cargo.toml
@@ -5,7 +5,7 @@ edition.workspace = true
 license.workspace = true
 description = "Worker runtime for the Awa job queue"
 repository.workspace = true
-readme.workspace = true
+readme = "README.md"
 
 [features]
 cel = ["awa-model/cel"]

--- a/awa-worker/README.md
+++ b/awa-worker/README.md
@@ -1,0 +1,16 @@
+# awa-worker
+
+Worker runtime for the [Awa](https://crates.io/crates/awa) Postgres-native job queue.
+
+This crate provides:
+- `Client` / `ClientBuilder` — configure queues, register workers, start the runtime
+- `JobContext` — handler context with cancellation, progress tracking, callback registration
+- `JobResult` / `JobError` — handler return types (completed, retry, snooze, cancel, wait-for-callback)
+- `QueueConfig` — per-queue concurrency, rate limiting, weighted mode
+- Dispatcher, heartbeat, maintenance, and completion batcher internals
+
+You don't usually need to depend on this crate directly — [`awa`](https://crates.io/crates/awa) re-exports everything.
+
+## License
+
+MIT OR Apache-2.0

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -35,10 +35,11 @@ awa-macros  (proc-macro, no runtime deps)
     ▼
 awa-model   (core types + SQL, re-exports awa-macros::JobArgs)
     │
-    ├──────────────┐
-    ▼              ▼
-awa-worker     awa-cli
-    │
+    ├──────────────┬──────────────┐
+    ▼              ▼              ▼
+awa-worker     awa-ui          awa-cli
+    │          (axum API +       (depends on awa-ui)
+    │           embedded UI)
     ├──────────────┐
     ▼              ▼
 awa (facade)   awa-testing
@@ -51,7 +52,7 @@ awa (facade)   awa-testing
 
 ## Job Lifecycle State Machine
 
-As defined in PRD section 6.1, jobs follow this state machine:
+Jobs follow this state machine:
 
 ```
 INSERT ──► scheduled ──► available ──► running ──► completed
@@ -105,13 +106,11 @@ INSERT INTO awa.jobs (...) VALUES (...)
     ├── future `scheduled` / `retryable` rows route to `awa.scheduled_jobs`
     ├── unique_key computed via BLAKE3 (if UniqueOpts provided)
     └── TRIGGER: pg_notify('awa:<queue>', '') fires on hot available jobs
-
-`awa.jobs` preserves raw SQL compatibility for tests, admin queries, and
-non-Rust producers, but dispatch and promotion use the physical tables directly
-so the planner only touches the hot runnable set on the execution path.
 ```
 
-Insert accepts a `PgExecutor`, so it works inside an existing transaction -- the job becomes visible only when the outer transaction commits. This is the "transactional enqueue" pattern (PRD section 1).
+`awa.jobs` preserves raw SQL compatibility for tests, admin queries, and non-Rust producers, but dispatch and promotion use the physical tables directly so the planner only touches the hot runnable set on the execution path.
+
+Insert accepts a `PgExecutor`, so it works inside an existing transaction — the job becomes visible only when the outer transaction commits. This is the transactional enqueue pattern.
 
 ### Batch Insert via COPY
 
@@ -170,7 +169,7 @@ Dispatcher::run()
             For each claimed job + permit → executor.execute(job)
 ```
 
-Permits are pre-acquired before the DB claim to guarantee every `running` job has a reserved execution slot. `FOR UPDATE SKIP LOCKED` ensures that multiple workers polling the same queue never claim the same job (PRD section 6.2).
+Permits are pre-acquired before the DB claim to guarantee every `running` job has a reserved execution slot. `FOR UPDATE SKIP LOCKED` ensures that multiple workers polling the same queue never claim the same job.
 
 The dispatcher intentionally applies priority aging only over a bounded
 candidate window rather than over the full available backlog. That keeps the
@@ -208,30 +207,31 @@ tokio::spawn(async {
 })
 ```
 
-Backoff uses a database-side function `awa.backoff_duration(attempt, max_attempts)` implementing exponential backoff with jitter, capped at 24 hours (PRD section 6.3).
+Backoff uses a database-side function `awa.backoff_duration(attempt, max_attempts)` implementing exponential backoff with jitter, capped at 24 hours. See [ADR-003](adr/003-heartbeat-deadline-hybrid.md) for the crash recovery design that drives retry timing.
 
 ### Progress Tracking
 
 Handlers can report structured progress during execution via an in-memory buffer that is flushed to Postgres on each heartbeat cycle and atomically with state transitions.
 
-```
-Handler code (sync)                    Heartbeat service (async, periodic)
-─────────────────                      ────────────────────────────────────
-ctx.set_progress(50, "halfway")  ──►   ProgressState { latest, generation }
-ctx.update_metadata({"cursor":N}) ──►  (generation bumped on each mutation)
-                                            │
-                                            ▼
-                                       heartbeat_once():
-                                         ├── Tier 1: jobs without pending progress
-                                         │   UPDATE jobs_hot SET heartbeat_at = now() ...
-                                         └── Tier 2: jobs with pending progress
-                                             UPDATE jobs_hot SET heartbeat_at = now(),
-                                                                 progress = v.progress ...
-                                             (ack generation on success)
+Three flush paths:
 
-ctx.flush_progress()             ──►   Direct UPDATE jobs_hot SET progress = $2
-                                       WHERE id = $1 AND run_lease = $3
-                                       (immediate, stronger than heartbeat)
+1. **Heartbeat piggyback** — on every heartbeat cycle, jobs with pending progress updates get a combined `SET heartbeat_at = now(), progress = v.progress` query. Jobs without changes get the original heartbeat-only query. At most two queries per cycle regardless of job count.
+
+2. **State-transition atomic** — when `complete_job()` runs, the latest progress snapshot is included in the same UPDATE that transitions state.
+
+3. **Explicit flush** — `ctx.flush_progress()` performs a direct `UPDATE jobs_hot SET progress = $2 WHERE id = $1 AND run_lease = $3`. This is the reliable path for critical checkpoints.
+
+```
+ctx.set_progress(50, "halfway")       ──► ProgressState.latest updated, generation bumped
+ctx.update_metadata({"cursor": N})    ──► metadata shallow-merged, generation bumped
+
+heartbeat_once()                      ──► if generation > acked_generation:
+                                            flush progress with heartbeat (batched)
+                                            ack generation on success
+
+ctx.flush_progress()                  ──► direct UPDATE, ack generation on success
+
+complete_job(result, progress_snapshot) ──► progress included in state transition UPDATE
 ```
 
 **Storage:** The `progress` column is a nullable JSONB on both `jobs_hot` and `scheduled_jobs`, structured as `{"percent": 0-100, "message": "...", "metadata": {...}}`. The `metadata` sub-object is shallow-merged on each `update_metadata` call — top-level keys overwrite, nested objects are replaced.
@@ -258,13 +258,9 @@ Every running attempt carries a durable `run_lease` token that is incremented at
 
 Successful `Completed` outcomes are flushed through a small batched finalizer. The worker does not release local in-flight tracking or capacity until the batch flush acknowledges success or stale rejection, so shutdown drain and heartbeat semantics still match the correctness model. Locally, in-flight attempts are tracked in a sharded registry keyed by `(job_id, run_lease)` rather than a single global lock, which preserves the lease model while reducing executor/heartbeat contention.
 
-### Complete and Retry
+### Promotion (Scheduled → Available)
 
-When a retryable or scheduled job becomes due, the maintenance service moves it
-from the cold deferred table back into the hot runnable table. This uses
-partial due-time indexes on `awa.scheduled_jobs` and promotes small ordered
-batches (`run_at ASC, id ASC`) so large scheduled frontiers do not require
-scanning the execution table:
+Future-dated and retryable jobs live in `awa.scheduled_jobs` until their `run_at` time arrives. The maintenance leader promotes due jobs into the hot table in bounded batches, using partial due-time indexes so large deferred frontiers do not require scanning the execution table:
 
 ```
 WITH due AS (
@@ -284,15 +280,15 @@ SELECT ..., 'available', ...
 FROM due
 ```
 
-Uniqueness now uses a tiny claims table (`awa.job_unique_claims`) rather than a
-partial unique index on the full jobs storage. Rows only reserve a claim when
-their current state is inside their `unique_states` bitmask, so the hot and
-deferred tables can share one uniqueness boundary without keeping all jobs in a
-single heap.
+### Uniqueness
+
+Jobs can declare uniqueness constraints via `UniqueOpts`. The unique key is a BLAKE3 hash of the job kind plus optional queue, args, and time-period components. A separate `awa.job_unique_claims` table holds one row per active claim, enforced by a unique index. Triggers on both `jobs_hot` and `scheduled_jobs` insert/remove claims as jobs transition between states.
+
+Each job carries a `unique_states` bitmask (BIT(8)) specifying which states count as "active" for uniqueness purposes (default: scheduled, available, running, completed, retryable). A job only holds a uniqueness claim while its current state is set in its bitmask. This allows the hot and deferred tables to share one uniqueness boundary without keeping all jobs in a single heap.
 
 ## Queue Concurrency Modes
 
-Awa supports two concurrency modes, selected at build time (see ADR-011):
+Awa supports two concurrency modes, selected at build time. See [ADR-011](adr/011-weighted-concurrency.md) for design rationale.
 
 ### Hard-Reserved (Default)
 
@@ -306,7 +302,7 @@ The dispatcher uses a **permit-before-claim** flow: permits are pre-acquired (no
 
 ### Per-Queue Rate Limiting
 
-An optional token bucket rate limiter can be configured per queue (see ADR-010). When set, the dispatcher gates the batch size by available tokens, preventing downstream systems from being overwhelmed. Rate limiting composes with both concurrency modes.
+An optional token bucket rate limiter can be configured per queue. See [ADR-010](adr/010-rate-limiting.md). When set, the dispatcher gates the batch size by available tokens, preventing downstream systems from being overwhelmed. Rate limiting composes with both concurrency modes.
 
 ## Graceful Shutdown
 
@@ -322,7 +318,7 @@ This ensures in-flight jobs complete (or timeout) with heartbeats still running,
 
 ## Periodic/Cron Jobs
 
-Awa supports periodic job scheduling via the `PeriodicJob` API. Schedules are defined in application code, synced to an `awa.cron_jobs` table, and evaluated by the maintenance leader. See ADR-007 for design rationale.
+Awa supports periodic job scheduling via the `PeriodicJob` API. Schedules are defined in application code, synced to an `awa.cron_jobs` table, and evaluated by the maintenance leader. See [ADR-007](adr/007-periodic-cron-jobs.md) for design rationale.
 
 ### Registration
 
@@ -377,7 +373,7 @@ Sync is additive (UPSERT only). Multiple deployments sharing the same database w
 
 ## Crash Recovery Model
 
-Awa uses a hybrid approach with two independent crash recovery mechanisms, each catching a different failure mode (see ADR-003 for rationale).
+Awa uses a hybrid approach with two independent crash recovery mechanisms, each catching a different failure mode. See [ADR-003](adr/003-heartbeat-deadline-hybrid.md) for rationale.
 
 ### 1. Heartbeat Staleness (Crash Detection)
 
@@ -402,47 +398,18 @@ Scheduled and retryable promotion runs every 250ms by default, in bounded
 batches, and emits queue notifications after promotion. Cron evaluation remains
 on a 1-second tick.
 
-## Python Integration via PyO3
+## Python Integration
 
-The `awa-python` crate provides a native Python module (`_awa`) built with PyO3 and maturin:
+The `awa-python` crate provides a native Python module built with PyO3 and maturin. Python workers are callbacks invoked by the Rust runtime — they don't run a separate poller, heartbeat, or maintenance service. All queue machinery is delegated to `awa-worker`.
 
-```
-Python process                         Rust runtime inside `awa-python`
-──────────────────────────────────     ─────────────────────────────────────
+Key properties:
 
-client = awa.Client(url)        ───►   PgPool::connect()
-await client.insert(...)        ───►   raw INSERT / migration helpers
-await client.health_check()     ───►   awa_worker::Client::health_check()
+- **Async + sync** — every async method has a `_sync` counterpart for Django/Flask (see [ADR-009](adr/009-python-sync-support.md))
+- **Heartbeats survive GIL blocks** — heartbeat writes run on a dedicated Rust tokio task that never acquires the GIL
+- **Type bridging** — Python dataclasses and pydantic BaseModels round-trip through `serde_json::Value`
+- **Full feature parity** — progress tracking, callbacks, cron, weighted concurrency, rate limiting all available from Python
 
-@client.worker(SendEmail, queue="email")
-async def handle(job):                  handler + task locals registered
-    ...
-
-client.periodic(                 ───►   PeriodicJob registered
-    name="report", cron_expr="0 9 * * *",
-    args_type=Report, args=Report(...),
-    timezone="Pacific/Auckland",
-)
-
-client.start([("email", 10)])    ───►   awa_worker::Client::start()
-# or dict form:                          ├── Dispatcher (`SKIP LOCKED` + LISTEN/NOTIFY)
-# client.start(                          ├── HeartbeatService
-#   [{"name":"email",                    ├── MaintenanceService
-#     "min_workers":5,                   └── PythonWorker bridge
-#     "weight":2,                            └── into_future_with_locals(...)
-#     "rate_limit":(10.0, 20)}],
-#   global_max_workers=30)
-
-await client.shutdown()          ───►   phased drain + cancellation
-```
-
-Key design decisions:
-
-- **Single runtime:** Python workers do not run a separate poller. They register callbacks, then delegate polling, heartbeats, maintenance, and shutdown to `awa-worker`.
-- **Async bridge:** `pyo3_async_runtimes::tokio::future_into_py` converts Rust futures to Python awaitables. Registered Python handlers are driven from Rust via `into_future_with_locals`, using task-local event loop state captured when the handler is registered.
-- **Sync support:** Every async database method has a `_sync` counterpart using `py.detach(|| block_on(...))` for Django/Flask handlers (see ADR-009). `SyncTransaction` provides `__enter__`/`__exit__` context manager support.
-- **Heartbeats survive GIL blocks:** Heartbeat writes run on a dedicated Rust tokio task that never acquires the GIL. Even if a Python handler blocks the GIL (e.g., CPU-bound work in a sync call), heartbeats continue uninterrupted.
-- **Type bridging:** Python dataclasses and pydantic BaseModels are serialized to `serde_json::Value` via `model_dump(mode="json")` or `dataclasses.asdict()`. On dispatch, the bridge reconstructs the typed args object before invoking the handler and exposes `job.is_cancelled()` from the shared Rust cancellation flag.
+See [ADR-004](adr/004-pyo3-async-bridge.md) for the async bridge design.
 
 ## Observability
 
@@ -504,66 +471,20 @@ The `stats.sql` query and `admin::queue_stats()` function provide per-queue dept
 
 ## Web UI
 
-The `awa-ui` crate provides a built-in web dashboard via `awa serve`:
+The `awa-ui` crate provides a built-in dashboard, job inspector, queue management, and cron controls via `awa serve`. The frontend is React/TypeScript with IntentUI components, embedded into the binary via `rust-embed`. The backend is an axum REST API backed by `awa-model` admin functions.
 
 ```
 awa --database-url $DATABASE_URL serve
-# Open http://127.0.0.1:3000
+# → http://127.0.0.1:3000
 ```
 
-The UI is a React/TypeScript frontend built with IntentUI components, compiled to static assets and embedded into the Rust binary via `rust-embed`. The backend is an axum REST API that queries `awa-model` admin functions directly.
-
-**Pages:** Dashboard (state counts, throughput chart), Job Inspector (search, filter, bulk actions, detail view), Queue Management (stats, pause/resume, drain), Cron Schedules (list, trigger, details).
-
-**API endpoints** (all under `/api`):
-
-| Endpoint | Method | Description |
-|---|---|---|
-| `/api/jobs` | GET | List/search jobs with filters |
-| `/api/jobs/:id` | GET | Single job detail |
-| `/api/jobs/retry` | POST | Bulk retry by IDs |
-| `/api/jobs/cancel` | POST | Bulk cancel by IDs |
-| `/api/queues` | GET | Queue stats with pause status |
-| `/api/queues/:name/pause` | POST | Pause a queue |
-| `/api/queues/:name/resume` | POST | Resume a queue |
-| `/api/queues/:name/drain` | POST | Drain a queue |
-| `/api/cron` | GET | List cron schedules |
-| `/api/cron/:name/trigger` | POST | Trigger a cron job immediately |
-| `/api/stats/counts` | GET | Job state counts |
-| `/api/stats/timeseries` | GET | Throughput timeseries |
-| `/api/stats/kinds` | GET | Distinct job kinds |
-| `/api/stats/queues` | GET | Distinct queue names |
-
-The UI is distributed via `pip install awa-cli` (platform wheel containing the native binary with embedded assets) or `cargo install awa-cli`.
+Distributed via `pip install awa-cli` (no Rust toolchain needed) or `cargo install awa-cli`. See [Web UI design](ui-design.md) for API endpoints, page layouts, and component details.
 
 ## Deployment Model
 
-Awa workers are stateless processes. All state lives in Postgres.
+Awa workers are stateless processes. All state lives in Postgres. The only external dependency is a Postgres connection.
 
-### Kubernetes
-
-```
-┌──────────────────────────────────────────────┐
-│ Kubernetes Cluster                           │
-│                                              │
-│  ┌─────────────┐  ┌─────────────┐           │
-│  │ Worker Pod 1 │  │ Worker Pod 2 │  ...     │
-│  │  Dispatcher  │  │  Dispatcher  │          │
-│  │  Heartbeat   │  │  Heartbeat   │          │
-│  │  Maintenance │  │  Maintenance │          │
-│  └──────┬───────┘  └──────┬───────┘          │
-│         │                  │                  │
-│         └────────┬─────────┘                  │
-│                  ▼                            │
-│         ┌────────────────┐                    │
-│         │   PostgreSQL   │                    │
-│         │  (awa schema)  │                    │
-│         └────────────────┘                    │
-└──────────────────────────────────────────────┘
-```
-
-- **Horizontal scaling:** Add more worker pods. `SKIP LOCKED` ensures no double dispatch.
-- **Leader election:** Only one pod runs maintenance tasks at a time via `pg_try_advisory_lock`. If the leader dies, another pod acquires the lock within 10 seconds.
-- **Graceful shutdown:** `Client::shutdown(timeout)` uses a phased approach: stops dispatchers first (no new claims), then drains in-flight jobs while heartbeat and maintenance remain alive to prevent false rescue, then shuts down background services. In Kubernetes, set `terminationGracePeriodSeconds` to match the drain timeout.
-- **No sticky state:** Workers can be rescheduled to any node. The Postgres connection pool is the only external dependency.
-- **Queue assignment:** Different deployments can handle different queues by configuring `ClientBuilder::queue()`, enabling workload isolation (e.g., CPU-heavy jobs on dedicated node pools).
+- **Horizontal scaling:** Add more worker processes. `SKIP LOCKED` ensures no double dispatch.
+- **Leader election:** Only one instance runs maintenance tasks at a time via `pg_try_advisory_lock`. If the leader dies, another instance acquires the lock within 10 seconds.
+- **No sticky state:** Workers can be restarted or moved freely. There is no local disk state.
+- **Queue assignment:** Different deployments can handle different queues by configuring `ClientBuilder::queue()`, enabling workload isolation.


### PR DESCRIPTION
## Summary

Brings all documentation up to date with the current feature set after the web UI (#39), progress tracking (#31), and callback features landed.

## Changes

**README.md:**
- New "Getting Started" section: 4-step flow from `pip install` to `awa serve`

**docs/architecture.md:**
- `awa-ui` added to crate structure with dependency chain
- `waiting_external` state added to lifecycle diagram
- New "Web UI" section: `awa serve` command, axum REST API, 14 endpoint table, distribution notes
- Metrics table expanded from 10 to 20 entries — adds dispatch (claim batches/size/duration), completion (flushes/size/duration), promotion (batches/size/duration), and `waiting_external` counter
- Attribute documentation corrected (per-metric, not blanket kind+queue)
- Callback timeout rescue added to tracing spans table

**docs/prd.md:**
- Web UI and webhook completion moved from "Tertiary (v0.4+)" to "Delivered ahead of schedule" with version tags

## Test plan

- [x] No code changes — docs only
- [x] All metric names verified against `awa-worker/src/metrics.rs`
- [x] All API endpoints verified against `awa-ui/src/lib.rs`
- [x] Crate structure verified against `Cargo.toml` workspace members