### PR TITLE
Bake the frontend into release artifacts; add smoke tests

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,29 +27,52 @@ jobs:
       - uses: actions/checkout@v4
       - name: Tag matches Cargo.toml versions
         shell: bash
+        # Real TOML parse via stdlib `tomllib` (Python 3.11+). Ubuntu runners
+        # ship Python ≥3.12, so no install step needed. `grep` worked for the
+        # current layout but is brittle against future drift (multi-line
+        # strings, commented lines, a stray `version = ...` in a sibling
+        # table).
         run: |
           set -euo pipefail
-          tag="${GITHUB_REF_NAME}"
-          # Strip leading "v" — Cargo versions don't carry the prefix.
-          expected="${tag#v}"
-          echo "Git tag:          ${tag}"
-          echo "Expected version: ${expected}"
+          python3 - <<'PY'
+          import os, sys, tomllib
 
-          ws=$(grep -m1 '^version' Cargo.toml | cut -d'"' -f2)
-          py=$(grep -m1 '^version' awa-python/Cargo.toml | cut -d'"' -f2)
-          pyproj=$(grep -m1 '^version' awa-python/pyproject.toml | cut -d'"' -f2)
+          expected = os.environ["GITHUB_REF_NAME"].removeprefix("v")
+          print(f"Git tag:          {os.environ['GITHUB_REF_NAME']}")
+          print(f"Expected version: {expected}")
 
-          fail=0
-          for pair in "Cargo.toml=${ws}" "awa-python/Cargo.toml=${py}" "awa-python/pyproject.toml=${pyproj}"; do
-            file="${pair%%=*}"; value="${pair#*=}"
-            if [ "${value}" != "${expected}" ]; then
-              echo "::error file=${file}::version mismatch: ${file} says '${value}', tag says '${expected}'"
-              fail=1
-            else
-              echo "ok: ${file} = ${value}"
-            fi
-          done
-          exit ${fail}
+          def cargo_version(path: str) -> str | None:
+              with open(path, "rb") as f:
+                  data = tomllib.load(f)
+              return (
+                  data.get("package", {}).get("version")
+                  or data.get("workspace", {}).get("package", {}).get("version")
+              )
+
+          def pyproject_version(path: str) -> str | None:
+              with open(path, "rb") as f:
+                  data = tomllib.load(f)
+              return data.get("project", {}).get("version")
+
+          checks = [
+              ("Cargo.toml", cargo_version("Cargo.toml")),
+              ("awa-python/Cargo.toml", cargo_version("awa-python/Cargo.toml")),
+              ("awa-python/pyproject.toml", pyproject_version("awa-python/pyproject.toml")),
+          ]
+
+          fail = 0
+          for file, value in checks:
+              if value is None:
+                  print(f"::error file={file}::could not read version from {file}")
+                  fail = 1
+              elif value != expected:
+                  print(f"::error file={file}::version mismatch: {file} says '{value}', tag says '{expected}'")
+                  fail = 1
+              else:
+                  print(f"ok: {file} = {value}")
+
+          sys.exit(fail)
+          PY
 
   # ─── Cross-compile CLI binaries ──────────────────────────────────────
   build-binaries:
@@ -119,9 +142,16 @@ jobs:
         run: |
           set -euo pipefail
           test -f awa-ui/static/index.html
-          # Fail early if the built index is empty or shorter than our placeholder,
-          # which would silently ship a broken UI.
-          [ "$(wc -c < awa-ui/static/index.html)" -gt 200 ]
+          # Vite emits hashed asset references; their absence means the build
+          # produced a degenerate index (or didn't run).
+          if ! grep -q '/assets/' awa-ui/static/index.html; then
+            echo "::error::awa-ui/static/index.html does not reference /assets/* — Vite build produced no frontend bundle"
+            cat awa-ui/static/index.html
+            exit 1
+          fi
+          test -d awa-ui/static/assets
+          ls awa-ui/static/assets/ | grep -q '\.js$'
+          ls awa-ui/static/assets/ | grep -q '\.css$'
 
       - name: Build (native)
         if: matrix.target != 'aarch64-unknown-linux-musl'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -431,6 +431,7 @@ jobs:
   # ─── Python wheels (maturin) ─────────────────────────────────────────
   python-wheels:
     name: Python wheels — ${{ matrix.target }}
+    needs: [version-check]
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -170,10 +170,19 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          # Single trap covers every failure path — serve may not be started
+          # yet when we exit (migrate failure, pg startup timeout), so guard
+          # the kill with :-.
+          serve_pid=
+          cleanup() {
+            [ -n "${serve_pid}" ] && kill "${serve_pid}" 2>/dev/null || true
+            docker rm -f awa-smoke-pg >/dev/null 2>&1 || true
+          }
+          trap cleanup EXIT
+
           docker run -d --name awa-smoke-pg \
             -e POSTGRES_PASSWORD=test -e POSTGRES_DB=awa_test \
             -p 15432:5432 postgres:17-alpine
-          trap 'docker rm -f awa-smoke-pg >/dev/null' EXIT
           for _ in $(seq 1 30); do
             if docker exec awa-smoke-pg pg_isready -U postgres >/dev/null 2>&1; then break; fi
             sleep 1
@@ -184,7 +193,6 @@ jobs:
           "${bin}" --database-url "${DATABASE_URL}" migrate
           "${bin}" --database-url "${DATABASE_URL}" serve --host 127.0.0.1 --port 3000 &
           serve_pid=$!
