### PR TITLE
Bump workspace to 0.5.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,7 +171,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "awa"
-version = "0.5.5-alpha.0"
+version = "0.5.5"
 dependencies = [
  "async-trait",
  "awa-macros",
@@ -196,7 +196,7 @@ dependencies = [
 
 [[package]]
 name = "awa-cli"
-version = "0.5.5-alpha.0"
+version = "0.5.5"
 dependencies = [
  "assert_cmd",
  "awa-model",
@@ -217,7 +217,7 @@ dependencies = [
 
 [[package]]
 name = "awa-macros"
-version = "0.5.5-alpha.0"
+version = "0.5.5"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -227,7 +227,7 @@ dependencies = [
 
 [[package]]
 name = "awa-model"
-version = "0.5.5-alpha.0"
+version = "0.5.5"
 dependencies = [
  "awa-macros",
  "blake3",
@@ -248,7 +248,7 @@ dependencies = [
 
 [[package]]
 name = "awa-testing"
-version = "0.5.5-alpha.0"
+version = "0.5.5"
 dependencies = [
  "async-trait",
  "awa-model",
@@ -263,7 +263,7 @@ dependencies = [
 
 [[package]]
 name = "awa-ui"
-version = "0.5.5-alpha.0"
+version = "0.5.5"
 dependencies = [
  "awa-model",
  "awa-testing",
@@ -285,7 +285,7 @@ dependencies = [
 
 [[package]]
 name = "awa-worker"
-version = "0.5.5-alpha.0"
+version = "0.5.5"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 exclude = ["awa-python", "spike", "benchmarks/portable/awa-bench"]
 
 [workspace.package]
-version = "0.5.5-alpha.0"
+version = "0.5.5"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "Postgres-native background job queue — transactional enqueue, heartbeat crash recovery, SKIP LOCKED dispatch"
@@ -23,9 +23,9 @@ categories = ["database", "asynchronous", "web-programming"]
 
 [workspace.dependencies]
 # Internal crates
-awa-model = { path = "awa-model", version = "0.5.5-alpha.0" }
-awa-macros = { path = "awa-macros", version = "0.5.5-alpha.0" }
-awa-worker = { path = "awa-worker", version = "0.5.5-alpha.0" }
+awa-model = { path = "awa-model", version = "0.5.5" }
+awa-macros = { path = "awa-macros", version = "0.5.5" }
+awa-worker = { path = "awa-worker", version = "0.5.5" }
 
 # Database
 sqlx = { version = "0.8", features = ["runtime-tokio-rustls", "postgres", "chrono", "json", "migrate", "uuid"] }

--- a/awa-cli/Cargo.toml
+++ b/awa-cli/Cargo.toml
@@ -13,7 +13,7 @@ path = "src/main.rs"
 
 [dependencies]
 awa-model.workspace = true
-awa-ui = { path = "../awa-ui", version = "0.5.5-alpha.0" }
+awa-ui = { path = "../awa-ui", version = "0.5.5" }
 axum.workspace = true
 sqlx.workspace = true
 tokio.workspace = true
@@ -25,7 +25,7 @@ chrono.workspace = true
 hex.workspace = true
 
 [dev-dependencies]
-awa-testing = { path = "../awa-testing", version = "0.5.5-alpha.0" }
+awa-testing = { path = "../awa-testing", version = "0.5.5" }
 assert_cmd = "2"
 serde.workspace = true
 uuid.workspace = true

--- a/awa-cli/pyproject.toml
+++ b/awa-cli/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "awa-cli"
-version = "0.5.5-alpha.0"
+version = "0.5.5"
 description = "CLI for the Awa Postgres-native job queue (migrations, admin, serve)"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/awa-python/Cargo.lock
+++ b/awa-python/Cargo.lock
@@ -89,7 +89,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "awa-macros"
-version = "0.5.5-alpha.0"
+version = "0.5.5"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -99,7 +99,7 @@ dependencies = [
 
 [[package]]
 name = "awa-model"
-version = "0.5.5-alpha.0"
+version = "0.5.5"
 dependencies = [
  "awa-macros",
  "blake3",
@@ -119,7 +119,7 @@ dependencies = [
 
 [[package]]
 name = "awa-python"
-version = "0.5.5-alpha.0"
+version = "0.5.5"
 dependencies = [
  "async-trait",
  "awa-model",
@@ -139,7 +139,7 @@ dependencies = [
 
 [[package]]
 name = "awa-worker"
-version = "0.5.5-alpha.0"
+version = "0.5.5"
 dependencies = [
  "async-trait",
  "awa-macros",

--- a/awa-python/Cargo.toml
+++ b/awa-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "awa-python"
-version = "0.5.5-alpha.0"
+version = "0.5.5"
 edition = "2021"
 
 [lib]
@@ -12,8 +12,8 @@ default = ["cel"]
 cel = ["awa-model/cel"]
 
 [dependencies]
-awa-model = { path = "../awa-model", version = "0.5.5-alpha.0" }
-awa-worker = { path = "../awa-worker", version = "0.5.5-alpha.0", features = ["__python-bridge"] }
+awa-model = { path = "../awa-model", version = "0.5.5" }
+awa-worker = { path = "../awa-worker", version = "0.5.5", features = ["__python-bridge"] }
 pyo3 = { version = "0.28", features = ["macros", "abi3-py310"] }
 pyo3-async-runtimes = { version = "0.28", features = ["tokio-runtime"] }
 sqlx = { version = "0.8", features = ["runtime-tokio-rustls", "postgres", "chrono", "json"] }

--- a/awa-python/pyproject.toml
+++ b/awa-python/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "maturin"
 [project]
 name = "awa-pg"
 requires-python = ">=3.10"
-version = "0.5.5-alpha.0"
+version = "0.5.5"
 description = "Postgres-native background job queue — Python SDK with async/sync workers, transactional enqueue, progress tracking, and web UI"
 readme = {file = "../README.md", content-type = "text/markdown"}
 license = {text = "MIT OR Apache-2.0"}

--- a/awa-python/uv.lock
+++ b/awa-python/uv.lock
@@ -88,7 +88,7 @@ wheels = [
 
 [[package]]
 name = "awa-pg"
-version = "0.5.5a0"
+version = "0.5.5"
 source = { editable = "." }
 
 [package.dev-dependencies]

--- a/awa-ui/frontend/package.json
+++ b/awa-ui/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "awa-ui-frontend",
   "private": true,
-  "version": "0.5.5-alpha.0",
+  "version": "0.5.5",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/awa/Cargo.toml
+++ b/awa/Cargo.toml
@@ -20,7 +20,7 @@ awa-macros.workspace = true
 awa-worker.workspace = true
 
 [dev-dependencies]
-awa-testing = { path = "../awa-testing", version = "0.5.5-alpha.0" }
+awa-testing = { path = "../awa-testing", version = "0.5.5" }
 sqlx.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/benchmarks/portable/awa-bench/Cargo.lock
+++ b/benchmarks/portable/awa-bench/Cargo.lock
@@ -96,7 +96,7 @@ dependencies = [
 
 [[package]]
 name = "awa-macros"
-version = "0.5.5-alpha.0"
+version = "0.5.5"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -106,7 +106,7 @@ dependencies = [
 
 [[package]]
 name = "awa-model"
-version = "0.5.5-alpha.0"
+version = "0.5.5"
 dependencies = [
  "awa-macros",
  "blake3",
@@ -125,7 +125,7 @@ dependencies = [
 
 [[package]]
 name = "awa-worker"
-version = "0.5.5-alpha.0"
+version = "0.5.5"
 dependencies = [
  "async-trait",
  "awa-macros",

--- a/examples/python-app-demo/uv.lock
+++ b/examples/python-app-demo/uv.lock
@@ -36,7 +36,7 @@ wheels = [
 
 [[package]]
 name = "awa-cli"
-version = "0.5.5a0"
+version = "0.5.5"
 source = { directory = "../../awa-cli" }
 
 [[package]]
@@ -62,7 +62,7 @@ requires-dist = [
 
 [[package]]
 name = "awa-pg"
-version = "0.5.5a0"
+version = "0.5.5"
 source = { directory = "../../awa-python" }
 
 [package.metadata]


### PR DESCRIPTION
## Summary

Promotes the 0.5.5-alpha.0 pre-release to a stable 0.5.5 cut. No code changes beyond the version strings — the alpha.0 that shipped to crates.io + PyPI has been exercising the release surface for ~1 day.

- Cargo.toml workspace version + path deps (awa-model / awa-macros / awa-worker)
- awa/Cargo.toml, awa-cli/Cargo.toml, awa-python/Cargo.toml dep version pins
- awa-cli/pyproject.toml and awa-python/pyproject.toml
- awa-ui/frontend/package.json
- Cargo.lock / awa-python/Cargo.lock / awa-bench/Cargo.lock regenerated
- uv.lock files regenerated (awa-python, examples/python-app-demo)

## Test plan

- [x] `cargo build --workspace` clean
- [x] `npm run lint` clean
- [x] No lingering `0.5.5-alpha.0` or `0.5.5a0` references in tracked toml/json/lock files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version 0.5.5 (stable release) released across all workspace packages, dependencies, and modules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->