### PR TITLE
bench: add absurd to portable benchmarks

### DIFF
--- a/benchmarks/portable/README.md
+++ b/benchmarks/portable/README.md
@@ -1,8 +1,8 @@
 # Portable Cross-System Benchmarks
 
 Comparable benchmark scenarios for Awa (native Rust and Docker), Awa-Python,
-Procrastinate (Python), River (Go), and Oban (Elixir) running against a shared
-Postgres instance.
+Absurd (Python SDK plus SQL schema), Procrastinate (Python), River (Go), and
+Oban (Elixir) running against a shared Postgres instance.
 
 ## Prerequisites
 
@@ -17,7 +17,7 @@ Postgres instance.
 uv run python benchmarks/portable/run.py
 
 # Run specific systems
-uv run python benchmarks/portable/run.py --systems awa,awa-docker,awa-python,procrastinate,river
+uv run python benchmarks/portable/run.py --systems awa,awa-docker,awa-python,absurd,procrastinate,river
 
 # Run a single scenario
 uv run python benchmarks/portable/run.py --scenario worker_throughput --job-count 50000 --worker-count 200
@@ -63,7 +63,7 @@ benchmarks/portable/
 ├── run.py                 # Orchestrator — builds, runs, collects results
 ├── isolated.py            # Repeats one-system-per-run isolated benchmarks
 ├── docker-compose.yml     # Shared Postgres 17 with per-system databases
-├── init-databases.sql     # Creates awa_bench, awa_docker_bench, awa_python_bench, procrastinate_bench, river_bench, oban_bench
+├── init-databases.sql     # Creates awa_bench, awa_docker_bench, awa_python_bench, absurd_bench, procrastinate_bench, river_bench, oban_bench
 ├── awa-bench/             # Rust binary (built locally or in Docker from workspace)
 │   ├── Cargo.toml
 │   ├── Dockerfile
@@ -71,6 +71,10 @@ benchmarks/portable/
 ├── awa-python-bench/      # Python runtime variant (Docker)
 │   ├── Dockerfile
 │   └── main.py
+├── absurd-bench/          # Python Absurd adapter (Docker)
+│   ├── Dockerfile
+│   ├── main.py
+│   └── pyproject.toml
 ├── procrastinate-bench/   # Python Procrastinate adapter (Docker)
 │   ├── Dockerfile
 │   ├── main.py
@@ -95,8 +99,8 @@ Each adapter:
 - Manages its own schema migration and cleanup
 
 `awa` runs natively from the local workspace. `awa-docker`, `awa-python`,
-`procrastinate`, River, and Oban run in Docker containers with `--network host`
-to connect to the shared Postgres.
+`absurd`, `procrastinate`, River, and Oban run in Docker containers with
+`--network host` to connect to the shared Postgres.
 
 ## Configuration
 
@@ -106,7 +110,7 @@ to connect to the shared Postgres.
 | `--job-count` | `10000` | Number of jobs per scenario |
 | `--worker-count` | `50` | Concurrent workers |
 | `--latency-iterations` | `100` | Iterations for pickup latency test |
-| `--systems` | `awa,awa-docker,awa-python,procrastinate,river,oban` | Comma-separated list of systems to run |
+| `--systems` | `awa,awa-docker,awa-python,absurd,procrastinate,river,oban` | Comma-separated list of systems to run |
 
 ## Fairness Constraints
 
@@ -122,6 +126,9 @@ to connect to the shared Postgres.
   duration so healthy jobs are not falsely rescued
 - Awa reuses one DB session across COPY batches so its temp-table reuse
   optimization is exercised in the portable harness
+- Absurd bulk enqueue uses batched `absurd.spawn_task(...)` calls because the
+  current Python SDK exposes single-task `spawn()` but no bulk helper; pickup
+  latency still uses the normal single-task SDK path
 - Pickup latency uses each system's normal single-job insert API rather than a
   batch insert helper
 - Chaos enqueue via direct SQL INSERT — all three systems have INSERT triggers