-          trap 'kill ${serve_pid} 2>/dev/null || true; docker rm -f awa-smoke-pg >/dev/null' EXIT
 
           for _ in $(seq 1 30); do
             if curl -sf http://127.0.0.1:3000/api/capabilities >/dev/null; then break; fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -628,8 +628,16 @@ jobs:
       - name: Wait for index
         run: sleep 30
 
+      # `npm run build` earlier in this job empties `awa-ui/static/` and
+      # removes the tracked `.gitkeep` (Vite's `emptyOutDir: true`), and
+      # re-populates it with the real bundle. That leaves the working tree
+      # dirty at publish time — which is exactly what we want, since the
+      # built bundle IS what we're shipping. `--allow-dirty` is how cargo
+      # consents to that; the `include` list in `awa-ui/Cargo.toml` is what
+      # actually gets the bundle into the .crate file (gitignored paths are
+      # otherwise skipped for git-backed packages).
       - name: Publish awa-ui
-        run: cargo publish --package awa-ui --no-verify
+        run: cargo publish --package awa-ui --no-verify --allow-dirty
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,9 +16,45 @@ permissions:
   attestations: write
 
 jobs:
+  # ─── Version-consistency gate ────────────────────────────────────────
+  # Runs first and gates everything else. A mismatch between the git tag
+  # and the workspace Cargo.toml version means the published crates/wheels
+  # will disagree with the GitHub release / Docker tag — fail early.
+  version-check:
+    name: Verify version consistency
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Tag matches Cargo.toml versions
+        shell: bash
+        run: |
+          set -euo pipefail
+          tag="${GITHUB_REF_NAME}"
+          # Strip leading "v" — Cargo versions don't carry the prefix.
+          expected="${tag#v}"
+          echo "Git tag:          ${tag}"
+          echo "Expected version: ${expected}"
+
+          ws=$(grep -m1 '^version' Cargo.toml | cut -d'"' -f2)
+          py=$(grep -m1 '^version' awa-python/Cargo.toml | cut -d'"' -f2)
+          pyproj=$(grep -m1 '^version' awa-python/pyproject.toml | cut -d'"' -f2)
+
+          fail=0
+          for pair in "Cargo.toml=${ws}" "awa-python/Cargo.toml=${py}" "awa-python/pyproject.toml=${pyproj}"; do
+            file="${pair%%=*}"; value="${pair#*=}"
+            if [ "${value}" != "${expected}" ]; then
+              echo "::error file=${file}::version mismatch: ${file} says '${value}', tag says '${expected}'"
+              fail=1
+            else
+              echo "ok: ${file} = ${value}"
+            fi
+          done
+          exit ${fail}
+
   # ─── Cross-compile CLI binaries ──────────────────────────────────────
   build-binaries:
     name: Build — ${{ matrix.target }}
+    needs: [version-check]
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -62,6 +98,31 @@ jobs:
         if: matrix.target == 'aarch64-unknown-linux-musl'
         run: cargo install cross --git https://github.com/cross-rs/cross --tag v0.2.5 --locked
 
+      # Frontend must be built before cargo so rust-embed in awa-ui picks it up.
+      # Without this the binary ships the "Frontend not built" placeholder (#162).
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+          cache-dependency-path: awa-ui/frontend/package-lock.json
+
+      - name: Install frontend dependencies
+        working-directory: awa-ui/frontend
+        run: npm ci
+
+      - name: Build frontend
+        working-directory: awa-ui/frontend
+        run: npm run build
+
+      - name: Verify frontend was embedded
+        shell: bash
+        run: |
+          set -euo pipefail
+          test -f awa-ui/static/index.html
+          # Fail early if the built index is empty or shorter than our placeholder,
+          # which would silently ship a broken UI.
+          [ "$(wc -c < awa-ui/static/index.html)" -gt 200 ]
+
       - name: Build (native)
         if: matrix.target != 'aarch64-unknown-linux-musl'
         run: cargo build --release --package awa-cli --target ${{ matrix.target }}
@@ -69,6 +130,58 @@ jobs:
       - name: Build (cross)
         if: matrix.target == 'aarch64-unknown-linux-musl'
         run: cross build --release --package awa-cli --target ${{ matrix.target }}
