### PR TITLE
Add pgque adapter + stamp adapter revisions into reports

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "benchmarks/portable/pgque-bench/vendor/pgque"]
+	path = benchmarks/portable/pgque-bench/vendor/pgque
+	url = https://github.com/NikolayS/pgque.git

--- a/benchmarks/portable/README.md
+++ b/benchmarks/portable/README.md
@@ -1,14 +1,16 @@
 # Portable Cross-System Benchmarks
 
 Comparable benchmark scenarios for Awa (native Rust and Docker), Awa-Python,
-Procrastinate (Python), River (Go), and Oban (Elixir) running against a shared
-Postgres instance.
+Procrastinate (Python), River (Go), Oban (Elixir), and PgQue (SQL/PL-pgSQL)
+running against a shared Postgres instance.
 
 ## Prerequisites
 
 - Docker and Docker Compose
 - Rust toolchain (for the Awa adapter)
 - No Go or Elixir installation required — River and Oban build inside Docker
+- Initialize git submodules so the PgQue adapter can install its SQL:
+  `git submodule update --init --recursive`
 
 ## Quick Start
 
@@ -66,7 +68,7 @@ benchmarks/portable/
 ├── run.py                 # Orchestrator — builds, runs, collects results
 ├── isolated.py            # Repeats one-system-per-run isolated benchmarks
 ├── docker-compose.yml     # Shared Postgres service (PG17 by default, PG18 via --pg-image)
-├── init-databases.sql     # Creates awa_bench, awa_docker_bench, awa_python_bench, procrastinate_bench, river_bench, oban_bench
+├── init-databases.sql     # Creates awa_bench, awa_docker_bench, awa_python_bench, procrastinate_bench, river_bench, oban_bench, pgque_bench
 ├── awa-bench/             # Rust binary (built locally or in Docker from workspace)
 │   ├── Cargo.toml
 │   ├── Dockerfile
@@ -88,6 +90,12 @@ benchmarks/portable/
 │   ├── config/
 │   ├── lib/
 │   └── priv/repo/migrations/
