### PR TITLE
Update OpenTelemetry dependencies from 0.29 to 0.31

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -165,9 +165,9 @@ dependencies = [
  "awa-worker",
  "axum",
  "chrono",
- "opentelemetry 0.29.1",
+ "opentelemetry",
  "opentelemetry-otlp",
- "opentelemetry_sdk 0.29.0",
+ "opentelemetry_sdk",
  "reqwest",
  "serde",
  "serde_json",
@@ -258,7 +258,7 @@ dependencies = [
  "serde_json",
  "sqlx",
  "tokio",
- "tower 0.5.3",
+ "tower",
  "tower-http",
  "tracing",
  "uuid",
@@ -276,7 +276,7 @@ dependencies = [
  "chrono",
  "chrono-tz",
  "croner",
- "opentelemetry 0.29.1",
+ "opentelemetry",
  "reqwest",
  "serde",
  "serde_json",
@@ -316,7 +316,7 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tower 0.5.3",
+ "tower",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -1045,12 +1045,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "glob"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
-
-[[package]]
 name = "h2"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1062,18 +1056,12 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap 2.13.0",
+ "indexmap",
  "slab",
  "tokio",
  "tokio-util",
  "tracing",
 ]
-
-[[package]]
-name = "hashbrown"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
@@ -1426,16 +1414,6 @@ checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
-]
-
-[[package]]
-name = "indexmap"
-version = "1.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
-dependencies = [
- "autocfg",
- "hashbrown 0.12.3",
 ]
 
 [[package]]
@@ -1836,23 +1814,9 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry"
-version = "0.27.1"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab70038c28ed37b97d8ed414b6429d343a8bbf44c9f79ec854f3a643029ba6d7"
-dependencies = [
- "futures-core",
- "futures-sink",
- "js-sys",
- "pin-project-lite",
- "thiserror 1.0.69",
- "tracing",
-]
-
-[[package]]
-name = "opentelemetry"
-version = "0.29.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e87237e2775f74896f9ad219d26a2081751187eb7c9f5c58dde20a23b95d16c"
+checksum = "b84bcd6ae87133e903af7ef497404dda70c60d0ea14895fc8a5e6722754fc2a0"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1864,30 +1828,28 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-http"
-version = "0.29.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46d7ab32b827b5b495bd90fa95a6cb65ccc293555dcc3199ae2937d2d237c8ed"
+checksum = "d7a6d09a73194e6b66df7c8f1b680f156d916a1a942abf2de06823dd02b7855d"
 dependencies = [
  "async-trait",
  "bytes",
  "http",
- "opentelemetry 0.29.1",
+ "opentelemetry",
  "reqwest",
- "tracing",
 ]
 
 [[package]]
 name = "opentelemetry-otlp"
-version = "0.29.0"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d899720fe06916ccba71c01d04ecd77312734e2de3467fd30d9d580c8ce85656"
+checksum = "1f69cd6acbb9af919df949cd1ec9e5e7fdc2ef15d234b6b795aaa525cc02f71f"
 dependencies = [
- "futures-core",
  "http",
- "opentelemetry 0.29.1",
+ "opentelemetry",
  "opentelemetry-http",
  "opentelemetry-proto",
- "opentelemetry_sdk 0.29.0",
+ "opentelemetry_sdk",
  "prost",
  "reqwest",
  "thiserror 2.0.18",
@@ -1898,51 +1860,32 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-proto"
-version = "0.29.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c40da242381435e18570d5b9d50aca2a4f4f4d8e146231adb4e7768023309b3"
+checksum = "a7175df06de5eaee9909d4805a3d07e28bb752c34cab57fa9cff549da596b30f"
 dependencies = [
- "opentelemetry 0.29.1",
- "opentelemetry_sdk 0.29.0",
+ "opentelemetry",
+ "opentelemetry_sdk",
  "prost",
  "tonic",
+ "tonic-prost",
 ]
 
 [[package]]
 name = "opentelemetry_sdk"
-version = "0.27.1"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "231e9d6ceef9b0b2546ddf52335785ce41252bc7474ee8ba05bfad277be13ab8"
-dependencies = [
- "async-trait",
- "futures-channel",
- "futures-executor",
- "futures-util",
- "glob",
- "opentelemetry 0.27.1",
- "percent-encoding",
- "rand 0.8.5",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "opentelemetry_sdk"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afdefb21d1d47394abc1ba6c57363ab141be19e27cc70d0e422b7f303e4d290b"
+checksum = "e14ae4f5991976fd48df6d843de219ca6d31b01daaab2dad5af2badeded372bd"
 dependencies = [
  "futures-channel",
  "futures-executor",
  "futures-util",
- "glob",
- "opentelemetry 0.29.1",
+ "opentelemetry",
  "percent-encoding",
  "rand 0.9.2",
- "serde_json",
  "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
- "tracing",
 ]
 
 [[package]]
@@ -2190,9 +2133,9 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.13.5"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
+checksum = "d2ea70524a2f82d518bce41317d0fae74151505651af45faf1ffbd6fd33f0568"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -2200,9 +2143,9 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.13.5"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
+checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
  "itertools",
@@ -2399,7 +2342,7 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-native-tls",
- "tower 0.5.3",
+ "tower",
  "tower-http",
  "tower-service",
  "url",
@@ -2814,7 +2757,7 @@ dependencies = [
  "futures-util",
  "hashbrown 0.15.5",
  "hashlink",
- "indexmap 2.13.0",
+ "indexmap",
  "log",
  "memchr",
  "once_cell",
@@ -3267,7 +3210,7 @@ version = "0.25.8+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16bff38f1d86c47f9ff0647e6838d7bb362522bdf44006c7068c2b1e606f1f3c"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap",
  "toml_datetime",
  "toml_parser",
  "winnow",
@@ -3284,9 +3227,9 @@ dependencies = [
 
 [[package]]
 name = "tonic"
-version = "0.12.3"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "877c5b330756d856ffcc4553ab34a5684481ade925ecc54bcd1bf02b1d0d4d52"
+checksum = "fec7c61a0695dc1887c1b53952990f3ad2e3a31453e1f49f10e75424943a93ec"
 dependencies = [
  "async-trait",
  "base64",
@@ -3299,33 +3242,24 @@ dependencies = [
  "hyper-util",
  "percent-encoding",
  "pin-project",
- "prost",
+ "sync_wrapper",
  "tokio",
  "tokio-stream",
- "tower 0.4.13",
+ "tower",
  "tower-layer",
  "tower-service",
  "tracing",
 ]
 
 [[package]]
-name = "tower"
-version = "0.4.13"
+name = "tonic-prost"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+checksum = "a55376a0bbaa4975a3f10d009ad763d8f4108f067c7c2e74f3001fb49778d309"
 dependencies = [
- "futures-core",
- "futures-util",
- "indexmap 1.9.3",
- "pin-project",
- "pin-project-lite",
- "rand 0.8.5",
- "slab",
- "tokio",
- "tokio-util",
- "tower-layer",
- "tower-service",
- "tracing",
+ "bytes",
+ "prost",
+ "tonic",
 ]
 
 [[package]]
@@ -3336,9 +3270,12 @@ checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",
+ "indexmap",
  "pin-project-lite",
+ "slab",
  "sync_wrapper",
  "tokio",
+ "tokio-util",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -3357,7 +3294,7 @@ dependencies = [
  "http-body",
  "iri-string",
  "pin-project-lite",
- "tower 0.5.3",
+ "tower",
  "tower-layer",
  "tower-service",
 ]
@@ -3420,14 +3357,12 @@ dependencies = [
 
 [[package]]
 name = "tracing-opentelemetry"
-version = "0.28.0"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97a971f6058498b5c0f1affa23e7ea202057a7301dbff68e968b2d578bcbd053"
+checksum = "1ac28f2d093c6c477eaa76b23525478f38de514fa9aeb1285738d4b97a9552fc"
 dependencies = [
  "js-sys",
- "once_cell",
- "opentelemetry 0.27.1",
- "opentelemetry_sdk 0.27.1",
+ "opentelemetry",
  "smallvec",
  "tracing",
  "tracing-core",
@@ -3710,7 +3645,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
- "indexmap 2.13.0",
+ "indexmap",
  "wasm-encoder",
  "wasmparser",
 ]
@@ -3723,7 +3658,7 @@ checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
  "bitflags",
  "hashbrown 0.15.5",
- "indexmap 2.13.0",
+ "indexmap",
  "semver",
 ]
 
@@ -4052,7 +3987,7 @@ checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
  "heck",
- "indexmap 2.13.0",
+ "indexmap",
  "prettyplease",
  "syn",
  "wasm-metadata",
@@ -4083,7 +4018,7 @@ checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
  "bitflags",
- "indexmap 2.13.0",
+ "indexmap",
  "log",
  "serde",
  "serde_derive",
@@ -4102,7 +4037,7 @@ checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap 2.13.0",
+ "indexmap",
  "log",
  "semver",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,8 +59,8 @@ croner = "2"
 # Logging / Observability
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
-opentelemetry = { version = "0.29", features = ["metrics"] }
-opentelemetry_sdk = { version = "0.29", features = ["metrics", "rt-tokio"] }
+opentelemetry = { version = "0.31", features = ["metrics"] }
+opentelemetry_sdk = { version = "0.31", features = ["metrics", "rt-tokio"] }
 
 # CEL expressions (optional)
 cel = { version = "0.13", features = ["json"] }

--- a/awa/Cargo.toml
+++ b/awa/Cargo.toml
@@ -31,8 +31,8 @@ uuid.workspace = true
 tracing-subscriber = { workspace = true }
 opentelemetry_sdk = { workspace = true, features = ["testing"] }
 opentelemetry = { workspace = true, features = ["testing"] }
-opentelemetry-otlp = { version = "0.29", features = ["grpc-tonic"] }
-tracing-opentelemetry = "0.28"
+opentelemetry-otlp = { version = "0.31", features = ["grpc-tonic"] }
+tracing-opentelemetry = "0.32"
 reqwest.workspace = true
 axum.workspace = true
 tracing = { workspace = true }

--- a/awa/tests/chaos_suite_test.rs
+++ b/awa/tests/chaos_suite_test.rs
@@ -7,7 +7,7 @@ use async_trait::async_trait;
 use awa::model::{insert_with, migrations, InsertOpts};
 use awa::{Client, JobArgs, JobContext, JobError, JobResult, QueueConfig, Worker};
 use chrono::{Duration as ChronoDuration, Utc};
-use opentelemetry_sdk::metrics::data::Sum;
+use opentelemetry_sdk::metrics::data::{AggregatedMetrics, MetricData};
 use opentelemetry_sdk::metrics::{InMemoryMetricExporter, SdkMeterProvider};
 use serde::{Deserialize, Serialize};
 use sqlx::postgres::PgPoolOptions;
@@ -361,11 +361,11 @@ fn sum_counter_metric(
 ) -> u64 {
     let mut total = 0;
     for rm in resource_metrics {
-        for scope_metrics in &rm.scope_metrics {
-            for metric in &scope_metrics.metrics {
-                if metric.name == name {
-                    if let Some(sum) = metric.data.as_any().downcast_ref::<Sum<u64>>() {
-                        total += sum.data_points.iter().map(|dp| dp.value).sum::<u64>();
+        for scope_metrics in rm.scope_metrics() {
+            for metric in scope_metrics.metrics() {
+                if metric.name() == name {
+                    if let AggregatedMetrics::U64(MetricData::Sum(sum)) = metric.data() {
+                        total += sum.data_points().map(|dp| dp.value()).sum::<u64>();
                     }
                 }
             }

--- a/awa/tests/concurrent_lifecycle_test.rs
+++ b/awa/tests/concurrent_lifecycle_test.rs
@@ -564,67 +564,59 @@ async fn test_concurrent_drain_20k() {
         .expect("Failed to get metrics");
 
     // Print claim and completion metrics for diagnosis
+    use opentelemetry_sdk::metrics::data::{AggregatedMetrics, MetricData};
     for rm in &resource_metrics {
-        for scope_metrics in &rm.scope_metrics {
-            for metric in &scope_metrics.metrics {
-                if metric.name.starts_with("awa.dispatch")
-                    || metric.name.starts_with("awa.completion")
+        for scope_metrics in rm.scope_metrics() {
+            for metric in scope_metrics.metrics() {
+                if metric.name().starts_with("awa.dispatch")
+                    || metric.name().starts_with("awa.completion")
                 {
-                    if let Some(sum) = metric
-                        .data
-                        .as_any()
-                        .downcast_ref::<opentelemetry_sdk::metrics::data::Sum<u64>>()
-                    {
-                        let total: u64 = sum.data_points.iter().map(|dp| dp.value).sum();
-                        println!("[metrics] {}: total={total}", metric.name);
-                    }
-                    if let Some(hist) = metric
-                        .data
-                        .as_any()
-                        .downcast_ref::<opentelemetry_sdk::metrics::data::Histogram<f64>>(
-                    ) {
-                        let mut count = 0u64;
-                        let mut sum = 0.0f64;
-                        let mut max = 0.0f64;
-                        for dp in &hist.data_points {
-                            count += dp.count;
-                            sum += dp.sum;
-                            if let Some(m) = dp.max {
-                                max = max.max(m);
-                            }
+                    match metric.data() {
+                        AggregatedMetrics::U64(MetricData::Sum(sum)) => {
+                            let total: u64 = sum.data_points().map(|dp| dp.value()).sum();
+                            println!("[metrics] {}: total={total}", metric.name());
                         }
-                        let mean = if count > 0 { sum / count as f64 } else { 0.0 };
-                        println!(
-                            "[metrics] {}: count={count} mean_ms={:.3} max_ms={:.3}",
-                            metric.name,
-                            mean * 1000.0,
-                            max * 1000.0
-                        );
-                    }
-                    if let Some(hist) = metric
-                        .data
-                        .as_any()
-                        .downcast_ref::<opentelemetry_sdk::metrics::data::Histogram<u64>>(
-                    ) {
-                        let mut count = 0u64;
-                        let mut sum = 0u64;
-                        let mut max = 0u64;
-                        for dp in &hist.data_points {
-                            count += dp.count;
-                            sum += dp.sum;
-                            if let Some(m) = dp.max {
-                                max = max.max(m);
+                        AggregatedMetrics::F64(MetricData::Histogram(hist)) => {
+                            let mut count = 0u64;
+                            let mut sum = 0.0f64;
+                            let mut max = 0.0f64;
+                            for dp in hist.data_points() {
+                                count += dp.count();
+                                sum += dp.sum();
+                                if let Some(m) = dp.max() {
+                                    max = max.max(m);
+                                }
                             }
+                            let mean = if count > 0 { sum / count as f64 } else { 0.0 };
+                            println!(
+                                "[metrics] {}: count={count} mean_ms={:.3} max_ms={:.3}",
+                                metric.name(),
+                                mean * 1000.0,
+                                max * 1000.0
+                            );
                         }
-                        let mean = if count > 0 {
-                            sum as f64 / count as f64
-                        } else {
-                            0.0
-                        };
-                        println!(
-                            "[metrics] {}: count={count} mean={mean:.1} max={max}",
-                            metric.name
-                        );
+                        AggregatedMetrics::U64(MetricData::Histogram(hist)) => {
+                            let mut count = 0u64;
+                            let mut sum = 0u64;
+                            let mut max = 0u64;
+                            for dp in hist.data_points() {
+                                count += dp.count();
+                                sum += dp.sum();
+                                if let Some(m) = dp.max() {
+                                    max = max.max(m);
+                                }
+                            }
+                            let mean = if count > 0 {
+                                sum as f64 / count as f64
+                            } else {
+                                0.0
+                            };
+                            println!(
+                                "[metrics] {}: count={count} mean={mean:.1} max={max}",
+                                metric.name()
+                            );
+                        }
+                        _ => {}
                     }
                 }
             }

--- a/awa/tests/failure_benchmark_test.rs
+++ b/awa/tests/failure_benchmark_test.rs
@@ -19,7 +19,7 @@ use async_trait::async_trait;
 use awa::model::migrations;
 use awa::{Client, JobArgs, JobContext, JobError, JobResult, QueueConfig, Worker};
 use bench_output::{BenchMetrics, BenchRescue, BenchThroughput, BenchmarkResult, SCHEMA_VERSION};
-use opentelemetry_sdk::metrics::data::Sum;
+use opentelemetry_sdk::metrics::data::{AggregatedMetrics, MetricData};
 use opentelemetry_sdk::metrics::{InMemoryMetricExporter, SdkMeterProvider};
 use serde::{Deserialize, Serialize};
 use sqlx::postgres::PgPoolOptions;
@@ -81,11 +81,11 @@ fn sum_counter_metric(
 ) -> u64 {
     let mut total = 0;
     for rm in resource_metrics {
-        for scope_metrics in &rm.scope_metrics {
-            for metric in &scope_metrics.metrics {
-                if metric.name == name {
-                    if let Some(sum) = metric.data.as_any().downcast_ref::<Sum<u64>>() {
-                        total += sum.data_points.iter().map(|dp| dp.value).sum::<u64>();
+        for scope_metrics in rm.scope_metrics() {
+            for metric in scope_metrics.metrics() {
+                if metric.name() == name {
+                    if let AggregatedMetrics::U64(MetricData::Sum(sum)) = metric.data() {
+                        total += sum.data_points().map(|dp| dp.value()).sum::<u64>();
                     }
                 }
             }
@@ -102,21 +102,20 @@ fn sum_counter_metric_with_attribute(
 ) -> u64 {
     let mut total = 0;
     for rm in resource_metrics {
-        for scope_metrics in &rm.scope_metrics {
-            for metric in &scope_metrics.metrics {
-                if metric.name != name {
+        for scope_metrics in rm.scope_metrics() {
+            for metric in scope_metrics.metrics() {
+                if metric.name() != name {
                     continue;
                 }
-                if let Some(sum) = metric.data.as_any().downcast_ref::<Sum<u64>>() {
+                if let AggregatedMetrics::U64(MetricData::Sum(sum)) = metric.data() {
                     total += sum
-                        .data_points
-                        .iter()
+                        .data_points()
                         .filter(|dp| {
-                            dp.attributes.iter().any(|kv| {
+                            dp.attributes().any(|kv| {
                                 kv.key.as_str() == attr_name && kv.value.as_str() == attr_value
                             })
                         })
-                        .map(|dp| dp.value)
+                        .map(|dp| dp.value())
                         .sum::<u64>();
                 }
             }

--- a/awa/tests/observability_test.rs
+++ b/awa/tests/observability_test.rs
@@ -10,7 +10,7 @@
 
 use awa::model::{insert_with, migrations, InsertOpts};
 use awa::{Client, JobArgs, JobError, JobResult, JobState, QueueConfig};
-use opentelemetry_sdk::metrics::data::{Histogram, Sum};
+use opentelemetry_sdk::metrics::data::{AggregatedMetrics, MetricData};
 use opentelemetry_sdk::metrics::{InMemoryMetricExporter, SdkMeterProvider};
 use serde::{Deserialize, Serialize};
 use sqlx::postgres::PgPoolOptions;
@@ -343,10 +343,10 @@ async fn test_job_execution_emits_otel_metrics() {
     let mut metrics_by_name: HashMap<String, Vec<&opentelemetry_sdk::metrics::data::Metric>> =
         HashMap::new();
     for rm in &resource_metrics {
-        for scope_metrics in &rm.scope_metrics {
-            for metric in &scope_metrics.metrics {
+        for scope_metrics in rm.scope_metrics() {
+            for metric in scope_metrics.metrics() {
                 metrics_by_name
-                    .entry(metric.name.to_string())
+                    .entry(metric.name().to_string())
                     .or_default()
                     .push(metric);
             }
@@ -363,16 +363,18 @@ async fn test_job_execution_emits_otel_metrics() {
     let completed_sum = completed_metrics
         .unwrap()
         .iter()
-        .find_map(|m| m.data.as_any().downcast_ref::<Sum<u64>>());
+        .find_map(|m| match m.data() {
+            AggregatedMetrics::U64(MetricData::Sum(sum)) => Some(sum),
+            _ => None,
+        });
     assert!(
         completed_sum.is_some(),
         "Expected Sum<u64> aggregation for awa.job.completed"
     );
     let total_completed: u64 = completed_sum
         .unwrap()
-        .data_points
-        .iter()
-        .map(|dp| dp.value)
+        .data_points()
+        .map(|dp| dp.value())
         .sum();
     assert!(
         total_completed >= 1,
@@ -389,16 +391,18 @@ async fn test_job_execution_emits_otel_metrics() {
     let duration_histogram = duration_metrics
         .unwrap()
         .iter()
-        .find_map(|m| m.data.as_any().downcast_ref::<Histogram<f64>>());
+        .find_map(|m| match m.data() {
+            AggregatedMetrics::F64(MetricData::Histogram(hist)) => Some(hist),
+            _ => None,
+        });
     assert!(
         duration_histogram.is_some(),
         "Expected Histogram<f64> aggregation for awa.job.duration"
     );
     let total_duration_count: u64 = duration_histogram
         .unwrap()
-        .data_points
-        .iter()
-        .map(|dp| dp.count)
+        .data_points()
+        .map(|dp| dp.count())
         .sum();
     assert!(
         total_duration_count >= 1,
@@ -413,19 +417,18 @@ async fn test_job_execution_emits_otel_metrics() {
         "Expected 'awa.job.wait_duration' metric, found metrics: {:?}",
         metrics_by_name.keys().collect::<Vec<_>>()
     );
-    let wait_histogram = wait_metrics
-        .unwrap()
-        .iter()
-        .find_map(|m| m.data.as_any().downcast_ref::<Histogram<f64>>());
+    let wait_histogram = wait_metrics.unwrap().iter().find_map(|m| match m.data() {
+        AggregatedMetrics::F64(MetricData::Histogram(hist)) => Some(hist),
+        _ => None,
+    });
     assert!(
         wait_histogram.is_some(),
         "Expected Histogram<f64> aggregation for awa.job.wait_duration"
     );
     let total_wait_count: u64 = wait_histogram
         .unwrap()
-        .data_points
-        .iter()
-        .map(|dp| dp.count)
+        .data_points()
+        .map(|dp| dp.count())
         .sum();
     assert!(
         total_wait_count >= 1,
@@ -439,14 +442,13 @@ async fn test_job_execution_emits_otel_metrics() {
     // We check the last data point rather than summing all points, since
     // intermediate exports may have captured non-zero in-flight counts.
     if let Some(in_flight_metrics) = metrics_by_name.get("awa.job.in_flight") {
-        if let Some(in_flight_sum) = in_flight_metrics
-            .iter()
-            .find_map(|m| m.data.as_any().downcast_ref::<Sum<i64>>())
-        {
+        if let Some(in_flight_sum) = in_flight_metrics.iter().find_map(|m| match m.data() {
+            AggregatedMetrics::I64(MetricData::Sum(sum)) => Some(sum),
+            _ => None,
+        }) {
             let max_in_flight: i64 = in_flight_sum
-                .data_points
-                .iter()
-                .map(|dp| dp.value)
+                .data_points()
+                .map(|dp| dp.value())
                 .max()
                 .unwrap_or(0);
             assert!(
@@ -527,10 +529,10 @@ async fn test_failed_job_emits_failure_metrics() {
     let mut metrics_by_name: HashMap<String, Vec<&opentelemetry_sdk::metrics::data::Metric>> =
         HashMap::new();
     for rm in &resource_metrics {
-        for scope_metrics in &rm.scope_metrics {
-            for metric in &scope_metrics.metrics {
+        for scope_metrics in rm.scope_metrics() {
+            for metric in scope_metrics.metrics() {
                 metrics_by_name
-                    .entry(metric.name.to_string())
+                    .entry(metric.name().to_string())
                     .or_default()
                     .push(metric);
             }
@@ -544,20 +546,15 @@ async fn test_failed_job_emits_failure_metrics() {
         "Expected 'awa.job.failed' metric, found metrics: {:?}",
         metrics_by_name.keys().collect::<Vec<_>>()
     );
-    let failed_sum = failed_metrics
-        .unwrap()
-        .iter()
-        .find_map(|m| m.data.as_any().downcast_ref::<Sum<u64>>());
+    let failed_sum = failed_metrics.unwrap().iter().find_map(|m| match m.data() {
+        AggregatedMetrics::U64(MetricData::Sum(sum)) => Some(sum),
+        _ => None,
+    });
     assert!(
         failed_sum.is_some(),
         "Expected Sum<u64> aggregation for awa.job.failed"
     );
-    let total_failed: u64 = failed_sum
-        .unwrap()
-        .data_points
-        .iter()
-        .map(|dp| dp.value)
-        .sum();
+    let total_failed: u64 = failed_sum.unwrap().data_points().map(|dp| dp.value()).sum();
     assert!(
         total_failed >= 1,
         "Expected awa.job.failed >= 1, got {}",

--- a/awa/tests/scheduling_benchmark_test.rs
+++ b/awa/tests/scheduling_benchmark_test.rs
@@ -8,7 +8,7 @@ use awa::{
     Client, InsertOpts, JobArgs, JobContext, JobError, JobResult, PeriodicJob, QueueConfig, Worker,
 };
 use chrono::{DateTime, Utc};
-use opentelemetry_sdk::metrics::data::{Histogram, Sum};
+use opentelemetry_sdk::metrics::data::{AggregatedMetrics, MetricData};
 use opentelemetry_sdk::metrics::{InMemoryMetricExporter, SdkMeterProvider};
 use serde::{Deserialize, Serialize};
 use sqlx::postgres::PgPoolOptions;
@@ -116,9 +116,9 @@ fn find_metric<'a>(
 ) -> Vec<&'a opentelemetry_sdk::metrics::data::Metric> {
     let mut out = Vec::new();
     for rm in resource_metrics {
-        for scope_metrics in &rm.scope_metrics {
-            for metric in &scope_metrics.metrics {
-                if metric.name == name {
+        for scope_metrics in rm.scope_metrics() {
+            for metric in scope_metrics.metrics() {
+                if metric.name() == name {
                     out.push(metric);
                 }
             }
@@ -133,9 +133,12 @@ fn print_counter_metric(
 ) {
     let total: u64 = find_metric(resource_metrics, name)
         .into_iter()
-        .filter_map(|metric| metric.data.as_any().downcast_ref::<Sum<u64>>())
-        .flat_map(|sum| sum.data_points.iter())
-        .map(|dp| dp.value)
+        .filter_map(|metric| match metric.data() {
+            AggregatedMetrics::U64(MetricData::Sum(sum)) => Some(sum),
+            _ => None,
+        })
+        .flat_map(|sum| sum.data_points())
+        .map(|dp| dp.value())
         .sum();
     println!("[metrics] {name}: total={total}");
 }
@@ -148,11 +151,11 @@ fn print_histogram_metric_u64(
     let mut sum = 0u64;
     let mut max = 0u64;
     for metric in find_metric(resource_metrics, name) {
-        if let Some(hist) = metric.data.as_any().downcast_ref::<Histogram<u64>>() {
-            for dp in &hist.data_points {
-                count += dp.count;
-                sum += dp.sum;
-                if let Some(dp_max) = dp.max {
+        if let AggregatedMetrics::U64(MetricData::Histogram(hist)) = metric.data() {
+            for dp in hist.data_points() {
+                count += dp.count();
+                sum += dp.sum();
+                if let Some(dp_max) = dp.max() {
                     max = max.max(dp_max);
                 }
             }
@@ -174,11 +177,11 @@ fn print_histogram_metric_f64(
     let mut sum = 0.0f64;
     let mut max = 0.0f64;
     for metric in find_metric(resource_metrics, name) {
-        if let Some(hist) = metric.data.as_any().downcast_ref::<Histogram<f64>>() {
-            for dp in &hist.data_points {
-                count += dp.count;
-                sum += dp.sum;
-                if let Some(dp_max) = dp.max {
+        if let AggregatedMetrics::F64(MetricData::Histogram(hist)) = metric.data() {
+            for dp in hist.data_points() {
+                count += dp.count();
+                sum += dp.sum();
+                if let Some(dp_max) = dp.max() {
                     max = max.max(dp_max);
                 }
             }


### PR DESCRIPTION
## Summary
- opentelemetry: 0.29 → 0.31
- opentelemetry_sdk: 0.29 → 0.31
- opentelemetry-otlp: 0.29 → 0.31
- tracing-opentelemetry: 0.28 → 0.32
- Transitive: tonic 0.12 → 0.14, prost 0.13 → 0.14

## API changes
The opentelemetry_sdk 0.31 release makes metric data struct fields `pub(crate)` with accessor methods, and replaces the `dyn Any` downcast pattern with a typed `AggregatedMetrics` enum. Updates in 5 test files:
- `observability_test.rs`
- `failure_benchmark_test.rs`
- `chaos_suite_test.rs`
- `scheduling_benchmark_test.rs`
- `concurrent_lifecycle_test.rs`

No changes needed in the main library code — the counter/histogram/gauge recording APIs are unchanged.

## Test plan
- [x] `cargo fmt --all` clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo build --workspace` succeeds
- [x] `cargo test --workspace --lib` unit tests pass
- [ ] CI integration tests pass