--- a/benchmarks/portable/absurd-bench/Dockerfile
+++ b/benchmarks/portable/absurd-bench/Dockerfile
@@ -1,0 +1,20 @@
+FROM python:3.12-slim
+
+ARG ABSURD_VERSION=0.3.0
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends curl ca-certificates postgresql-client \
+    && rm -rf /var/lib/apt/lists/*
+RUN curl -LsSf https://astral.sh/uv/install.sh | sh
+RUN curl -fsSL https://raw.githubusercontent.com/earendil-works/absurd/${ABSURD_VERSION}/sql/absurd.sql -o /opt/absurd.sql
+
+ENV PATH="/root/.local/bin:${PATH}"
+ENV ABSURD_SQL_PATH="/opt/absurd.sql"
+
+WORKDIR /app
+COPY absurd-bench ./absurd-bench
+
+WORKDIR /app/absurd-bench
+RUN uv sync
+
+ENTRYPOINT ["sh", "-lc", "cd /app/absurd-bench && uv run python main.py"]

--- a/benchmarks/portable/absurd-bench/main.py
+++ b/benchmarks/portable/absurd-bench/main.py
@@ -1,0 +1,279 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+from time import monotonic
+
+from absurd_sdk import AsyncAbsurd
+from psycopg import AsyncConnection, sql
+from psycopg.rows import dict_row
+
+
+ABSURD_SQL_PATH = Path(os.environ.get("ABSURD_SQL_PATH", "/opt/absurd.sql"))
+POLL_INTERVAL_SECS = 0.05
+
+
+def database_url() -> str:
+    url = os.environ.get("DATABASE_URL")
+    if not url:
+        raise RuntimeError("DATABASE_URL must be set")
+    return url
+
+
+def env_int(key: str, default: int) -> int:
+    value = os.environ.get(key)
+    return int(value) if value is not None else default
+
+
+def ensure_schema() -> None:
+    result = subprocess.run(
+        [
+            "psql",
+            database_url(),
+            "-v",
+            "ON_ERROR_STOP=1",
+            "-f",
+            str(ABSURD_SQL_PATH),
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"failed to apply {ABSURD_SQL_PATH}: {result.stderr or result.stdout}"
+        )
+
+
+def build_app(queue: str) -> AsyncAbsurd:
+    app = AsyncAbsurd(database_url(), queue_name=queue)
+
+    @app.register_task("bench_job")
+    async def bench_job(_params: dict, _ctx) -> None:
+        return None
+
+    return app
+
+
+async def connect() -> AsyncConnection:
+    return await AsyncConnection.connect(
+        database_url(),
+        autocommit=True,
+        row_factory=dict_row,
+    )
+
+
+async def recreate_queue(queue: str) -> None:
+    app = build_app(queue)
+    try:
+        await app.drop_queue()
+        await app.create_queue()
+    finally:
+        await app.close()
+
+
+async def count_completed(conn: AsyncConnection, queue: str) -> int:
+    async with conn.cursor() as cur:
+        await cur.execute(
+            sql.SQL("SELECT count(*)::bigint AS cnt FROM absurd.{} WHERE state = 'completed'").format(
+                sql.Identifier(f"t_{queue}")
+            )
+        )
+        row = await cur.fetchone()
+    return int(row["cnt"])
+
+
+async def count_by_state(conn: AsyncConnection, queue: str) -> dict[str, int]:
+    async with conn.cursor() as cur:
+        await cur.execute(
+            sql.SQL(
+                "SELECT state::text AS state, count(*)::bigint AS count "
+                "FROM absurd.{} GROUP BY state"
+            ).format(sql.Identifier(f"t_{queue}"))
+        )
+        rows = await cur.fetchall()
+    return {row["state"]: int(row["count"]) for row in rows}
+
+
+async def wait_for_completion(
+    conn: AsyncConnection,
+    queue: str,
+    expected: int,
+    timeout_secs: float,
+) -> None:
+    deadline = monotonic() + timeout_secs
+    while True:
+        completed = await count_completed(conn, queue)
+        if completed >= expected:
+            return
+        if monotonic() >= deadline:
+            counts = await count_by_state(conn, queue)
+            raise TimeoutError(
+                f"Timeout waiting for {expected} completions on {queue}: {counts}"
+            )
+        await asyncio.sleep(POLL_INTERVAL_SECS)
+
+
+async def wait_for_task_completion(
+    app: AsyncAbsurd,
+    task_id: str,
+    timeout_secs: float,
+) -> None:
+    deadline = monotonic() + timeout_secs
+    while True:
+        snapshot = await app.fetch_task_result(task_id)
+        if snapshot is None:
+            raise RuntimeError(f"task {task_id} disappeared")
+        if snapshot.state == "completed":
+            return
+        if snapshot.state in {"failed", "cancelled"}:
+            raise RuntimeError(f"task {task_id} ended in state {snapshot.state}")
+        if monotonic() >= deadline:
+            raise TimeoutError(f"Timeout waiting for task {task_id} to complete")
+        await asyncio.sleep(POLL_INTERVAL_SECS)
+
+
+async def enqueue_batch(conn: AsyncConnection, queue: str, count: int) -> None:
+    batch_size = 500
+    query = (
+        "SELECT task_id FROM absurd.spawn_task(%s, %s, %s::jsonb, %s::jsonb)"
+    )
+    async with conn.cursor() as cur:
+        for batch_start in range(0, count, batch_size):
+            batch_end = min(batch_start + batch_size, count)
+            params = [
+                (queue, "bench_job", json.dumps({"seq": i}), "{}")
+                for i in range(batch_start, batch_end)
+            ]
+            await cur.executemany(query, params)
+
+
+async def run_worker(queue: str, worker_count: int) -> tuple[AsyncAbsurd, asyncio.Task[None]]:
+    worker_app = build_app(queue)
+    worker_task = asyncio.create_task(
+        worker_app.start_worker(
+            concurrency=worker_count,
+            poll_interval=POLL_INTERVAL_SECS,
+        )
+    )
+    return worker_app, worker_task
+
+
+async def stop_worker(worker_app: AsyncAbsurd, worker_task: asyncio.Task[None]) -> None:
+    worker_app.stop_worker()
+    await worker_task
+    await worker_app.close()
+
+
+async def scenario_enqueue_throughput(job_count: int) -> dict:
+    queue = "absurd_enqueue_bench"
+    await recreate_queue(queue)
+    conn = await connect()
+    try:
+        start = monotonic()
+        await enqueue_batch(conn, queue, job_count)
+        elapsed = monotonic() - start
+    finally:
+        await conn.close()
+
+    return {
+        "system": "absurd",
+        "scenario": "enqueue_throughput",
+        "config": {"job_count": job_count},
+        "results": {
+            "duration_ms": round(elapsed * 1000),
+            "jobs_per_sec": job_count / max(elapsed, 0.001),
+        },
+    }
+
+
+async def scenario_worker_throughput(job_count: int, worker_count: int) -> dict:
+    queue = "absurd_worker_bench"
+    await recreate_queue(queue)
+    conn = await connect()
+    worker_app: AsyncAbsurd | None = None
+    worker_task: asyncio.Task[None] | None = None
+    try:
+        await enqueue_batch(conn, queue, job_count)
+        start = monotonic()
+        worker_app, worker_task = await run_worker(queue, worker_count)
+        await wait_for_completion(conn, queue, job_count, 120)
+        elapsed = monotonic() - start
+    finally:
+        if worker_app is not None and worker_task is not None:
+            await stop_worker(worker_app, worker_task)
+        await conn.close()
+
+    return {
+        "system": "absurd",
+        "scenario": "worker_throughput",
+        "config": {"job_count": job_count, "worker_count": worker_count},
+        "results": {
+            "duration_ms": round(elapsed * 1000),
+            "jobs_per_sec": job_count / max(elapsed, 0.001),
+        },
+    }
+
+
+async def scenario_pickup_latency(iterations: int, worker_count: int) -> dict:
+    queue = "absurd_latency_bench"
+    await recreate_queue(queue)
+    control_app = build_app(queue)
+    worker_app, worker_task = await run_worker(queue, worker_count)
+
+    try:
+        await asyncio.sleep(0.5)
+        latencies_us: list[int] = []
+        for i in range(iterations):
+            start = monotonic()
+            result = await control_app.spawn("bench_job", {"seq": i})
+            await wait_for_task_completion(control_app, result["task_id"], 10)
+            latencies_us.append(round((monotonic() - start) * 1_000_000))
+    finally:
+        await stop_worker(worker_app, worker_task)
+        await control_app.close()
+
+    latencies_us.sort()
+    n = len(latencies_us)
+    return {
+        "system": "absurd",
+        "scenario": "pickup_latency",
+        "config": {"iterations": iterations, "worker_count": worker_count},
+        "results": {
+            "mean_us": sum(latencies_us) / n,
+            "p50_us": latencies_us[n // 2],
+            "p95_us": latencies_us[min(int(n * 0.95), n - 1)],
+            "p99_us": latencies_us[min(int(n * 0.99), n - 1)],
+        },
+    }
+
+
+async def main() -> None:
+    scenario = os.environ.get("SCENARIO", "all")
+    job_count = env_int("JOB_COUNT", 10000)
+    worker_count = env_int("WORKER_COUNT", 50)
+    latency_iterations = env_int("LATENCY_ITERATIONS", 100)
+
+    ensure_schema()
+
+    results: list[dict] = []
+    if scenario == "all" or scenario == "enqueue_throughput":
+        print("[absurd] Running enqueue_throughput...", file=sys.stderr)
+        results.append(await scenario_enqueue_throughput(job_count))
+    if scenario == "all" or scenario == "worker_throughput":
+        print("[absurd] Running worker_throughput...", file=sys.stderr)
+        results.append(await scenario_worker_throughput(job_count, worker_count))
+    if scenario == "all" or scenario == "pickup_latency":
+        print("[absurd] Running pickup_latency...", file=sys.stderr)
+        results.append(await scenario_pickup_latency(latency_iterations, worker_count))
+
+    print(json.dumps(results, indent=2))
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/benchmarks/portable/absurd-bench/pyproject.toml
+++ b/benchmarks/portable/absurd-bench/pyproject.toml
@@ -1,0 +1,11 @@
+[project]
+name = "portable-absurd-bench"
+version = "0.1.0"
+requires-python = ">=3.12"
+dependencies = [
+    "absurd-sdk==0.3.0",
+    "psycopg[binary]==3.3.3",
+]
+
+[tool.uv]
+package = false

--- a/benchmarks/portable/awa-bench/Cargo.lock
+++ b/benchmarks/portable/awa-bench/Cargo.lock
@@ -89,7 +89,7 @@ dependencies = [
 
 [[package]]
 name = "awa-macros"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -99,7 +99,7 @@ dependencies = [
 
 [[package]]
 name = "awa-model"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "awa-macros",
  "blake3",
@@ -118,7 +118,7 @@ dependencies = [
 
 [[package]]
 name = "awa-worker"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "async-trait",
  "awa-macros",

--- a/benchmarks/portable/full_suite.py
+++ b/benchmarks/portable/full_suite.py
@@ -22,6 +22,7 @@ DEFAULT_SYSTEMS = [
     "awa",
     "awa-docker",
     "awa-python",
+    "absurd",
     "procrastinate",
     "river",
     "oban",

--- a/benchmarks/portable/init-databases.sql
+++ b/benchmarks/portable/init-databases.sql
@@ -2,6 +2,7 @@
 CREATE DATABASE awa_bench;
 CREATE DATABASE awa_docker_bench;
 CREATE DATABASE awa_python_bench;
+CREATE DATABASE absurd_bench;
 CREATE DATABASE procrastinate_bench;
 CREATE DATABASE river_bench;
 CREATE DATABASE oban_bench;

--- a/benchmarks/portable/isolated.py
+++ b/benchmarks/portable/isolated.py
@@ -157,7 +157,7 @@ def main() -> None:
     parser.add_argument("--job-count", type=int, default=50000)
     parser.add_argument("--worker-count", type=int, default=200)
     parser.add_argument("--latency-iterations", type=int, default=100)
-    parser.add_argument("--systems", default="awa,awa-docker,awa-python,procrastinate,river,oban")
+    parser.add_argument("--systems", default="awa,awa-docker,awa-python,absurd,procrastinate,river,oban")
     parser.add_argument("--repetitions", type=int, default=3)
     parser.add_argument("--skip-build", action="store_true")
     args = parser.parse_args()

--- a/benchmarks/portable/run.py
+++ b/benchmarks/portable/run.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python3
 """
-Portable benchmark orchestrator for Awa, Awa-Python, Procrastinate, River, and Oban.
+Portable benchmark orchestrator for Awa, Absurd, Procrastinate, River, and Oban.
 
 Usage:
     python run.py [--scenario SCENARIO] [--job-count N] [--worker-count N]
-                  [--systems awa,awa-docker,awa-python,procrastinate,river,oban] [--skip-build]
+                  [--systems awa,awa-docker,awa-python,absurd,procrastinate,river,oban] [--skip-build]
 
 Requires: Docker, cargo (for Awa adapter).
 """
@@ -176,6 +176,23 @@ def build_procrastinate():
         raise RuntimeError("Failed to build procrastinate-bench image")
 
 
+def build_absurd():
+    """Build the Absurd benchmark Docker image."""
+    print("\n=== Building Absurd benchmark ===", file=sys.stderr)
+    result = run_cmd(
+        [
+            "docker", "build",
+            "-f", str(SCRIPT_DIR / "absurd-bench" / "Dockerfile"),
+            "-t", "absurd-bench",
+            ".",
+        ],
+        cwd=str(SCRIPT_DIR),
+        timeout=1800,
+    )
+    if result.returncode != 0:
+        raise RuntimeError("Failed to build absurd-bench image")
+
+
 def run_awa_python(scenario: str, job_count: int, worker_count: int,
                    latency_iterations: int) -> list[dict]:
     """Run Awa-Python benchmark in Docker."""
@@ -198,6 +215,30 @@ def run_awa_python(scenario: str, job_count: int, worker_count: int,
         raise RuntimeError(f"awa-python-bench failed: {result.stderr}")
     print(result.stderr, file=sys.stderr, end="")
     return with_system_name(json.loads(result.stdout), "awa-python")
+
+
+def run_absurd(scenario: str, job_count: int, worker_count: int,
+               latency_iterations: int) -> list[dict]:
+    """Run Absurd benchmark in Docker."""
+    print("\n=== Running Absurd benchmarks ===", file=sys.stderr)
+    result = run_cmd(
+        [
+            "docker", "run", "--rm",
+            "--network", "host",
+            "-e", f"DATABASE_URL={pg_url('absurd_bench')}",
+            "-e", f"SCENARIO={scenario}",
+            "-e", f"JOB_COUNT={job_count}",
+            "-e", f"WORKER_COUNT={worker_count}",
+            "-e", f"LATENCY_ITERATIONS={latency_iterations}",
+            "absurd-bench",
+        ],
+        capture=True, timeout=1800,
+    )
+    if result.returncode != 0:
+        print(f"Absurd stderr: {result.stderr}", file=sys.stderr)
+        raise RuntimeError(f"absurd-bench failed: {result.stderr}")
+    print(result.stderr, file=sys.stderr, end="")
+    return json.loads(result.stdout)
 
 
 def run_procrastinate(scenario: str, job_count: int, worker_count: int,
@@ -333,7 +374,7 @@ def main():
     parser.add_argument("--job-count", type=int, default=10000)
     parser.add_argument("--worker-count", type=int, default=50)
     parser.add_argument("--latency-iterations", type=int, default=100)
-    parser.add_argument("--systems", default="awa,awa-docker,awa-python,procrastinate,river,oban",
+    parser.add_argument("--systems", default="awa,awa-docker,awa-python,absurd,procrastinate,river,oban",
                         help="Comma-separated list of systems to benchmark")
     parser.add_argument("--skip-build", action="store_true",
                         help="Skip building, use cached images/binaries")
@@ -348,6 +389,7 @@ def main():
         "awa": build_awa,
         "awa-docker": build_awa_docker,
         "awa-python": build_awa_python,
+        "absurd": build_absurd,
         "procrastinate": build_procrastinate,
         "river": build_river,
         "oban": build_oban,
@@ -356,6 +398,7 @@ def main():
         "awa": run_awa,
         "awa-docker": run_awa_docker,
         "awa-python": run_awa_python,
+        "absurd": run_absurd,
         "procrastinate": run_procrastinate,
         "river": run_river,
         "oban": run_oban,


### PR DESCRIPTION
## Summary
- add a Docker-based absurd portable benchmark adapter pinned to Absurd 0.3.0
- wire absurd into benchmarks/portable/run.py, benchmarks/portable/isolated.py, the benchmark DB bootstrap, and README docs
- benchmark enqueue throughput via batched absurd.spawn_task(...) calls and use the async worker path for worker throughput and pickup latency

## Verification
- python3 -m py_compile benchmarks/portable/run.py benchmarks/portable/isolated.py benchmarks/portable/absurd-bench/main.py
- uv run python benchmarks/portable/run.py --systems absurd --job-count 100 --worker-count 10 --latency-iterations 10

## Notes
- Absurd is a durable execution system rather than a pure queue, so this adapter exercises its queue-adjacent spawn/claim/complete path rather than step-heavy workflows.
- The Python SDK currently exposes single-task spawn() but no bulk enqueue helper, so the enqueue benchmark uses batched SQL calls to absurd.spawn_task(...).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
- Added Absurd as a supported system in the portable benchmark suite
- Users can now run performance benchmarks for Absurd using the existing portable benchmark infrastructure
- Benchmarks include enqueue and worker throughput, plus pickup latency measurements
- Absurd integration is available in all benchmark modes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->