### PR TITLE
awa serve: --read-only flag for explicit opt-in

### DIFF
--- a/awa-cli/src/main.rs
+++ b/awa-cli/src/main.rs
@@ -85,6 +85,16 @@ enum Commands {
         /// Hex-encoded 32-byte key used to verify callback signatures.
         #[arg(long, env = "AWA_CALLBACK_HMAC_SECRET")]
         callback_hmac_secret: Option<String>,
+        /// Force the server into read-only mode regardless of DB privilege.
+        ///
+        /// By default the server probes the Postgres connection and enables
+        /// read-only mode only when the DB reports `transaction_read_only =
+        /// on` (e.g. a read replica). Setting this flag forces read-only —
+        /// mutation endpoints return 503 and `/api/capabilities` reports
+        /// `read_only: true`. Useful for incident read-outs, shared debug
+        /// instances, or public UI sessions against a writable DB.
+        #[arg(long, env = "AWA_READ_ONLY")]
+        read_only: bool,
     },
 }
 
@@ -256,6 +266,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             pool_acquire_timeout,
             cache_ttl,
             callback_hmac_secret,
+            read_only,
         } => {
             let db_url = require_pool(&cli.database_url)?;
             let pool = PgPoolOptions::new()
@@ -273,12 +284,21 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 .map(parse_callback_hmac_secret)
                 .transpose()
                 .map_err(|err| format!("invalid callback HMAC secret: {err}"))?;
+            let read_only_mode = if read_only {
+                awa_ui::state::ReadOnlyMode::ReadOnly
+            } else {
+                awa_ui::state::ReadOnlyMode::Auto
+            };
             let app =
-                awa_ui::router_with_callback_secret(pool, cache_duration, callback_hmac_secret)
+                awa_ui::router_with(pool, cache_duration, callback_hmac_secret, read_only_mode)
                     .await?;
             let addr = format!("{host}:{port}");
             let listener = tokio::net::TcpListener::bind(&addr).await?;
-            tracing::info!("AWA UI listening on http://{addr}");
+            if read_only {
+                tracing::info!("AWA UI listening on http://{addr} (forced read-only)");
+            } else {
+                tracing::info!("AWA UI listening on http://{addr}");
+            }
             axum::serve(listener, app).await?;
         }
 

--- a/awa-ui/src/lib.rs
+++ b/awa-ui/src/lib.rs
@@ -13,24 +13,48 @@ use rust_embed::Embed;
 use sqlx::PgPool;
 use tower_http::cors::CorsLayer;
 
-use crate::state::{detect_read_only, AppState};
+use crate::state::{AppState, ReadOnlyMode};
 
 #[derive(Embed)]
 #[folder = "static/"]
 struct StaticAssets;
 
 /// Create the awa-ui router with all API routes and static file serving.
+///
+/// Read-only mode is auto-detected by probing the database connection — see
+/// [`router_with`] to force it explicitly.
 pub async fn router(pool: PgPool, cache_ttl: Duration) -> Result<Router, sqlx::Error> {
-    router_with_callback_secret(pool, cache_ttl, None).await
+    router_with(pool, cache_ttl, None, ReadOnlyMode::Auto).await
 }
 
 /// Create the awa-ui router with optional callback signature verification.