+
+      # Smoke-test the binary: start `awa serve` against an ephemeral Postgres
+      # and verify GET / returns the built frontend, not the placeholder page.
+      # Runs only on the x86_64 Linux job — the binary from aarch64-musl cross
+      # cannot execute on the runner, and macOS runners don't have Docker.
+      - name: Smoke-test embedded frontend
+        if: matrix.target == 'x86_64-unknown-linux-musl'
+        shell: bash
+        run: |
+          set -euo pipefail
+          docker run -d --name awa-smoke-pg \
+            -e POSTGRES_PASSWORD=test -e POSTGRES_DB=awa_test \
+            -p 15432:5432 postgres:17-alpine
+          trap 'docker rm -f awa-smoke-pg >/dev/null' EXIT
+          for _ in $(seq 1 30); do
+            if docker exec awa-smoke-pg pg_isready -U postgres >/dev/null 2>&1; then break; fi
+            sleep 1
+          done
+
+          DATABASE_URL="postgres://postgres:test@localhost:15432/awa_test"
+          bin="target/${{ matrix.target }}/release/awa"
+          "${bin}" --database-url "${DATABASE_URL}" migrate
+          "${bin}" --database-url "${DATABASE_URL}" serve --host 127.0.0.1 --port 3000 &
+          serve_pid=$!
+          trap 'kill ${serve_pid} 2>/dev/null || true; docker rm -f awa-smoke-pg >/dev/null' EXIT
+
+          for _ in $(seq 1 30); do
+            if curl -sf http://127.0.0.1:3000/api/capabilities >/dev/null; then break; fi
+            sleep 1
+          done
+
+          body=$(curl -sf http://127.0.0.1:3000/)
+          if echo "${body}" | grep -qi "Frontend not built"; then
+            echo "::error::awa serve is returning the placeholder page — the frontend was not embedded"
+            echo "${body}"
+            exit 1
+          fi
+          if ! echo "${body}" | grep -q "/assets/"; then
+            echo "::error::awa serve / did not reference any /assets/* paths — the embedded frontend looks wrong"
+            echo "${body}"
+            exit 1
+          fi
+          echo "ok: embedded frontend reachable via GET /"
+
+          # And while we're here, sanity-check `awa --version` reports the tag.
+          awa_version=$("${bin}" --version | awk '{print $NF}')
+          expected="${GITHUB_REF_NAME#v}"
+          if [ "${awa_version}" != "${expected}" ]; then
+            echo "::error::awa --version '${awa_version}' does not match tag '${expected}'"
+            exit 1
+          fi
+          echo "ok: awa --version = ${awa_version}"
 
       - name: Package binary
         if: matrix.release_asset
@@ -146,7 +259,73 @@ jobs:
       - uses: docker/setup-qemu-action@v4
       - uses: docker/setup-buildx-action@v4
 
-      - name: Build and push
+      # Smoke-test BEFORE pushing so a broken image never lands in the registry.
+      # We build a local single-platform (amd64) image, boot it against an
+      # ephemeral Postgres, and verify GET / returns the embedded frontend,
+      # not the "Frontend not built" placeholder (#162). We also check
+      # `awa --version` matches the git tag.
+      - name: Build local image for smoke test
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: docker/Dockerfile.runtime
+          push: false
+          load: true
+          platforms: linux/amd64
+          tags: awa:smoke
+
+      - name: Smoke-test local image
+        shell: bash
+        run: |
+          set -euo pipefail
+          expected="${GITHUB_REF_NAME#v}"
+          image="awa:smoke"
+
+          docker network create awa-smoke >/dev/null
+          trap 'docker rm -f awa-smoke-pg awa-smoke-app >/dev/null 2>&1 || true; docker network rm awa-smoke >/dev/null 2>&1 || true' EXIT
+
+          docker run -d --name awa-smoke-pg --network awa-smoke \
+            -e POSTGRES_PASSWORD=test -e POSTGRES_DB=awa_test \
+            postgres:17-alpine >/dev/null
+          for _ in $(seq 1 30); do
+            if docker exec awa-smoke-pg pg_isready -U postgres >/dev/null 2>&1; then break; fi
+            sleep 1
+          done
+
+          DATABASE_URL="postgres://postgres:test@awa-smoke-pg:5432/awa_test"
+          docker run --rm --network awa-smoke \
+            "${image}" --database-url "${DATABASE_URL}" migrate
+
+          docker run -d --name awa-smoke-app --network awa-smoke \
+            -p 3000:3000 \
+            "${image}" --database-url "${DATABASE_URL}" serve --host 0.0.0.0 --port 3000 >/dev/null
+
+          for _ in $(seq 1 30); do
+            if curl -sf http://127.0.0.1:3000/api/capabilities >/dev/null; then break; fi
+            sleep 1
+          done
+
+          body=$(curl -sf http://127.0.0.1:3000/)
+          if echo "${body}" | grep -qi "Frontend not built"; then
+            echo "::error::Docker image serves the placeholder page — the frontend was not embedded"
+            echo "${body}"
+            docker logs awa-smoke-app || true
+            exit 1
+          fi
+          if ! echo "${body}" | grep -q "/assets/"; then
+            echo "::error::Docker image GET / did not reference /assets/* — embedded frontend looks wrong"
+            echo "${body}"
+            exit 1
+          fi
+
+          awa_version=$(docker run --rm "${image}" --version | awk '{print $NF}')
+          if [ "${awa_version}" != "${expected}" ]; then
+            echo "::error::Docker awa --version '${awa_version}' does not match tag '${expected}'"
+            exit 1
+          fi
+          echo "ok: ${image} serves built frontend and reports version ${awa_version}"
+
+      - name: Build and push (multi-arch)
         id: build-and-push
         uses: docker/build-push-action@v6
         with:
@@ -265,6 +444,7 @@ jobs:
   # ─── CLI wheels (maturin, bindings=bin) ──────────────────────────────
   cli-wheels:
     name: CLI wheels — ${{ matrix.target }}
+    needs: [version-check]
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -286,6 +466,39 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
+
+      # Frontend must be built before maturin invokes cargo so rust-embed in
+      # awa-ui picks it up — the CLI wheel otherwise ships the "Frontend not
+      # built" placeholder (#162).
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+          cache-dependency-path: awa-ui/frontend/package-lock.json
+
+      - name: Install frontend dependencies
+        working-directory: awa-ui/frontend
+        run: npm ci
+
+      - name: Build frontend
+        working-directory: awa-ui/frontend
+        run: npm run build
+
+      - name: Verify frontend was embedded
+        shell: bash
+        run: |
+          set -euo pipefail
+          test -f awa-ui/static/index.html
+          # Vite emits hashed asset references; their absence means the build
+          # produced a degenerate index (or didn't run).
+          if ! grep -q '/assets/' awa-ui/static/index.html; then
+            echo "::error::awa-ui/static/index.html does not reference /assets/* — Vite build produced no frontend bundle"
+            cat awa-ui/static/index.html
+            exit 1
+          fi
+          test -d awa-ui/static/assets
+          ls awa-ui/static/assets/ | grep -q '\.js$'
+          ls awa-ui/static/assets/ | grep -q '\.css$'
 
       - name: Build CLI wheels
         uses: PyO3/maturin-action@v1
@@ -343,10 +556,45 @@ jobs:
   # ─── Publish Rust crates ─────────────────────────────────────────────
   publish-crates:
     name: Publish to crates.io
+    needs: [version-check]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
+
+      # awa-ui embeds `awa-ui/static/` via rust-embed; without building the
+      # frontend first, the crate published to crates.io carries no assets and
+      # every downstream `cargo install awa-cli` bakes in the placeholder HTML
+      # (#162).
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+          cache-dependency-path: awa-ui/frontend/package-lock.json
+
+      - name: Install frontend dependencies
+        working-directory: awa-ui/frontend
+        run: npm ci
+
+      - name: Build frontend
+        working-directory: awa-ui/frontend
+        run: npm run build
+
+      - name: Verify frontend was embedded
+        shell: bash
+        run: |
+          set -euo pipefail
+          test -f awa-ui/static/index.html
+          # Vite emits hashed asset references; their absence means the build
+          # produced a degenerate index (or didn't run).
+          if ! grep -q '/assets/' awa-ui/static/index.html; then
+            echo "::error::awa-ui/static/index.html does not reference /assets/* — Vite build produced no frontend bundle"
+            cat awa-ui/static/index.html
+            exit 1
+          fi
+          test -d awa-ui/static/assets
+          ls awa-ui/static/assets/ | grep -q '\.js$'
+          ls awa-ui/static/assets/ | grep -q '\.css$'
 
       - name: Publish awa-macros
         run: cargo publish --package awa-macros --no-verify

--- a/awa-cli/src/main.rs
+++ b/awa-cli/src/main.rs
@@ -4,7 +4,11 @@ use clap::{Parser, Subcommand};
 use sqlx::postgres::PgPoolOptions;
 
 #[derive(Parser)]
-#[command(name = "awa", about = "Awa — Postgres-native background job queue")]
+#[command(
+    name = "awa",
+    version,
+    about = "Awa — Postgres-native background job queue"
+)]
 struct Cli {
     /// Database URL (not required for migrate --sql without --pending)
     #[arg(long, env = "DATABASE_URL")]

--- a/awa-python/tests/test_callback_edge_cases.py
+++ b/awa-python/tests/test_callback_edge_cases.py
@@ -19,6 +19,23 @@ import pytest
 
 import awa
 
+
+def _timeout_multiplier() -> float:
+    """CI runners are slower and loaded — scale generously so timeouts
+    reflect the real budget for the work, not the runner's throughput.
+    Matches the pattern used in test_chaos_recovery.py."""
+    raw = os.environ.get("AWA_CHAOS_TIMEOUT_MULTIPLIER")
+    if raw is not None:
+        try:
+            return max(float(raw), 1.0)
+        except ValueError:
+            pass
+    return 3.0 if os.environ.get("CI") else 1.0
+
+
+def _scaled(timeout: float) -> float:
+    return timeout * _timeout_multiplier()
+
 DATABASE_URL = os.environ.get(
     "DATABASE_URL", "postgres://postgres:test@localhost:15432/awa_test"
 )
@@ -63,7 +80,7 @@ async def _setup_waiting_job(client, queue: str, order_id: int, **insert_kwargs)
         leader_election_interval_ms=100,
     )
     # Wait for handler to register callback
