### PR TITLE
Add Python + Rust examples with tests

### DIFF
--- a/examples/python/email_campaign.py
+++ b/examples/python/email_campaign.py
@@ -1,0 +1,140 @@
+"""
+Email Campaign with Bulk Insert, Priority, and Admin Operations
+
+Demonstrates:
+- Fast bulk job insertion with COPY protocol
+- Priority levels (transactional emails before marketing)
+- Simulated failures with retry
+- Admin operations: retry_failed, queue_stats
+- Periodic cron schedule
+
+In production you'd split this into:
+- A marketing service that bulk-enqueues campaign emails (the insert_many_copy
+  section) — triggered by an admin action or scheduled campaign
+- A worker process: client.start([("email", 10)]) as a separate deployment
+- An admin/ops script or the web UI for retry_failed, queue_stats, drain
+- The periodic schedule runs on the worker (leader evaluates it)
+
+Run (single-process demo):
+    cd awa-python
+    DATABASE_URL=postgres://... .venv/bin/python ../examples/python/email_campaign.py
+"""
+
+import asyncio
+import os
+import random
+from dataclasses import dataclass
+
+import awa
+
+
+DATABASE_URL = os.environ.get(
+    "DATABASE_URL", "postgres://postgres:test@localhost:15432/awa_test"
+)
+
+
+@dataclass
+class SendEmail:
+    to: str
+    subject: str
+    template: str
+    campaign_id: str = ""
+
+
+async def main():
+    client = awa.Client(DATABASE_URL)
+    await client.migrate()
+    print("AWA Email Campaign Example\n")
+
+    sent_count = 0
+
+    @client.worker(SendEmail, queue="email")
+    async def handle_email(job):
+        nonlocal sent_count
+        await asyncio.sleep(0.01)
+        # Simulate 5% failure rate
+        if random.random() < 0.05:
+            raise Exception(f"SMTP refused for {job.args['to']}")
+        sent_count += 1
+
+    # ── Periodic schedule ───────────────────────────────────────
+
+    client.periodic(
+        name="email_health",
+        cron_expr="0 * * * *",
+        args_type=SendEmail,
+        args=SendEmail(to="", subject="noop", template="noop"),
+        queue="email",
+        tags=["internal"],
+    )
+
+    # ── Bulk enqueue marketing campaign (fast COPY insert) ──────
+
+    campaign_id = "spring_2026"
+    recipients = [f"user{i}@example.com" for i in range(200)]
+
+    print(f"Bulk inserting {len(recipients)} campaign emails (COPY protocol)...")
+    campaign_jobs = [
+        SendEmail(to=email, subject="Spring Sale", template="promo", campaign_id=campaign_id)
+        for email in recipients
+    ]
+    await client.insert_many_copy(
+        campaign_jobs,
+        queue="email",
+        priority=3,  # low priority — marketing
+        tags=["marketing", campaign_id],
+        metadata={"campaign": campaign_id},
+    )
+    print(f"  ✓ {len(recipients)} marketing emails enqueued\n")
+
+    # ── High-priority transactional emails ──────────────────────
+
+    print("Enqueuing 5 transactional emails (priority 1)...")
+    for i in range(5):
+        await client.insert(
+            SendEmail(to=f"vip{i}@example.com", subject="Order Confirmed", template="order"),
+            queue="email",
+            priority=1,  # processed before marketing
+            tags=["transactional"],
+        )
+    print("  ✓ Transactional emails will be processed first\n")
+
+    # ── Process ─────────────────────────────────────────────────
+
+    client.start([("email", 5)], leader_election_interval_ms=500)
+
+    print("Processing...")
+    for tick in range(60):
+        await asyncio.sleep(1)
+        stats = await client.queue_stats()
+        eq = next((s for s in stats if s["queue"] == "email"), None)
+        if eq:
+            avail, running, failed = eq["available"], eq["running"], eq["failed"]
+            if tick % 5 == 0:
+                print(f"  avail={avail} running={running} failed={failed}")
+            if avail == 0 and running == 0:
+                break
+
+    # ── Retry failures ──────────────────────────────────────────
+
+    stats = await client.queue_stats()
+    eq = next((s for s in stats if s["queue"] == "email"), None)
+    fail_count = (eq or {}).get("failed", 0)
+
+    print(f"\nFirst pass: {sent_count} sent, {fail_count} failed")
+
+    if fail_count > 0:
+        retried = await client.retry_failed(queue="email")
+        print(f"Retrying {len(retried)} failed emails...")
+        await asyncio.sleep(5)
+
+    print(f"Final: {sent_count} total sent")
+    health = await client.health_check()
+    print(f"Health: leader={health.leader} heartbeat={health.heartbeat_alive}")
+
+    await client.shutdown()
+    print("✓ Done")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/python/etl_pipeline.py
+++ b/examples/python/etl_pipeline.py
@@ -1,0 +1,173 @@
+"""
+ETL Pipeline with Progress Tracking and Checkpointing
+
+Demonstrates:
+- Transactional enqueue (all-or-nothing batch of jobs)
+- Structured progress with percent, message, and metadata
+- Checkpoint/resume: a crashed job resumes from the last processed row
+- Periodic scheduling for daily runs
+- Queue stats monitoring
+
+In production you'd split this into:
+- A scheduler/API that enqueues ImportTable jobs (the "Enqueue jobs" section)
+- A worker process running `client.start([("etl", 3)])` as a separate
+  deployment (e.g. k8s Deployment with replicas=2)
+- The periodic schedule is registered on the worker and evaluated by
+  whichever instance wins leader election
+- Monitor via the web UI: `awa serve --database-url $DATABASE_URL`
+
+Run (single-process demo):
+    cd awa-python
+    DATABASE_URL=postgres://... .venv/bin/python ../examples/python/etl_pipeline.py
+"""
+
+import asyncio
+import os
+from dataclasses import dataclass
+
+import awa
+
+
+DATABASE_URL = os.environ.get(
+    "DATABASE_URL", "postgres://postgres:test@localhost:15432/awa_test"
+)
+
+
+# ── Job types ───────────────────────────────────────────────────────
+
+
+@dataclass
+class ImportTable:
+    """Import rows from a source table into the warehouse."""
+    source_table: str
+    batch_size: int = 1000
+
+
+@dataclass
+class AggregateMetrics:
+    """Roll up imported data into summary metrics."""
+    date: str
+    tables: list  # list of table names to aggregate
+
+
+# ── Simulated data source ───────────────────────────────────────────
+
+
+TOTAL_ROWS = {"users": 5000, "orders": 12000, "events": 50000}
+
+
+def fetch_rows(table: str, offset: int, limit: int) -> list[dict]:
+    total = TOTAL_ROWS.get(table, 1000)
+    if offset >= total:
+        return []
+    end = min(offset + limit, total)
+    return [{"id": i} for i in range(offset, end)]
+
+
+# ── Main ────────────────────────────────────────────────────────────
+
+
+async def main():
+    client = awa.Client(DATABASE_URL)
+    await client.migrate()
+    print("AWA ETL Pipeline Example\n")
+
+    # ── Worker handlers (WORKER PROCESS in production) ────────────
+
+    @client.worker(ImportTable, queue="etl")
+    async def handle_import(job):
+        table = job.args["source_table"]
+        batch_size = job.args.get("batch_size", 1000)
+        total = TOTAL_ROWS.get(table, 1000)
+
+        # Resume from checkpoint if this is a retry
+        checkpoint = (job.progress or {}).get("metadata", {})
+        offset = checkpoint.get("last_offset", 0)
+        rows_imported = checkpoint.get("rows_imported", 0)
+
+        if offset > 0:
+            print(f"  Resuming {table} from offset {offset}")
+
+        while True:
+            rows = fetch_rows(table, offset, batch_size)
+            if not rows:
+                break
+
+            rows_imported += len(rows)
+            offset += len(rows)
+
+            pct = min(100, int(100 * rows_imported / total))
+            job.set_progress(pct, f"Importing {table}: {rows_imported}/{total}")
+            job.update_metadata({
+                "last_offset": offset,
+                "rows_imported": rows_imported,
+                "source_table": table,
+            })
+
+            if (offset // batch_size) % 5 == 0:
+                await job.flush_progress()
+
+            await asyncio.sleep(0.005)
+
+        print(f"  ✓ {table}: imported {rows_imported} rows")
+
+    @client.worker(AggregateMetrics, queue="etl")
+    async def handle_aggregate(job):
+        tables = job.args["tables"]
+        for i, table in enumerate(tables):
+            pct = int(100 * (i + 1) / len(tables))
+            job.set_progress(pct, f"Aggregating {table}")
+            await asyncio.sleep(0.02)
+        print(f"  ✓ Aggregated {len(tables)} tables for {job.args['date']}")
+
+    # ── Schedule a daily run ────────────────────────────────────
+
+    client.periodic(
+        name="daily_users_import",
+        cron_expr="0 2 * * *",
+        args_type=ImportTable,
+        args=ImportTable(source_table="users"),
+        queue="etl",
+        tags=["etl", "daily"],
+    )
+
+    # ── Enqueue jobs transactionally ────────────────────────────
+
+    async with await client.transaction() as tx:
+        for table in ["users", "orders", "events"]:
+            await tx.insert(
+                ImportTable(source_table=table, batch_size=500),
+                queue="etl",
+                tags=["etl", "import", table],
+                metadata={"pipeline_run": "2026-03-22"},
+            )
+        await tx.insert(
+            AggregateMetrics(date="2026-03-22", tables=["users", "orders", "events"]),
+            queue="etl",
+            priority=3,  # runs after imports
+            tags=["etl", "aggregate"],
+        )
+    print("Enqueued 4 ETL jobs (3 imports + 1 aggregation)\n")
+
+    # ── Start workers and monitor ───────────────────────────────
+
+    client.start([("etl", 3)], leader_election_interval_ms=500)
+
+    for _ in range(60):
+        await asyncio.sleep(1)
+        stats = await client.queue_stats()
+        etl = next((s for s in stats if s["queue"] == "etl"), None)
+        if etl:
+            avail, running = etl["available"], etl["running"]
+            if avail == 0 and running == 0:
+                print(f"\n✓ All jobs completed")
+                break
+            print(f"  Queue: available={avail} running={running}")
+
+    health = await client.health_check()
+    print(f"Health: leader={health.leader} heartbeat={health.heartbeat_alive}")
+    await client.shutdown()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/python/test_examples.py
+++ b/examples/python/test_examples.py
@@ -1,0 +1,55 @@
+"""
+Tests for Python examples.
+
+Run:
+    cd awa-python
+    DATABASE_URL=postgres://postgres:test@localhost:15432/awa_test \
+    .venv/bin/pytest ../examples/python/test_examples.py -v
+"""
+
+import os
+import subprocess
+import sys
+
+import pytest
+
+DATABASE_URL = os.environ.get(
+    "DATABASE_URL", "postgres://postgres:test@localhost:15432/awa_test"
+)
+
+EXAMPLES_DIR = os.path.dirname(__file__)
+PYTHON = sys.executable
+
+
+def run_example(script_name: str, timeout: int = 60) -> subprocess.CompletedProcess:
+    """Run an example script as a subprocess with a timeout."""
+    script_path = os.path.join(EXAMPLES_DIR, script_name)
+    env = {**os.environ, "DATABASE_URL": DATABASE_URL}
+    return subprocess.run(
+        [PYTHON, script_path],
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        env=env,
+    )
+
+
+class TestExamples:
+    def test_etl_pipeline(self):
+        result = run_example("etl_pipeline.py", timeout=60)
+        assert result.returncode == 0, f"ETL pipeline failed:\n{result.stderr}"
+        assert "All jobs completed" in result.stdout
+        assert "Health: leader=True" in result.stdout
+
+    def test_webhook_payments(self):
+        result = run_example("webhook_payments.py", timeout=60)
+        assert result.returncode == 0, f"Webhook payments failed:\n{result.stderr}"
+        assert "All payments processed" in result.stdout
+        assert "Queue stats:" in result.stdout
+
+    def test_email_campaign(self):
+        result = run_example("email_campaign.py", timeout=120)
+        assert result.returncode == 0, f"Email campaign failed:\n{result.stderr}"
+        assert "200 marketing emails enqueued" in result.stdout
+        assert "Transactional emails will be processed first" in result.stdout
+        assert "Done" in result.stdout

--- a/examples/python/webhook_payments.py
+++ b/examples/python/webhook_payments.py
@@ -1,0 +1,152 @@
+"""
+Webhook Payment Processing
+
+Demonstrates:
+- Multiple job types across different queues
+- Priority-based dispatch (high-value payments first)
+- Follow-up job enqueue from within a handler
+- Queue stats and health monitoring
+- Metadata for correlation and audit
+
+In production you'd split this into:
+- A checkout API (FastAPI/Django) that calls client.insert(ChargeCustomer(...))
+  when a customer clicks "Pay" — this is the "Enqueue payment jobs" section
+- A worker process: client.start([("payments", 4), ("notifications", 2)])
+  as a separate deployment
+- The charge handler enqueues receipt jobs — picked up by the notifications
+  worker (same or different process on that queue)
+
+Run (single-process demo):
+    cd awa-python
+    DATABASE_URL=postgres://... .venv/bin/python ../examples/python/webhook_payments.py
+"""
+
+import asyncio
+import os
+import uuid
+from dataclasses import dataclass, field
+
+import awa
+
+
+DATABASE_URL = os.environ.get(
+    "DATABASE_URL", "postgres://postgres:test@localhost:15432/awa_test"
+)
+
+
+# ── Job types ───────────────────────────────────────────────────────
+
+
+@dataclass
+class ChargeCustomer:
+    customer_id: str
+    amount_cents: int
+    currency: str = "nzd"
+    idempotency_key: str = field(default_factory=lambda: str(uuid.uuid4())[:8])
+
+
+@dataclass
+class SendReceipt:
+    customer_id: str
+    charge_id: str
+    amount_cents: int
+
+
+# ── Main ────────────────────────────────────────────────────────────
+
+
+async def main():
+    client = awa.Client(DATABASE_URL)
+    await client.migrate()
+    print("AWA Webhook Payments Example\n")
+
+    # ── Register workers ────────────────────────────────────────
+
+    @client.worker(ChargeCustomer, queue="payments")
+    async def handle_charge(job):
+        customer_id = job.args["customer_id"]
+        amount = job.args["amount_cents"]
+        idem_key = job.args["idempotency_key"]
+
+        job.set_progress(25, f"Initiating charge for {customer_id}")
+        await job.flush_progress()
+
+        # Simulate calling a payment gateway
+        charge_id = f"ch_{idem_key}"
+        await asyncio.sleep(0.05)
+
+        job.set_progress(75, f"Charge {charge_id} succeeded")
+        job.update_metadata({"charge_id": charge_id, "gateway": "simulated"})
+
+        # Enqueue a follow-up receipt job from within the handler
+        await client.insert(
+            SendReceipt(
+                customer_id=customer_id,
+                charge_id=charge_id,
+                amount_cents=amount,
+            ),
+            queue="notifications",
+            tags=["receipt", customer_id],
+        )
+
+        print(f"  ✓ Charged {customer_id}: ${amount/100:.2f} → {charge_id}")
+
+    @client.worker(SendReceipt, queue="notifications")
+    async def handle_receipt(job):
+        customer_id = job.args["customer_id"]
+        charge_id = job.args["charge_id"]
+        amount = job.args["amount_cents"]
+        await asyncio.sleep(0.02)
+        print(f"  ✉ Receipt sent to {customer_id}: ${amount/100:.2f} ({charge_id})")
+
+    # ── Enqueue payment jobs ────────────────────────────────────
+
+    customers = [
+        ("cust_alice", 4999),
+        ("cust_bob", 12500),
+        ("cust_carol", 750),
+        ("cust_dave", 99900),
+    ]
+
+    for customer_id, amount in customers:
+        job = await client.insert(
+            ChargeCustomer(customer_id=customer_id, amount_cents=amount),
+            queue="payments",
+            priority=1 if amount > 10000 else 2,
+            tags=["payment", customer_id],
+            metadata={"source": "checkout"},
+        )
+        print(f"  Enqueued charge for {customer_id}: ${amount/100:.2f} (job #{job.id})")
+
+    print()
+
+    # ── Start workers and monitor ───────────────────────────────
+
+    client.start(
+        [("payments", 2), ("notifications", 1)],
+        leader_election_interval_ms=500,
+    )
+
+    for _ in range(30):
+        await asyncio.sleep(1)
+        stats = await client.queue_stats()
+        payments = next((s for s in stats if s["queue"] == "payments"), None)
+        notifs = next((s for s in stats if s["queue"] == "notifications"), None)
+
+        p_busy = (payments or {}).get("available", 0) + (payments or {}).get("running", 0)
+        n_busy = (notifs or {}).get("available", 0) + (notifs or {}).get("running", 0)
+
+        if p_busy == 0 and n_busy == 0:
+            print(f"\n✓ All payments processed and receipts sent")
+            break
+
+    print("\nQueue stats:")
+    for stat in await client.queue_stats():
+        if stat["queue"] in ("payments", "notifications"):
+            print(f"  {stat['queue']}: failed={stat['failed']} completed/hr={stat['completed_last_hour']}")
+
+    await client.shutdown()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
Adds 3 Python examples, 1 Rust example, tests for all, and fixes stale README.

Supersedes #62 and #63.

### Python examples (`examples/python/`)
- **etl_pipeline.py**: transactional enqueue, progress checkpointing, periodic schedule
- **webhook_payments.py**: multi-queue, priority dispatch, follow-up jobs from handlers
- **email_campaign.py**: COPY bulk insert, priority levels, retry_failed admin ops
- **test_examples.py**: pytest tests running each script as subprocess with output assertions
- Each example documents production deployment split (producer vs worker process)

### Rust example (`awa/examples/etl_pipeline.rs`)
- Typed `#[derive(JobArgs)]`, transactional enqueue, progress + checkpoint/resume
- Uses current Worker trait: `perform(&self, ctx: &JobContext)`
- `cargo clippy` clean, runs in ~2s

### README fix
- Updated stale `perform(job, ctx)` to `perform(ctx)` and removed unused `JobRow` import

### CI
Both already in CI from main: Python example tests in `python-build-test`, Rust example in `cli-smoke`.

### Validation
- All 3 Python examples pass locally (pytest 3/3)
- Rust example: clippy clean, 4 jobs complete in ~2s
- QA team reviewed and found only the README issue (now fixed)

Closes #62, closes #63.