### PR TITLE
feat: add job inspection dump commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,9 @@ awa-python/python/awa/lib_awa.dylib.dSYM/
 /awa-ui/frontend/node_modules
 /awa-ui/static/assets
 /awa-ui/static/index.html
+
+# Local worktrees and generated artifacts
+/.claude/
+/artifacts/
+/awa-cli/dist/
+/corectness/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -112,6 +112,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
+name = "assert_cmd"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a686bbee5efb88a82df0621b236e74d925f470e5445d3220a5648b892ec99c9"
+dependencies = [
+ "anstyle",
+ "bstr",
+ "libc",
+ "predicates",
+ "predicates-core",
+ "predicates-tree",
+ "wait-timeout",
+]
+
+[[package]]
 name = "async-lock"
 version = "3.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -183,17 +198,21 @@ dependencies = [
 name = "awa-cli"
 version = "0.5.3"
 dependencies = [
+ "assert_cmd",
  "awa-model",
+ "awa-testing",
  "awa-ui",
  "axum",
  "chrono",
  "clap",
  "hex",
+ "serde",
  "serde_json",
  "sqlx",
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "uuid",
 ]
 
 [[package]]
@@ -413,6 +432,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
 dependencies = [
  "hybrid-array",
+]
+
+[[package]]
+name = "bstr"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+dependencies = [
+ "memchr",
+ "regex-automata",
+ "serde",
 ]
 
 [[package]]
@@ -720,6 +750,12 @@ dependencies = [
  "pem-rfc7468",
  "zeroize",
 ]
+
+[[package]]
+name = "difflib"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
 
 [[package]]
 name = "digest"