-    deadline = asyncio.get_event_loop().time() + 5
+    deadline = asyncio.get_event_loop().time() + _scaled(5)
     while not callback_ids and asyncio.get_event_loop().time() < deadline:
         await asyncio.sleep(0.1)
     await client.shutdown()
@@ -294,7 +311,7 @@ async def test_stale_callback_rejected_after_rescue(client):
 
     # Run first attempt → parks in waiting_external
     await client.start([(queue, 1)], poll_interval_ms=50, leader_election_interval_ms=100)
-    deadline = asyncio.get_event_loop().time() + 5
+    deadline = asyncio.get_event_loop().time() + _scaled(5)
     while not callback_ids and asyncio.get_event_loop().time() < deadline:
         await asyncio.sleep(0.1)
     await client.shutdown()
@@ -312,7 +329,7 @@ async def test_stale_callback_rejected_after_rescue(client):
         promote_interval_ms=100,
         leader_election_interval_ms=100,
     )
-    deadline = asyncio.get_event_loop().time() + 5
+    deadline = asyncio.get_event_loop().time() + _scaled(5)
     while len(attempts) < 2 and asyncio.get_event_loop().time() < deadline:
         await asyncio.sleep(0.1)
     await client.shutdown()
@@ -362,7 +379,7 @@ async def test_callback_timeout_rescued_by_runtime(client):
     )
 
     # Wait for the job to go through: attempt 1 → timeout → rescue → attempt 2 → complete
