### PR TITLE
Fix JobArgs derive to resolve through awa facade crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -200,6 +200,7 @@ dependencies = [
 name = "awa-macros"
 version = "0.5.0-alpha.0"
 dependencies = [
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
  "syn",
@@ -2069,6 +2070,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-crate"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
+dependencies = [
+ "toml_edit",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3114,6 +3124,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_datetime"
+version = "1.1.0+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97251a7c317e03ad83774a8752a7e81fb6067740609f75ea2b585b569a59198f"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.25.8+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16bff38f1d86c47f9ff0647e6838d7bb362522bdf44006c7068c2b1e606f1f3c"
+dependencies = [
+ "indexmap 2.13.0",
+ "toml_datetime",
+ "toml_parser",
+ "winnow",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.0+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2334f11ee363607eb04df9b8fc8a13ca1715a72ba8662a26ac285c98aabb4011"
+dependencies = [
+ "winnow",
+]
+
+[[package]]
 name = "tonic"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3849,6 +3889,15 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winnow"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a90e88e4667264a994d34e6d1ab2d26d398dcdca8b7f52bec8668957517fc7d8"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wit-bindgen"

--- a/awa-macros/Cargo.toml
+++ b/awa-macros/Cargo.toml
@@ -14,3 +14,4 @@ proc-macro = true
 syn.workspace = true
 quote.workspace = true
 proc-macro2.workspace = true
+proc-macro-crate = "3"

--- a/awa-macros/src/lib.rs
+++ b/awa-macros/src/lib.rs
@@ -1,6 +1,8 @@
 use proc_macro::TokenStream;
+use proc_macro2::Span;
+use proc_macro_crate::{crate_name, FoundCrate};
 use quote::quote;
-use syn::{parse_macro_input, DeriveInput, LitStr};
+use syn::{parse_macro_input, DeriveInput, Ident, LitStr};
 
 /// Derive macro for job argument types.
 ///
@@ -53,12 +55,31 @@ pub fn derive_job_args(input: TokenStream) -> TokenStream {
 
     let kind_str = custom_kind.unwrap_or_else(|| camel_to_snake(&name.to_string()));
 
-    // Resolve the trait path directly through `awa_model`.
-    // This means external crates using the derive currently need a direct
-    // dependency on `awa-model`, even if they otherwise depend on the `awa`
-    // facade crate for runtime APIs.
+    // Resolve the path to awa_model::JobArgs. Users may depend on either
+    // the `awa` facade crate or `awa-model` directly. We check for `awa`
+    // first (which re-exports awa_model), then fall back to `awa-model`.
+    let model_path = if let Ok(found) = crate_name("awa") {
+        // User depends on the `awa` facade which re-exports awa_model.
+        let ident = match found {
+            FoundCrate::Itself => Ident::new("awa", Span::call_site()),
+            FoundCrate::Name(name) => Ident::new(&name, Span::call_site()),
+        };
+        quote!(::#ident::awa_model)
+    } else if let Ok(found) = crate_name("awa-model") {
+        // User depends on awa-model directly.
+        match found {
+            FoundCrate::Itself => quote!(crate),
+            FoundCrate::Name(name) => {
+                let ident = Ident::new(&name, Span::call_site());
+                quote!(::#ident)
+            }
+        }
+    } else {
+        quote!(::awa_model)
+    };
+
     let expanded = quote! {
-        impl ::awa_model::JobArgs for #name {
+        impl #model_path::JobArgs for #name {
             fn kind() -> &'static str {
                 #kind_str
             }

--- a/awa/src/lib.rs
+++ b/awa/src/lib.rs
@@ -3,9 +3,9 @@
 //! This is the facade crate that re-exports the main types from awa-model,
 //! awa-macros, and awa-worker for ergonomic usage.
 
-// Re-export awa_model for advanced users and internal consumers.
-// Note: the current JobArgs derive macro still expands to `::awa_model::JobArgs`,
-// so external binaries that want the derive must depend on `awa-model` directly.
+// Re-export awa_model so the JobArgs derive macro can resolve its trait path
+// through the facade crate (::awa::awa_model::JobArgs). Users only need to
+// depend on `awa` — no separate `awa-model` dependency required.
 #[doc(hidden)]
 pub use awa_model;
 


### PR DESCRIPTION
## Summary

The `JobArgs` derive macro expanded to `::awa_model::JobArgs`, forcing users to add `awa-model` as a direct dependency even when using the `awa` facade crate. This meant the README Rust example didn't compile with just `awa` as a dependency.

## Fix

Uses `proc-macro-crate` to detect which crate the user depends on:
- `awa` (facade) → emits `::awa::awa_model::JobArgs` (resolves via the `#[doc(hidden)] pub use awa_model` re-export)
- `awa-model` (direct) → emits `::awa_model::JobArgs` (same as before)

## Test plan

- [x] `cargo clippy --all-targets --all-features` clean
- [x] External crate with only `awa` dep compiles and runs `JobArgs` derive
- [x] Internal examples (`etl_pipeline.rs`) still compile
- [x] awa-macros unit tests pass