@@ -2087,6 +2123,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "predicates"
+version = "3.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ada8f2932f28a27ee7b70dd6c1c39ea0675c55a36879ab92f3a715eaa1e63cfe"
+dependencies = [
+ "anstyle",
+ "difflib",
+ "predicates-core",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cad38746f3166b4031b1a0d39ad9f954dd291e7854fcc0eed52ee41a0b50d144"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0de1b847b39c8131db0467e9df1ff60e6d0562ab8e9a16e568ad0fdb372e2f2"
+dependencies = [
+ "predicates-core",
+ "termtree",
+]
+
+[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3007,6 +3070,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "termtree"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
+
+[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3488,6 +3557,15 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "walkdir"

--- a/README.md
+++ b/README.md
@@ -32,6 +32,15 @@ Core concurrency invariants (no duplicate processing after rescue, stale complet
 
 ## Getting Started
 
+The quickest way to reason about Awa is:
+
+- your app inserts a durable job row inside Postgres, often in the same transaction as business data
+- workers claim runnable rows, heartbeat while they are executing, and safely rescue stale work after crashes
+- the job row itself is the source of truth for state, progress, callbacks, and retry history
+- operators inspect and control that state through the CLI or the built-in UI
+
+If you keep that model in mind, the APIs make more sense: enqueue work, run workers, then inspect the resulting row rather than guessing what happened in memory.
+
 ```bash
 # 1. Install
 pip install awa-pg awa-cli     # Python
@@ -44,6 +53,8 @@ awa --database-url $DATABASE_URL migrate
 
 # 4. Monitor
 awa --database-url $DATABASE_URL serve   # → http://127.0.0.1:3000
+awa --database-url $DATABASE_URL job dump 123
+awa --database-url $DATABASE_URL job dump-run 123
 ```
 
 Language-specific guides:
@@ -218,6 +229,8 @@ awa --database-url $DATABASE_URL migrate
 awa --database-url $DATABASE_URL serve
 awa --database-url $DATABASE_URL queue stats
 awa --database-url $DATABASE_URL job list --state failed
+awa --database-url $DATABASE_URL job dump 123
+awa --database-url $DATABASE_URL job dump-run 123
 ```
 
 ## Architecture

--- a/awa-cli/Cargo.toml
+++ b/awa-cli/Cargo.toml
@@ -23,3 +23,9 @@ tracing-subscriber.workspace = true
 serde_json.workspace = true
 chrono.workspace = true
 hex.workspace = true
+
+[dev-dependencies]
+awa-testing = { path = "../awa-testing", version = "0.5.3" }
+assert_cmd = "2"
+serde.workspace = true
+uuid.workspace = true

--- a/awa-cli/README.md
+++ b/awa-cli/README.md
@@ -13,6 +13,8 @@ awa --database-url $DATABASE_URL migrate
 # Admin
 awa --database-url $DATABASE_URL queue stats
 awa --database-url $DATABASE_URL job list --state failed
+awa --database-url $DATABASE_URL job dump 12345
+awa --database-url $DATABASE_URL job dump-run 12345
 awa --database-url $DATABASE_URL job retry 12345
 
 # Web UI
@@ -26,6 +28,8 @@ awa --database-url $DATABASE_URL serve
 |---------|-------------|
 | `migrate` | Run database migrations (or extract SQL) |
 | `job list` | List jobs with state/kind/queue filters |
+| `job dump` | Dump one job as a detailed JSON inspection snapshot |
+| `job dump-run` | Dump one attempt-oriented inspection snapshot |
 | `job retry` | Retry a failed/cancelled job |
 | `job cancel` | Cancel a job |
 | `job retry-failed` | Retry all failed jobs by kind |

--- a/awa-cli/src/main.rs
+++ b/awa-cli/src/main.rs
@@ -93,6 +93,15 @@ fn parse_callback_hmac_secret(secret: &str) -> Result<[u8; 32], String> {
 
 #[derive(Subcommand)]
 enum JobCommands {
+    /// Dump a single job as a detailed JSON inspection snapshot
+    Dump { id: i64 },
+    /// Dump one attempt as a detailed JSON inspection snapshot
+    DumpRun {
+        id: i64,
+        /// Attempt number to inspect. Defaults to the current attempt.
+        #[arg(long)]
+        attempt: Option<i16>,
+    },
     /// Retry a failed or cancelled job
     Retry { id: i64 },
     /// Cancel a job
@@ -282,6 +291,16 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 Commands::Migrate { .. } | Commands::Serve { .. } => unreachable!(),
 
                 Commands::Job { command } => match command {
+                    JobCommands::Dump { id } => {
+                        let dump = awa_model::admin::dump_job(&pool, id).await?;
+                        println!("{}", serde_json::to_string_pretty(&dump)?);
+                    }
+
+                    JobCommands::DumpRun { id, attempt } => {
+                        let dump = awa_model::admin::dump_run(&pool, id, attempt).await?;
+                        println!("{}", serde_json::to_string_pretty(&dump)?);
+                    }
+
                     JobCommands::Retry { id } => {
                         awa_model::admin::retry(&pool, id).await?;
                         println!("Retried job {id}");

--- a/awa-cli/tests/inspection_cli_test.rs
+++ b/awa-cli/tests/inspection_cli_test.rs
@@ -203,6 +203,31 @@ async fn dump_run_reconstructs_historical_attempt_from_errors() {
 }
 
 #[tokio::test]
+async fn dump_run_preserves_historical_attempts_after_retry_reset() {
+    let pool = setup_pool().await;
+    let queue = unique_queue("cli_dump_run_retry_reset");
+    let (job_id, _callback_id) = seed_inspection_job(&pool, &queue).await;
+
+    awa_model::admin::retry(&pool, job_id)
+        .await
+        .expect("retry should succeed");
+
+    let assert = run_cli(&["job", "dump-run", &job_id.to_string(), "--attempt", "2"])
+        .assert()
+        .success();
+    let stdout = String::from_utf8(assert.get_output().stdout.clone()).expect("stdout utf8");
+    let payload: Value = serde_json::from_str(&stdout).expect("dump output should be json");
+
+    assert_eq!(payload["source"].as_str(), Some("error_history"));
+    assert_eq!(payload["selected_attempt"].as_i64(), Some(2));
+    assert_eq!(payload["current_attempt"].as_i64(), Some(0));
+    assert_eq!(payload["state"].as_str(), Some("retryable"));
+    assert_eq!(payload["error"].as_str(), Some("second failure"));
+
+    awa_testing::setup::clean_queue(&pool, &queue).await;
+}
+
+#[tokio::test]
 async fn dump_run_rejects_unknown_attempt() {
     let pool = setup_pool().await;
     let queue = unique_queue("cli_dump_run_invalid");

--- a/awa-cli/tests/inspection_cli_test.rs
+++ b/awa-cli/tests/inspection_cli_test.rs
@@ -1,0 +1,218 @@
+use assert_cmd::Command;
+use awa_model::{insert_with, InsertOpts, JobArgs};
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+use uuid::Uuid;
+
+#[derive(Debug, Serialize, Deserialize)]
+struct InspectEmail {
+    to: String,
+    subject: String,
+}
+
+impl JobArgs for InspectEmail {
+    fn kind() -> &'static str {
+        "inspect_email"
+    }
+}
+
+fn database_url() -> String {
+    awa_testing::setup::database_url()
+}
+
+async fn setup_pool() -> sqlx::PgPool {
+    awa_testing::setup::setup(4).await
+}
+
+fn unique_queue(prefix: &str) -> String {
+    format!("{prefix}_{}", rand_suffix())
+}
+
+fn rand_suffix() -> String {
+    Uuid::new_v4().simple().to_string()[..8].to_string()
+}
+
+async fn seed_inspection_job(pool: &sqlx::PgPool, queue: &str) -> (i64, Uuid) {
+    awa_testing::setup::clean_queue(pool, queue).await;
+
+    let job = insert_with(
+        pool,
+        &InspectEmail {
+            to: "alice@example.com".into(),
+            subject: "Inspect".into(),
+        },
+        InsertOpts {
+            queue: queue.to_string(),
+            metadata: json!({"tenant": "acme"}),
+            tags: vec!["cli".into(), "inspect".into()],
+            ..Default::default()
+        },
+    )
+    .await
+    .expect("job should insert");
+
+    let callback_id = Uuid::new_v4();
+    sqlx::query(
+        r#"
+        UPDATE awa.jobs
+        SET state = 'waiting_external',
+            priority = 1,
+            attempt = 3,
+            run_lease = 7,
+            attempted_at = now() - interval '2 minutes',
+            heartbeat_at = now() - interval '10 seconds',
+            callback_id = $2,
+            callback_timeout_at = now() + interval '30 minutes',
+            callback_filter = 'payload.kind == "payment"',
+            callback_on_complete = 'payload.status == "ok"',
+            callback_on_fail = 'payload.status == "fail"',
+            callback_transform = 'payload',
+            progress = $3::jsonb,
+            metadata = $4::jsonb,
+            errors = ARRAY[$5::jsonb, $6::jsonb]
+        WHERE id = $1
+        "#,
+    )
+    .bind(job.id)
+    .bind(callback_id)
+    .bind(json!({
+        "percent": 42,
+        "message": "waiting on gateway",
+        "metadata": {"cursor": 99}
+    }))
+    .bind(json!({
+        "tenant": "acme",
+        "_awa_original_priority": 4
+    }))
+    .bind(json!({
+        "error": "first failure",
+        "attempt": 1,
+        "at": "2026-04-01T00:00:00Z"
+    }))
+    .bind(json!({
+        "error": "second failure",
+        "attempt": 2,
+        "at": "2026-04-01T00:05:00Z"
+    }))
+    .execute(pool)
+    .await
+    .expect("job should update");
+
+    (job.id, callback_id)
+}
+
+fn run_cli(args: &[&str]) -> Command {
+    let mut command = Command::cargo_bin("awa").expect("awa binary should build");
+    command.env("DATABASE_URL", database_url()).args(args);
+    command
+}
+
+#[tokio::test]
+async fn job_dump_prints_rich_job_snapshot() {
+    let pool = setup_pool().await;
+    let queue = unique_queue("cli_dump_job");
+    let (job_id, _callback_id) = seed_inspection_job(&pool, &queue).await;
+
+    let assert = run_cli(&["job", "dump", &job_id.to_string()])
+        .assert()
+        .success();
+    let stdout = String::from_utf8(assert.get_output().stdout.clone()).expect("stdout utf8");
+    let payload: Value = serde_json::from_str(&stdout).expect("dump output should be json");
+
+    assert_eq!(payload["job"]["id"].as_i64(), Some(job_id));
+    assert_eq!(payload["job"]["queue"].as_str(), Some(queue.as_str()));
+    assert_eq!(payload["job"]["state"].as_str(), Some("waiting_external"));
+    assert_eq!(payload["summary"]["original_priority"].as_i64(), Some(4));
+    assert_eq!(payload["summary"]["can_retry"].as_bool(), Some(true));
+    assert_eq!(payload["summary"]["can_cancel"].as_bool(), Some(true));
+    assert_eq!(payload["summary"]["error_count"].as_u64(), Some(2));
+
+    let labels: Vec<_> = payload["timeline"]
+        .as_array()
+        .expect("timeline array")
+        .iter()
+        .filter_map(|item| item.get("label").and_then(Value::as_str))
+        .collect();
+    assert!(labels.contains(&"Created"));
+    assert!(labels.contains(&"Attempt 1 failed"));
+    assert!(labels.contains(&"Attempt 2 failed"));
+    assert!(labels.contains(&"Attempt 3 — waiting for callback"));
+
+    awa_testing::setup::clean_queue(&pool, &queue).await;
+}
+
+#[tokio::test]
+async fn dump_run_defaults_to_current_attempt_snapshot() {
+    let pool = setup_pool().await;
+    let queue = unique_queue("cli_dump_run_current");
+    let (job_id, callback_id) = seed_inspection_job(&pool, &queue).await;
+
+    let assert = run_cli(&["job", "dump-run", &job_id.to_string()])
+        .assert()
+        .success();
+    let stdout = String::from_utf8(assert.get_output().stdout.clone()).expect("stdout utf8");
+    let payload: Value = serde_json::from_str(&stdout).expect("dump output should be json");
+    let callback_id_text = callback_id.to_string();
+
+    assert_eq!(payload["job_id"].as_i64(), Some(job_id));
+    assert_eq!(payload["queue"].as_str(), Some(queue.as_str()));
+    assert_eq!(payload["source"].as_str(), Some("current_job_row"));
+    assert_eq!(payload["selected_attempt"].as_i64(), Some(3));
+    assert_eq!(payload["current_attempt"].as_i64(), Some(3));
+    assert_eq!(payload["selected_run_lease"].as_i64(), Some(7));
+    assert_eq!(payload["state"].as_str(), Some("waiting_external"));
+    assert_eq!(
+        payload["callback"]["callback_id"].as_str(),
+        Some(callback_id_text.as_str())
+    );
+    assert_eq!(payload["progress"]["percent"].as_i64(), Some(42));
+    assert_eq!(payload["metadata"]["tenant"].as_str(), Some("acme"));
+
+    awa_testing::setup::clean_queue(&pool, &queue).await;
+}
+
+#[tokio::test]
+async fn dump_run_reconstructs_historical_attempt_from_errors() {
+    let pool = setup_pool().await;
+    let queue = unique_queue("cli_dump_run_history");
+    let (job_id, _callback_id) = seed_inspection_job(&pool, &queue).await;
+
+    let assert = run_cli(&["job", "dump-run", &job_id.to_string(), "--attempt", "2"])
+        .assert()
+        .success();
+    let stdout = String::from_utf8(assert.get_output().stdout.clone()).expect("stdout utf8");
+    let payload: Value = serde_json::from_str(&stdout).expect("dump output should be json");
+
+    assert_eq!(payload["source"].as_str(), Some("error_history"));
+    assert_eq!(payload["selected_attempt"].as_i64(), Some(2));
+    assert_eq!(payload["state"].as_str(), Some("retryable"));
+    assert_eq!(payload["error"].as_str(), Some("second failure"));
+    assert_eq!(payload["terminal"].as_bool(), Some(false));
+    assert!(payload["selected_run_lease"].is_null());
+    assert_eq!(
+        payload["finished_at"].as_str(),
+        Some("2026-04-01T00:05:00Z")
+    );
+    assert!(payload["notes"]
+        .as_array()
+        .expect("notes array")
+        .iter()
+        .any(|entry| entry.as_str().unwrap_or_default().contains("errors[]")));
+
+    awa_testing::setup::clean_queue(&pool, &queue).await;
+}
+
+#[tokio::test]
+async fn dump_run_rejects_unknown_attempt() {
+    let pool = setup_pool().await;
+    let queue = unique_queue("cli_dump_run_invalid");
+    let (job_id, _callback_id) = seed_inspection_job(&pool, &queue).await;
+
+    let assert = run_cli(&["job", "dump-run", &job_id.to_string(), "--attempt", "4"])
+        .assert()
+        .failure();
+    let stderr = String::from_utf8(assert.get_output().stderr.clone()).expect("stderr utf8");
+    assert!(stderr.contains("attempt 4 is not available"));
+
+    awa_testing::setup::clean_queue(&pool, &queue).await;
+}

--- a/awa-model/src/admin.rs
+++ b/awa-model/src/admin.rs
@@ -1064,12 +1064,7 @@ where
         return Err(AwaError::Validation("attempt must be >= 0".to_string()));
     }
 
-    if job.attempt == 0 {
-        if selected_attempt != 0 {
-            return Err(AwaError::Validation(format!(
-                "job {job_id} has not started yet; only attempt 0 is available"
-            )));
-        }
+    if job.attempt == 0 && selected_attempt == 0 {
         return Ok(RunDump {
             job_id: job.id,
             kind: job.kind.clone(),
@@ -1126,7 +1121,14 @@ where
         });
     }
 
-    if selected_attempt == 0 || selected_attempt > job.attempt {
+    if selected_attempt == 0 {
+        return Err(AwaError::Validation(format!(
+            "attempt {selected_attempt} is not available for job {job_id}; current attempt is {}",
+            job.attempt
+        )));
+    }
+
+    if job.attempt > 0 && selected_attempt > job.attempt {
         return Err(AwaError::Validation(format!(
             "attempt {selected_attempt} is not available for job {job_id}; current attempt is {}",
             job.attempt

--- a/awa-model/src/admin.rs
+++ b/awa-model/src/admin.rs
@@ -9,6 +9,235 @@ use std::cmp::max;
 use std::collections::HashMap;
 use uuid::Uuid;
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct JobTimelineEvent {
+    pub timestamp: DateTime<Utc>,
+    pub label: String,
+    pub state: Option<JobState>,
+    pub detail: Option<String>,
+    pub is_error: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct JobDumpSummary {
+    pub original_priority: i16,
+    pub can_retry: bool,
+    pub can_cancel: bool,
+    pub error_count: usize,
+    pub latest_error: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct JobDump {
+    pub job: JobRow,
+    pub summary: JobDumpSummary,
+    pub timeline: Vec<JobTimelineEvent>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum RunDumpSource {
+    CurrentJobRow,
+    ErrorHistory,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct CallbackDump {
+    pub callback_id: Option<Uuid>,
+    pub callback_timeout_at: Option<DateTime<Utc>>,
+    pub callback_filter: Option<String>,
+    pub callback_on_complete: Option<String>,
+    pub callback_on_fail: Option<String>,
+    pub callback_transform: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct RunDump {
+    pub job_id: i64,
+    pub kind: String,
+    pub queue: String,
+    pub selected_attempt: i16,
+    pub current_attempt: i16,
+    pub current_run_lease: i64,
+    pub selected_run_lease: Option<i64>,
+    pub source: RunDumpSource,
+    pub state: JobState,
+    pub started_at: Option<DateTime<Utc>>,
+    pub finished_at: Option<DateTime<Utc>>,
+    pub error: Option<String>,
+    pub terminal: Option<bool>,
+    pub progress: Option<serde_json::Value>,
+    pub metadata: Option<serde_json::Value>,
+    pub callback: Option<CallbackDump>,
+    pub raw_error_entry: Option<serde_json::Value>,
+    pub notes: Vec<String>,
+}
+
+#[derive(Debug, Clone)]
+struct ErrorEntry {
+    attempt: Option<i16>,
+    error: Option<String>,
+    at: Option<DateTime<Utc>>,
+    terminal: bool,
+    raw: serde_json::Value,
+}
+
+fn parse_error_entry(value: &serde_json::Value) -> Option<ErrorEntry> {
+    let obj = value.as_object()?;
+    let attempt = obj
+        .get("attempt")
+        .and_then(|v| v.as_i64())
+        .and_then(|v| i16::try_from(v).ok());
+    let error = obj
+        .get("error")
+        .and_then(|v| v.as_str())
+        .map(ToOwned::to_owned);
+    let at = obj
+        .get("at")
+        .and_then(|v| v.as_str())
+        .and_then(|v| chrono::DateTime::parse_from_rfc3339(v).ok())
+        .map(|v| v.with_timezone(&Utc));
+    let terminal = obj
+        .get("terminal")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+    Some(ErrorEntry {
+        attempt,
+        error,
+        at,
+        terminal,
+        raw: value.clone(),
+    })
+}
+
+fn original_priority(job: &JobRow) -> i16 {
+    job.metadata
+        .get("_awa_original_priority")
+        .and_then(|v| v.as_i64())
+        .and_then(|v| i16::try_from(v).ok())
+        .unwrap_or(job.priority)
+}
+
+fn build_job_timeline(job: &JobRow) -> Vec<JobTimelineEvent> {
+    let mut events = Vec::new();
+    events.push(JobTimelineEvent {
+        timestamp: job.created_at,
+        label: "Created".to_string(),
+        state: None,
+        detail: None,
+        is_error: false,
+    });
+
+    if let Some(errors) = &job.errors {
+        for entry in errors.iter().filter_map(parse_error_entry) {
+            if let Some(timestamp) = entry.at {
+                let label = match entry.attempt {
+                    Some(attempt) => format!("Attempt {attempt} failed"),
+                    None => "Error".to_string(),
+                };
+                events.push(JobTimelineEvent {
+                    timestamp,
+                    label,
+                    state: Some(JobState::Failed),
+                    detail: entry.error,
+                    is_error: true,
+                });
+            }
+        }
+    }
+
+    if let Some(attempted_at) = job.attempted_at {
+        let label = if job.state == JobState::WaitingExternal {
+            format!("Attempt {} — waiting for callback", job.attempt)
+        } else if job.state.is_terminal() {
+            format!("Attempt {} started", job.attempt)
+        } else {
+            format!("Attempt {} running", job.attempt)
+        };
+        let state = if job.state.is_terminal() {
+            Some(JobState::Running)
+        } else {
+            Some(job.state)
+        };
+        events.push(JobTimelineEvent {
+            timestamp: attempted_at,
+            label,
+            state,
+            detail: None,
+            is_error: false,
+        });
+    }
+
+    if let Some(finalized_at) = job.finalized_at {
+        let label = match job.state {
+            JobState::Completed => format!("Completed (attempt {})", job.attempt),
+            JobState::Failed => format!(
+                "Failed after {} attempt{}",
+                job.attempt,
+                if job.attempt == 1 { "" } else { "s" }
+            ),
+            JobState::Cancelled => "Cancelled".to_string(),
+            _ => "Finalized".to_string(),
+        };
+        events.push(JobTimelineEvent {
+            timestamp: finalized_at,
+            label,
+            state: Some(job.state),
+            detail: None,
+            is_error: false,
+        });
+    }
+
+    events.sort_by_key(|event| event.timestamp);
+    events
+}
+
+fn build_job_dump(job: JobRow) -> JobDump {
+    let latest_error = job
+        .errors
+        .as_ref()
+        .and_then(|errors| errors.last())
+        .cloned();
+    let summary = JobDumpSummary {
+        original_priority: original_priority(&job),
+        can_retry: matches!(
+            job.state,
+            JobState::Failed | JobState::Cancelled | JobState::WaitingExternal
+        ),
+        can_cancel: !job.state.is_terminal(),
+        error_count: job.errors.as_ref().map(|errors| errors.len()).unwrap_or(0),
+        latest_error,
+    };
+    let timeline = build_job_timeline(&job);
+    JobDump {
+        job,
+        summary,
+        timeline,
+    }
+}
+
+fn callback_dump(job: &JobRow) -> Option<CallbackDump> {
+    let callback = CallbackDump {
+        callback_id: job.callback_id,
+        callback_timeout_at: job.callback_timeout_at,
+        callback_filter: job.callback_filter.clone(),
+        callback_on_complete: job.callback_on_complete.clone(),
+        callback_on_fail: job.callback_on_fail.clone(),
+        callback_transform: job.callback_transform.clone(),
+    };
+    if callback.callback_id.is_none()
+        && callback.callback_timeout_at.is_none()
+        && callback.callback_filter.is_none()
+        && callback.callback_on_complete.is_none()
+        && callback.callback_on_fail.is_none()
+        && callback.callback_transform.is_none()
+    {
+        None
+    } else {
+        Some(callback)
+    }
+}
+
 /// Retry a single failed, cancelled, or waiting_external job.
 pub async fn retry<'e, E>(executor: E, job_id: i64) -> Result<Option<JobRow>, AwaError>
 where
@@ -804,6 +1033,146 @@ where
         .await?;
 
     row.ok_or(AwaError::JobNotFound { id: job_id })
+}
+
+/// Build a read-only inspection snapshot for one job.
+pub async fn dump_job<'e, E>(executor: E, job_id: i64) -> Result<JobDump, AwaError>
+where
+    E: PgExecutor<'e>,
+{
+    let job = get_job(executor, job_id).await?;
+    Ok(build_job_dump(job))
+}
+
+/// Build a read-only inspection snapshot for one attempt.
+///
+/// Awa does not currently persist a standalone runs table. The current attempt
+/// is inspected from the live job row. Historical attempts are reconstructed
+/// from the structured `errors[]` history.
+pub async fn dump_run<'e, E>(
+    executor: E,
+    job_id: i64,
+    attempt: Option<i16>,
+) -> Result<RunDump, AwaError>
+where
+    E: PgExecutor<'e>,
+{
+    let job = get_job(executor, job_id).await?;
+    let selected_attempt = attempt.unwrap_or(job.attempt);
+
+    if selected_attempt < 0 {
+        return Err(AwaError::Validation("attempt must be >= 0".to_string()));
+    }
+
+    if job.attempt == 0 {
+        if selected_attempt != 0 {
+            return Err(AwaError::Validation(format!(
+                "job {job_id} has not started yet; only attempt 0 is available"
+            )));
+        }
+        return Ok(RunDump {
+            job_id: job.id,
+            kind: job.kind.clone(),
+            queue: job.queue.clone(),
+            selected_attempt,
+            current_attempt: job.attempt,
+            current_run_lease: job.run_lease,
+            selected_run_lease: Some(job.run_lease),
+            source: RunDumpSource::CurrentJobRow,
+            state: job.state,
+            started_at: job.attempted_at,
+            finished_at: job.finalized_at,
+            error: None,
+            terminal: None,
+            progress: job.progress.clone(),
+            metadata: Some(job.metadata.clone()),
+            callback: callback_dump(&job),
+            raw_error_entry: None,
+            notes: vec!["Job has not been claimed yet; attempt 0 is the pre-run snapshot.".into()],
+        });
+    }
+
+    if selected_attempt == job.attempt {
+        let latest_error = job
+            .errors
+            .as_ref()
+            .into_iter()
+            .flatten()
+            .filter_map(parse_error_entry)
+            .find(|entry| entry.attempt == Some(selected_attempt));
+        return Ok(RunDump {
+            job_id: job.id,
+            kind: job.kind.clone(),
+            queue: job.queue.clone(),
+            selected_attempt,
+            current_attempt: job.attempt,
+            current_run_lease: job.run_lease,
+            selected_run_lease: Some(job.run_lease),
+            source: RunDumpSource::CurrentJobRow,
+            state: job.state,
+            started_at: job.attempted_at,
+            finished_at: if job.state.is_terminal() {
+                job.finalized_at
+            } else {
+                None
+            },
+            error: latest_error.as_ref().and_then(|entry| entry.error.clone()),
+            terminal: latest_error.as_ref().map(|entry| entry.terminal),
+            progress: job.progress.clone(),
+            metadata: Some(job.metadata.clone()),
+            callback: callback_dump(&job),
+            raw_error_entry: latest_error.map(|entry| entry.raw),
+            notes: vec![],
+        });
+    }
+
+    if selected_attempt == 0 || selected_attempt > job.attempt {
+        return Err(AwaError::Validation(format!(
+            "attempt {selected_attempt} is not available for job {job_id}; current attempt is {}",
+            job.attempt
+        )));
+    }
+
+    let historical = job
+        .errors
+        .as_ref()
+        .into_iter()
+        .flatten()
+        .filter_map(parse_error_entry)
+        .find(|entry| entry.attempt == Some(selected_attempt))
+        .ok_or_else(|| {
+            AwaError::Validation(format!(
+                "attempt {selected_attempt} is not present in the recorded error history for job {job_id}"
+            ))
+        })?;
+
+    Ok(RunDump {
+        job_id: job.id,
+        kind: job.kind.clone(),
+        queue: job.queue.clone(),
+        selected_attempt,
+        current_attempt: job.attempt,
+        current_run_lease: job.run_lease,
+        selected_run_lease: None,
+        source: RunDumpSource::ErrorHistory,
+        state: if historical.terminal {
+            JobState::Failed
+        } else {
+            JobState::Retryable
+        },
+        started_at: None,
+        finished_at: historical.at,
+        error: historical.error,
+        terminal: Some(historical.terminal),
+        progress: None,
+        metadata: None,
+        callback: None,
+        raw_error_entry: Some(historical.raw),
+        notes: vec![
+            "Historical attempts are reconstructed from errors[] because Awa does not persist a standalone runs table.".into(),
+            "Only the current attempt has live progress, callback, and metadata fields.".into(),
+        ],
+    })
 }
 
 /// Count jobs grouped by state.

--- a/docs/getting-started-python.md
+++ b/docs/getting-started-python.md
@@ -2,6 +2,17 @@
 
 This guide takes you from `pip install` to a job reaching `completed`.
 
+## Mental Model
+
+Before the code, here is the operational model Awa is built around:
+
+- inserting a job writes a durable row to Postgres, so enqueueing can live inside the same transaction as your application write
+- workers claim that row when it becomes runnable, heartbeat while it is executing, and rescue it if the worker dies
+- retries, callback waits, and progress checkpoints are persisted back onto the job row instead of being held only in memory
+- when you debug or operate the system, inspect the row first; the CLI and UI are designed around that read-only inspection path
+
+That means “what happened?” is usually a database inspection question, not a worker-log archaeology exercise.
+
 ## Prerequisites
 
 - PostgreSQL running locally or remotely
@@ -91,9 +102,13 @@ job 1 state = JobState.Completed
 
 ```bash
 awa --database-url "$DATABASE_URL" job list --queue email
+awa --database-url "$DATABASE_URL" job dump 1
+awa --database-url "$DATABASE_URL" job dump-run 1
 awa --database-url "$DATABASE_URL" queue stats
 awa --database-url "$DATABASE_URL" serve
 ```
+
+`job dump` gives you the whole job snapshot as JSON. `job dump-run` focuses on one attempt: the current attempt uses live row data, while historical attempts are reconstructed from the stored `errors[]` history.
 
 The UI starts on `http://127.0.0.1:3000` by default.
 

--- a/docs/getting-started-rust.md
+++ b/docs/getting-started-rust.md
@@ -2,6 +2,17 @@
 
 This guide takes you from `cargo add` to a job reaching `completed`.
 
+## Mental Model
+
+Before writing code, it helps to know what Awa is doing for you:
+
+- enqueueing inserts a durable row into Postgres; if your transaction rolls back, the job disappears too
+- workers claim runnable rows, increment the attempt, and keep the claim alive with heartbeats
+- retries, callback waits, and progress updates all land back on that same job row
+- inspection is row-centric: when something looks wrong, dump the job and inspect its current state, progress, callback config, and recorded errors
+
+The important habit is to treat Postgres as the system of record for job execution, not worker memory.
+
 ## Prerequisites
 
 - PostgreSQL running locally or remotely
@@ -123,9 +134,13 @@ Then inspect what happened:
 
 ```bash
 awa --database-url "$DATABASE_URL" job list --queue email
+awa --database-url "$DATABASE_URL" job dump 1
+awa --database-url "$DATABASE_URL" job dump-run 1
 awa --database-url "$DATABASE_URL" queue stats
 awa --database-url "$DATABASE_URL" serve
 ```
+
+`job dump` prints the full job snapshot as JSON. `job dump-run` prints one attempt-oriented view: the current attempt comes from the live job row, while older attempts are reconstructed from the recorded error history.
 
 The UI starts on `http://127.0.0.1:3000` by default.
 


### PR DESCRIPTION
## Summary
- teach the higher-level Awa mental model in the top-level and language quickstarts
- add read-only job and run inspection snapshots in the admin layer
- expose `awa job dump` and `awa job dump-run` with integration coverage for current, historical, and retry-reset attempts
- preserve historical `dump-run --attempt N` inspection after `admin::retry` resets the live row back to attempt `0`

## Testing
- cargo fmt --all
- SQLX_OFFLINE=true cargo clippy --all-targets --all-features -- -D warnings
- SQLX_OFFLINE=true cargo build --workspace
- cargo test -p awa-cli --test inspection_cli_test
- cargo test -p awa-model -p awa-cli