-    deadline = asyncio.get_event_loop().time() + 10
+    deadline = asyncio.get_event_loop().time() + _scaled(10)
     while len(attempts) < 2 and asyncio.get_event_loop().time() < deadline:
         await asyncio.sleep(0.2)
     await client.shutdown()

--- a/awa-python/tests/test_chaos_recovery.py
+++ b/awa-python/tests/test_chaos_recovery.py
@@ -1,4 +1,5 @@
 import asyncio
+import contextlib
 import os
 import sys
 import uuid
@@ -183,9 +184,106 @@ async def test_callback_timeout_is_rescued_and_retried(client):
         await _stop_process(worker)
 
 
-async def _start_worker(
-    queue: str, role: str
-) -> asyncio.subprocess.Process:
+class ChaosWorker:
+    """Wraps a subprocess and continuously drains its stdout into an
+    in-memory list, so the test can match lines at its own pace without
+    the pipe backing up.
+
+    Why this exists: the worker prints heartbeat/maintenance/tracing
+    output at ~50+ lines/sec. Linux's default pipe capacity is 64 KiB —
+    roughly nine seconds of output. If the test matches an expected line
+    and then stops reading while it does a DB poll, the pipe fills, the
+    worker's next write blocks on stdout, and any tokio worker thread
+    holding the write-blocked logger stalls. With the completion batcher
+    on a blocked thread, a `running → completed` transition never gets
+    committed and the test times out. Draining in the background keeps
+    the pipe empty so writes never block.
+    """
+
+    def __init__(self, process: asyncio.subprocess.Process) -> None:
+        self.process = process
+        self.lines: list[str] = []
+        self._new_line = asyncio.Event()
+        self._closed = asyncio.Event()
+        self._drainer = asyncio.create_task(self._drain())
+
+    @property
+    def pid(self) -> int | None:
+        return self.process.pid
+
+    @property
+    def returncode(self) -> int | None:
+        return self.process.returncode
+
+    async def _drain(self) -> None:
+        assert self.process.stdout is not None
+        try:
+            while True:
+                line = await self.process.stdout.readline()
+                if not line:
+                    break
+                self.lines.append(line.decode().rstrip("\n"))
+                self._new_line.set()
+        finally:
+            self._closed.set()
+            self._new_line.set()
+
+    async def wait_for_line(self, expected: str, timeout: float) -> str:
+        """Return the first line (past or future) containing `expected`.
+
+        Keeps position by scanning from index 0 every call — acceptable
+        because `expected` markers embed PIDs / job IDs / attempt numbers
+        that are unique per test call.
+        """
+        async def scan() -> str:
+            cursor = 0
+            while True:
+                while cursor < len(self.lines):
+                    line = self.lines[cursor]
+                    cursor += 1
+                    if expected in line:
+                        return line
+                if self._closed.is_set() and cursor >= len(self.lines):
+                    raise AssertionError(
+                        "worker exited before emitting expected output.\n"
+                        + "\n".join(self.lines)
+                    )
+                self._new_line.clear()
+                await self._new_line.wait()
+
+        try:
+            return await asyncio.wait_for(scan(), timeout=scaled_timeout(timeout))
+        except TimeoutError as exc:
+            raise AssertionError(
+                f"timed out waiting for worker output: {expected}\n"
+                + "\n".join(self.lines)
+            ) from exc
+
+    def terminate(self) -> None:
+        if self.process.returncode is None:
+            self.process.terminate()
+
+    def kill(self) -> None:
+        if self.process.returncode is None:
+            self.process.kill()
+
+    async def wait(self) -> int:
+        return await self.process.wait()
+
+    async def shutdown(self) -> None:
+        if self.process.returncode is None:
+            self.terminate()
+            try:
+                await asyncio.wait_for(self.process.wait(), timeout=scaled_timeout(5))
+            except TimeoutError:
+                self.kill()
+                await asyncio.wait_for(self.process.wait(), timeout=scaled_timeout(5))
+        self._drainer.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await self._drainer
+
+
+async def _start_worker(queue: str, role: str) -> ChaosWorker:
     env = os.environ.copy()
     env.update(
         {
@@ -195,42 +293,18 @@ async def _start_worker(
             "PYTHONUNBUFFERED": "1",
         }
     )
-    return await asyncio.create_subprocess_exec(
+    process = await asyncio.create_subprocess_exec(
         sys.executable,
         str(WORKER_SCRIPT),
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.STDOUT,
         env=env,
     )
+    return ChaosWorker(process)
 
 
-async def _wait_for_line(
-    process: asyncio.subprocess.Process, expected: str, timeout: float
-) -> str:
-    if process.stdout is None:
-        raise AssertionError("worker process stdout was not captured")
-
-    seen: list[str] = []
-
-    async def read_until_match() -> str:
-        while True:
-            line = await process.stdout.readline()
-            if not line:
-                raise AssertionError(
-                    "worker exited before emitting expected output.\n"
-                    + "\n".join(seen)
-                )
-            text = line.decode().strip()
-            seen.append(text)
-            if expected in text:
-                return text
-
-    try:
-        return await asyncio.wait_for(read_until_match(), timeout=scaled_timeout(timeout))
-    except TimeoutError as exc:
-        raise AssertionError(
-            f"timed out waiting for worker output: {expected}\n" + "\n".join(seen)
-        ) from exc
+async def _wait_for_line(worker: ChaosWorker, expected: str, timeout: float) -> str:
+    return await worker.wait_for_line(expected, timeout)
 
 
 async def _wait_for_job_state(
@@ -264,13 +338,7 @@ async def _wait_for_job_state(
         await asyncio.sleep(0.2)
 
 
-async def _stop_process(process: asyncio.subprocess.Process | None) -> None:
-    if process is None or process.returncode is not None:
+async def _stop_process(worker: ChaosWorker | None) -> None:
+    if worker is None:
         return
-
-    process.terminate()
-    try:
-        await asyncio.wait_for(process.wait(), timeout=scaled_timeout(5))
-    except TimeoutError:
-        process.kill()
-        await asyncio.wait_for(process.wait(), timeout=scaled_timeout(5))
+    await worker.shutdown()

--- a/awa-python/tests/test_chaos_recovery.py
+++ b/awa-python/tests/test_chaos_recovery.py
@@ -88,7 +88,9 @@ async def test_worker_sigkill_job_is_rescued_and_completed(client):
             timeout=5,
         )
 
-        row = await _wait_for_job_state(client, job.id, "completed", timeout=10)
+        row = await _wait_for_job_state(
+            client, job.id, "completed", timeout=10, worker=worker_b
+        )
         assert row["attempt"] == 2
         assert row["finalized_at"] is not None
     finally:
@@ -135,7 +137,9 @@ async def test_worker_hang_is_cancelled_by_deadline_rescue_and_retried(client):
             timeout=5,
         )
 
-        row = await _wait_for_job_state(client, job.id, "completed", timeout=10)
+        row = await _wait_for_job_state(
+            client, job.id, "completed", timeout=10, worker=worker
+        )
         assert row["attempt"] == 2
         assert row["finalized_at"] is not None
     finally:
@@ -177,7 +181,9 @@ async def test_callback_timeout_is_rescued_and_retried(client):
             timeout=5,
         )
 
-        final_row = await _wait_for_job_state(client, job.id, "completed", timeout=10)
+        final_row = await _wait_for_job_state(
+            client, job.id, "completed", timeout=10, worker=worker
+        )
         assert final_row["attempt"] == 2
         assert final_row["finalized_at"] is not None
     finally:
@@ -308,7 +314,11 @@ async def _wait_for_line(worker: ChaosWorker, expected: str, timeout: float) -> 
 
 
 async def _wait_for_job_state(
-    client: awa.AsyncClient, job_id: int, expected_state: str, timeout: float
+    client: awa.AsyncClient,
+    job_id: int,
+    expected_state: str,
+    timeout: float,
+    worker: "ChaosWorker | None" = None,
 ):
     deadline = asyncio.get_running_loop().time() + scaled_timeout(timeout)
 
@@ -319,7 +329,11 @@ async def _wait_for_job_state(
             SELECT id,
                    state::text AS state,
                    attempt,
-                   finalized_at::text AS finalized_at
+                   run_lease,
+                   heartbeat_at::text AS heartbeat_at,
+                   deadline_at::text AS deadline_at,
+                   finalized_at::text AS finalized_at,
+                   EXTRACT(EPOCH FROM (now() - heartbeat_at))::float AS heartbeat_age_s
             FROM awa.jobs
             WHERE id = $1
             """,
@@ -331,9 +345,15 @@ async def _wait_for_job_state(
             return row
 
         if asyncio.get_running_loop().time() >= deadline:
-            raise AssertionError(
-                f"job {job_id} did not reach state {expected_state!r}: {row!r}"
-            )
+            diag = f"job {job_id} did not reach state {expected_state!r}: {row!r}"
+            if worker is not None:
+                tail = worker.lines[-40:]
+                diag += (
+                    f"\nworker pid={worker.pid} returncode={worker.returncode}"
+                    f" stdout_lines={len(worker.lines)}\n"
+                    "-- last 40 stdout lines --\n" + "\n".join(tail)
+                )
+            raise AssertionError(diag)
 
         await asyncio.sleep(0.2)
 

--- a/awa-ui/Cargo.toml
+++ b/awa-ui/Cargo.toml
@@ -6,6 +6,17 @@ license.workspace = true
 description = "Web UI and JSON API for the Awa job queue"
 repository.workspace = true
 readme = "README.md"
+# The built React bundle (`static/index.html`, `static/assets/*`) is
+# .gitignored for dev ergonomics, so cargo publish would skip it by default
+# and ship an awa-ui crate with no embedded frontend. Explicitly include the
+# built output here — release.yml runs `npm run build` before this crate is
+# packaged (see #162 / PR #163).
+include = [
+    "/src/**/*",
+    "/static/**/*",
+    "/Cargo.toml",
+    "/README.md",
+]
 
 [dependencies]
 awa-model.workspace = true

--- a/awa-ui/Cargo.toml
+++ b/awa-ui/Cargo.toml
@@ -14,6 +14,7 @@ readme = "README.md"
 include = [
     "/src/**/*",
     "/static/**/*",
+    "/build.rs",
     "/Cargo.toml",
     "/README.md",
 ]

--- a/awa-ui/build.rs
+++ b/awa-ui/build.rs
@@ -1,0 +1,26 @@
+//! Cache-invalidation bridge for `rust-embed` + `static/`.
+//!
+//! `#[derive(Embed)] #[folder = "static/"]` emits `include_bytes!` per file,
+//! so Cargo invalidates when an existing embedded file's contents change. It
+//! does not invalidate when files are added or removed under the folder: the
+//! derive macro's output is keyed off `src/lib.rs` and the crate's declared
+//! inputs, not off the directory listing.
+//!
+//! This matters with `actions/cache` / `Swatinem/rust-cache`: a restored
+//! `target/` from a prior build whose Vite output produced different
+//! hash-stamped `assets/index-<hash>.{js,css}` filenames would reuse the old
+//! compiled binary and serve stale embedded assets. The HTML would point at
+//! asset paths the embedded filesystem no longer contains, and a smoke test
+//! that only greps for `/assets/` would not catch the mismatch.
+//!
+//! Watching `static/` and `static/assets/` invalidates this crate whenever a
+//! file is added or removed (directory mtime changes). File-content changes
+//! are already covered by `include_bytes!` fingerprinting in the generated
+//! code, so individual files do not need to be enumerated here.
+
+fn main() {
+    let manifest_dir = std::env::var("CARGO_MANIFEST_DIR")
+        .expect("CARGO_MANIFEST_DIR is always set during build scripts");
+    println!("cargo:rerun-if-changed={manifest_dir}/static");
+    println!("cargo:rerun-if-changed={manifest_dir}/static/assets");
+}

--- a/awa-ui/frontend/package.json
+++ b/awa-ui/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "awa-ui-frontend",
   "private": true,
-  "version": "0.1.0",
+  "version": "0.5.3",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/awa/tests/telemetry_test.rs
+++ b/awa/tests/telemetry_test.rs
@@ -695,6 +695,14 @@ async fn test_failure_path_metrics_reach_prometheus() {
     wait_for_job_count(&pool, queue, "waiting_external", 2).await;
     wait_for_job_count(&pool, queue, "retryable", 2).await;
 
+    // Backdate callback_timeout_at so the next callback-rescue tick
+    // transitions these jobs into retryable. The rescue itself sets
+    // run_at = now() + backoff_duration(attempt, max_attempts) — which can
+    // be several seconds — so we can't backdate run_at before the rescue
+    // fires (the new retryable rows would inherit future run_at). Wait for
+    // waiting_external to drain first, then backdate run_at for every
+    // retryable row (both the original retry_once jobs and the callback
+    // rescues).
     sqlx::query(
         "UPDATE awa.jobs SET callback_timeout_at = now() - interval '1 second' \
          WHERE queue = $1 AND state = 'waiting_external'",
@@ -703,6 +711,12 @@ async fn test_failure_path_metrics_reach_prometheus() {
     .execute(&pool)
     .await
     .expect("Failed to backdate callback_timeout_at");
+
+    // Retryable jumps from 2 to 4 once both callback rescues land. No row
+    // leaves retryable until run_at is backdated (below), so the count is
+    // monotonic and waiting for >= 4 is the right signal that the rescue
+    // pass is done.
+    wait_for_job_count(&pool, queue, "retryable", 4).await;
 
     sqlx::query(
         "UPDATE awa.jobs SET run_at = now() - interval '1 second' \
@@ -1104,11 +1118,26 @@ async fn dashboard_panels_have_observed_data() {
     .await
     .expect("Failed to backdate callback timeouts");
 
-    sqlx::query("UPDATE awa.jobs SET run_at = now() - interval '1 second' WHERE id = ANY($1)")
-        .bind(&retry_job_ids)
-        .execute(&pool)
-        .await
-        .expect("Failed to backdate retryable jobs");
+    // Wait for the callback rescue to land — waiting_external drains and
+    // retryable count jumps from 2 to 4. Then backdate run_at for ALL
+    // retryable rows (both the original retry_once jobs and the freshly
+    // rescued callback_timeout jobs). Doing this before the rescue lets
+    // the newly-rescued rows inherit `run_at = now() + backoff_duration`
+    // and stall the test (see maintenance.rs:560-561).
+    wait_for_job_count(&pool, queue, "retryable", 4).await;
+
+    sqlx::query(
+        "UPDATE awa.jobs SET run_at = now() - interval '1 second' \
+         WHERE queue = $1 AND state = 'retryable'",
+    )
+    .bind(queue)
+    .execute(&pool)
+    .await
+    .expect("Failed to backdate retryable jobs");
+    // Silence the unused-binding warning — IDs are only needed for the
+    // callback backdate above; the run_at backdate intentionally targets
+    // the queue-wide set so it covers the rescued rows.
+    let _ = &retry_job_ids;
 
     sqlx::query("UPDATE awa.jobs SET run_at = now() - interval '1 second' WHERE id = ANY($1)")
         .bind(&scheduled_job_ids)

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,10 +1,26 @@
 # Multi-stage Dockerfile for awa CLI
 # Builds a minimal static binary for multi-arch deployment.
+#
+# The frontend is built first (node stage), then rust-embed picks up
+# `awa-ui/static/` when the cargo stage runs. Without this ordering the
+# binary ships the placeholder HTML ("Frontend not built. ...") — see
+# issue #162.
 
-FROM rust:1.84-alpine AS builder
+FROM node:22-alpine AS frontend
+WORKDIR /src
+COPY awa-ui/frontend/package.json awa-ui/frontend/package-lock.json awa-ui/frontend/
+RUN --mount=type=cache,target=/root/.npm \
+    cd awa-ui/frontend && npm ci
+COPY awa-ui/frontend awa-ui/frontend
+# Vite writes to ../static (i.e. awa-ui/static) relative to the frontend dir.
+RUN cd awa-ui/frontend && npm run build
+
+FROM rust:1.90-alpine AS builder
 RUN apk add --no-cache musl-dev
 WORKDIR /src
 COPY . .
+# Replace the source's empty static/ with the built frontend from the node stage.
+COPY --from=frontend /src/awa-ui/static/ awa-ui/static/
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/src/target \
     SQLX_OFFLINE=true cargo build --release --package awa-cli \


### PR DESCRIPTION
## Summary

Closes #162. The 0.5.3 Docker image and release binaries ship with no frontend baked in — `awa-ui` embeds `awa-ui/static/` via `rust-embed` at compile time, but neither `release.yml` nor `docker/Dockerfile` ran the Vite build first. Every `cargo build` therefore picked up an empty `static/` and fell through to the "Frontend not built" placeholder HTML at runtime.

This PR fixes the root cause at every release-artifact boundary and adds smoke tests that will stop a broken UI from shipping again. It also sorts out version consistency across the release.

## Changes

### Fix the embed

- **`docker/Dockerfile`** — new `node:22-alpine` stage runs `npm ci && npm run build`; the cargo stage copies `awa-ui/static/` in before compile. `rust:1.84` → `1.90` (workspace deps now require `edition2024`).
- **`release.yml` build-binaries** — adds `setup-node` + `npm ci` + `npm run build` before every `cargo build --release`, for all four target triples.
- **`release.yml` cli-wheels** — same frontend-build-first step, so PyPI CLI wheels carry the real bundle.
- **`release.yml` publish-crates** — same pre-step, so the `awa-ui` crate on crates.io carries `static/` assets. Without this, every downstream `cargo install awa-cli` baked in the placeholder.

### Smoke gates

- **Pre-cargo check (every Linux/macOS job that compiles awa-ui)** — asserts `awa-ui/static/index.html` exists, contains `/assets/` refs, and `static/assets/` has at least one `.js` and one `.css`. Catches degenerate or skipped Vite builds before we spend ten minutes on a broken binary.
- **Binary smoke test (x86_64-musl)** — after `cargo build`, boots the fresh binary against an ephemeral Postgres, asserts `GET /` is not the placeholder page and references `/assets/*`, and checks `awa --version` matches the git tag.
- **Docker smoke test** — the docker job now builds a local amd64 image first and runs the same smoke against it, *before* `push: true` with the multi-arch tags. A broken image never lands in GHCR.

### Version hygiene

- **`version-check` gate** — new job that runs before every downstream step; fails the release if the git tag (minus `v`) doesn't match `Cargo.toml`, `awa-python/Cargo.toml`, and `awa-python/pyproject.toml`. All other jobs gain `needs: [version-check]`.
- **`awa --version`** — `#[command(version)]` on the clap struct; now reports the cargo pkg version. Validated: `awa --version` → `awa 0.5.3`.
- **`awa-ui/frontend/package.json`** — synced from stale `0.1.0` to workspace `0.5.3`. No runtime impact (frontend is `\"private\": true`) but removes a drift source.

## Validation

Done locally against `docker/Dockerfile`:

- `docker build -f docker/Dockerfile -t awa:local-smoke .` — succeeds
- Ran image against ephemeral Postgres, `GET /`:
  - Returns Vite-built `<!doctype html>` with 2 `/assets/*` refs, 0 "Frontend not built" matches
  - Served `/assets/index-*.js` — 911 kB of real bundle
  - `/api/capabilities` → `{\"read_only\":false,\"poll_interval_ms\":5000}`
- `docker run --rm awa:local-smoke --version` → `awa 0.5.3`
- `cargo fmt --all` + `cargo clippy -p awa-cli --all-targets -- -D warnings` clean

Self-tested the pre-cargo check shell snippet against three shapes:

- built tree — passes
- missing `static/index.html` — correctly fails
- degenerate index.html without `/assets/` refs — correctly fails

## Why CI changes are the belt *and* the braces

rust-embed failing silently (compile succeeds, runtime serves placeholder) is the bug we just hit. Rebuilding the binary correctly is the fix, but without post-build gates, a future change that breaks the flow (e.g. someone moves the frontend, bumps Node, introduces a build error the cargo step doesn't see) would ship the same regression unnoticed. The smoke tests fail loud at the exact symptom an end-user would see.

## Not in this PR

- #161 (`--read-only` flag) — separate issue, separate PR.
- #143 (split `awa-api` out of `awa-ui`) — public-API refactor, wants its own review. Release-pipeline changes here transfer cleanly.

## Release expectations

The next tag push (`vX.Y.Z`) will:

1. Fail fast if Cargo.toml versions don't match the tag.
2. Only compile binaries whose embedded frontend has been verified.
3. Only ship a Docker image that has already served a built frontend.
4. Publish crates only after the same pre-checks pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI enforces release/version consistency across manifests before build/publish
  * Frontend is built and its assets are embedded in containers and published packages
  * Frontend package version bumped to 0.5.3
  * CLI metadata updated so the tool reports the release version
  * Packaging updated to include built UI assets for crate publication

* **Tests**
  * Added smoke tests validating served frontend and CLI version against the release tag
  * Stabilized telemetry integration test timing for callback/rescue behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->