### PR TITLE
Harden callback resolution: race fix, run_lease guard, cancel_callback

### DIFF
--- a/awa-model/src/admin.rs
+++ b/awa-model/src/admin.rs
@@ -996,6 +996,7 @@ pub async fn complete_external<'e, E>(
     executor: E,
     callback_id: Uuid,
     _payload: Option<serde_json::Value>,
+    run_lease: Option<i64>,
 ) -> Result<JobRow, AwaError>
 where
     E: PgExecutor<'e>,
@@ -1015,10 +1016,12 @@ where
             deadline_at = NULL,
             progress = NULL
         WHERE callback_id = $1 AND state IN ('waiting_external', 'running')
+          AND ($2::bigint IS NULL OR run_lease = $2)
         RETURNING *
         "#,
     )
     .bind(callback_id)
+    .bind(run_lease)
     .fetch_optional(executor)
     .await?;
 
@@ -1034,6 +1037,7 @@ pub async fn fail_external<'e, E>(
     executor: E,
     callback_id: Uuid,
     error: &str,
+    run_lease: Option<i64>,
 ) -> Result<JobRow, AwaError>
 where
     E: PgExecutor<'e>,
@@ -1057,11 +1061,13 @@ where
                 'at', now()
             )::jsonb
         WHERE callback_id = $1 AND state IN ('waiting_external', 'running')
+          AND ($3::bigint IS NULL OR run_lease = $3)
         RETURNING *
         "#,
     )
     .bind(callback_id)
     .bind(error)
+    .bind(run_lease)
     .fetch_optional(executor)
     .await?;
 
@@ -1079,7 +1085,11 @@ where
 /// terminal transitions, retry puts the job back to `available`. Allowing
 /// retry from `running` would risk concurrent dispatch if the original
 /// handler hasn't finished yet.
-pub async fn retry_external<'e, E>(executor: E, callback_id: Uuid) -> Result<JobRow, AwaError>
+pub async fn retry_external<'e, E>(
+    executor: E,
+    callback_id: Uuid,
+    run_lease: Option<i64>,
+) -> Result<JobRow, AwaError>
 where
     E: PgExecutor<'e>,
 {
@@ -1099,16 +1109,51 @@ where
             heartbeat_at = NULL,
             deadline_at = NULL
         WHERE callback_id = $1 AND state = 'waiting_external'
+          AND ($2::bigint IS NULL OR run_lease = $2)
         RETURNING *
         "#,
     )
     .bind(callback_id)
+    .bind(run_lease)
     .fetch_optional(executor)
     .await?;
 
     row.ok_or(AwaError::CallbackNotFound {
         callback_id: callback_id.to_string(),
     })
+}
+
+/// Cancel (clear) a registered callback for a running job.
+///
+/// Best-effort cleanup: returns `Ok(true)` if a row was updated,
+/// `Ok(false)` if no match (already resolved, rescued, or wrong lease).
+/// Callers should not treat `false` as an error.
+pub async fn cancel_callback<'e, E>(
+    executor: E,
+    job_id: i64,
+    run_lease: i64,
+) -> Result<bool, AwaError>
+where
+    E: PgExecutor<'e>,
+{
+    let result = sqlx::query(
+        r#"
+        UPDATE awa.jobs
+        SET callback_id = NULL,
+            callback_timeout_at = NULL,
+            callback_filter = NULL,
+            callback_on_complete = NULL,
+            callback_on_fail = NULL,
+            callback_transform = NULL
+        WHERE id = $1 AND callback_id IS NOT NULL AND state = 'running' AND run_lease = $2
+        "#,
+    )
+    .bind(job_id)
+    .bind(run_lease)
+    .execute(executor)
+    .await?;
+
+    Ok(result.rows_affected() > 0)
 }
 
 // ── CEL callback expressions ──────────────────────────────────────────
