### PR TITLE
Reject null bytes in job args/metadata with clear validation error

### DIFF
--- a/awa-model/src/insert.rs
+++ b/awa-model/src/insert.rs
@@ -5,6 +5,35 @@ use crate::JobArgs;
 use sqlx::postgres::PgConnection;
 use sqlx::{PgExecutor, PgPool};
 
+/// Reject JSON values containing null bytes (`\u0000`), which Postgres
+/// JSONB does not support. Produces a clear validation error instead of
+/// an opaque database error.
+fn reject_null_bytes(value: &serde_json::Value) -> Result<(), AwaError> {
+    match value {
+        serde_json::Value::String(s) if s.contains('\0') => Err(AwaError::Validation(
+            "job args/metadata must not contain null bytes (\\u0000): Postgres JSONB does not support them".into(),
+        )),
+        serde_json::Value::Array(arr) => {
+            for v in arr {
+                reject_null_bytes(v)?;
+            }
+            Ok(())
+        }
+        serde_json::Value::Object(map) => {
+            for (k, v) in map {
+                if k.contains('\0') {
+                    return Err(AwaError::Validation(
+                        "job args/metadata keys must not contain null bytes (\\u0000)".into(),
+                    ));
+                }
+                reject_null_bytes(v)?;
+            }
+            Ok(())
+        }
+        _ => Ok(()),
+    }
+}
+
 /// Insert a job with default options.
 pub async fn insert<'e, E>(executor: E, args: &impl JobArgs) -> Result<JobRow, AwaError>
 where
@@ -25,6 +54,8 @@ where
 {
     let kind = args.kind_str();
     let args_json = args.to_args()?;
+    reject_null_bytes(&args_json)?;
+    reject_null_bytes(&opts.metadata)?;
 
     let state = if opts.run_at.is_some() {
         JobState::Scheduled
@@ -173,6 +204,12 @@ where
         return Ok(Vec::new());
     }
 
+    // Validate all args/metadata before touching the DB
+    for job in jobs {
+        reject_null_bytes(&job.args)?;
+        reject_null_bytes(&job.opts.metadata)?;
+    }
+
     let count = jobs.len();
     let rows = precompute_row_values(jobs);
 
@@ -240,6 +277,12 @@ pub async fn insert_many_copy(
 ) -> Result<Vec<JobRow>, AwaError> {
     if jobs.is_empty() {
         return Ok(Vec::new());
+    }
+
+    // Validate all args/metadata before touching the DB
+    for job in jobs {
+        reject_null_bytes(&job.args)?;
+        reject_null_bytes(&job.opts.metadata)?;
     }
 
     let rows = precompute_row_values(jobs);

--- a/awa/tests/integration_test.rs
+++ b/awa/tests/integration_test.rs
@@ -1436,3 +1436,56 @@ async fn test_builder_requires_at_least_one_queue() {
 
     assert!(matches!(result, Err(BuildError::NoQueuesConfigured)));
 }
+
+#[tokio::test]
+async fn test_null_byte_in_args_rejected_with_validation_error() {
+    let client = setup().await;
+    let queue = "integ_null_byte";
+
+    let result = insert_with(
+        client.pool(),
+        &SendEmail {
+            to: "test\x00@example.com".into(),
+            subject: "Hello".into(),
+        },
+        InsertOpts {
+            queue: queue.into(),
+            ..Default::default()
+        },
+    )
+    .await;
+
+    assert!(result.is_err(), "Null byte in args should be rejected");
+    let err = result.unwrap_err();
+    assert!(
+        matches!(err, AwaError::Validation(_)),
+        "Expected Validation error, got: {err:?}"
+    );
+    assert!(
+        err.to_string().contains("null bytes"),
+        "Error should mention null bytes, got: {err}"
+    );
+}
+
+#[tokio::test]
+async fn test_null_byte_in_metadata_rejected() {
+    let client = setup().await;
+    let queue = "integ_null_byte_meta";
+
+    let result = insert_with(
+        client.pool(),
+        &SendEmail {
+            to: "alice@example.com".into(),
+            subject: "Hello".into(),
+        },
+        InsertOpts {
+            queue: queue.into(),
+            metadata: serde_json::json!({"key": "value\x00with_null"}),
+            ..Default::default()
+        },
+    )
+    .await;
+
+    assert!(result.is_err(), "Null byte in metadata should be rejected");
+    assert!(matches!(result.unwrap_err(), AwaError::Validation(_)));
+}


### PR DESCRIPTION
## Problem

Postgres JSONB does not support `\u0000` (null byte). Inserting job args or metadata containing null bytes produced an opaque `DatabaseError: unsupported Unicode escape sequence` — confusing for users.

Found via adversarial testing of the 0.4.0 release.

## Fix

Added `reject_null_bytes()` validation in the Rust insert layer, before any SQL is executed. Recursively scans JSON string values, array elements, and object keys. Returns `AwaError::Validation` with a clear message explaining the Postgres JSONB limitation.

Covers all three insert paths: `insert_with`, `insert_many`, `insert_many_copy`.

Python inserts go through the same Rust layer, so they get the same validation automatically.

## Tests

- `test_null_byte_in_args_rejected_with_validation_error` — null byte in string field
- `test_null_byte_in_metadata_rejected` — null byte in metadata value