### PR TITLE
Fix GitHub Release: use gh CLI instead of softprops/action-gh-release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -192,16 +192,23 @@ jobs:
           pattern: "{binary-*,wheels-*,cli-wheels-*}"
           merge-multiple: true
 
-      - name: Create draft release with assets
-        uses: softprops/action-gh-release@v2
-        with:
-          draft: true
-          generate_release_notes: true
-          prerelease: ${{ contains(github.ref_name, 'alpha') || contains(github.ref_name, 'beta') || contains(github.ref_name, 'rc') }}
-          fail_on_unmatched_files: false
-          files: |
-            *.tar.gz
-            *.whl
+      - name: Upload assets to GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          tag="${GITHUB_REF_NAME}"
+          # Create the release if it doesn't already exist
+          if ! gh release view "$tag" --json tagName >/dev/null 2>&1; then
+            prerelease_flag=""
+            if echo "$tag" | grep -qE 'alpha|beta|rc'; then
+              prerelease_flag="--prerelease"
+            fi
+            gh release create "$tag" --title "$tag" --generate-notes $prerelease_flag
+          fi
+          # Upload all artifacts (skip duplicates)
+          for f in *.tar.gz *.whl; do
+            [ -e "$f" ] && gh release upload "$tag" "$f" --clobber || true
+          done
 
   # ─── Python wheels (maturin) ─────────────────────────────────────────
   python-wheels:


### PR DESCRIPTION
## Problem

`softprops/action-gh-release` fails with `target_commitish cannot be changed when release is immutable` when we create the GH release before the pipeline runs. This has failed on every release (alpha.0, alpha.1, v0.5.0).

## Fix

Replace with `gh release create` (only if release doesn't exist) + `gh release upload --clobber`. Works whether the release was pre-created or not.

## Test plan

- [x] CI passes (no runtime changes)
- [ ] Next tag push will verify the release pipeline end-to-end