### PR TITLE
[codex] Stabilize nightly chaos benchmarks

### DIFF
--- a/.github/workflows/nightly-chaos.yml
+++ b/.github/workflows/nightly-chaos.yml
@@ -99,7 +99,9 @@ jobs:
             | tee artifacts/nightly/rust-scheduled-2m-4k.txt
       - name: Run failure-mode benchmark matrix
         if: always()
-        timeout-minutes: 10
+        timeout-minutes: 30
+        env:
+          AWA_BENCH_TIMEOUT_MULTIPLIER: "3"
         continue-on-error: true
         run: |
           set -o pipefail

--- a/awa/tests/chaos_suite_test.rs
+++ b/awa/tests/chaos_suite_test.rs
@@ -338,15 +338,25 @@ async fn run_python_helper(mode: &str, queue: &str, extra_env: &[(&str, String)]
 }
 
 async fn current_leader_backend_pid(pool: &sqlx::PgPool) -> Option<i32> {
+    // Keep this in sync with awa-worker/src/maintenance.rs::LOCK_KEY.
+    const LEADER_LOCK_KEY: i64 = 0x_4157_415f_4d41_494e;
+    const LEADER_LOCK_CLASSID: i32 = ((LEADER_LOCK_KEY >> 32) & 0xffff_ffff) as i32;
+    const LEADER_LOCK_OBJID: i32 = (LEADER_LOCK_KEY & 0xffff_ffff) as i32;
+
     let rows: Vec<(i32,)> = sqlx::query_as(
         r#"
-        SELECT pid
+        SELECT DISTINCT pid
         FROM pg_locks
         WHERE locktype = 'advisory'
           AND granted
+          AND classid = $1
+          AND objid = $2
+          AND objsubid = 1
         ORDER BY pid
         "#,
     )
+    .bind(LEADER_LOCK_CLASSID)
+    .bind(LEADER_LOCK_OBJID)
     .fetch_all(pool)
     .await
     .expect("Failed to query advisory lock holders");

--- a/awa/tests/failure_benchmark_test.rs
+++ b/awa/tests/failure_benchmark_test.rs
@@ -43,6 +43,24 @@ async fn setup(max_conns: u32) -> sqlx::PgPool {
     pool
 }
 
+fn benchmark_timeout_multiplier() -> f64 {
+    if let Ok(raw) = std::env::var("AWA_BENCH_TIMEOUT_MULTIPLIER") {
+        if let Ok(parsed) = raw.parse::<f64>() {
+            return parsed.max(1.0);
+        }
+    }
+
+    if std::env::var_os("CI").is_some() {
+        1.5
+    } else {
+        1.0
+    }
+}
+
+fn scaled_timeout(timeout: Duration) -> Duration {
+    timeout.mul_f64(benchmark_timeout_multiplier())
+}
+
 async fn reset_runtime_state(pool: &sqlx::PgPool) {
     sqlx::query(
         "TRUNCATE awa.jobs_hot, awa.scheduled_jobs, awa.queue_meta, awa.job_unique_claims RESTART IDENTITY CASCADE",
@@ -302,7 +320,7 @@ async fn run_scenario(pool: &sqlx::PgPool, config: &ScenarioConfig) {
     // Wait for all jobs to reach terminal states
     // Scenarios with deadline_hang or callback_timeout need extra time for
     // rescue cycles; 180s is generous enough for the full mixed matrix.
-    let timeout = Duration::from_secs(180);
+    let timeout = scaled_timeout(Duration::from_secs(180));
     let deadline = Instant::now() + timeout;
     loop {
         let counts = queue_state_counts(pool, &queue).await;
@@ -715,7 +733,7 @@ async fn test_failure_bench_stale_heartbeat_rescue() {
     client.start().await.expect("Failed to start client");
 
     // Wait for all jobs to reach completed
-    let timeout = Duration::from_secs(60);
+    let timeout = scaled_timeout(Duration::from_secs(60));
     let deadline = Instant::now() + timeout;
     loop {
         let counts = queue_state_counts(&pool, queue).await;

--- a/awa/tests/scheduling_benchmark_test.rs
+++ b/awa/tests/scheduling_benchmark_test.rs
@@ -76,7 +76,26 @@ async fn clean_cron_names(pool: &sqlx::PgPool, names: &[String]) {
     }
 }
 
+fn benchmark_timeout_multiplier() -> f64 {
+    if let Ok(raw) = std::env::var("AWA_BENCH_TIMEOUT_MULTIPLIER") {
+        if let Ok(parsed) = raw.parse::<f64>() {
+            return parsed.max(1.0);
+        }
+    }
+
+    if std::env::var_os("CI").is_some() {
+        3.0
+    } else {
+        1.0
+    }
+}
+
+fn scaled_timeout(timeout: Duration) -> Duration {
+    timeout.mul_f64(benchmark_timeout_multiplier())
+}
+
 async fn wait_for_leader(client: &Client, timeout: Duration) {
+    let timeout = scaled_timeout(timeout);
     let start = Instant::now();
     loop {
         let health = client.health_check().await;
@@ -92,6 +111,7 @@ async fn wait_for_leader(client: &Client, timeout: Duration) {
 }
 
 async fn wait_for_dispatch(client: &Client, timeout: Duration) {
+    let timeout = scaled_timeout(timeout);
     let start = Instant::now();
     loop {
         let health = client.health_check().await;


### PR DESCRIPTION
## Summary
- narrow the chaos-suite leader PID helper to the actual Awa maintenance advisory lock
- add CI-aware timeout scaling to scheduling and failure benchmark tests
- raise the nightly failure-matrix step timeout and set a higher benchmark timeout multiplier for that step

## Root Cause
Issue #154 ended up being two separate nightly problems:

1. The April 9 Python nightly deadlock matched the heartbeat/completion deadlock fixed in #155.
2. The remaining Rust nightly failures were dominated by benchmark and chaos-lane timing sensitivity:
   - the chaos-suite helper was querying all advisory locks instead of the Awa leader-election lock
   - several benchmark waits used fixed internal timeouts that were too tight for the nightly lane
   - the nightly failure-matrix workflow step itself did not give the full mixed matrix enough time on slower runners

## Impact
- leader failover checks no longer depend on unrelated advisory locks in Postgres
- scheduling and failure benchmark tests have room to complete on CI without loosening local defaults too much
- the nightly failure matrix now runs with workflow settings that match the observed runtime of the rescue-heavy scenarios

## Validation
- `CI=1 DATABASE_URL=postgres://postgres:postgres@localhost:5432/awa_test cargo test --package awa --test chaos_suite_test test_leader_failover_rescues_callback_timeouts -- --exact --ignored --nocapture`
- `DATABASE_URL=postgres://postgres:postgres@localhost:5432/awa_test cargo test --package awa --test scheduling_benchmark_test test_scheduled_steady_2m_due_4k_per_sec -- --exact --ignored --nocapture`
- `DATABASE_URL=postgres://postgres:postgres@localhost:5432/awa_test cargo test --package awa --test failure_benchmark_test test_failure_bench_stale_heartbeat_rescue -- --exact --ignored --nocapture`
- `CI=1 AWA_BENCH_TIMEOUT_MULTIPLIER=3 DATABASE_URL=postgres://postgres:postgres@localhost:5432/awa_test cargo test --package awa --test failure_benchmark_test test_failure_bench_full_matrix -- --exact --ignored --nocapture`

Issue: #154