### PR TITLE
Add Postgres failover smoke test

### DIFF
--- a/.github/workflows/nightly-chaos.yml
+++ b/.github/workflows/nightly-chaos.yml
@@ -11,6 +11,26 @@ env:
   DATABASE_URL: postgres://postgres:postgres@localhost:5432/awa_test
 
 jobs:
+  postgres-failover-smoke:
+    name: Postgres failover smoke
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: ". -> target"
+      - name: Show Docker versions
+        run: |
+          docker --version
+          docker compose version
+      - name: Run Postgres failover smoke test
+        run: cargo test --package awa --test postgres_failover_smoke_test -- --ignored --nocapture
+
   rust-nightly:
     name: Rust nightly benchmarks
     runs-on: ubuntu-latest

--- a/awa/tests/postgres_failover_smoke_test.rs
+++ b/awa/tests/postgres_failover_smoke_test.rs
@@ -1,0 +1,430 @@
+//! Smoke test for Postgres hot-standby promotion behind a stable proxy endpoint.
+//!
+//! This is intentionally ignored in the normal test suite because it requires
+//! Docker Compose and boots a primary/replica stack on demand.
+
+use async_trait::async_trait;
+use awa::model::{insert_with, migrations, InsertOpts};
+use awa::{Client, JobArgs, JobContext, JobError, JobResult, QueueConfig, Worker};
+use chrono::{Duration as ChronoDuration, Utc};
+use serde::{Deserialize, Serialize};
+use sqlx::postgres::PgPoolOptions;
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::time::{Duration, Instant};
+use uuid::Uuid;
+
+fn repo_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("workspace root should exist")
+        .to_path_buf()
+}
+
+fn compose_file() -> PathBuf {
+    repo_root().join("docker/failover-smoke/compose.yml")
+}
+
+fn project_name() -> String {
+    format!("awa-failover-{}", Uuid::new_v4().simple())
+}
+
+fn database_url(port: u16) -> String {
+    format!("postgres://postgres:test@127.0.0.1:{port}/awa_failover_test")
+}
+
+fn run_command(mut command: Command, context: &str) -> String {
+    let output = command
+        .output()
+        .unwrap_or_else(|err| panic!("{context} failed to start: {err}"));
+    assert!(
+        output.status.success(),
+        "{context} failed with status {}.\nstdout:\n{}\nstderr:\n{}",
+        output.status,
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    String::from_utf8(output.stdout).expect("command output should be utf-8")
+}
+
+fn try_command(mut command: Command) -> Result<String, String> {
+    let output = command
+        .output()
+        .map_err(|err| format!("failed to start command: {err}"))?;
+    if !output.status.success() {
+        return Err(format!(
+            "status {}.\nstdout:\n{}\nstderr:\n{}",
+            output.status,
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr),
+        ));
+    }
+    String::from_utf8(output.stdout).map_err(|err| format!("utf8 decode failed: {err}"))
+}
+
+fn docker_compose(project: &str, args: &[&str]) -> Command {
+    let mut command = Command::new("docker");
+    command.arg("compose");
+    command.arg("-f").arg(compose_file());
+    command.arg("-p").arg(project);
+    command.args(args);
+    command.current_dir(repo_root());
+    command
+}
+
+struct ComposeStack {
+    project: String,
+}
+
+impl ComposeStack {
+    fn up() -> Self {
+        let project = project_name();
+        run_command(
+            docker_compose(&project, &["up", "-d", "--build"]),
+            "docker compose up",
+        );
+        Self { project }
+    }
+
+    fn proxy_port(&self) -> u16 {
+        let output = run_command(
+            docker_compose(&self.project, &["port", "haproxy", "5432"]),
+            "docker compose port haproxy",
+        );
+        let binding = output.trim();
+        let port = binding
+            .rsplit(':')
+            .next()
+            .expect("compose port output should contain a port");
+        port.parse::<u16>()
+            .expect("compose port output should end in a valid port")
+    }
+
+    fn stop_primary(&self) {
+        run_command(
+            docker_compose(&self.project, &["stop", "primary"]),
+            "docker compose stop primary",
+        );
+    }
+
+    fn primary_wal_lsn(&self) -> String {
+        run_command(
+            docker_compose(
+                &self.project,
+                &[
+                    "exec",
+                    "-T",
+                    "primary",
+                    "sh",
+                    "-lc",
+                    "PGPASSWORD=test psql -U postgres -d awa_failover_test -At -c \"SELECT pg_current_wal_lsn()\"",
+                ],
+            ),
+            "docker compose exec primary pg_current_wal_lsn",
+        )
+        .trim()
+        .to_string()
+    }
+
+    fn replica_has_replayed(&self, lsn: &str) -> bool {
+        let output = try_command(
+            docker_compose(
+                &self.project,
+                &[
+                    "exec",
+                    "-T",
+                    "replica",
+                    "sh",
+                    "-lc",
+                    &format!(
+                        "PGPASSWORD=test psql -U postgres -d awa_failover_test -At -c \"SELECT pg_last_wal_replay_lsn() >= '{lsn}'::pg_lsn\""
+                    ),
+                ],
+            ),
+        );
+        matches!(output.as_deref(), Ok("t\n") | Ok("t"))
+    }
+
+    fn promote_replica(&self) {
+        run_command(
+            docker_compose(
+                &self.project,
+                &[
+                    "exec",
+                    "-T",
+                    "replica",
+                    "sh",
+                    "-lc",
+                    "PGPASSWORD=test psql -U postgres -d awa_failover_test -c \"SELECT pg_promote(wait_seconds => 30);\"",
+                ],
+            ),
+            "docker compose exec replica pg_promote",
+        );
+    }
+}
+
+impl Drop for ComposeStack {
+    fn drop(&mut self) {
+        let _ = Command::new("docker")
+            .arg("compose")
+            .arg("-f")
+            .arg(compose_file())
+            .arg("-p")
+            .arg(&self.project)
+            .args(["down", "-v", "--remove-orphans"])
+            .current_dir(repo_root())
+            .status();
+    }
+}
+
+async fn connect_pool(database_url: &str) -> sqlx::PgPool {
+    PgPoolOptions::new()
+        .max_connections(20)
+        .acquire_timeout(Duration::from_secs(5))
+        .connect(database_url)
+        .await
+        .expect("failed to connect to failover test database")
+}
+
+async fn wait_for_pool(database_url: &str, timeout: Duration) -> sqlx::PgPool {
+    let start = Instant::now();
+    loop {
+        match PgPoolOptions::new()
+            .max_connections(5)
+            .acquire_timeout(Duration::from_secs(2))
+            .connect(database_url)
+            .await
+        {
+            Ok(pool) => return pool,
+            Err(err) => {
+                assert!(
+                    start.elapsed() < timeout,
+                    "timed out connecting to failover test database: {err}"
+                );
+                tokio::time::sleep(Duration::from_millis(250)).await;
+            }
+        }
+    }
+}
+
+async fn wait_for_replica_replay(stack: &ComposeStack, lsn: &str, timeout: Duration) {
+    let start = Instant::now();
+    loop {
+        if stack.replica_has_replayed(lsn) {
+            return;
+        }
+
+        assert!(
+            start.elapsed() < timeout,
+            "timed out waiting for replica to replay primary LSN {lsn}"
+        );
+        tokio::time::sleep(Duration::from_millis(250)).await;
+    }
+}
+
+async fn wait_for_writable(database_url: &str, timeout: Duration) {
+    let start = Instant::now();
+    loop {
+        if let Ok(pool) = PgPoolOptions::new()
+            .max_connections(2)
+            .acquire_timeout(Duration::from_secs(2))
+            .connect(database_url)
+            .await
+        {
+            let writable = sqlx::query_scalar::<_, bool>("SELECT NOT pg_is_in_recovery()")
+                .fetch_one(&pool)
+                .await
+                .unwrap_or(false);
+            if writable {
+                pool.close().await;
+                return;
+            }
+            pool.close().await;
+        }
+
+        assert!(
+            start.elapsed() < timeout,
+            "timed out waiting for promoted writable database"
+        );
+        tokio::time::sleep(Duration::from_millis(250)).await;
+    }
+}
+
+async fn queue_state_counts(pool: &sqlx::PgPool, queue: &str) -> HashMap<String, i64> {
+    let rows: Vec<(String, i64)> = sqlx::query_as(
+        r#"
+        SELECT state::text, count(*)::bigint
+        FROM awa.jobs
+        WHERE queue = $1
+        GROUP BY state
+        "#,
+    )
+    .bind(queue)
+    .fetch_all(pool)
+    .await
+    .expect("failed to query queue state counts");
+
+    rows.into_iter().collect()
+}
+
+fn state_count(counts: &HashMap<String, i64>, state: &str) -> i64 {
+    counts.get(state).copied().unwrap_or(0)
+}
+
+async fn wait_for_counts(
+    pool: &sqlx::PgPool,
+    queue: &str,
+    predicate: impl Fn(&HashMap<String, i64>) -> bool,
+    timeout: Duration,
+) -> HashMap<String, i64> {
+    let start = Instant::now();
+    loop {
+        let counts = queue_state_counts(pool, queue).await;
+        if predicate(&counts) {
+            return counts;
+        }
+
+        assert!(
+            start.elapsed() < timeout,
+            "timed out waiting for queue {queue}; last counts: {counts:?}"
+        );
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+}
+
+async fn wait_for_client_postgres_recovery(client: &Client, timeout: Duration) {
+    let start = Instant::now();
+    loop {
+        let health = client.health_check().await;
+        if health.postgres_connected
+            && health.poll_loop_alive
+            && health.heartbeat_alive
+            && health.maintenance_alive
+        {
+            return;
+        }
+
+        assert!(
+            start.elapsed() < timeout,
+            "timed out waiting for client recovery; last health: {:?}",
+            health
+        );
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, JobArgs)]
+struct FailoverJob {
+    seq: i64,
+}
+
+struct CompleteWorker;
+
+#[async_trait]
+impl Worker for CompleteWorker {
+    fn kind(&self) -> &'static str {
+        "failover_job"
+    }
+
+    async fn perform(&self, _ctx: &JobContext) -> Result<JobResult, JobError> {
+        Ok(JobResult::Completed)
+    }
+}
+
+fn failover_client(pool: sqlx::PgPool, queue: &str) -> Client {
+    Client::builder(pool)
+        .queue(
+            queue,
+            QueueConfig {
+                max_workers: 4,
+                poll_interval: Duration::from_millis(25),
+                ..QueueConfig::default()
+            },
+        )
+        .heartbeat_interval(Duration::from_millis(50))
+        .promote_interval(Duration::from_millis(50))
+        .heartbeat_rescue_interval(Duration::from_millis(100))
+        .leader_election_interval(Duration::from_millis(100))
+        .leader_check_interval(Duration::from_millis(100))
+        .register_worker(CompleteWorker)
+        .build()
+        .expect("failed to build failover smoke client")
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+#[ignore = "requires docker compose"]
+async fn test_postgres_hot_standby_promotion_keeps_awa_working() {
+    let stack = ComposeStack::up();
+    let proxy_port = stack.proxy_port();
+    let url = database_url(proxy_port);
+
+    let app_pool = wait_for_pool(&url, Duration::from_secs(30)).await;
+    migrations::run(&app_pool)
+        .await
+        .expect("migrations should succeed through proxy");
+
+    let queue = format!("failover_smoke_{}", Uuid::new_v4().simple());
+    let client_pool = connect_pool(&url).await;
+    let client = failover_client(client_pool, &queue);
+    client.start().await.expect("client should start");
+
+    for seq in 0..8_i64 {
+        insert_with(
+            &app_pool,
+            &FailoverJob { seq },
+            InsertOpts {
+                queue: queue.clone(),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("initial insert should succeed");
+    }
+
+    wait_for_counts(
+        &app_pool,
+        &queue,
+        |counts| state_count(counts, "completed") == 8,
+        Duration::from_secs(10),
+    )
+    .await;
+
+    let synced_lsn = stack.primary_wal_lsn();
+    wait_for_replica_replay(&stack, &synced_lsn, Duration::from_secs(30)).await;
+
+    stack.stop_primary();
+    stack.promote_replica();
+    wait_for_writable(&url, Duration::from_secs(30)).await;
+    wait_for_client_postgres_recovery(&client, Duration::from_secs(30)).await;
+
+    for seq in 8..16_i64 {
+        insert_with(
+            &app_pool,
+            &FailoverJob { seq },
+            InsertOpts {
+                queue: queue.clone(),
+                run_at: Some(Utc::now() + ChronoDuration::milliseconds(200)),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("post-promotion insert should succeed");
+    }
+
+    let counts = wait_for_counts(
+        &app_pool,
+        &queue,
+        |counts| {
+            state_count(counts, "completed") == 16
+                && state_count(counts, "scheduled") == 0
+                && state_count(counts, "running") == 0
+                && state_count(counts, "available") == 0
+        },
+        Duration::from_secs(20),
+    )
+    .await;
+
+    assert_eq!(state_count(&counts, "completed"), 16);
+    client.shutdown(Duration::from_secs(5)).await;
+}

--- a/docker/failover-smoke/compose.yml
+++ b/docker/failover-smoke/compose.yml
@@ -1,0 +1,70 @@
+services:
+  primary:
+    image: postgres:17-alpine
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: test
+      POSTGRES_DB: awa_failover_test
+    command:
+      - postgres
+      - -c
+      - wal_level=replica
+      - -c
+      - max_wal_senders=10
+      - -c
+      - max_replication_slots=10
+      - -c
+      - hot_standby=on
+      - -c
+      - hba_file=/etc/postgresql/pg_hba.conf
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres -d awa_failover_test"]
+      interval: 2s
+      timeout: 2s
+      retries: 30
+    volumes:
+      - primary-data:/var/lib/postgresql/data
+      - ./primary/pg_hba.conf:/etc/postgresql/pg_hba.conf:ro
+      - ./primary/init:/docker-entrypoint-initdb.d:ro
+
+  replica:
+    image: postgres:17-alpine
+    depends_on:
+      primary:
+        condition: service_healthy
+    environment:
+      PGDATA: /var/lib/postgresql/data
+      POSTGRES_PASSWORD: test
+      POSTGRES_DB: awa_failover_test
+      REPLICATION_USER: replicator
+      REPLICATION_PASSWORD: replpass
+    command:
+      - /bin/sh
+      - /scripts/replica-entrypoint.sh
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres -d awa_failover_test"]
+      interval: 2s
+      timeout: 2s
+      retries: 30
+    volumes:
+      - replica-data:/var/lib/postgresql/data
+      - ./replica/replica-entrypoint.sh:/scripts/replica-entrypoint.sh:ro
+
+  haproxy:
+    build:
+      context: ./haproxy
+    depends_on:
+      primary:
+        condition: service_healthy
+      replica:
+        condition: service_started
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: test
+      POSTGRES_DB: awa_failover_test
+    ports:
+      - "127.0.0.1::5432"
+
+volumes:
+  primary-data:
+  replica-data:

--- a/docker/failover-smoke/haproxy/Dockerfile
+++ b/docker/failover-smoke/haproxy/Dockerfile
@@ -1,0 +1,11 @@
+FROM haproxy:3.1-alpine
+
+USER root
+RUN apk add --no-cache postgresql17-client
+
+COPY haproxy.cfg /usr/local/etc/haproxy/haproxy.cfg
+COPY check-primary.sh /usr/local/bin/check-primary.sh
+
+RUN chmod +x /usr/local/bin/check-primary.sh
+
+USER haproxy

--- a/docker/failover-smoke/haproxy/check-primary.sh
+++ b/docker/failover-smoke/haproxy/check-primary.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+set -eu
+
+export PGPASSWORD="${POSTGRES_PASSWORD:-test}"
+export PGCONNECT_TIMEOUT=2
+
+result="$(psql \
+  -h "$HAPROXY_SERVER_ADDR" \
+  -p "$HAPROXY_SERVER_PORT" \
+  -U "${POSTGRES_USER:-postgres}" \
+  -d "${POSTGRES_DB:-awa_failover_test}" \
+  -Atqc "SELECT NOT pg_is_in_recovery()")"
+
+[ "$result" = "t" ]

--- a/docker/failover-smoke/haproxy/haproxy.cfg
+++ b/docker/failover-smoke/haproxy/haproxy.cfg
@@ -1,0 +1,25 @@
+global
+    log stdout format raw daemon
+    external-check
+    insecure-fork-wanted
+
+defaults
+    log global
+    mode tcp
+    option tcplog
+    timeout connect 3s
+    timeout client 1m
+    timeout server 1m
+    timeout check 3s
+
+frontend postgres_rw
+    bind *:5432
+    default_backend postgres_rw_backends
+
+backend postgres_rw_backends
+    option external-check
+    external-check path "/usr/local/bin:/usr/bin:/bin"
+    external-check command /usr/local/bin/check-primary.sh
+    default-server inter 500ms fall 1 rise 1 on-marked-down shutdown-sessions
+    server primary primary:5432 check
+    server replica replica:5432 check backup

--- a/docker/failover-smoke/primary/init/01-replication.sql
+++ b/docker/failover-smoke/primary/init/01-replication.sql
@@ -1,0 +1,1 @@
+CREATE ROLE replicator WITH REPLICATION LOGIN PASSWORD 'replpass';

--- a/docker/failover-smoke/primary/pg_hba.conf
+++ b/docker/failover-smoke/primary/pg_hba.conf
@@ -1,0 +1,3 @@
+local   all             all                                     trust
+host    all             all             0.0.0.0/0               scram-sha-256
+host    replication     replicator      0.0.0.0/0               scram-sha-256

--- a/docker/failover-smoke/replica/replica-entrypoint.sh
+++ b/docker/failover-smoke/replica/replica-entrypoint.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+set -eu
+
+if [ ! -s "$PGDATA/PG_VERSION" ]; then
+  rm -rf "$PGDATA"/*
+  export PGPASSWORD="$REPLICATION_PASSWORD"
+  until pg_basebackup -h primary -p 5432 -D "$PGDATA" -U "$REPLICATION_USER" -Fp -Xs -P -R; do
+    sleep 1
+  done
+  echo "hot_standby = on" >> "$PGDATA/postgresql.auto.conf"
+fi
+
+exec docker-entrypoint.sh postgres

--- a/docs/test-plan.md
+++ b/docs/test-plan.md
@@ -74,6 +74,7 @@ See [the full test plan](../prd.md) for detailed descriptions of each test case.
 | T71 | Mixed Rust/Python workers share the same queue correctly | Cross-language resilience | Implemented |
 | T72 | Runtime recovers after terminating Postgres worker backends | Resilience | Implemented |
 | T73 | Sustained mixed workload survives Python node death and Rust node reconnect under load | Resilience | Implemented |
+| T74 | Hot-standby promotion via stable endpoint: reconnect, insert, and scheduled promotion still work after cutover | HA failover | Implemented |
 | B1 | Late completion after rescue is no-op (state guard) | Bug fix | Implemented |
 | B2 | Late completion after cancel is no-op (state guard) | Bug fix | Implemented |
 | B3 | Shutdown waits for in-flight jobs | Bug fix | Implemented |
@@ -149,6 +150,9 @@ DATABASE_URL=postgres://postgres:test@localhost:15432/awa_test \
   AWA_PYTHON_BIN="$PWD/awa-python/.venv/bin/python" \
   cargo test --package awa --test chaos_suite_test \
   -- --ignored --test-threads=1 --nocapture
+
+# Postgres hot-standby promotion smoke (boots primary + replica + stable proxy endpoint via Docker Compose)
+cargo test --package awa --test postgres_failover_smoke_test -- --ignored --nocapture
 
 # COPY integration tests
 DATABASE_URL=postgres://postgres:test@localhost:15432/awa_test cargo test --package awa --test copy_test -- --nocapture


### PR DESCRIPTION
## Summary
- add an ignored Rust smoke test that boots a primary/standby Postgres pair behind a stable HAProxy endpoint
- validate that Awa can migrate, process jobs, survive standby promotion, and continue processing scheduled work after cutover
- run the smoke test in a dedicated nightly/manual CI job and document it in the test plan

## Validation
- cargo test -p awa --test postgres_failover_smoke_test -- --ignored --nocapture