+├── pgque-bench/           # PgQue (SQL/PL-pgSQL) adapter (Docker, Python driver)
+│   ├── Dockerfile
+│   ├── adapter.json
+│   ├── main.py
+│   ├── pyproject.toml
+│   └── vendor/pgque/      # Git submodule pinned to upstream NikolayS/pgque
 └── results/               # JSON output from benchmark runs
 ```
 
@@ -192,6 +200,7 @@ Per run: `benchmarks/portable/results/<scenario>-<timestamp>-<id>/`
 | procrastinate | ✓ | ✓ |
 | river | ✓ | ✓ |
 | oban | ✓ | ✓ |
+| pgque | — | ✓ |
 
 `awa-docker` is excluded by default from the long-horizon runner because its
 line on any multi-hour dead-tuple / latency plot is the awa-native line —

--- a/benchmarks/portable/bench_harness/adapters.py
+++ b/benchmarks/portable/bench_harness/adapters.py
@@ -169,6 +169,18 @@ def build_oban(skip: bool) -> None:
     )
 
 
+def build_pgque(skip: bool) -> None:
+    # Build context is REPO_ROOT so the Dockerfile can COPY the vendored
+    # pgque submodule alongside the adapter source. Reminds developers to
+    # `git submodule update --init` (the README documents this).
+    _docker_build(
+        "pgque-bench",
+        SCRIPT_DIR / "pgque-bench" / "Dockerfile",
+        REPO_ROOT,
+        skip,
+    )
+
+
 # ─── Launch specs ────────────────────────────────────────────────────────
 
 
@@ -246,6 +258,10 @@ def launch_oban(manifest, overrides):
     return _docker_launch("oban-bench", manifest, overrides)
 
 
+def launch_pgque(manifest, overrides):
+    return _docker_launch("pgque-bench", manifest, overrides)
+
+
 # ─── Registry ────────────────────────────────────────────────────────────
 
 
@@ -287,8 +303,13 @@ ADAPTERS: dict[str, AdapterEntry] = {
         builder=build_oban,
         launcher=launch_oban,
     ),
+    "pgque": AdapterEntry(
+        bench_dir=SCRIPT_DIR / "pgque-bench",
+        builder=build_pgque,
+        launcher=launch_pgque,
+    ),
 }
 
 # Default --systems list for long-horizon. awa-docker is opt-in (it duplicates
 # the awa-native line in cross-system plots — same Rust, same SQL).
-DEFAULT_SYSTEMS = ["awa", "awa-python", "procrastinate", "river", "oban"]
+DEFAULT_SYSTEMS = ["awa", "awa-python", "procrastinate", "river", "oban", "pgque"]

--- a/benchmarks/portable/bench_harness/orchestrator.py
+++ b/benchmarks/portable/bench_harness/orchestrator.py
@@ -46,6 +46,7 @@ from .phases import (
 )
 from .plots import render_all
 from .sample import Sample
+from .versions import capture_adapter_revision
 from .writers import (
     RawCsvWriter,
     build_manifest,
@@ -600,7 +601,17 @@ def drive(
                 worker_count=worker_count,
                 high_load_multiplier=high_load_multiplier,
             )
-            adapter_descriptors[system] = descriptor or {}
+            # Merge the runtime descriptor the adapter emitted with the
+            # harness-proven revision block (git SHA / submodule SHA /
+            # pinned upstream version). The runtime half records what the
+            # process claimed about itself; the harness half records what
+            # we can prove by inspecting the source tree and pinned
+            # manifests. Both ship in manifest.json so a reader can tell
+            # *exactly* which code was under test without cross-referencing
+            # anything outside the run directory.
+            entry = dict(descriptor or {})
+            entry["revision"] = capture_adapter_revision(system)
+            adapter_descriptors[system] = entry
     finally:
         drain_stop.set()
         drain_thread.join(timeout=10)
@@ -623,7 +634,12 @@ def drive(
     write_manifest(manifest, run_dir / "manifest.json")
     summary = compute_summary(raw_csv, run_id=run_id, scenario=scenario, phases=phases)
     write_summary(summary, run_dir / "summary.json")
-    write_run_readme(run_dir / "README.md", scenario=scenario, phases=phases)
+    write_run_readme(
+        run_dir / "README.md",
+        scenario=scenario,
+        phases=phases,
+        adapters=adapter_descriptors,
+    )
     # Build system_meta so plots can group variants of the same family
     # (e.g. awa, awa-docker, awa-python all share the "awa" family colour).
     system_meta: dict[str, tuple[str, str]] = {}

--- a/benchmarks/portable/bench_harness/versions.py
+++ b/benchmarks/portable/bench_harness/versions.py
@@ -1,0 +1,198 @@
+"""Harness-side version capture for each adapter.
+
+The runtime descriptor each adapter emits on startup (`kind: descriptor`) is
+one half of the story: it records whatever the process chose to claim about
+itself at start-of-run. This module records the other half — what the
+harness can prove by inspecting the source tree and pinned manifests:
+
+- `awa*`: the git SHA / branch / dirty state of the awa checkout (since
+  the native `awa-bench`, the Docker image, and the Python wheel all compile
+  from it). This is the canonical answer to "which commit of awa was
+  benchmarked?".
+- `pgque`: the submodule SHA of `pgque-bench/vendor/pgque` (that SQL is
+  embedded into the image at build time).
+- `procrastinate` / `river` / `oban`: the pinned upstream library version
+  declared in the adapter's dependency file (pyproject.toml, go.mod, mix.exs).
+
+The resulting block is attached to each adapter's entry in manifest.json as
+`adapters.<system>.revision`, so `manifest.json` answers "what exact code was
+compared?" without needing to cross-reference anything outside the run's
+results directory.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+from pathlib import Path
+from typing import Any
+
+SCRIPT_DIR = Path(__file__).resolve().parent.parent
+REPO_ROOT = SCRIPT_DIR.parent.parent
+
+
+def _git(args: list[str], cwd: Path = REPO_ROOT) -> str | None:
+    try:
+        res = subprocess.run(
+            ["git", *args],
+            cwd=str(cwd),
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return None
+    return res.stdout.strip() if res.returncode == 0 else None
+
+
+def _awa_repo_revision() -> dict[str, Any]:
+    """Git state of the awa repo — shared by awa, awa-docker, awa-python."""
+    sha = _git(["rev-parse", "HEAD"])
+    short = _git(["rev-parse", "--short", "HEAD"])
+    branch = _git(["rev-parse", "--abbrev-ref", "HEAD"])
+    dirty = bool((_git(["status", "--porcelain"]) or "").strip())
+    return {
+        "source": "awa repo",
+        "git_sha": sha,
+        "git_short": short,
+        "git_branch": branch,
+        "dirty": dirty,
+    }
+
+
+def _pgque_submodule_revision() -> dict[str, Any]:
+    """pgque upstream SHA via the submodule pointer."""
+    base = _awa_repo_revision()
+    sub_path = "benchmarks/portable/pgque-bench/vendor/pgque"
+    status = _git(["submodule", "status", sub_path])
+    # `git submodule status` prints " <sha> <path> (<describe>)"; leading
+    # char is '-' for uninitialised, '+' for mismatch, space for in-sync.
+    submodule_sha: str | None = None
+    submodule_describe: str | None = None
+    if status:
+        m = re.match(r"^[\s\-+]?([0-9a-f]{7,40})\s+\S+(?:\s+\((.+?)\))?", status)
+        if m:
+            submodule_sha = m.group(1)
+            submodule_describe = m.group(2)
+    return {
+        **base,
+        "source": "awa repo + pgque submodule",
+        "pgque_submodule_sha": submodule_sha,
+        "pgque_submodule_describe": submodule_describe,
+    }
+
+
+# Regexes cheap enough to inline; these files are small and well-pinned.
+_PROCRASTINATE_RE = re.compile(r'"procrastinate==([^"]+)"')
+_RIVER_RE = re.compile(r"github\.com/riverqueue/river\s+v(\S+)")
+_OBAN_RE = re.compile(r":oban,\s*\"~>\s*(\S+?)\"")
+
+
+def _read(path: Path) -> str:
+    try:
+        return path.read_text()
+    except OSError:
+        return ""
+
+
+def _procrastinate_revision() -> dict[str, Any]:
+    text = _read(SCRIPT_DIR / "procrastinate-bench" / "pyproject.toml")
+    m = _PROCRASTINATE_RE.search(text)
+    return {
+        "source": "procrastinate-bench/pyproject.toml",
+        "library": "procrastinate",
+        "pinned_version": m.group(1) if m else None,
+    }
+
+
+def _river_revision() -> dict[str, Any]:
+    text = _read(SCRIPT_DIR / "river-bench" / "go.mod")
+    m = _RIVER_RE.search(text)
+    return {
+        "source": "river-bench/go.mod",
+        "library": "github.com/riverqueue/river",
+        "pinned_version": f"v{m.group(1)}" if m else None,
+    }
+
+
+def _oban_revision() -> dict[str, Any]:
+    text = _read(SCRIPT_DIR / "oban-bench" / "mix.exs")
+    m = _OBAN_RE.search(text)
+    return {
+        "source": "oban-bench/mix.exs",
+        "library": "oban",
+        "pinned_version_constraint": f"~> {m.group(1)}" if m else None,
+    }
+
+
+_CAPTURE: dict[str, Any] = {
+    "awa": _awa_repo_revision,
+    "awa-docker": _awa_repo_revision,
+    "awa-python": _awa_repo_revision,
+    "pgque": _pgque_submodule_revision,
+    "procrastinate": _procrastinate_revision,
+    "river": _river_revision,
+    "oban": _oban_revision,
+}
+
+
+def capture_adapter_revision(system: str) -> dict[str, Any]:
+    """Return a best-effort revision block for `system`.
+
+    Always returns a dict. Unknown systems get a single-field marker so the
+    report still shows *something* rather than silently omitting the adapter
+    from the versions surface.
+    """
+    getter = _CAPTURE.get(system)
+    if getter is None:
+        return {"source": "unknown", "note": f"no version capture registered for {system!r}"}
+    return getter()
+
+
+def capture_all(systems: list[str]) -> dict[str, dict]:
+    return {system: capture_adapter_revision(system) for system in systems}
+
+
+def format_revision_oneline(system: str, entry: dict | None) -> str:
+    """Render a one-line revision string for Markdown reports.
+
+    `entry` is the manifest's `adapters.<system>` dict. It combines the
+    runtime descriptor fields the adapter emitted (`version`,
+    `schema_version`) with the harness-captured `revision` block (git
+    SHA / submodule SHA / pinned upstream version). Returns a pipe-
+    separator-safe one-liner suitable for a Markdown table cell.
+    """
+    entry = entry or {}
+    rev = entry.get("revision") or {}
+    parts: list[str] = []
+    short = rev.get("git_short")
+    branch = rev.get("git_branch")
+    dirty = rev.get("dirty")
+    if short:
+        tag = f"`{short}`"
+        if branch and branch != "HEAD":
+            tag += f" on `{branch}`"
+        if dirty:
+            tag += " (dirty)"
+        parts.append(tag)
+    sub_sha = rev.get("pgque_submodule_sha")
+    if sub_sha:
+        describe = rev.get("pgque_submodule_describe")
+        tag = f"pgque submodule `{sub_sha[:7]}`"
+        if describe:
+            tag += f" (`{describe}`)"
+        parts.append(tag)
+    pinned = rev.get("pinned_version") or rev.get("pinned_version_constraint")
+    library = rev.get("library")
+    if pinned:
+        parts.append(f"{library or 'upstream'} `{pinned}`" if library else f"`{pinned}`")
+    adapter_version = entry.get("version")
+    schema_version = entry.get("schema_version")
+    runtime_bits: list[str] = []
+    if adapter_version:
+        runtime_bits.append(f"adapter `{adapter_version}`")
+    if schema_version and schema_version != adapter_version:
+        runtime_bits.append(f"schema `{schema_version}`")
+    if runtime_bits:
+        parts.append(f"runtime: {', '.join(runtime_bits)}")
+    return " · ".join(parts) if parts else "_no revision metadata_"

--- a/benchmarks/portable/bench_harness/writers.py
+++ b/benchmarks/portable/bench_harness/writers.py
@@ -467,7 +467,35 @@ def write_manifest(manifest: dict, path: Path) -> None:
 # ────────────────────────────────────────────────────────────────────────
 
 
-def write_run_readme(path: Path, *, scenario: str | None, phases: list[Phase]) -> None:
+def _versions_section(adapters: dict[str, dict] | None) -> str:
+    if not adapters:
+        return ""
+    from .versions import format_revision_oneline
+
+    lines = ["## Adapter versions", ""]
+    lines.append("| System | Revision |")
+    lines.append("| :--- | :--- |")
+    for system in sorted(adapters):
+        lines.append(
+            f"| `{system}` | {format_revision_oneline(system, adapters[system])} |"
+        )
+    lines.append("")
+    lines.append(
+        "_Full detail (git SHA, branch, dirty flag, submodule describe, pinned "
+        "dep version, adapter-reported runtime metadata) is in `manifest.json` "
+        "under `adapters.<system>.revision`._"
+    )
+    lines.append("")
+    return "\n".join(lines)
+
+
+def write_run_readme(
+    path: Path,
+    *,
+    scenario: str | None,
+    phases: list[Phase],
+    adapters: dict[str, dict] | None = None,
+) -> None:
     phase_desc = " → ".join(
         f"{p.label} ({p.type.value}, {p.duration_s}s)" for p in phases
     )
@@ -475,6 +503,7 @@ def write_run_readme(path: Path, *, scenario: str | None, phases: list[Phase]) -
         "# Long-horizon bench run\n\n"
         f"- Scenario: `{scenario or 'custom'}`\n"
         f"- Phases: {phase_desc}\n\n"
+        f"{_versions_section(adapters)}"
         "## Files\n\n"
         "- `raw.csv` — tidy long-form per-sample metrics (system × subject × metric).\n"
         "- `summary.json` — per-system per-phase aggregates + recovery metrics.\n"
@@ -482,8 +511,9 @@ def write_run_readme(path: Path, *, scenario: str | None, phases: list[Phase]) -
         "- `plots/` — publication-quality plots (PNG 300dpi + SVG).\n\n"
         "## Rerun\n\n"
         "Reproduce with the exact CLI in `manifest.json -> cli`, using the same\n"
-        "pinned PG image. Results will differ slightly across hardware; the\n"
-        "shape of the curves is what matters cross-system.\n"
+        "pinned PG image, and the same git SHA / submodule pointers recorded\n"
+        "under `adapters.<system>.revision`. Results will differ slightly\n"
+        "across hardware; the shape of the curves is what matters cross-system.\n"
     )
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(body)

--- a/benchmarks/portable/full_suite.py
+++ b/benchmarks/portable/full_suite.py
@@ -20,6 +20,9 @@ CHAOS = SCRIPT_DIR / "chaos.py"
 RESULTS_DIR = SCRIPT_DIR / "results"
 RESULT_PATH_RE = re.compile(r"Results saved to (.+)")
 
+sys.path.insert(0, str(SCRIPT_DIR))
+from bench_harness.versions import capture_all, format_revision_oneline  # noqa: E402
+
 DEFAULT_SYSTEMS = [
     "awa",
     "awa-docker",
@@ -285,6 +288,36 @@ def print_repetition_summary(summary: dict[str, dict]) -> None:
             )
 
 
+def _versions_preamble(systems: list[str]) -> list[str]:
+    """Emit an 'Adapter versions' table at the top of a full_suite report.
+
+    full_suite.py runs multiple reps across adapters and aggregates. The
+    per-run manifest.json already carries revision info (orchestrator
+    writes it); at the aggregate layer the operator-facing Markdown
+    benefits from having the same info inlined so a report stands alone.
+    """
+    revisions = capture_all(systems)
+    lines = ["## Adapter versions", ""]
+    lines.append("| System | Revision |")
+    lines.append("| :--- | :--- |")
+    for system in sorted(revisions):
+        # The aggregate report doesn't have the runtime descriptor
+        # (adapter.started_at etc.) — synthesise a minimal entry so
+        # format_revision_oneline renders just the revision half.
+        entry = {"revision": revisions[system]}
+        lines.append(
+            f"| `{system}` | {format_revision_oneline(system, entry)} |"
+        )
+    lines.append("")
+    lines.append(
+        "_Full detail (adapter runtime version, schema version, docker image "
+        "digest) is in each run's `manifest.json` under "
+        "`adapters.<system>`._"
+    )
+    lines.append("")
+    return lines
+
+
 def write_benchmark_exports(summary: dict[str, dict], timestamp: str) -> None:
     markdown_path = RESULTS_DIR / f"benchmark_summary_{timestamp}.md"
     csv_path = RESULTS_DIR / f"benchmark_summary_{timestamp}.csv"
@@ -323,12 +356,16 @@ def write_benchmark_exports(summary: dict[str, dict], timestamp: str) -> None:
         writer.writeheader()
         writer.writerows(benchmark_rows)
 
-    lines = [
-        "# Benchmark Summary",
-        "",
-        "| System | Worker Throughput Mean | Worker Throughput Stdev | Pickup p50 Mean |",
-        "|---|---:|---:|---:|",
-    ]
+    lines: list[str] = ["# Benchmark Summary", ""]
+    lines.extend(_versions_preamble(list(summary.keys())))
+    lines.extend(
+        [
+            "## Results",
+            "",
+            "| System | Worker Throughput Mean | Worker Throughput Stdev | Pickup p50 Mean |",
+            "|---|---:|---:|---:|",
+        ]
+    )
     for system, data in summary.items():
         worker = data["benchmarks"].get("worker_throughput", {})
         latency = data["benchmarks"].get("pickup_latency", {})
@@ -361,12 +398,16 @@ def write_chaos_exports(summary: dict[str, dict], timestamp: str) -> None:
         writer.writeheader()
         writer.writerows(chaos_rows)
 
-    lines = [
-        "# Chaos Summary",
-        "",
-        "| System | Scenario | Successes | Max Lost | Mean Total (s) |",
-        "|---|---|---:|---:|---:|",
-    ]
+    lines: list[str] = ["# Chaos Summary", ""]
+    lines.extend(_versions_preamble(list(summary.keys())))
+    lines.extend(
+        [
+            "## Results",
+            "",
+            "| System | Scenario | Successes | Max Lost | Mean Total (s) |",
+            "|---|---|---:|---:|---:|",
+        ]
+    )
     for system, data in summary.items():
         for scenario, values in data["chaos"].items():
             lines.append(

--- a/benchmarks/portable/full_suite.py
+++ b/benchmarks/portable/full_suite.py
@@ -27,6 +27,7 @@ DEFAULT_SYSTEMS = [
     "procrastinate",
     "river",
     "oban",
+    "pgque",
 ]
 
 CHART_COLORS = [

--- a/benchmarks/portable/init-databases.sql
+++ b/benchmarks/portable/init-databases.sql
@@ -11,6 +11,7 @@ CREATE DATABASE awa_python_bench;
 CREATE DATABASE procrastinate_bench;
 CREATE DATABASE river_bench;
 CREATE DATABASE oban_bench;
+CREATE DATABASE pgque_bench;
 
 \connect awa_bench
 CREATE EXTENSION IF NOT EXISTS pgstattuple;
@@ -28,4 +29,7 @@ CREATE EXTENSION IF NOT EXISTS pgstattuple;
 CREATE EXTENSION IF NOT EXISTS pgstattuple;
 
 \connect oban_bench
+CREATE EXTENSION IF NOT EXISTS pgstattuple;
+
+\connect pgque_bench
 CREATE EXTENSION IF NOT EXISTS pgstattuple;

--- a/benchmarks/portable/pgque-bench/Dockerfile
+++ b/benchmarks/portable/pgque-bench/Dockerfile
@@ -1,0 +1,18 @@
+FROM python:3.12-slim
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends curl ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+RUN curl -LsSf https://astral.sh/uv/install.sh | sh
+
+ENV PATH="/root/.local/bin:${PATH}"
+
+WORKDIR /app
+# Build context is REPO_ROOT (see bench_harness/adapters.py). Copy adapter +
+# vendored pgque submodule (sql/pgque.sql is loaded at startup).
+COPY benchmarks/portable/pgque-bench ./benchmarks/portable/pgque-bench
+
+WORKDIR /app/benchmarks/portable/pgque-bench
+RUN uv sync
+
+ENTRYPOINT ["sh", "-lc", "cd /app/benchmarks/portable/pgque-bench && exec uv run python main.py"]

--- a/benchmarks/portable/pgque-bench/adapter.json
+++ b/benchmarks/portable/pgque-bench/adapter.json
@@ -1,0 +1,17 @@
+{
+  "system": "pgque",
+  "display_name": "PgQue (Python)",
+  "db_name": "pgque_bench",
+  "event_tables": [
+    "pgque.queue",
+    "pgque.consumer",
+    "pgque.subscription",
+    "pgque.tick",
+    "pgque.event_template",
+    "pgque.retry_queue",
+    "pgque.dead_letter",
+    "pgque.config"
+  ],
+  "event_indexes": [],
+  "extensions": []
+}

--- a/benchmarks/portable/pgque-bench/main.py
+++ b/benchmarks/portable/pgque-bench/main.py
@@ -1,0 +1,512 @@
+#!/usr/bin/env python3
+"""Long-horizon benchmark adapter for pgque (NikolayS/pgque).
+
+Contract: benchmarks/portable/CONTRIBUTING_ADAPTERS.md
+
+pgque is pure SQL+PL/pgSQL, installed via ``\\i sql/pgque.sql`` (vendored as a
+git submodule under ``vendor/pgque``). This adapter:
+
+* loads pgque on startup (idempotent), creates the bench queue + consumer,
+  tightens ticker config so latency is comparable to other adapters
+* drives ``pgque.ticker(queue)`` and ``pgque.maint()`` in background tasks
+  (no pg_cron in our test image)
+* enqueues with ``pgque.send`` from a producer task honouring fixed-rate or
+  depth-target modes
+* consumes via a single consumer name (PgQ semantics) that loops
+  receive -> parallel-process-batch -> ack; intra-batch parallelism uses
+  ``WORKER_COUNT`` as a semaphore
+* samples queue depth from ``pgque.get_consumer_info`` and emits the required
+  long-horizon metrics every ``SAMPLE_EVERY_S``
+* exits cleanly on SIGTERM in <= 5s.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import collections
+import datetime as _dt
+import json
+import os
+import signal
+import sys
+import time
+from pathlib import Path
+
+import psycopg
+from psycopg.rows import dict_row
+
+ADAPTER_DIR = Path(__file__).resolve().parent
+PGQUE_SQL = ADAPTER_DIR / "vendor" / "pgque" / "sql" / "pgque.sql"
+
+QUEUE_NAME = "long_horizon_bench"
+CONSUMER_NAME = "bench_consumer"
+
+
+# ─── env helpers ─────────────────────────────────────────────────────────
+
+
+def database_url() -> str:
+    url = os.environ.get("DATABASE_URL")
+    if not url:
+        raise RuntimeError("DATABASE_URL must be set")
+    return url
+
+
+def env_int(key: str, default: int) -> int:
+    value = os.environ.get(key)
+    return int(value) if value is not None else default
+
+
+def env_str(key: str, default: str) -> str:
+    value = os.environ.get(key)
+    return value if value is not None else default
+
+
+def read_producer_rate(default: int) -> int:
+    control_file = os.environ.get("PRODUCER_RATE_CONTROL_FILE")
+    if not control_file:
+        return default
+    try:
+        with open(control_file) as fh:
+            return int(float(fh.read().strip()))
+    except Exception:
+        return default
+
+
+# ─── output helpers ──────────────────────────────────────────────────────
+
+
+def _emit(record: dict) -> None:
+    print(json.dumps(record), flush=True)
+
+
+def _now_iso() -> str:
+    return (
+        _dt.datetime.now(_dt.timezone.utc)
+        .isoformat(timespec="milliseconds")
+        .replace("+00:00", "Z")
+    )
+
+
+def _percentiles(events, *, window_s: float, now: float):
+    cutoff = now - window_s
+    values = [v for t, v in events if t >= cutoff]
+    if not values:
+        return 0.0, 0.0, 0.0
+    values.sort()
+    n = len(values)
+
+    def q(p):
+        idx = min(n - 1, max(0, int(round(p * (n - 1)))))
+        return values[idx]
+
+    return q(0.50), q(0.95), q(0.99)
+
+
+# ─── pgque install / setup ───────────────────────────────────────────────
+
+
+async def aconnect() -> psycopg.AsyncConnection:
+    conn = await psycopg.AsyncConnection.connect(database_url(), row_factory=dict_row)
+    await conn.set_autocommit(True)
+    return conn
+
+
+def install_pgque_sync() -> None:
+    """Run ``pgque.sql`` (idempotent) using a sync connection — psycopg
+    handles the multi-statement script naturally with ``execute()``."""
+    sql = PGQUE_SQL.read_text()
+    with psycopg.connect(database_url(), autocommit=True) as conn:
+        with conn.cursor() as cur:
+            cur.execute(sql)
+            print(f"[pgque] installed pgque from {PGQUE_SQL}", file=sys.stderr)
+
+
+async def setup_queue(conn: psycopg.AsyncConnection) -> None:
+    async with conn.cursor() as cur:
+        await cur.execute("SELECT pgque.create_queue(%s)", (QUEUE_NAME,))
+        await cur.execute("SELECT pgque.subscribe(%s, %s)", (QUEUE_NAME, CONSUMER_NAME))
+        # Tighten ticker so latency is comparable to other adapters. Defaults
+        # are seconds-scale (3s lag, 60s idle) which would make this a wall-
+        # clock test of the ticker, not the queue.
+        for param, value in (
+            ("ticker_max_count", "200"),
+            ("ticker_max_lag", "100 milliseconds"),
+            ("ticker_idle_period", "500 milliseconds"),
+        ):
+            await cur.execute(
+                "SELECT pgque.set_queue_config(%s, %s, %s)",
+                (QUEUE_NAME, param, value),
+            )
+
+
+async def discover_event_tables(conn: psycopg.AsyncConnection) -> list[str]:
+    """Return the per-queue rotated child tables created by pgque.create_queue
+    so the runtime descriptor can be a superset of adapter.json's static
+    declarations."""
+    async with conn.cursor() as cur:
+        await cur.execute(
+            """
+            SELECT n.nspname || '.' || c.relname AS qname
+            FROM pg_class c
+            JOIN pg_namespace n ON n.oid = c.relnamespace
+            WHERE n.nspname = 'pgque'
+              AND c.relkind = 'r'
+              AND c.relname LIKE 'event_%'
+            ORDER BY 1
+            """
+        )
+        rows = await cur.fetchall()
+    return [r["qname"] for r in rows]
+
+
+# ─── scenario ────────────────────────────────────────────────────────────
+
+
+async def scenario_long_horizon() -> None:
+    sample_every_s = env_int("SAMPLE_EVERY_S", 10)
+    producer_rate = env_int("PRODUCER_RATE", 800)
+    producer_mode = env_str("PRODUCER_MODE", "fixed")
+    target_depth = env_int("TARGET_DEPTH", 1000)
+    worker_count = env_int("WORKER_COUNT", 32)
+    payload_bytes = env_int("JOB_PAYLOAD_BYTES", 256)
+    work_ms = env_int("JOB_WORK_MS", 1)
+
+    db_name = database_url().rsplit("/", 1)[-1]
+
+    # Setup connection — used for create_queue/subscribe + descriptor query.
+    setup_conn = await aconnect()
+    try:
+        await setup_queue(setup_conn)
+        rotated_tables = await discover_event_tables(setup_conn)
+    finally:
+        await setup_conn.close()
+
+    # Static manifest event_tables ∪ runtime-discovered child tables.
+    static_tables = [
+        "pgque.queue",
+        "pgque.consumer",
+        "pgque.subscription",
+        "pgque.tick",
+        "pgque.event_template",
+        "pgque.retry_queue",
+        "pgque.dead_letter",
+        "pgque.config",
+    ]
+    descriptor_tables = sorted(set(static_tables) | set(rotated_tables))
+    _emit(
+        {
+            "kind": "descriptor",
+            "system": "pgque",
+            "event_tables": descriptor_tables,
+            "extensions": [],
+            "version": "0.1.0",
+            "schema_version": os.environ.get("PGQUE_SCHEMA_VERSION", "alpha3+3b75f58"),
+            "db_name": db_name,
+            "started_at": _now_iso(),
+        }
+    )
+
+    latencies_ms: collections.deque[tuple[float, float]] = collections.deque(
+        maxlen=32768
+    )
+    enqueued = 0
+    completed = 0
+    queue_depth = 0
+    current_producer_target_rate = float(producer_rate)
+    payload_padding = "x" * max(0, payload_bytes - 64)
+
+    shutdown = asyncio.Event()
+    loop = asyncio.get_running_loop()
+    for sig in (signal.SIGINT, signal.SIGTERM):
+        try:
+            loop.add_signal_handler(sig, shutdown.set)
+        except NotImplementedError:
+            signal.signal(sig, lambda *_a: shutdown.set())
+
+    # Per-task connections (psycopg AsyncConnection isn't safe to share).
+    producer_conn = await aconnect()
+    consumer_conn = await aconnect()
+    ticker_conn = await aconnect()
+    maint_conn = await aconnect()
+    maint_step2_conn = await aconnect()
+    depth_conn = await aconnect()
+
+    work_sem = asyncio.Semaphore(worker_count)
+
+    async def producer() -> None:
+        nonlocal enqueued, current_producer_target_rate
+        seq = 0
+        next_t = loop.time()
+        while not shutdown.is_set():
+            if producer_mode == "depth-target":
+                current_producer_target_rate = 0.0
+                if queue_depth >= target_depth:
+                    await asyncio.sleep(0.05)
+                    continue
+                next_t = loop.time()
+            else:
+                effective_rate = read_producer_rate(producer_rate)
+                current_producer_target_rate = float(effective_rate)
+                if effective_rate <= 0:
+                    next_t = loop.time()
+                    await asyncio.sleep(0.1)
+                    continue
+                next_t = max(next_t + (1.0 / effective_rate), loop.time())
+                sleep_for = next_t - loop.time()
+                if sleep_for > 0:
+                    await asyncio.sleep(sleep_for)
+            payload = json.dumps(
+                {
+                    "seq": seq,
+                    "created_at": _now_iso(),
+                    "padding": payload_padding,
+                }
+            )
+            try:
+                async with producer_conn.cursor() as cur:
+                    await cur.execute(
+                        "SELECT pgque.send(%s, %s::text)", (QUEUE_NAME, payload)
+                    )
+                enqueued += 1
+                seq += 1
+            except Exception as exc:
+                print(f"[pgque] producer send failed: {exc}", file=sys.stderr)
+                await asyncio.sleep(0.05)
+
+    async def ticker_task() -> None:
+        # No pg_cron in the bench env; we drive the ticker ourselves. 50ms is
+        # well below queue_ticker_max_lag (100ms) so we never pace the ticker.
+        while not shutdown.is_set():
+            try:
+                async with ticker_conn.cursor() as cur:
+                    await cur.execute("SELECT pgque.ticker(%s)", (QUEUE_NAME,))
+            except Exception as exc:
+                print(f"[pgque] ticker failed: {exc}", file=sys.stderr)
+            await asyncio.sleep(0.05)
+
+    async def maint_task() -> None:
+        # Rotation step1, retry, vacuum. Step2 must be a separate transaction.
+        while not shutdown.is_set():
+            try:
+                async with maint_conn.cursor() as cur:
+                    await cur.execute("SELECT pgque.maint()")
+            except Exception as exc:
+                print(f"[pgque] maint failed: {exc}", file=sys.stderr)
+            for _ in range(60):  # ~30s, but interruptible
+                if shutdown.is_set():
+                    return
+                await asyncio.sleep(0.5)
+
+    async def maint_step2_task() -> None:
+        while not shutdown.is_set():
+            try:
+                async with maint_step2_conn.cursor() as cur:
+                    await cur.execute("SELECT pgque.maint_rotate_tables_step2()")
+            except Exception as exc:
+                print(f"[pgque] maint_step2 failed: {exc}", file=sys.stderr)
+            for _ in range(60):
+                if shutdown.is_set():
+                    return
+                await asyncio.sleep(0.5)
+
+    async def process_one(msg: dict) -> None:
+        nonlocal completed
+        async with work_sem:
+            try:
+                ev_time = msg["created_at"]
+                if isinstance(ev_time, str):
+                    ev_time = _dt.datetime.fromisoformat(ev_time)
+                now = _dt.datetime.now(_dt.timezone.utc)
+                if ev_time.tzinfo is None:
+                    ev_time = ev_time.replace(tzinfo=_dt.timezone.utc)
+                latency_ms = max(0.0, (now - ev_time).total_seconds() * 1000.0)
+            except Exception:
+                latency_ms = 0.0
+            latencies_ms.append((time.monotonic(), latency_ms))
+            if work_ms:
+                await asyncio.sleep(work_ms / 1000.0)
+            completed += 1
+
+    async def consumer_task() -> None:
+        # Single consumer name; one batch in flight at a time. Intra-batch
+        # parallelism is bounded by the semaphore. We LISTEN for ticker
+        # notifications but also poll on a short timer so we recover if a
+        # NOTIFY is missed (e.g. during reconnects).
+        #
+        # We drive next_batch + get_batch_events directly (rather than
+        # pgque.receive) so we always know the batch_id even for empty
+        # batches — PgQ opens a batch on next_batch regardless of event
+        # count, and we MUST finish_batch to advance the consumer cursor.
+        # Otherwise the consumer wedges on the first empty batch.
+        listen_conn = await aconnect()
+        try:
+            async with listen_conn.cursor() as cur:
+                await cur.execute(f'LISTEN "pgque_{QUEUE_NAME}"')
+            while not shutdown.is_set():
+                try:
+                    async with consumer_conn.cursor() as cur:
+                        await cur.execute(
+                            "SELECT pgque.next_batch(%s, %s) AS batch_id",
+                            (QUEUE_NAME, CONSUMER_NAME),
+                        )
+                        row = await cur.fetchone()
+                        batch_id = row["batch_id"] if row else None
+                except Exception as exc:
+                    print(f"[pgque] next_batch failed: {exc}", file=sys.stderr)
+                    await asyncio.sleep(0.1)
+                    continue
+
+                if batch_id is None:
+                    # No tick boundary yet — wait for NOTIFY or up to 100ms.
+                    try:
+                        await asyncio.wait_for(_drain_notifies(listen_conn), 0.1)
+                    except asyncio.TimeoutError:
+                        pass
+                    continue
+
+                # Pull events (may be empty — still need to finish the batch).
+                try:
+                    async with consumer_conn.cursor() as cur:
+                        await cur.execute(
+                            "SELECT ev_data FROM pgque.get_batch_events(%s)",
+                            (batch_id,),
+                        )
+                        rows = await cur.fetchall()
+                except Exception as exc:
+                    print(f"[pgque] get_batch_events failed: {exc}", file=sys.stderr)
+                    rows = []
+
+                if rows:
+                    msgs = []
+                    for r in rows:
+                        try:
+                            msgs.append(json.loads(r["ev_data"]))
+                        except Exception:
+                            msgs.append({"created_at": _now_iso()})
+                    await asyncio.gather(*(process_one(m) for m in msgs))
+
+                try:
+                    async with consumer_conn.cursor() as cur:
+                        await cur.execute("SELECT pgque.finish_batch(%s)", (batch_id,))
+                except Exception as exc:
+                    print(f"[pgque] finish_batch failed: {exc}", file=sys.stderr)
+        finally:
+            await listen_conn.close()
+
+    async def _drain_notifies(listen_conn: psycopg.AsyncConnection) -> None:
+        # AsyncConnection.notifies() yields forever; we read just one to
+        # signal "wake up". A small sleep keeps us off the hot loop if a
+        # NOTIFY storm arrives.
+        async for _ in listen_conn.notifies():
+            return
+
+    async def depth_poller() -> None:
+        nonlocal queue_depth
+        while not shutdown.is_set():
+            try:
+                async with depth_conn.cursor() as cur:
+                    await cur.execute(
+                        "SELECT pending_events FROM pgque.get_consumer_info(%s, %s)",
+                        (QUEUE_NAME, CONSUMER_NAME),
+                    )
+                    row = await cur.fetchone()
+                    queue_depth = int(row["pending_events"]) if row else 0
+            except Exception:
+                pass
+            await asyncio.sleep(1.0)
+
+    async def sampler() -> None:
+        now_epoch = int(time.time())
+        sleep_for = sample_every_s - (now_epoch % sample_every_s)
+        await asyncio.sleep(sleep_for)
+        last_enq, last_cmp = 0, 0
+        last_tick = loop.time()
+        while not shutdown.is_set():
+            deadline = loop.time() + sample_every_s
+            while not shutdown.is_set() and loop.time() < deadline:
+                await asyncio.sleep(min(0.5, deadline - loop.time()))
+            if shutdown.is_set():
+                break
+            dt = max(0.001, loop.time() - last_tick)
+            last_tick = loop.time()
+            enq_rate = (enqueued - last_enq) / dt
+            cmp_rate = (completed - last_cmp) / dt
+            last_enq, last_cmp = enqueued, completed
+            p50, p95, p99 = _percentiles(latencies_ms, window_s=30.0, now=loop.time())
+            ts = _now_iso()
+            for metric, value, window_s in [
+                ("claim_p50_ms", p50, 30.0),
+                ("claim_p95_ms", p95, 30.0),
+                ("claim_p99_ms", p99, 30.0),
+                ("enqueue_rate", enq_rate, float(sample_every_s)),
+                ("completion_rate", cmp_rate, float(sample_every_s)),
+                ("queue_depth", float(queue_depth), 0.0),
+                ("producer_target_rate", current_producer_target_rate, 0.0),
+            ]:
+                _emit(
+                    {
+                        "t": ts,
+                        "system": "pgque",
+                        "kind": "adapter",
+                        "subject_kind": "adapter",
+                        "subject": "",
+                        "metric": metric,
+                        "value": value,
+                        "window_s": window_s,
+                    }
+                )
+
+    tasks: list[asyncio.Task[None]] = [
+        asyncio.create_task(producer(), name="producer"),
+        asyncio.create_task(ticker_task(), name="ticker"),
+        asyncio.create_task(maint_task(), name="maint"),
+        asyncio.create_task(maint_step2_task(), name="maint_step2"),
+        asyncio.create_task(consumer_task(), name="consumer"),
+        asyncio.create_task(depth_poller(), name="depth"),
+        asyncio.create_task(sampler(), name="sampler"),
+    ]
+    try:
+        await shutdown.wait()
+    finally:
+        shutdown.set()
+        for t in tasks:
+            t.cancel()
+        try:
+            await asyncio.wait_for(
+                asyncio.gather(*tasks, return_exceptions=True), timeout=5.0
+            )
+        except asyncio.TimeoutError:
+            pass
+        for c in (
+            producer_conn,
+            consumer_conn,
+            ticker_conn,
+            maint_conn,
+            maint_step2_conn,
+            depth_conn,
+        ):
+            try:
+                await c.close()
+            except Exception:
+                pass
+        print("[pgque] long_horizon: shutdown signal received", file=sys.stderr)
+
+
+# ─── entrypoint ──────────────────────────────────────────────────────────
+
+
+async def main() -> None:
+    install_pgque_sync()
+    scenario = os.environ.get("SCENARIO", "long_horizon")
+    if scenario == "migrate_only":
+        print("[pgque] migrate_only: pgque.sql installed.", file=sys.stderr)
+        return
+    if scenario == "long_horizon":
+        await scenario_long_horizon()
+        return
+    raise RuntimeError(f"[pgque] unsupported SCENARIO: {scenario}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/benchmarks/portable/pgque-bench/pyproject.toml
+++ b/benchmarks/portable/pgque-bench/pyproject.toml
@@ -1,0 +1,10 @@
+[project]
+name = "portable-pgque-bench"
+version = "0.1.0"
+requires-python = ">=3.12"
+dependencies = [
+    "psycopg[binary]==3.3.3",
+]
+
+[tool.uv]
+package = false

--- a/benchmarks/portable/tests/test_harness_smoke.py
+++ b/benchmarks/portable/tests/test_harness_smoke.py
@@ -243,3 +243,91 @@ def test_format_validation_error_is_readable():
         # and one bullet per error.
         assert "invalid configuration" in formatted
         assert formatted.count("\n  - ") >= 2
+
+
+# ── versions / README revision rendering ────────────────────────────────
+
+
+from bench_harness.versions import capture_adapter_revision, capture_all
+from bench_harness.writers import write_run_readme
+
+
+def test_versions_known_systems_return_dicts():
+    # Every registered adapter must get *some* dict back — the harness is
+    # the authoritative source on what was compared, so silently returning
+    # nothing would be a reporting regression.
+    for system in ("awa", "awa-docker", "awa-python", "procrastinate", "river", "oban", "pgque"):
+        rev = capture_adapter_revision(system)
+        assert isinstance(rev, dict)
+        assert "source" in rev
+
+
+def test_versions_unknown_system_is_still_a_dict():
+    rev = capture_adapter_revision("totally-made-up")
+    assert rev.get("source") == "unknown"
+    assert "note" in rev
+
+
+def test_versions_capture_all_covers_each():
+    out = capture_all(["awa", "procrastinate"])
+    assert set(out) == {"awa", "procrastinate"}
+
+
+def test_versions_upstream_pins_resolve():
+    # These are read from pyproject.toml / go.mod / mix.exs — regressions
+    # here (e.g. regex drift after a file reformat) silently drop versions
+    # from the report, so pin them explicitly.
+    assert capture_adapter_revision("procrastinate").get("pinned_version")
+    assert capture_adapter_revision("river").get("pinned_version")
+    assert capture_adapter_revision("oban").get("pinned_version_constraint")
+
+
+def test_readme_includes_versions_table(tmp_path: Path):
+    phases = [
+        parse_phase_spec("warmup_1=warmup:10s"),
+        parse_phase_spec("smoke=clean:20s"),
+    ]
+    adapters = {
+        "awa": {
+            "version": "0.5.4-alpha.1",
+            "schema_version": "current",
+            "revision": {
+                "source": "awa repo",
+                "git_short": "abc1234",
+                "git_branch": "main",
+                "dirty": False,
+            },
+        },
+        "procrastinate": {
+            "version": "3.7.3",
+            "revision": {
+                "source": "procrastinate-bench/pyproject.toml",
+                "library": "procrastinate",
+                "pinned_version": "3.7.3",
+            },
+        },
+        "pgque": {
+            "revision": {
+                "source": "awa repo + pgque submodule",
+                "git_short": "abc1234",
+                "git_branch": "main",
+                "dirty": False,
+                "pgque_submodule_sha": "3b75f585c3d3fe3985a1688266d0f232c79213ec",
+                "pgque_submodule_describe": "alpha3-5-g3b75f58",
+            },
+        },
+    }
+    out = tmp_path / "README.md"
+    write_run_readme(out, scenario="custom", phases=phases, adapters=adapters)
+    body = out.read_text()
+    assert "Adapter versions" in body
+    assert "abc1234" in body  # awa SHA
+    assert "procrastinate" in body and "3.7.3" in body  # pinned upstream
+    assert "3b75f58" in body  # pgque submodule short SHA
+
+
+def test_readme_omits_section_when_no_adapters(tmp_path: Path):
+    phases = [parse_phase_spec("warmup_1=warmup:10s")]
+    out = tmp_path / "README.md"
+    write_run_readme(out, scenario=None, phases=phases, adapters=None)
+    assert "Adapter versions" not in out.read_text()


### PR DESCRIPTION
## Summary

- **Port the pgque adapter** (NikolayS/pgque, PL/pgSQL queue) onto the
  vacuum-aware-storage-redesign harness. Cherry-picked from
  \`feat/pgque-portable-bench\` (originally on main), cleanly on top of the
  new \`bench_harness\` package. Long-horizon only — chaos is deferred to
  #174's unification work, matching pgque's state on main.
- **Capture adapter revisions in every report.** Both awa and pgque are
  under active development, and upstream-library adapters (procrastinate,
  river, oban) are pinned at specific versions; the previous output said
  \`version: 0.5.4-alpha.1\` for awa with no commit info, and had no
  visible pointer at the pgque submodule at all. This PR plumbs an
  authoritative revision block through to \`manifest.json\`, the per-run
  \`README.md\`, and \`full_suite.py\`'s aggregate Markdown reports.

## Changes

### pgque adapter (commit 1)

- \`.gitmodules\` vendors \`NikolayS/pgque\` @ \`3b75f58\` (nested \`pgq/pgq\`
  @ \`d23425f\`) under \`benchmarks/portable/pgque-bench/vendor/pgque\`.
- New \`benchmarks/portable/pgque-bench/\` — \`Dockerfile\`, \`adapter.json\`
  (per CONTRIBUTING_ADAPTERS.md), \`main.py\` (long-horizon contract:
  descriptor, ticker + maint background tasks, depth-target or fixed-rate
  producer, semaphore-parallel consumer via \`next_batch\`/\`finish_batch\`),
  \`pyproject.toml\`.
- Registered in \`bench_harness/adapters.py\` \`ADAPTERS\` +
  \`DEFAULT_SYSTEMS\`, \`full_suite.py\` \`DEFAULT_SYSTEMS\`, and
  \`init-databases.sql\` (\`CREATE DATABASE pgque_bench\` + pgstattuple).

### Revision capture (commit 2)

- New \`benchmarks/portable/bench_harness/versions.py\`. Per-adapter
  version source:
  - \`awa\` / \`awa-docker\` / \`awa-python\` — awa repo git SHA / branch
    / dirty flag (all three compile from the same checkout).
  - \`pgque\` — awa repo SHA + the \`vendor/pgque\` submodule SHA +
    describe.
  - \`procrastinate\` / \`river\` / \`oban\` — pinned upstream version
    extracted from \`pyproject.toml\` / \`go.mod\` / \`mix.exs\`.
  - Unknown systems: \`{source: "unknown", note: ...}\` so missing
    capture shows up in the report, not silent drop.
- Wired into four surfaces:
  - \`manifest.json.adapters.<system>.revision\` (authoritative,
    machine-readable).
  - Per-run \`README.md\` — new "Adapter versions" table.
  - \`full_suite.py\` \`benchmark_summary_*.md\` and \`chaos_summary_*.md\`
    — "Adapter versions" preamble above the "Results" section so an
    aggregate report stands alone.
  - Single formatter \`format_revision_oneline\` used by all three
    Markdown surfaces — change it once, every report moves in lockstep.

## Example output

From a fresh pgque long-horizon smoke run's \`README.md\`:

\`\`\`
## Adapter versions

| System | Revision |
| :--- | :--- |
| \`pgque\` | \`335c763\` on \`feature/vacuum-aware-storage-redesign\` · pgque submodule \`3b75f58\` (\`alpha3-5-g3b75f58\`) · runtime: adapter \`0.1.0\`, schema \`alpha3+3b75f58\` |
\`\`\`

## Tests

- Harness tests: 33/33 pass (6 new tests covering version capture per
  adapter, regex extraction of upstream pins, unknown-system fallback,
  and README rendering).
- End-to-end: pgque long-horizon smoke run with 20s warmup + 40s clean,
  pgque installed from submodule, descriptor ingested, 497 \`raw.csv\`
  rows emitted across all declared \`event_tables\`, clean SIGTERM
  shutdown. \`manifest.json.adapters.pgque.revision\` and \`README.md\`
  both show the expected SHAs.

## Setup for reviewers

\`\`\`
git submodule update --init --recursive
\`\`\`

The Dockerfile \`COPY\`s the submodule content at image-build time — no
runtime clone.

## Related

- Adapter ported from \`feat/pgque-portable-bench\` (unmerged, main-based).
  That branch is now superseded by this one for the vacuum-aware-storage
  history.
- #174 unifies chaos + long-horizon; when that lands, pgque gains chaos
  coverage for free and the per-adapter edits in \`ADAPTERS\` go away.
- Awa-metrics consolidation (#176) is orthogonal — this PR doesn't touch
  OTel metrics, only report Markdown.