@@ -1286,19 +1331,26 @@ pub async fn resolve_callback(
     callback_id: Uuid,
     payload: Option<serde_json::Value>,
     default_action: DefaultAction,
+    run_lease: Option<i64>,
 ) -> Result<ResolveOutcome, AwaError> {
     let mut tx = pool.begin().await?;
 
     // Query jobs_hot directly (not the awa.jobs UNION ALL view) because
     // FOR UPDATE is not reliably supported on UNION views. Waiting_external
-    // jobs are always in jobs_hot (the check constraint on scheduled_jobs
-    // only allows scheduled/retryable).
+    // and running jobs are always in jobs_hot (the check constraint on
+    // scheduled_jobs only allows scheduled/retryable).
+    //
+    // Accepts both 'waiting_external' and 'running' to handle the race where
+    // a fast callback arrives before the executor transitions running ->
+    // waiting_external (matching complete_external/fail_external behavior).
     let job = sqlx::query_as::<_, JobRow>(
         "SELECT * FROM awa.jobs_hot WHERE callback_id = $1
-         AND state = 'waiting_external'
+         AND state IN ('waiting_external', 'running')
+         AND ($2::bigint IS NULL OR run_lease = $2)
          FOR UPDATE",
     )
     .bind(callback_id)
+    .bind(run_lease)
     .fetch_optional(&mut *tx)
     .await?
     .ok_or(AwaError::CallbackNotFound {

--- a/awa-python/src/client.rs
+++ b/awa-python/src/client.rs
@@ -851,7 +851,7 @@ impl PyClient {
         pyo3_async_runtimes::tokio::future_into_py(py, async move {
             let uuid = uuid::Uuid::parse_str(&callback_id)
                 .map_err(|e| map_awa_error(awa_model::AwaError::Validation(e.to_string())))?;
-            let row = awa_model::admin::complete_external(&pool, uuid, payload_json)
+            let row = awa_model::admin::complete_external(&pool, uuid, payload_json, None)
                 .await
                 .map_err(map_awa_error)?;
             Ok(PyJob::from(row))
@@ -868,7 +868,7 @@ impl PyClient {
         pyo3_async_runtimes::tokio::future_into_py(py, async move {
             let uuid = uuid::Uuid::parse_str(&callback_id)
                 .map_err(|e| map_awa_error(awa_model::AwaError::Validation(e.to_string())))?;
-            let row = awa_model::admin::fail_external(&pool, uuid, &error)
+            let row = awa_model::admin::fail_external(&pool, uuid, &error, None)
                 .await
                 .map_err(map_awa_error)?;
             Ok(PyJob::from(row))
@@ -884,7 +884,7 @@ impl PyClient {
         pyo3_async_runtimes::tokio::future_into_py(py, async move {
             let uuid = uuid::Uuid::parse_str(&callback_id)
                 .map_err(|e| map_awa_error(awa_model::AwaError::Validation(e.to_string())))?;
-            let row = awa_model::admin::retry_external(&pool, uuid)
+            let row = awa_model::admin::retry_external(&pool, uuid, None)
                 .await
                 .map_err(map_awa_error)?;
             Ok(PyJob::from(row))
@@ -907,7 +907,7 @@ impl PyClient {
             pyo3_async_runtimes::tokio::get_runtime().block_on(async {
                 let uuid = uuid::Uuid::parse_str(&callback_id)
                     .map_err(|e| map_awa_error(awa_model::AwaError::Validation(e.to_string())))?;
-                let row = awa_model::admin::complete_external(&pool, uuid, payload_json)
+                let row = awa_model::admin::complete_external(&pool, uuid, payload_json, None)
                     .await
                     .map_err(map_awa_error)?;
                 Ok(PyJob::from(row))
@@ -926,7 +926,7 @@ impl PyClient {
             pyo3_async_runtimes::tokio::get_runtime().block_on(async {
                 let uuid = uuid::Uuid::parse_str(&callback_id)
                     .map_err(|e| map_awa_error(awa_model::AwaError::Validation(e.to_string())))?;
-                let row = awa_model::admin::fail_external(&pool, uuid, &error)
+                let row = awa_model::admin::fail_external(&pool, uuid, &error, None)
                     .await
                     .map_err(map_awa_error)?;
                 Ok(PyJob::from(row))
@@ -940,7 +940,7 @@ impl PyClient {
             pyo3_async_runtimes::tokio::get_runtime().block_on(async {
                 let uuid = uuid::Uuid::parse_str(&callback_id)
                     .map_err(|e| map_awa_error(awa_model::AwaError::Validation(e.to_string())))?;
-                let row = awa_model::admin::retry_external(&pool, uuid)
+                let row = awa_model::admin::retry_external(&pool, uuid, None)
                     .await
                     .map_err(map_awa_error)?;
                 Ok(PyJob::from(row))
@@ -967,9 +967,10 @@ impl PyClient {
         pyo3_async_runtimes::tokio::future_into_py(py, async move {
             let uuid = uuid::Uuid::parse_str(&callback_id)
                 .map_err(|e| map_awa_error(awa_model::AwaError::Validation(e.to_string())))?;
-            let outcome = awa_model::admin::resolve_callback(&pool, uuid, payload_json, action)
-                .await
-                .map_err(map_awa_error)?;
+            let outcome =
+                awa_model::admin::resolve_callback(&pool, uuid, payload_json, action, None)
+                    .await
+                    .map_err(map_awa_error)?;
             Ok(resolve_outcome_to_py(outcome))
         })
     }
@@ -992,9 +993,10 @@ impl PyClient {
             pyo3_async_runtimes::tokio::get_runtime().block_on(async {
                 let uuid = uuid::Uuid::parse_str(&callback_id)
                     .map_err(|e| map_awa_error(awa_model::AwaError::Validation(e.to_string())))?;
-                let outcome = awa_model::admin::resolve_callback(&pool, uuid, payload_json, action)
-                    .await
-                    .map_err(map_awa_error)?;
+                let outcome =
+                    awa_model::admin::resolve_callback(&pool, uuid, payload_json, action, None)
+                        .await
+                        .map_err(map_awa_error)?;
                 Ok(resolve_outcome_to_py(outcome))
             })
         })

--- a/awa/tests/cel_callback_test.rs
+++ b/awa/tests/cel_callback_test.rs
@@ -124,6 +124,7 @@ async fn test_c1_resolve_no_expressions_default_complete() {
         callback_id,
         Some(serde_json::json!({"status": "ok"})),
         DefaultAction::Complete,
+        None,
     )
     .await
     .unwrap();
@@ -151,6 +152,7 @@ async fn test_c2_resolve_no_expressions_default_ignore() {
         callback_id,
         Some(serde_json::json!({"status": "ok"})),
         DefaultAction::Ignore,
+        None,
     )
     .await
     .unwrap();
@@ -187,6 +189,7 @@ async fn test_c3_filter_false_ignored() {
         callback_id,
         Some(serde_json::json!({"status": "test"})),
         DefaultAction::Complete,
+        None,
     )
     .await
     .unwrap();
@@ -222,6 +225,7 @@ async fn test_c4_filter_pass_complete() {
         callback_id,
         Some(serde_json::json!({"status": "live", "event": "charge.succeeded"})),
         DefaultAction::Ignore,
+        None,
     )
     .await
     .unwrap();
@@ -256,6 +260,7 @@ async fn test_c5_on_fail_matched() {
         callback_id,
         Some(serde_json::json!({"event": "charge.failed"})),
         DefaultAction::Complete,
+        None,
     )
     .await
     .unwrap();
@@ -302,6 +307,7 @@ async fn test_c6_fail_takes_precedence() {
         callback_id,
         Some(serde_json::json!({"anything": true})),
         DefaultAction::Complete,
+        None,
     )
     .await
     .unwrap();
@@ -336,6 +342,7 @@ async fn test_c7_transform_payload() {
         callback_id,
         Some(serde_json::json!({"amount_cents": 4200})),
         DefaultAction::Ignore,
+        None,
     )
     .await
     .unwrap();
@@ -395,6 +402,7 @@ async fn test_c8_invalid_filter_fail_open() {
         callback_id,
         Some(serde_json::json!({"ok": true})),
         DefaultAction::Ignore,
+        None,
     )
     .await
     .unwrap();
@@ -450,6 +458,7 @@ async fn test_c9_invalid_transform_fail_open() {
         callback_id,
         Some(payload.clone()),
         DefaultAction::Ignore,
+        None,
     )
     .await
     .unwrap();
@@ -493,6 +502,7 @@ async fn test_c10_fallthrough_to_default() {
         callback_id,
         Some(serde_json::json!({"event": "charge.pending"})),
         DefaultAction::Ignore,
+        None,
     )
     .await
     .unwrap();
@@ -568,14 +578,26 @@ async fn test_c12_double_resolve() {
     let (_job_id, callback_id) = insert_and_wait(&client, queue, &PlainCallbackWorker).await;
 
     // First resolve succeeds
-    admin::resolve_callback(client.pool(), callback_id, None, DefaultAction::Complete)
-        .await
-        .unwrap();
+    admin::resolve_callback(
+        client.pool(),
+        callback_id,
+        None,
+        DefaultAction::Complete,
+        None,
+    )
+    .await
+    .unwrap();
 
     // Second resolve fails
-    let err = admin::resolve_callback(client.pool(), callback_id, None, DefaultAction::Complete)
-        .await
-        .unwrap_err();
+    let err = admin::resolve_callback(
+        client.pool(),
+        callback_id,
+        None,
+        DefaultAction::Complete,
+        None,
+    )
+    .await
+    .unwrap_err();
 
     match err {
         AwaError::CallbackNotFound { .. } => {}
@@ -633,6 +655,7 @@ async fn test_c14_deeply_nested_payload() {
             }
         })),
         DefaultAction::Ignore,
+        None,
     )
     .await
     .unwrap();
@@ -664,6 +687,7 @@ async fn test_c15_missing_field_fail_open() {
         callback_id,
         Some(serde_json::json!({"other": "data"})),
         DefaultAction::Ignore,
+        None,
     )
     .await
     .unwrap();
@@ -674,15 +698,15 @@ async fn test_c15_missing_field_fail_open() {
     assert_eq!(job.state, JobState::WaitingExternal);
 }
 
-// ── C16: resolve_callback rejects running state (only waiting_external) ──
-// Unlike complete_external/fail_external which accept running for race handling,
-// resolve_callback only accepts waiting_external to prevent cross-attempt
-// state corruption.
+// ── C16: resolve_callback accepts running state (race handling) ──
+// A fast callback can arrive before the executor transitions running ->
+// waiting_external. resolve_callback now matches complete_external/fail_external
+// behavior by accepting both states.
 
 #[tokio::test]
-async fn test_c16_resolve_rejects_running() {
+async fn test_c16_resolve_accepts_running() {
     let client = setup().await;
-    let queue = "test_c16_running_rejected";
+    let queue = "test_c16_running_accepted";
     clean_queue(client.pool(), queue).await;
 
     let job = awa::insert_with(
@@ -710,15 +734,20 @@ async fn test_c16_resolve_rejects_running() {
     .await
     .unwrap();
 
-    // resolve_callback should NOT find it (only waiting_external)
-    let err = admin::resolve_callback(client.pool(), callback_id, None, DefaultAction::Complete)
-        .await
-        .unwrap_err();
+    // resolve_callback should now find it (accepts running state)
+    let result = admin::resolve_callback(
+        client.pool(),
+        callback_id,
+        Some(serde_json::json!({"status": "ok"})),
+        DefaultAction::Complete,
+        None,
+    )
+    .await
+    .unwrap();
 
-    match err {
-        AwaError::CallbackNotFound { .. } => {}
-        other => panic!("Expected CallbackNotFound, got: {other:?}"),
-    }
+    assert!(result.is_completed());
+    let updated = client.get_job(job.id).await.unwrap();
+    assert_eq!(updated.state, JobState::Completed);
 }
 
 // ── C17: Concurrent resolve_callback (FOR UPDATE prevents race) ──
@@ -738,10 +767,10 @@ async fn test_c17_concurrent_resolve() {
 
     // Spawn on separate tasks to guarantee true parallel execution
     let h1 = tokio::spawn(async move {
-        admin::resolve_callback(&pool1, callback_id, None, DefaultAction::Complete).await
+        admin::resolve_callback(&pool1, callback_id, None, DefaultAction::Complete, None).await
     });
     let h2 = tokio::spawn(async move {
-        admin::resolve_callback(&pool2, callback_id, None, DefaultAction::Complete).await
+        admin::resolve_callback(&pool2, callback_id, None, DefaultAction::Complete, None).await
     });
 
     let r1 = h1.await.expect("task 1 panicked");
@@ -835,9 +864,15 @@ async fn test_c19_cel_disabled_resolve_error() {
         .unwrap();
 
     // Without cel feature, expressions present → Validation error (non-destructive)
-    let err = admin::resolve_callback(client.pool(), callback_id, None, DefaultAction::Complete)
-        .await
-        .unwrap_err();
+    let err = admin::resolve_callback(
+        client.pool(),
+        callback_id,
+        None,
+        DefaultAction::Complete,
+        None,
+    )
+    .await
+    .unwrap_err();
 
     match err {
         AwaError::Validation(msg) => {

--- a/awa/tests/external_wait_test.rs
+++ b/awa/tests/external_wait_test.rs
@@ -2,7 +2,7 @@
 //!
 //! Set DATABASE_URL=postgres://postgres:test@localhost:15432/awa_test
 
-use awa::model::{admin, migrations};
+use awa::model::{admin, admin::DefaultAction, migrations};
 use awa::{AwaError, JobArgs, JobContext, JobError, JobResult, JobRow, JobState, Worker};
 use awa_testing::TestClient;
 use serde::{Deserialize, Serialize};
@@ -143,6 +143,7 @@ async fn test_e2_complete_external() {
         client.pool(),
         callback_id,
         Some(serde_json::json!({"paid": true})),
+        None,
     )
     .await
     .unwrap();
@@ -178,7 +179,7 @@ async fn test_e3_fail_external() {
     let waiting_job = client.get_job(job.id).await.unwrap();
     let callback_id = waiting_job.callback_id.unwrap();
 
-    let failed = admin::fail_external(client.pool(), callback_id, "payment declined")
+    let failed = admin::fail_external(client.pool(), callback_id, "payment declined", None)
         .await
         .unwrap();
     assert_eq!(failed.state, JobState::Failed);
@@ -217,7 +218,7 @@ async fn test_e4_retry_external() {
     let waiting_job = client.get_job(job.id).await.unwrap();
     let callback_id = waiting_job.callback_id.unwrap();
 
-    let retried = admin::retry_external(client.pool(), callback_id)
+    let retried = admin::retry_external(client.pool(), callback_id, None)
         .await
         .unwrap();
     assert_eq!(retried.state, JobState::Available);
@@ -383,12 +384,12 @@ async fn test_e6_double_completion() {
     let callback_id = waiting_job.callback_id.unwrap();
 
     // First completion succeeds
-    admin::complete_external(client.pool(), callback_id, None)
+    admin::complete_external(client.pool(), callback_id, None, None)
         .await
         .unwrap();
 
     // Second completion fails with CallbackNotFound
-    let err = admin::complete_external(client.pool(), callback_id, None)
+    let err = admin::complete_external(client.pool(), callback_id, None, None)
         .await
         .unwrap_err();
     match err {
@@ -403,7 +404,7 @@ async fn test_e7_wrong_callback_id() {
     let client = setup().await;
     let fake_id = uuid::Uuid::new_v4();
 
-    let err = admin::complete_external(client.pool(), fake_id, None)
+    let err = admin::complete_external(client.pool(), fake_id, None, None)
         .await
         .unwrap_err();
     match err {
@@ -539,7 +540,7 @@ async fn test_e11_race_complete_during_running() {
 
     // Racing: external system completes BEFORE the executor transitions to waiting_external
     // The job is still in 'running' state
-    let completed = admin::complete_external(client.pool(), callback_id, None)
+    let completed = admin::complete_external(client.pool(), callback_id, None, None)
         .await
         .unwrap();
     assert_eq!(completed.state, JobState::Completed);
@@ -617,7 +618,7 @@ async fn test_e12_crash_clears_stale_callback() {
     assert!(rescued[0].callback_timeout_at.is_none());
 
     // Now the stale callback_id should not be found
-    let err = admin::complete_external(client.pool(), callback_id, None)
+    let err = admin::complete_external(client.pool(), callback_id, None, None)
         .await
         .unwrap_err();
     match err {
@@ -686,7 +687,7 @@ async fn test_e13_uniqueness_during_waiting_external() {
 
     // Complete the job — uniqueness should still hold since completed is in bitmask
     let waiting_job = client.get_job(job.id).await.unwrap();
-    admin::complete_external(client.pool(), waiting_job.callback_id.unwrap(), None)
+    admin::complete_external(client.pool(), waiting_job.callback_id.unwrap(), None, None)
         .await
         .unwrap();
 
@@ -707,6 +708,251 @@ async fn test_e14_migration() {
     migrations::run(&pool).await.unwrap();
     let version = migrations::current_version(&pool).await.unwrap();
     assert_eq!(version, migrations::CURRENT_VERSION);
+}
+
+// ── E15: resolve_callback accepts running state (race condition fix) ──
+
+/// E15: A fast callback arriving before the executor transitions running ->
+/// waiting_external should now be accepted by resolve_callback.
+#[tokio::test]
+async fn test_e15_resolve_callback_during_running_state() {
+    let client = setup().await;
+    let queue = "test_e15_resolve_running";
+    clean_queue(client.pool(), queue).await;
+
+    let job = awa::insert_with(
+        client.pool(),
+        &ExternalPayment { order_id: 60 },
+        awa::InsertOpts {
+            queue: queue.to_string(),
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+
+    // Manually set to running with callback_id (simulating register done,
+    // executor hasn't transitioned to waiting_external yet)
+    let callback_id = uuid::Uuid::new_v4();
+    sqlx::query(
+        "UPDATE awa.jobs SET state = 'running', attempt = 1, run_lease = run_lease + 1,
+         heartbeat_at = now(), callback_id = $2, callback_timeout_at = now() + interval '1 hour'
+         WHERE id = $1",
+    )
+    .bind(job.id)
+    .bind(callback_id)
+    .execute(client.pool())
+    .await
+    .unwrap();
+
+    let result = admin::resolve_callback(
+        client.pool(),
+        callback_id,
+        None,
+        DefaultAction::Complete,
+        None,
+    )
+    .await
+    .unwrap();
+
+    assert!(result.is_completed());
+    let completed = client.get_job(job.id).await.unwrap();
+    assert_eq!(completed.state, JobState::Completed);
+}
+
+// ── E16: Stale callback rejected by run_lease guard ──
+
+/// E16: A callback carrying an old run_lease should be rejected when the job
+/// has been re-claimed with a new lease.
+#[tokio::test]
+async fn test_e16_stale_callback_rejected_by_run_lease() {
+    let client = setup().await;
+    let queue = "test_e16_run_lease";
+    clean_queue(client.pool(), queue).await;
+
+    let job = awa::insert_with(
+        client.pool(),
+        &ExternalPayment { order_id: 61 },
+        awa::InsertOpts {
+            queue: queue.to_string(),
+            max_attempts: 3,
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+
+    // Work the job to get it to waiting_external
+    let result = client
+        .work_one_in_queue(&ExternalPaymentWorker, Some(queue))
+        .await
+        .unwrap();
+    assert!(result.is_waiting_external());
+
+    let waiting = client.get_job(job.id).await.unwrap();
+    let _old_callback_id = waiting.callback_id.unwrap();
+    let old_lease = waiting.run_lease;
+
+    // Simulate rescue: move job back to available, clearing callback
+    sqlx::query(
+        "UPDATE awa.jobs SET state = 'available', callback_id = NULL,
+         callback_timeout_at = NULL, callback_filter = NULL,
+         callback_on_complete = NULL, callback_on_fail = NULL,
+         callback_transform = NULL, attempt = 0, run_at = now()
+         WHERE id = $1",
+    )
+    .bind(job.id)
+    .execute(client.pool())
+    .await
+    .unwrap();
+
+    // Re-claim with new lease (work again)
+    let result2 = client
+        .work_one_in_queue(&ExternalPaymentWorker, Some(queue))
+        .await
+        .unwrap();
+    assert!(result2.is_waiting_external());
+
+    let reclaimed = client.get_job(job.id).await.unwrap();
+    let new_callback_id = reclaimed.callback_id.unwrap();
+    let new_lease = reclaimed.run_lease;
+    assert_ne!(
+        old_lease, new_lease,
+        "run_lease should increment on re-claim"
+    );
+
+    // Try to complete the NEW callback with the OLD run_lease — should fail
+    let err = admin::complete_external(client.pool(), new_callback_id, None, Some(old_lease))
+        .await
+        .unwrap_err();
+    match err {
+        AwaError::CallbackNotFound { .. } => {}
+        other => panic!("Expected CallbackNotFound, got: {other:?}"),
+    }
+
+    // Complete with correct lease should succeed
+    let completed = admin::complete_external(client.pool(), new_callback_id, None, Some(new_lease))
+        .await
+        .unwrap();
+    assert_eq!(completed.state, JobState::Completed);
+}
+
+// ── E17: cancel_callback clears fields ──
+
+/// E17: cancel_callback with matching lease NULLs all callback fields.
+#[tokio::test]
+async fn test_e17_cancel_callback_clears_fields() {
+    let client = setup().await;
+    let queue = "test_e17_cancel_callback";
+    clean_queue(client.pool(), queue).await;
+
+    let job = awa::insert_with(
+        client.pool(),
+        &ExternalPayment { order_id: 62 },
+        awa::InsertOpts {
+            queue: queue.to_string(),
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+
+    // Manually claim and register callback (staying in running state)
+    sqlx::query(
+        "UPDATE awa.jobs SET state = 'running', attempt = 1, run_lease = run_lease + 1,
+         heartbeat_at = now() WHERE id = $1",
+    )
+    .bind(job.id)
+    .execute(client.pool())
+    .await
+    .unwrap();
+
+    let running = client.get_job(job.id).await.unwrap();
+    let run_lease = running.run_lease;
+
+    let _callback_id = admin::register_callback(
+        client.pool(),
+        job.id,
+        run_lease,
+        std::time::Duration::from_secs(3600),
+    )
+    .await
+    .unwrap();
+
+    // Verify callback fields are set
+    let with_cb = client.get_job(job.id).await.unwrap();
+    assert!(with_cb.callback_id.is_some());
+    assert!(with_cb.callback_timeout_at.is_some());
+
+    // Cancel callback
+    let cancelled = admin::cancel_callback(client.pool(), job.id, run_lease)
+        .await
+        .unwrap();
+    assert!(cancelled, "cancel_callback should return true");
+
+    // Verify all callback fields are cleared
+    let after = client.get_job(job.id).await.unwrap();
+    assert!(after.callback_id.is_none());
+    assert!(after.callback_timeout_at.is_none());
+    // Job is still running
+    assert_eq!(after.state, JobState::Running);
+}
+
+// ── E18: cancel_callback with wrong lease is a no-op ──
+
+/// E18: cancel_callback with a mismatched run_lease should not clear anything.
+#[tokio::test]
+async fn test_e18_cancel_callback_wrong_lease_noop() {
+    let client = setup().await;
+    let queue = "test_e18_cancel_noop";
+    clean_queue(client.pool(), queue).await;
+
+    let job = awa::insert_with(
+        client.pool(),
+        &ExternalPayment { order_id: 63 },
+        awa::InsertOpts {
+            queue: queue.to_string(),
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+
+    // Manually claim and register callback
+    sqlx::query(
+        "UPDATE awa.jobs SET state = 'running', attempt = 1, run_lease = run_lease + 1,
+         heartbeat_at = now() WHERE id = $1",
+    )
+    .bind(job.id)
+    .execute(client.pool())
+    .await
+    .unwrap();
+
+    let running = client.get_job(job.id).await.unwrap();
+    let run_lease = running.run_lease;
+
+    admin::register_callback(
+        client.pool(),
+        job.id,
+        run_lease,
+        std::time::Duration::from_secs(3600),
+    )
+    .await
+    .unwrap();
+
+    // Cancel with wrong lease
+    let result = admin::cancel_callback(client.pool(), job.id, run_lease + 999)
+        .await
+        .unwrap();
+    assert!(
+        !result,
+        "cancel_callback with wrong lease should return false"
+    );
+
+    // Callback fields should still be set
+    let after = client.get_job(job.id).await.unwrap();
+    assert!(after.callback_id.is_some());
+    assert!(after.callback_timeout_at.is_some());
 }
 
 /// Internal bridge misuse should still fail the job descriptively at runtime.

--- a/awa/tests/progress_test.rs
+++ b/awa/tests/progress_test.rs
@@ -568,7 +568,7 @@ async fn test_complete_external_clears_progress() {
     let callback_id = waiting.callback_id.expect("callback_id should be set");
 
     // Complete externally
-    let completed = admin::complete_external(tc.pool(), callback_id, None)
+    let completed = admin::complete_external(tc.pool(), callback_id, None, None)
         .await
         .unwrap();
     assert_eq!(completed.state, JobState::Completed);
@@ -608,7 +608,7 @@ async fn test_fail_external_preserves_progress() {
     };
     let callback_id = waiting.callback_id.expect("callback_id should be set");
 
-    let failed = admin::fail_external(tc.pool(), callback_id, "external error")
+    let failed = admin::fail_external(tc.pool(), callback_id, "external error", None)
         .await
         .unwrap();
     assert_eq!(failed.state, JobState::Failed);

--- a/correctness/AwaCbk.tla
+++ b/correctness/AwaCbk.tla
@@ -152,9 +152,7 @@ LoseLeader(i) ==
 BlockingPreconditions(op) ==
     /\ op \in BlockingOps
     /\ callbackId = CbId
-    /\ IF op = "resolve"
-          THEN jobState = "waiting_external"
-          ELSE jobState \in {"waiting_external", "running"}
+    /\ jobState \in {"waiting_external", "running"}
 
 \* Phase 1a: Try to lock. Row is free -> acquire lock.
 BlockingTryLock(op) ==
@@ -212,7 +210,7 @@ FailExecute ==
 \* the FOR UPDATE lock. CEL evaluation is abstracted as nondeterministic choice.
 ResolveCompleteExecute ==
     /\ rowLock = "resolve"
-    /\ jobState = "waiting_external"
+    /\ jobState \in {"waiting_external", "running"}
     /\ callbackId = CbId
     /\ jobState' = "completed"
     /\ callbackId' = NoCb
@@ -225,7 +223,7 @@ ResolveCompleteExecute ==
 
 ResolveFailExecute ==
     /\ rowLock = "resolve"
-    /\ jobState = "waiting_external"
+    /\ jobState \in {"waiting_external", "running"}
     /\ callbackId = CbId
     /\ jobState' = "failed"
     /\ callbackId' = NoCb
@@ -238,7 +236,7 @@ ResolveFailExecute ==
 
 ResolveIgnoreRelease ==
     /\ rowLock = "resolve"
-    /\ jobState = "waiting_external"
+    /\ jobState \in {"waiting_external", "running"}
     /\ callbackId = CbId
     /\ rowLock' = NoLock
     /\ UNCHANGED <<jobState, callbackId, callbackTimedOut, heartbeatFresh, owner, lease, taskLease, leader, resolved, blockedOps>>
@@ -400,7 +398,7 @@ LockHolderConsistent ==
     /\ rowLock = "fail" =>
         (callbackId = CbId /\ jobState \in {"waiting_external", "running"})
     /\ rowLock = "resolve" =>
-        (jobState = "waiting_external" /\ callbackId = CbId)
+        (jobState \in {"waiting_external", "running"} /\ callbackId = CbId)
     /\ rowLock = "timeout_rescue" =>
         (jobState = "waiting_external" /\ callbackId = CbId /\ callbackTimedOut)
     /\ rowLock = "heartbeat_rescue" =>


### PR DESCRIPTION
## Summary

Prerequisite correctness hardening for HttpWorker (ADR-018, PR #100). These fixes are independently valuable — the `resolve_callback` race affects anyone using CEL callback configs today.

- **resolve_callback race fix**: Widen state filter from `= 'waiting_external'` to `IN ('waiting_external', 'running')`, matching `complete_external`/`fail_external`. A fast callback can arrive before the executor transitions `running` → `waiting_external`.
- **run_lease guard**: Add optional `run_lease: Option<i64>` parameter to `complete_external`, `fail_external`, `retry_external`, `resolve_callback`. When provided, rejects callbacks carrying a stale lease from a previous attempt. Existing callers pass `None` (no behavioral change).
- **cancel_callback**: New best-effort function that NULLs callback fields for a running job with a matching lease. For HttpWorker to clean up on definitive dispatch failure.
- **TLA+ spec updated**: `resolve` precondition and `LockHolderConsistent` invariant accept `running` state. TLC re-verified both safety (`AtMostOnceResolution`, 21,945 states, 0 errors) and liveness configs.

## Test plan

- [x] `cargo fmt --all` — clean
- [x] `SQLX_OFFLINE=true cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `SQLX_OFFLINE=true cargo build --workspace` — compiles
- [x] TLC safety check (`AwaCbk.cfg`) — 0 errors, 21,945 states, `AtMostOnceResolution` holds
- [x] TLC liveness check (`AwaCbkLiveness.cfg`) — 0 errors, `TimedOutEventuallyLeaves` holds
- [x] Full test suite — all tests pass
- [x] New tests: E15 (resolve during running), E16 (stale lease rejected), E17 (cancel_callback clears), E18 (cancel wrong lease no-op)
- [x] C16 updated: reversed assertion to verify `resolve_callback` now accepts `running` state