### PR TITLE
0.5.6: self-heal storage transition state when singleton row is missing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,7 +171,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "awa"
-version = "0.5.5"
+version = "0.5.6"
 dependencies = [
  "async-trait",
  "awa-macros",
@@ -196,7 +196,7 @@ dependencies = [
 
 [[package]]
 name = "awa-cli"
-version = "0.5.5"
+version = "0.5.6"
 dependencies = [
  "assert_cmd",
  "awa-model",
@@ -217,7 +217,7 @@ dependencies = [
 
 [[package]]
 name = "awa-macros"
-version = "0.5.5"
+version = "0.5.6"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -227,7 +227,7 @@ dependencies = [
 
 [[package]]
 name = "awa-model"
-version = "0.5.5"
+version = "0.5.6"
 dependencies = [
  "awa-macros",
  "blake3",
@@ -248,7 +248,7 @@ dependencies = [
 
 [[package]]
 name = "awa-testing"
-version = "0.5.5"
+version = "0.5.6"
 dependencies = [
  "async-trait",
  "awa-model",
@@ -263,7 +263,7 @@ dependencies = [
 
 [[package]]
 name = "awa-ui"
-version = "0.5.5"
+version = "0.5.6"
 dependencies = [
  "awa-model",
  "awa-testing",
@@ -285,7 +285,7 @@ dependencies = [
 
 [[package]]
 name = "awa-worker"
-version = "0.5.5"
+version = "0.5.6"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 exclude = ["awa-python", "spike", "benchmarks/portable/awa-bench"]
 
 [workspace.package]
-version = "0.5.5"
+version = "0.5.6"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "Postgres-native background job queue — transactional enqueue, heartbeat crash recovery, SKIP LOCKED dispatch"
@@ -23,9 +23,9 @@ categories = ["database", "asynchronous", "web-programming"]
 
 [workspace.dependencies]
 # Internal crates
-awa-model = { path = "awa-model", version = "0.5.5" }
-awa-macros = { path = "awa-macros", version = "0.5.5" }
-awa-worker = { path = "awa-worker", version = "0.5.5" }
+awa-model = { path = "awa-model", version = "0.5.6" }
+awa-macros = { path = "awa-macros", version = "0.5.6" }
+awa-worker = { path = "awa-worker", version = "0.5.6" }
 
 # Database
 sqlx = { version = "0.8", features = ["runtime-tokio-rustls", "postgres", "chrono", "json", "migrate", "uuid"] }

--- a/awa-cli/Cargo.toml
+++ b/awa-cli/Cargo.toml
@@ -13,7 +13,7 @@ path = "src/main.rs"
 
 [dependencies]
 awa-model.workspace = true
-awa-ui = { path = "../awa-ui", version = "0.5.5" }
+awa-ui = { path = "../awa-ui", version = "0.5.6" }
 axum.workspace = true
 sqlx.workspace = true
 tokio.workspace = true
@@ -25,7 +25,7 @@ chrono.workspace = true
 hex.workspace = true
 
 [dev-dependencies]
-awa-testing = { path = "../awa-testing", version = "0.5.5" }
+awa-testing = { path = "../awa-testing", version = "0.5.6" }
 assert_cmd = "2"
 serde.workspace = true
 uuid.workspace = true

--- a/awa-cli/pyproject.toml
+++ b/awa-cli/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "awa-cli"
-version = "0.5.5"
+version = "0.5.6"
 description = "CLI for the Awa Postgres-native job queue (migrations, admin, serve)"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/awa-model/migrations/v011_storage_transition_self_heal.sql
+++ b/awa-model/migrations/v011_storage_transition_self_heal.sql
@@ -1,0 +1,97 @@
+-- Self-heal v010's storage transition metadata.
+--
+-- v010 introduced awa.storage_transition_state (a singleton row) plus
+-- awa.active_storage_engine() and awa.assert_writable_canonical_storage().
+-- Two failure modes were observed in the wild on 0.5.5:
+--
+--   1. The singleton row could be missing (concurrent test fixtures that
+--      truncate awa tables, partial v010 application that wrote the table
+--      but not the seed row, logical dump/restore that omitted the table,
+--      etc.). active_storage_engine() then returned NULL.
+--   2. NULL leaked into assert_writable_canonical_storage() and the user
+--      saw `storage engine "<NULL>" is not writable in this release`.
+--      The multi-row CTE insert path silently inserted zero rows because
+--      both `engine = 'canonical'` and `engine <> 'canonical'` are false
+--      against NULL.
+--
+-- This migration is purely defensive:
+--
+--   * Re-seed the singleton row idempotently.
+--   * Replace active_storage_engine() with a NULL-safe version that
+--     coalesces a missing/blank engine to 'canonical' (the only writable
+--     engine in 0.5.x).
+--   * Harden assert_writable_canonical_storage() to treat NULL as
+--     canonical (belt-and-braces; not strictly needed once #2 lands).
+
+INSERT INTO awa.storage_transition_state (
+    singleton,
+    current_engine,
+    prepared_engine,
+    state,
+    transition_epoch,
+    details,
+    entered_at,
+    updated_at,
+    finalized_at
+)
+VALUES (
+    TRUE,
+    'canonical',
+    NULL,
+    'canonical',
+    0,
+    '{}'::jsonb,
+    now(),
+    now(),
+    NULL
+)
+ON CONFLICT (singleton) DO NOTHING;
+
+CREATE OR REPLACE FUNCTION awa.active_storage_engine()
+RETURNS TEXT
+LANGUAGE sql
+STABLE
+SET search_path = pg_catalog, awa
+AS $$
+    SELECT COALESCE(
+        (
+            SELECT NULLIF(
+                btrim(
+                    CASE
+                        WHEN state IN ('mixed_transition', 'active')
+                            THEN COALESCE(prepared_engine, current_engine)
+                        ELSE current_engine
+                    END
+                ),
+                ''
+            )
+            FROM awa.storage_transition_state
+            WHERE singleton
+        ),
+        'canonical'
+    )
+$$;
+
+CREATE OR REPLACE FUNCTION awa.assert_writable_canonical_storage()
+RETURNS BOOLEAN
+LANGUAGE plpgsql
+STABLE
+SET search_path = pg_catalog, awa
+AS $$
+DECLARE
+    active_engine TEXT;
+BEGIN
+    active_engine := COALESCE(awa.active_storage_engine(), 'canonical');
+
+    IF active_engine <> 'canonical' THEN
+        RAISE EXCEPTION 'storage engine "%" is not writable in this release', active_engine
+            USING ERRCODE = '55000';
+    END IF;
+
+    RETURN TRUE;
+END;
+$$;
+
+INSERT INTO awa.schema_version (version, description)
+VALUES (11, 'Storage transition self-heal: NULL-safe engine resolution and singleton re-seed')
+ON CONFLICT (version) DO NOTHING;

--- a/awa-model/src/migrations.rs
+++ b/awa-model/src/migrations.rs
@@ -4,7 +4,7 @@ use sqlx::PgPool;
 use tracing::info;
 
 /// Current schema version.
-pub const CURRENT_VERSION: i32 = 10;
+pub const CURRENT_VERSION: i32 = 11;
 
 /// All migrations in order. SQL lives in `awa-model/migrations/*.sql`
 /// for easy inspection by users who run their own migration tooling.
@@ -42,6 +42,11 @@ const MIGRATIONS: &[(i32, &str, &[&str])] = &[
         "Storage transition metadata and canonical compat routing",
         &[V10_UP],
     ),
+    (
+        11,
+        "Storage transition self-heal: NULL-safe engine resolution and singleton re-seed",
+        &[V11_UP],
+    ),
 ];
 
 const V1_UP: &str = include_str!("../migrations/v001_canonical_schema.sql");
@@ -53,6 +58,7 @@ const V6_UP: &str = include_str!("../migrations/v006_remove_hot_table_triggers.s
 const V7_UP: &str = include_str!("../migrations/v007_backoff_interval_fix.sql");
 const V9_UP: &str = include_str!("../migrations/v009_descriptors.sql");
 const V10_UP: &str = include_str!("../migrations/v010_storage_transition_prep.sql");
+const V11_UP: &str = include_str!("../migrations/v011_storage_transition_self_heal.sql");
 
 /// Old version numbers from pre-0.4 releases that used V3/V4/V5 numbering.
 /// Also tolerates the unreleased inline-V6 branch numbering used during review.

--- a/awa-python/Cargo.lock
+++ b/awa-python/Cargo.lock
@@ -89,7 +89,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "awa-macros"
-version = "0.5.5"
+version = "0.5.6"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -99,7 +99,7 @@ dependencies = [
 
 [[package]]
 name = "awa-model"
-version = "0.5.5"
+version = "0.5.6"
 dependencies = [
  "awa-macros",
  "blake3",
@@ -119,7 +119,7 @@ dependencies = [
 
 [[package]]
 name = "awa-python"
-version = "0.5.5"
+version = "0.5.6"
 dependencies = [
  "async-trait",
  "awa-model",
@@ -139,7 +139,7 @@ dependencies = [
 
 [[package]]
 name = "awa-worker"
-version = "0.5.5"
+version = "0.5.6"
 dependencies = [
  "async-trait",
  "awa-macros",

--- a/awa-python/Cargo.toml
+++ b/awa-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "awa-python"
-version = "0.5.5"
+version = "0.5.6"
 edition = "2021"
 
 [lib]
@@ -12,8 +12,8 @@ default = ["cel"]
 cel = ["awa-model/cel"]
 
 [dependencies]
-awa-model = { path = "../awa-model", version = "0.5.5" }
-awa-worker = { path = "../awa-worker", version = "0.5.5", features = ["__python-bridge"] }
+awa-model = { path = "../awa-model", version = "0.5.6" }
+awa-worker = { path = "../awa-worker", version = "0.5.6", features = ["__python-bridge"] }
 pyo3 = { version = "0.28", features = ["macros", "abi3-py310"] }
 pyo3-async-runtimes = { version = "0.28", features = ["tokio-runtime"] }
 sqlx = { version = "0.8", features = ["runtime-tokio-rustls", "postgres", "chrono", "json"] }

--- a/awa-python/pyproject.toml
+++ b/awa-python/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "maturin"
 [project]
 name = "awa-pg"
 requires-python = ">=3.10"
-version = "0.5.5"
+version = "0.5.6"
 description = "Postgres-native background job queue — Python SDK with async/sync workers, transactional enqueue, progress tracking, and web UI"
 readme = {file = "../README.md", content-type = "text/markdown"}
 license = {text = "MIT OR Apache-2.0"}

--- a/awa-python/uv.lock
+++ b/awa-python/uv.lock
@@ -88,7 +88,7 @@ wheels = [
 
 [[package]]
 name = "awa-pg"
-version = "0.5.5"
+version = "0.5.6"
 source = { editable = "." }
 
 [package.dev-dependencies]

--- a/awa-ui/frontend/package.json
+++ b/awa-ui/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "awa-ui-frontend",
   "private": true,
-  "version": "0.5.5",
+  "version": "0.5.6",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/awa/Cargo.toml
+++ b/awa/Cargo.toml
@@ -20,7 +20,7 @@ awa-macros.workspace = true
 awa-worker.workspace = true
 
 [dev-dependencies]
-awa-testing = { path = "../awa-testing", version = "0.5.5" }
+awa-testing = { path = "../awa-testing", version = "0.5.6" }
 sqlx.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/awa/tests/migration_test.rs
+++ b/awa/tests/migration_test.rs
@@ -996,10 +996,15 @@ struct SelfHealSingleJob {
 }
 
 async fn delete_storage_transition_singleton(pool: &PgPool) {
-    sqlx::query("DELETE FROM awa.storage_transition_state WHERE singleton")
+    let result = sqlx::query("DELETE FROM awa.storage_transition_state WHERE singleton")
         .execute(pool)
         .await
         .expect("failed to delete storage_transition_state singleton");
+    assert_eq!(
+        result.rows_affected(),
+        1,
+        "expected to delete exactly one singleton row; the v010 seed must run before this helper or the test is not exercising the missing-row path"
+    );
 }
 
 #[tokio::test]
@@ -1100,10 +1105,7 @@ async fn test_v011_reseeds_singleton_when_upgrading_from_v010() {
     // Simulate a database that received v010 but lost its singleton row
     // and is being re-migrated from v10 → current. Roll the recorded
     // schema_version back to 10 so v011 re-runs.
-    sqlx::query("DELETE FROM awa.storage_transition_state WHERE singleton")
-        .execute(&pool)
-        .await
-        .unwrap();
+    delete_storage_transition_singleton(&pool).await;
     sqlx::query("DELETE FROM awa.schema_version WHERE version > 10")
         .execute(&pool)
         .await

--- a/awa/tests/migration_test.rs
+++ b/awa/tests/migration_test.rs
@@ -7,7 +7,8 @@
 //! Set DATABASE_URL=postgres://postgres:test@localhost:15432/awa_test
 
 use awa::model::{insert_many, insert_many_copy_from_pool, migrations, storage};
-use awa::{InsertOpts, InsertParams, UniqueOpts};
+use awa::{InsertOpts, InsertParams, JobArgs, UniqueOpts};
+use serde::{Deserialize, Serialize};
 use sqlx::postgres::PgPoolOptions;
 use sqlx::PgPool;
 use std::sync::OnceLock;
@@ -967,6 +968,165 @@ async fn test_insert_many_copy_preserves_unique_skip_after_non_canonical_activat
     .await
     .unwrap();
     assert_eq!(stored, vec![1, 2, 3]);
+}
+
+// ── v011 self-heal regression tests ──────────────
+//
+// The 0.5.5 release shipped v010, which seeded the singleton row in
+// awa.storage_transition_state via `INSERT … ON CONFLICT DO NOTHING`.
+// The row could go missing in the wild — e.g. test fixtures that truncate
+// awa tables between runs, partial v010 application that wrote the table
+// but not the seed row, or logical dump/restore that omitted the table.
+// When the row was missing, awa.active_storage_engine() returned NULL,
+// which surfaced two user-visible bugs:
+//
+//   1. Single inserts (via awa.insert_job_compat) raised
+//      `storage engine "<NULL>" is not writable in this release`.
+//   2. insert_many silently inserted zero rows (NULL fails both
+//      `engine = 'canonical'` and `engine <> 'canonical'`).
+//
+// v011 makes active_storage_engine() coalesce a missing/blank row to
+// 'canonical', re-seeds the singleton, and hardens the assertion. The
+// tests below exercise the two failure modes.
+
+#[derive(Debug, Serialize, Deserialize, JobArgs)]
+#[awa(kind = "self_heal_single_test")]
+struct SelfHealSingleJob {
+    pub value: String,
+}
+
+async fn delete_storage_transition_singleton(pool: &PgPool) {
+    sqlx::query("DELETE FROM awa.storage_transition_state WHERE singleton")
+        .execute(pool)
+        .await
+        .expect("failed to delete storage_transition_state singleton");
+}
+
+#[tokio::test]
+async fn test_active_storage_engine_defaults_to_canonical_when_singleton_missing() {
+    let _guard = test_mutex().lock().await;
+    let pool = pool().await;
+    reset_schema(&pool).await;
+
+    migrations::run(&pool).await.unwrap();
+    delete_storage_transition_singleton(&pool).await;
+
+    let active: String = sqlx::query_scalar("SELECT awa.active_storage_engine()")
+        .fetch_one(&pool)
+        .await
+        .expect("active_storage_engine should be NULL-safe after v011");
+    assert_eq!(active, "canonical");
+
+    let assert_ok: bool = sqlx::query_scalar("SELECT awa.assert_writable_canonical_storage()")
+        .fetch_one(&pool)
+        .await
+        .expect("assert_writable_canonical_storage should treat missing singleton as canonical");
+    assert!(assert_ok);
+}
+
+#[tokio::test]
+async fn test_inserts_succeed_when_singleton_missing() {
+    let _guard = test_mutex().lock().await;
+    let pool = pool().await;
+    reset_schema(&pool).await;
+
+    migrations::run(&pool).await.unwrap();
+    delete_storage_transition_singleton(&pool).await;
+
+    // Single insert path goes through awa.insert_job_compat, which calls
+    // assert_writable_canonical_storage. Pre-v011 this raised <NULL>.
+    let single = awa::model::insert(
+        &pool,
+        &SelfHealSingleJob {
+            value: "self_heal_single".to_string(),
+        },
+    )
+    .await
+    .expect("single insert must not fail when singleton row is missing");
+    assert_eq!(single.kind, "self_heal_single_test");
+
+    // insert_many uses the multi-row CTE that branches on the engine value.
+    // Pre-v011 a NULL engine made both branches false and silently inserted
+    // zero rows.
+    let queue = "self_heal_many";
+    let jobs = vec![
+        InsertParams {
+            kind: "self_heal_batch".to_string(),
+            args: serde_json::json!({"seq": 1}),
+            opts: InsertOpts {
+                queue: queue.to_string(),
+                ..Default::default()
+            },
+        },
+        InsertParams {
+            kind: "self_heal_batch".to_string(),
+            args: serde_json::json!({"seq": 2}),
+            opts: InsertOpts {
+                queue: queue.to_string(),
+                ..Default::default()
+            },
+        },
+    ];
+    let inserted = insert_many(&pool, &jobs)
+        .await
+        .expect("insert_many must not silently drop rows when singleton row is missing");
+    assert_eq!(inserted.len(), 2);
+
+    // insert_many_copy reads active_storage_engine() into a Rust String,
+    // which would error on NULL pre-v011.
+    let copy_queue = "self_heal_copy";
+    let copy_jobs = vec![InsertParams {
+        kind: "self_heal_copy_job".to_string(),
+        args: serde_json::json!({"seq": 100}),
+        opts: InsertOpts {
+            queue: copy_queue.to_string(),
+            ..Default::default()
+        },
+    }];
+    let copy_inserted = insert_many_copy_from_pool(&pool, &copy_jobs)
+        .await
+        .expect("insert_many_copy must not fail when singleton row is missing");
+    assert_eq!(copy_inserted.len(), 1);
+}
+
+#[tokio::test]
+async fn test_v011_reseeds_singleton_when_upgrading_from_v010() {
+    let _guard = test_mutex().lock().await;
+    let pool = pool().await;
+    reset_schema(&pool).await;
+
+    migrations::run(&pool).await.unwrap();
+
+    // Simulate a database that received v010 but lost its singleton row
+    // and is being re-migrated from v10 → current. Roll the recorded
+    // schema_version back to 10 so v011 re-runs.
+    sqlx::query("DELETE FROM awa.storage_transition_state WHERE singleton")
+        .execute(&pool)
+        .await
+        .unwrap();
+    sqlx::query("DELETE FROM awa.schema_version WHERE version > 10")
+        .execute(&pool)
+        .await
+        .unwrap();
+
+    migrations::run(&pool).await.unwrap();
+
+    let row_count: i64 =
+        sqlx::query_scalar("SELECT count(*) FROM awa.storage_transition_state WHERE singleton")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    assert_eq!(
+        row_count, 1,
+        "v011 should re-seed the singleton row when missing"
+    );
+
+    let status = storage::status(&pool)
+        .await
+        .expect("storage_status should succeed after re-seed");
+    assert_eq!(status.current_engine, "canonical");
+    assert_eq!(status.active_engine, "canonical");
+    assert_eq!(status.state, "canonical");
 }
 
 // ── Legacy V3-only upgrade (0.3.0 exact, no V4/V5) ──────────────

--- a/benchmarks/portable/awa-bench/Cargo.lock
+++ b/benchmarks/portable/awa-bench/Cargo.lock
@@ -96,7 +96,7 @@ dependencies = [
 
 [[package]]
 name = "awa-macros"
-version = "0.5.5"
+version = "0.5.6"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -106,7 +106,7 @@ dependencies = [
 
 [[package]]
 name = "awa-model"
-version = "0.5.5"
+version = "0.5.6"
 dependencies = [
  "awa-macros",
  "blake3",
@@ -125,7 +125,7 @@ dependencies = [
 
 [[package]]
 name = "awa-worker"
-version = "0.5.5"
+version = "0.5.6"
 dependencies = [
  "async-trait",
  "awa-macros",

--- a/examples/python-app-demo/uv.lock
+++ b/examples/python-app-demo/uv.lock
@@ -36,7 +36,7 @@ wheels = [
 
 [[package]]
 name = "awa-cli"
-version = "0.5.5"
+version = "0.5.6"
 source = { directory = "../../awa-cli" }
 
 [[package]]
@@ -62,7 +62,7 @@ requires-dist = [
 
 [[package]]
 name = "awa-pg"
-version = "0.5.5"
+version = "0.5.6"
 source = { directory = "../../awa-python" }
 
 [package.metadata]


### PR DESCRIPTION
## Summary

A 0.5.5 user reported `storage engine "<NULL>" is not writable in this release` after upgrading from 0.5.4. This patch adds a `v011` self-heal migration that fixes the root cause and ships a 0.5.6 patch release.

## Root cause

`v010` introduced `awa.storage_transition_state` with a singleton row seeded via `INSERT … ON CONFLICT DO NOTHING`. The row could be missing in the wild: perhaps concurrent test fixtures that don't include `awa` tables or data, partial v010 application that wrote the table but not the seed row, or a logical dump/restore that omitted the table. When the row is missing, `awa.active_storage_engine()` returns SQL `NULL`, which surfaces two bugs:

1. Single inserts (via `awa.insert_job_compat`) raise `storage engine "<NULL>" is not writable in this release`.
2. `insert_many` silently inserts **zero rows** because both `engine = 'canonical'` and `engine <> 'canonical'` evaluate false against `NULL` — silent data loss.
3. `insert_many_copy` decodes the `NULL` into a Rust `String` and errors with a confusing sqlx decode error.

## Fix (v011 migration)

- `awa.active_storage_engine()` now `COALESCE`s a missing/blank row to `'canonical'` (the only writable engine in 0.5.x).
- Re-seed the singleton row idempotently (`ON CONFLICT DO NOTHING`).
- Harden `awa.assert_writable_canonical_storage()` to treat `NULL` as canonical (belt-and-braces).

The fix is purely additive — `feature/vacuum-aware-storage-redesign` will rebase this in once 0.5.6 ships.

## Tests

Three new regression tests in `awa/tests/migration_test.rs`:

- `test_active_storage_engine_defaults_to_canonical_when_singleton_missing` — function-level NULL safety.
- `test_inserts_succeed_when_singleton_missing` — exercises all three insert paths (`insert`, `insert_many`, `insert_many_copy`) against a database with the singleton deleted.
- `test_v011_reseeds_singleton_when_upgrading_from_v010` — verifies forward-migration from a v010-only database with a missing row re-seeds correctly.

## Test plan

- [x] `cargo fmt --all`
- [x] `SQLX_OFFLINE=true cargo clippy --all-targets --all-features -- -D warnings`
- [x] `SQLX_OFFLINE=true cargo build --workspace`
- [x] `cargo test --package awa-model --lib` (36 passed)
- [x] `cargo test --package awa --test migration_test -- --test-threads=1` (23 passed including 3 new)
- [x] `cargo test --package awa --test integration_test --test copy_test --test validation_test` (89 passed)
- [ ] CI green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated all package versions from 0.5.5 to 0.5.6 across the workspace, including core libraries and dependencies.

* **Bug Fixes**
  * Introduced database migration v011 with enhanced storage engine state handling. Now includes defensive mechanisms to automatically detect and recover from storage transition failures, ensuring robust storage state management during upgrades.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->