+///
+/// Read-only mode is auto-detected. Prefer [`router_with`] when you need to
+/// force read-only or writable behaviour regardless of DB privilege.
 pub async fn router_with_callback_secret(
     pool: PgPool,
     cache_ttl: Duration,
     callback_hmac_secret: Option<[u8; 32]>,
 ) -> Result<Router, sqlx::Error> {
-    let read_only = detect_read_only(&pool).await?;
+    router_with(pool, cache_ttl, callback_hmac_secret, ReadOnlyMode::Auto).await
+}
+
+/// Create the awa-ui router with full control over callback signing and
+/// read-only behaviour.
+///
+/// `read_only_mode`:
+/// - [`ReadOnlyMode::Auto`] — probe the DB (matches legacy behaviour)
+/// - [`ReadOnlyMode::ReadOnly`] — force mutation endpoints off even if the
+///   DB can write
+/// - [`ReadOnlyMode::Writable`] — force mutation endpoints on; the DB still
+///   has the final say at query time
+pub async fn router_with(
+    pool: PgPool,
+    cache_ttl: Duration,
+    callback_hmac_secret: Option<[u8; 32]>,
+    read_only_mode: ReadOnlyMode,
+) -> Result<Router, sqlx::Error> {
+    let read_only = read_only_mode.resolve(&pool).await?;
     let state = AppState::new(pool, read_only, cache_ttl, callback_hmac_secret);
     let api = Router::new()
         // Jobs

--- a/awa-ui/src/state.rs
+++ b/awa-ui/src/state.rs
@@ -50,6 +50,39 @@ pub async fn detect_read_only(pool: &PgPool) -> Result<bool, sqlx::Error> {
     Ok(read_only)
 }
 
+/// How the API server decides whether to accept mutation requests.
+///
+/// `Auto` (the default) probes the Postgres connection — useful for running
+/// the UI against a read replica or a read-only role without extra config.
+/// Forcing `ReadOnly` is the operator escape hatch when the DB is writable
+/// but mutations should still be disabled (e.g. an incident read-out, a
+/// shared debugging instance, a less-trusted public UI session).
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum ReadOnlyMode {
+    /// Probe the DB connection — read-only if Postgres reports
+    /// `transaction_read_only = on`, writable otherwise.
+    #[default]
+    Auto,
+    /// Force read-only regardless of DB privilege. Mutation endpoints return
+    /// 503 (the same status the auto-detect path uses) and
+    /// `/api/capabilities` reports `read_only: true`.
+    ReadOnly,
+    /// Force writable. Mutations are always permitted at the HTTP layer; the
+    /// DB still has the final say at query time.
+    Writable,
+}
+
+impl ReadOnlyMode {
+    /// Resolve to a concrete boolean, probing the pool only when `Auto`.
+    pub async fn resolve(self, pool: &PgPool) -> Result<bool, sqlx::Error> {
+        match self {
+            Self::Auto => detect_read_only(pool).await,
+            Self::ReadOnly => Ok(true),
+            Self::Writable => Ok(false),
+        }
+    }
+}
+
 #[derive(Debug, Serialize)]
 pub struct Capabilities {
     pub read_only: bool,

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -128,7 +128,27 @@ If you're connecting to a read replica, increase `--cache-ttl` to reduce load. T
 
 ### Read-only mode
 
-`awa serve` auto-detects read-only databases (replicas, read-only transactions) and disables mutation endpoints (retry, cancel, pause, drain). The frontend hides the corresponding buttons. No configuration needed.
+`awa serve` disables mutation endpoints (retry, cancel, pause, drain) whenever the server is running in read-only mode. `/api/capabilities` reports `read_only: true` and the frontend hides the corresponding buttons. Mutation requests against a read-only server return `503 Service Unavailable` with a clear error body.
+
+There are two ways to opt in:
+
+| Mode | Trigger | When to use |
+|---|---|---|
+| Auto-detect (default) | Server probes `current_setting('transaction_read_only')` on startup | Pointed at a read replica or a Postgres role without write grants |
+| Forced | `--read-only` flag or `AWA_READ_ONLY=1` env var | Writable DB but you want mutations off — incident read-outs, shared debugging instances, less-trusted public UI sessions |
+
+```bash
+# Auto-detect (current behaviour)
+awa --database-url "$DATABASE_URL" serve
+
+# Explicit — force read-only regardless of DB privileges
+awa --database-url "$DATABASE_URL" serve --read-only
+
+# Same via env var
+AWA_READ_ONLY=1 awa --database-url "$DATABASE_URL" serve
+```
+
+Once forced, there is no way for a frontend user to flip back to writable without restarting the server — that's the whole point.
 
 ## Next
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -208,6 +208,14 @@ awa --database-url "$DATABASE_URL" serve --host 0.0.0.0 --port 3000
 
 The UI is read/write admin surface. Put it behind your normal authentication, network policy, and ingress controls.
 
+For a UI pinned to a less-trusted network or shared with stakeholders who shouldn't trigger retries, cancels, or pauses, run with `--read-only` (or set `AWA_READ_ONLY=1`):
+
+```bash
+awa --database-url "$DATABASE_URL" serve --read-only
+```
+
+This forces read-only even when the Postgres connection is fully writable — the UI hides mutation buttons and every mutation endpoint returns 503. See [configuration.md#read-only-mode](configuration.md#read-only-mode) for the tradeoff versus pointing at a read replica.
+
 If you expose the callback receiver endpoints for `HttpWorker`, also configure
 `AWA_CALLBACK_HMAC_SECRET` (or `--callback-hmac-secret`) so `awa-ui` verifies
 `X-Awa-Signature` on callback requests.


### PR DESCRIPTION
## Summary

Closes #161. Adds a `--read-only` flag (and `AWA_READ_ONLY` env var) to `awa serve` so operators can force read-only mode regardless of DB privilege.

Before this change the server only entered read-only mode when the DB connection itself reported `transaction_read_only = on`. That covers read replicas and read-only roles, but leaves no escape hatch for the case where the DB is writable and you still want mutations disabled — incident read-outs, shared debugging instances, a public UI session where nobody should be able to cancel production jobs.

## What's new

| Surface | Change |
|---|---|
| `awa-ui::state` | New `ReadOnlyMode { Auto, ReadOnly, Writable }` enum with `resolve(pool)` — probes only on `Auto`, otherwise returns the forced value. |
| `awa-ui::router_with` | New constructor that takes `ReadOnlyMode`. Existing `router` and `router_with_callback_secret` stay as thin wrappers that default to `Auto` — no signature break for existing callers. |
| `awa-cli` | `--read-only` flag + `AWA_READ_ONLY` env var on `awa serve`. When set, picks `ReadOnlyMode::ReadOnly`; otherwise `Auto`. Startup log line surfaces `(forced read-only)` so it's visible in container logs. |
| `docs/configuration.md` | Expanded the "Read-only mode" section with a table covering both opt-in paths, example invocations, and a note on the `503` response. |
| `docs/deployment.md` | Web UI deployment section mentions the flag with an example. |

## Behavior

```bash
# Auto-detect (unchanged default)
awa --database-url "$URL" serve

# Force read-only on a writable DB
awa --database-url "$URL" serve --read-only
AWA_READ_ONLY=1 awa --database-url "$URL" serve
```

`/api/capabilities` reports `read_only: true` when forced. Mutation endpoints return `503 Service Unavailable` with a clear error body — same status code as the auto-detect path, so frontend error handling stays identical.

## Validation

Tested end-to-end with a local Docker Postgres:

```
--- /api/capabilities (--read-only) ---
{"read_only":true,"poll_interval_ms":5000}
--- POST /api/jobs/1/retry ---
status: 503
{"error":"awa serve is connected to a read-only database; admin actions are disabled"}

--- /api/capabilities (no flag, same DB) ---
{"read_only":false,"poll_interval_ms":5000}
```

- `cargo fmt --all` clean
- `SQLX_OFFLINE=true cargo clippy --all-targets --all-features -- -D warnings` clean
- `cargo build --workspace` clean
- `cargo test -p awa-ui --no-run` — all 4 test binaries build

## Not in this PR

- **#143 (split `awa-api` from `awa-ui`)** — I started this refactor alongside `#161` since they touch the same area. Partway through it became clear that without a concrete external consumer, the split is pre-optimising: the cost `awa-ui` imposes on a hypothetical API-only consumer is ~1 MB of embedded bundle + rust-embed (compile-time). I backed it out and kept `#161` narrow. Adding `ReadOnlyMode` in-place in `awa-ui::state` is independently useful regardless of where the API crate ends up living if we revisit the split. See the comment on #143 for the full reasoning.

## Test plan

- [x] `cargo fmt` + `cargo clippy` clean
- [x] `cargo build --workspace` clean
- [x] All `awa-ui` test binaries compile (run them against a DB in CI)
- [x] End-to-end smoke: forced read-only blocks mutations, default flag behaviour unchanged
- [ ] `npm run build` + full `awa-ui` integration suite against Postgres in CI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `--read-only` option (env `AWA_READ_ONLY`) for `awa serve` to force the UI into read-only mode; mutation endpoints are disabled, the UI hides mutation controls, and the server startup message indicates when read-only is forced.

* **Documentation**
  * Updated configuration and deployment docs to explain read-only behavior, auto-detection vs forced mode, client-facing capability reporting, and 503 responses for disallowed mutations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->