### PR TITLE
Docs pass for 0.6.0-alpha.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,59 @@
+# Changelog
+
+Notable changes between releases. Detailed migration notes for storage
+transitions live in [`docs/upgrade-0.5-to-0.6.md`](docs/upgrade-0.5-to-0.6.md).
+
+## [0.6.0-alpha.0] — unreleased
+
+### Added
+
+- **Vacuum-aware queue storage engine, default-on** ([ADR-019](docs/adr/019-queue-storage-redesign.md)).
+  Append-only `ready_entries`, `deferred_jobs`, `done_entries`, and
+  `dlq_entries` tables, paired with a partitioned receipt ring, keep the
+  dead-tuple footprint bounded under sustained load. Replaces the
+  canonical row-mutating engine for new installs.
+- **Receipt-plane ring partitioning** ([ADR-023](docs/adr/023-receipt-plane-ring-partitioning.md)).
+  `lease_claims` and `lease_claim_closures` are partitioned by claim
+  slot and rotated by the maintenance leader.
+- **Dead Letter Queue** ([ADR-020](docs/adr/020-dead-letter-queue.md)).
+  Per-queue `dlq_enabled` policy and a full operator surface:
+  `awa dlq depth | list | retry | retry-bulk | move | purge`, plus the
+  matching admin UI tab. See [`docs/dead-letter-queue.md`](docs/dead-letter-queue.md).
+- **Descriptor catalog** ([ADR-022](docs/adr/022-descriptor-catalog.md)).
+  Code-declared queue and job-kind metadata (`display_name`,
+  `description`, `owner`, `tags`, `docs_url`) drives admin UI labels
+  and stale/drift detection.
+- **Per-claim deadlines** in receipts mode. `QueueConfig.deadline_duration`
+  writes `lease_claims.deadline_at`; the rescue path force-closes
+  expired claims with `'deadline_expired'`.
+- **Storage transition tooling**. `awa storage prepare`,
+  `prepare-queue-storage-schema`, `enter-mixed-transition`, `finalize`,
+  and `abort` cover the staged upgrade path. Fresh installs auto-finalize
+  on first migrate.
+- **`transition_role` runtime capability**. The `enter_mixed_transition`
+  SQL gate requires a live `queue_storage_target` runtime, so a stale
+  fleet cannot accidentally skip the staged path.
+- **Migrations** v012, v013, and v014. All idempotent.
+
+### Changed
+
+- New installs default to the queue-storage engine; canonical
+  row-mutating storage is no longer the implicit backend.
+- Receipts mode is on by default for fresh deployments.
+
+### Removed
+
+- `benchmarks/portable/` extracted to its own repo at
+  [hardbyte/postgresql-job-queue-benchmarking](https://github.com/hardbyte/postgresql-job-queue-benchmarking).
+- The pre-0.6 `EXPERIMENTAL_LEASE_CLAIM_RECEIPTS` env alias.
+
+### Upgrade notes
+
+- Update your dependency to `awa = "0.6"` (Rust) /
+  `awa-cli`, `awa-pg` (Python) at the matching version.
+- Existing 0.5.x clusters with canonical data must walk the staged
+  storage transition documented in
+  [`docs/upgrade-0.5-to-0.6.md`](docs/upgrade-0.5-to-0.6.md). Fresh
+  installs auto-finalize.
+- Rollback after `enter-mixed-transition` followed by queue-storage
+  writes is one-way (database restore only).

--- a/awa-cli/README.md
+++ b/awa-cli/README.md
@@ -1,46 +1,113 @@
 # awa-cli
 
-CLI for the [Awa](https://crates.io/crates/awa) Postgres-native job queue.
+Command-line interface for the [Awa](https://crates.io/crates/awa)
+Postgres-native job queue. Run migrations, inspect and manage jobs,
+walk the storage transition, drive the Dead Letter Queue, list cron
+schedules, and serve the web admin UI.
+
+## Install
+
+The CLI is shipped as both a Rust binary and a Python wheel. Either
+distribution gives you the same `awa` executable.
 
 ```bash
-# Install (no Rust toolchain needed)
+# Python (no Rust toolchain needed)
 pip install awa-cli
-# or: cargo install awa-cli
 
+# Rust
+cargo install awa-cli
+```
+
+## Quick start
+
+```bash
 # Run migrations
 awa --database-url $DATABASE_URL migrate
 
-# Admin
+# Inspect
 awa --database-url $DATABASE_URL queue stats
 awa --database-url $DATABASE_URL job list --state failed
 awa --database-url $DATABASE_URL job dump 12345
 awa --database-url $DATABASE_URL job dump-run 12345
+
+# Admin
 awa --database-url $DATABASE_URL job retry 12345
+awa --database-url $DATABASE_URL queue pause email
+awa --database-url $DATABASE_URL queue drain email
 
 # Web UI
 awa --database-url $DATABASE_URL serve
 # → http://127.0.0.1:3000
 ```
 
+`DATABASE_URL` may be passed as the `--database-url` flag or read from
+the environment.
+
 ## Commands
 
-| Command | Description |
-|---------|-------------|
-| `migrate` | Run database migrations (or extract SQL) |
-| `job list` | List jobs with state/kind/queue filters |
-| `job dump` | Dump one job as a detailed JSON inspection snapshot |
-| `job dump-run` | Dump one attempt-oriented inspection snapshot |
-| `job retry` | Retry a failed/cancelled job |
-| `job cancel` | Cancel a job |
-| `job retry-failed` | Retry all failed jobs by kind |
-| `job discard` | Delete failed jobs by kind |
-| `queue stats` | Show per-queue depth, lag, throughput |
-| `queue pause` | Pause a queue |
-| `queue resume` | Resume a paused queue |
-| `queue drain` | Cancel all pending jobs in a queue |
-| `cron list` | List registered cron schedules |
-| `cron remove` | Remove a cron schedule |
-| `serve` | Start the web UI dashboard |
+| Command                                      | Description                                                  |
+| -------------------------------------------- | ------------------------------------------------------------ |
+| `migrate`                                    | Apply migrations, or extract / print SQL with `--sql` /  `--extract-to` |
+| `job list`                                   | List jobs with `--state` / `--kind` / `--queue` filters      |
+| `job dump <id>`                              | Pretty-print one job and its full lifecycle metadata         |
+| `job dump-run <id> [--attempt N]`            | Pretty-print one attempt run                                 |
+| `job retry <id>`                             | Retry a failed or cancelled job                              |
+| `job cancel <id>`                            | Cancel a job                                                 |
+| `job retry-failed --kind K`                  | Retry every failed job of a given kind                       |
+| `job discard --kind K`                       | Delete every failed job of a given kind                      |
+| `queue stats`                                | Per-queue depth, lag, and throughput                         |
+| `queue pause / resume / drain <queue>`       | Queue admin                                                  |
+| `cron list / remove`                         | List or remove cron schedules                                |
+| `dlq depth [--queue Q]`                      | Total DLQ rows, optionally split by queue                    |
+| `dlq list`                                   | List DLQ entries with `--kind` / `--queue` / `--tag` / `--before-*` filters |
+| `dlq retry <id>`                             | Retry a single DLQ row                                       |
+| `dlq retry-bulk`                             | Retry every DLQ row matching the filter (`--all` required if no filter is given) |
+| `dlq move`                                   | Move existing failed terminal rows into the DLQ              |
+| `dlq purge`                                  | Delete DLQ rows matching the filter (`--all` required if no filter is given) |
+| `storage status`                             | Current storage-transition state                             |
+| `storage prepare --engine E`                 | Prepare a future storage engine without changing routing     |
+| `storage prepare-queue-storage-schema`       | Materialize the queue-storage schema (tables, indexes, functions) |
+| `storage enter-mixed-transition`             | Begin routing new writes to the prepared engine              |
+| `storage finalize`                           | Finalize the transition once drain and capability gates pass |
+| `storage abort`                              | Abort a prepared or mixed-transition rollout                 |
+| `serve`                                      | Start the embedded web admin UI                              |
+
+Run `awa <command> --help` for the flags on any subcommand.
+
+## Storage transition
+
+For an existing 0.5.x cluster moving to the queue-storage engine, the
+typical sequence is:
+
+```bash
+awa --database-url $DATABASE_URL storage prepare-queue-storage-schema
+awa --database-url $DATABASE_URL storage prepare --engine queue_storage
+# ... roll out a binary that supports queue storage to all workers ...
+awa --database-url $DATABASE_URL storage enter-mixed-transition
+# ... drain the canonical engine ...
+awa --database-url $DATABASE_URL storage finalize
+```
+
+See [`docs/upgrade-0.5-to-0.6.md`](../docs/upgrade-0.5-to-0.6.md) for
+the full pre-flight checklist, gate semantics, and rollback notes.
+Fresh installs auto-finalize on first migrate and do not need this
+sequence.
+
+## Dead Letter Queue
+
+`dlq retry-bulk` and `dlq purge` require an explicit filter (`--kind`,
+`--queue`, or `--tag`) or `--all`. This is intentional — a bare bulk
+retry / purge with no filter would touch every DLQ row, which is
+almost never what you want. See
+[`docs/dead-letter-queue.md`](../docs/dead-letter-queue.md).
+
+## Web UI
+
+`awa serve` starts an embedded admin UI ([`awa-ui`](../awa-ui)) bound
+to `127.0.0.1:3000` by default. The UI is read-only when the database
+reports `transaction_read_only = on` (e.g. on a replica) or when
+`--read-only` is passed explicitly. Mutation endpoints return 503 in
+that mode.
 
 ## License
 

--- a/awa-macros/README.md
+++ b/awa-macros/README.md
@@ -1,10 +1,20 @@
 # awa-macros
 
-Derive macros for the [Awa](https://crates.io/crates/awa) job queue.
+Procedural macros for the [Awa](https://crates.io/crates/awa)
+Postgres-native job queue.
 
-Provides `#[derive(JobArgs)]` which generates:
-- A `kind()` method returning the CamelCase→snake_case job kind string
-- Serde trait bounds for JSON serialization
+You don't normally depend on this crate directly — `#[derive(JobArgs)]`
+is re-exported by both [`awa`](https://crates.io/crates/awa) and
+[`awa-model`](https://crates.io/crates/awa-model). Add `awa` to your
+dependencies and the derive comes with it.
+
+## What's in here
+
+- `#[derive(JobArgs)]` — implements `awa::JobArgs` for a struct,
+  generating the `kind()` method that identifies the job type across
+  Rust and Python workers.
+
+## Usage
 
 ```rust
 use awa::JobArgs;
@@ -19,7 +29,28 @@ struct SendEmail {
 assert_eq!(SendEmail::kind(), "send_email");
 ```
 
-You get this automatically when you depend on [`awa`](https://crates.io/crates/awa).
+The default kind string is the struct's name converted from
+`CamelCase` to `snake_case`. Override it explicitly with
+`#[awa(kind = "...")]`:
+
+```rust
+#[derive(Debug, Serialize, Deserialize, JobArgs)]
+#[awa(kind = "outbound_smtp_send")]
+struct SendEmail {
+    to: String,
+    subject: String,
+}
+
+assert_eq!(SendEmail::kind(), "outbound_smtp_send");
+```
+
+The macro resolves `JobArgs` through whichever of `awa` or
+`awa-model` is in your `Cargo.toml`, so the same derive works for
+applications using the facade crate and for libraries depending on
+`awa-model` directly.
+
+`Serialize` and `Deserialize` must be derived alongside `JobArgs` —
+the runtime serialises job arguments as JSON.
 
 ## License
 

--- a/awa-model/README.md
+++ b/awa-model/README.md
@@ -1,15 +1,88 @@
 # awa-model
 
-Core types, SQL queries, and migrations for the [Awa](https://crates.io/crates/awa) job queue.
+Schema, types, and admin surface for the [Awa](https://crates.io/crates/awa)
+Postgres-native job queue. This is the foundation crate: every other
+`awa-*` crate depends on it, and it owns the SQL migrations, the row
+types, and the admin queries that back both the CLI and the web UI.
 
-This crate provides:
-- `JobRow`, `JobState`, `InsertOpts`, `UniqueOpts` — job data types
-- `insert`, `insert_with`, `insert_many`, `insert_many_copy` — job insertion
-- `admin::*` — retry, cancel, pause, drain, queue stats, callback resolution
-- `migrations::run` — schema creation and migration
-- `cron::*` — periodic job schedule management
+Most Rust applications should depend on the [`awa`](https://crates.io/crates/awa)
+facade rather than `awa-model` directly. Reach for this crate when you
+need a smaller dependency footprint (e.g. an enqueue-only producer that
+does not link the worker runtime), or when you are building tooling
+against the admin API.
 
-You don't usually need to depend on this crate directly — [`awa`](https://crates.io/crates/awa) re-exports everything.
+## What's in here
+
+- **Job model** — `JobRow`, `JobState`, `InsertOpts`, `UniqueOpts`,
+  `InsertParams`.
+- **Insertion** — `insert`, `insert_with`, `insert_many`,
+  `insert_many_copy` (COPY-batched for large fan-outs).
+- **Migrations** — `migrations::run` applies the schema; `migrations`,
+  `migrations_range`, and `current_migration_version` expose the
+  catalog for tooling.
+- **Admin** (`admin`) — retry, cancel (single, by unique key, bulk),
+  pause/resume/drain queues, queue and job-kind overviews, runtime
+  instance snapshots, dirty-key recompute, and descriptor sync
+  (`sync_queue_descriptors`, `sync_job_kind_descriptors`,
+  `cleanup_stale_descriptors`).
+- **Dead Letter Queue** (`dlq`) — `DlqRow`, `DlqMetadata`,
+  `ListDlqFilter`, `RetryFromDlqOpts`, list / retry / move / purge
+  helpers backing the `awa dlq` CLI and the DLQ admin UI tab.
+- **Cron** (`cron`) — `PeriodicJob`, `PeriodicJobBuilder`, `CronJobRow`.
+- **Queue storage** (`queue_storage`) — `QueueStorage`,
+  `QueueStorageConfig`, `ClaimedRuntimeJob`, `RotateOutcome`,
+  `PruneOutcome`. The vacuum-aware engine introduced in 0.6.
+- **Storage status** (`storage`) — `StorageStatus` and the
+  transition-state primitives the `awa storage` CLI surfaces.
+- **Bridge adapters** (`bridge`) — `PreparedRow` and friends used by
+  the Python and tokio-postgres enqueue bridges.
+- **Errors** — `AwaError`, the single error type shared across the
+  workspace.
+
+`#[derive(JobArgs)]` is re-exported from [`awa-macros`](https://crates.io/crates/awa-macros)
+so applications get the macro automatically.
+
+## Example: enqueue-only producer
+
+```rust
+use awa_model::{insert, InsertOpts, JobArgs};
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, JobArgs)]
+struct SendEmail {
+    to: String,
+    subject: String,
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let pool = sqlx::PgPool::connect(&std::env::var("DATABASE_URL")?).await?;
+    awa_model::migrations::run(&pool).await?;
+
+    let job = insert(&pool, &SendEmail {
+        to: "ada@example.com".into(),
+        subject: "hi".into(),
+    }, InsertOpts::default()).await?;
+
+    println!("enqueued {}", job.id);
+    Ok(())
+}
+```
+
+## Versioning
+
+`awa-model` is versioned in lockstep with the rest of the workspace.
+Pin to the same minor version as `awa` and `awa-worker` if you depend
+on multiple crates directly.
+
+## See also
+
+- [Architecture overview](../docs/architecture.md)
+- [Migrations reference](../docs/migrations.md)
+- [Configuration](../docs/configuration.md)
+- [Dead Letter Queue](../docs/dead-letter-queue.md)
+- [ADR-019: queue storage engine](../docs/adr/019-queue-storage-redesign.md)
+- [ADR-022: descriptor catalog](../docs/adr/022-descriptor-catalog.md)
 
 ## License
 

--- a/awa-python/python/awa/client.py
+++ b/awa-python/python/awa/client.py
@@ -284,10 +284,9 @@ class AsyncClient:
 
     # --- Dead Letter Queue -------------------------------------------------
     #
-    # DLQ rows live in queue_storage `dlq_entries`, outside the hot claim
-    # path. These methods expose the operator-level admin surface: inspect,
-    # retry, move failed jobs in, and purge. See `awa-model/src/dlq.rs` for
-    # semantics.
+    # DLQ rows live in `dlq_entries`, outside the hot claim path. These
+    # methods expose the operator-level admin surface: inspect, retry,
+    # move failed jobs in, and purge.
 
     async def list_dlq(
         self,

--- a/awa-testing/README.md
+++ b/awa-testing/README.md
@@ -2,16 +2,83 @@
 
 Test utilities for the [Awa](https://crates.io/crates/awa) job queue.
 
-Provides `TestClient` for integration testing job handlers without running the full worker runtime:
+`awa-testing` lets you exercise job handlers and admin code paths in
+unit and integration tests without spinning up the full worker
+runtime. Use it for in-tree tests of the workspace, in your own
+crate's tests, or anywhere you want to drive a single job through a
+real Postgres without configuring queues, dispatchers, and
+maintenance leaders.
+
+The crate is `dev-dependencies`-shaped: there is no embedded Postgres,
+you point it at a real test database (typically a local container on
+port `15432`).
+
+## What's in here
+
+- `TestClient` — synchronous-feeling wrapper around a `PgPool`:
+  - `migrate()` runs the schema and resets the runtime backend so
+    tests start from a known state.
+  - `clean()` truncates `awa.jobs`, `awa.queue_meta`, and the
+    runtime-storage backend rows for cross-test isolation.
+  - `insert(&args)` enqueues one job.
+  - `work_one(&worker)` / `work_one_in_queue(&worker, queue)` claim
+    and execute exactly one job through the supplied `Worker`,
+    returning a `WorkResult` (`Completed`, `Failed`, `Snoozed`,
+    `Cancelled`, `WaitingExternal`, `NoJob`).
+  - `get_job(id)` returns the current `JobRow`.
+- `WorkResult` — enum with `is_completed()`, `is_failed()`,
+  `is_waiting_external()`, `is_no_job()` predicates.
+- `setup` module — `database_url()`, `database_url_with_app_name()`,
+  `pool()`, `pool_with_url()` helpers and `reset_runtime_backend()`
+  for explicit test cleanup.
+
+## Usage
 
 ```rust
-let client = TestClient::from_pool(pool).await;
-client.migrate().await?;
+use awa::JobArgs;
+use awa_testing::TestClient;
+use serde::{Deserialize, Serialize};
 
-let job = client.insert(&SendEmail { to: "test@example.com".into(), subject: "Test".into() }).await?;
-let result = client.work_one_in_queue(&MyWorker, Some("default")).await?;
-assert!(result.is_completed());
+#[derive(Serialize, Deserialize, JobArgs)]
+struct SendEmail {
+    to: String,
+    subject: String,
+}
+
+struct SendEmailWorker;
+
+#[async_trait::async_trait]
+impl awa::Worker for SendEmailWorker {
+    type Args = SendEmail;
+    fn kind(&self) -> &'static str { "send_email" }
+    async fn perform(&self, ctx: &awa::JobContext<Self::Args>) -> awa::JobResult {
+        // ... run the side-effect under test ...
+        Ok(())
+    }
+}
+
+#[tokio::test]
+async fn send_email_completes() {
+    let pool = awa_testing::setup::pool(4).await;
+    let client = TestClient::from_pool(pool).await;
+    client.migrate().await.unwrap();
+
+    client.insert(&SendEmail {
+        to: "test@example.com".into(),
+        subject: "Test".into(),
+    }).await.unwrap();
+
+    let result = client.work_one_in_queue(&SendEmailWorker, Some("default")).await.unwrap();
+    assert!(result.is_completed());
+}
 ```
+
+## See also
+
+- [Test plan](../docs/test-plan.md)
+- [Development](../docs/development.md)
+- For Python projects, the equivalent helpers live in
+  [`awa.testing`](../awa-python/python/awa/testing.py).
 
 ## License
 

--- a/awa-ui/README.md
+++ b/awa-ui/README.md
@@ -1,16 +1,58 @@
 # awa-ui
 
-Web UI and REST API for the [Awa](https://crates.io/crates/awa) job queue.
+Embedded web admin UI and REST API for the [Awa](https://crates.io/crates/awa)
+job queue.
 
-Provides an axum router with:
-- **Dashboard** — job state counts, throughput timeseries
-- **Job inspector** — search, filter, bulk retry/cancel, detail view
-- **Queue management** — stats, pause/resume, drain
-- **Cron schedules** — list, trigger, details
+`awa-ui` is shipped as an axum router and a static React/TypeScript
+bundle (built with [IntentUI](https://intentui.com) components and
+embedded via `rust-embed`). The CLI's `awa serve` mounts this router
+at `/` and `/api/*`; you can also embed it inside your own axum
+application.
 
-The frontend is React/TypeScript with [IntentUI](https://intentui.com) components, compiled to static assets and embedded via `rust-embed`.
+## Tabs
 
-Used by `awa-cli` to serve the UI via `awa serve`. See the [UI design doc](../docs/ui-design.md) for API endpoints and component details.
+- **Dashboard** — job state counts, throughput timeseries, runtime
+  capability summary.
+- **Jobs** — search, filter (state, kind, queue, has-error, tag),
+  bulk retry / cancel, and a detail view with progress, attempt
+  history, lifecycle hooks, and structured metadata.
+- **Kinds** — registered job kinds with descriptor metadata
+  (display name, description, owner, tags, docs URL) and stale /
+  drift indicators.
+- **Queues** — per-queue stats, descriptor metadata, pause / resume /
+  drain.
+- **Runtime** — live worker instances and their capabilities. Hosts
+  the **storage-transition card** when the cluster is mid-migration:
+  prepared / mixed / finalized state, drain progress, and the gates
+  blocking finalization.
+- **Cron** — registered periodic schedules with next-run preview.
+- **DLQ** (`/dlq`) — Dead Letter Queue browser with kind / queue /
+  tag filters, single and bulk retry, move, and purge actions. The
+  DLQ tab is reachable from the Jobs tab via the row links on
+  DLQ-state jobs.
+
+## Read-only mode
+
+When the backend is read-only — either Postgres reports
+`transaction_read_only = on` (e.g. a read replica) or the operator
+passes `--read-only` to `awa serve` — every mutation endpoint returns
+503 and `/api/capabilities` reports `read_only: true`. The frontend
+hides destructive actions in that mode.
+
+## REST surface
+
+The router exposes JSON endpoints under `/api/*` covering jobs,
+queues, kinds, runtime instances, cron, DLQ, storage transition, and
+capabilities. See [the UI design doc](../docs/ui-design.md) for the
+endpoint catalogue and response shapes.
+
+## Frontend stack
+
+- React 18 with TanStack Router and TanStack Query
+- TypeScript
+- IntentUI / react-aria-components
+- Vite build, output embedded via `rust-embed` so `awa serve` ships a
+  single binary
 
 ## License
 

--- a/awa-worker/README.md
+++ b/awa-worker/README.md
@@ -1,16 +1,65 @@
 # awa-worker
 
-Worker runtime for the [Awa](https://crates.io/crates/awa) Postgres-native job queue.
+Worker runtime for the [Awa](https://crates.io/crates/awa) Postgres-native
+job queue: dispatch, claim, heartbeat, completion-batching, maintenance,
+and lifecycle hooks.
 
-This crate provides:
-- `Client` / `ClientBuilder` — configure queues, register workers, start the runtime
-- `JobContext` — handler context with cancellation, progress tracking, callback registration
-- `JobEvent<T>` / `UntypedJobEvent` — post-commit lifecycle hooks for cleanup and notifications
-- `JobResult` / `JobError` — handler return types (completed, retry, snooze, cancel, wait-for-callback)
-- `QueueConfig` — per-queue concurrency, rate limiting, weighted mode
-- Dispatcher, heartbeat, maintenance, and completion batcher internals
+Most Rust applications depend on the [`awa`](https://crates.io/crates/awa)
+facade and never reach for this crate directly. Use `awa-worker` when
+you need the runtime types without the re-export shim — typically when
+you are building higher-level frameworks or alternate transports on
+top of Awa.
 
-You don't usually need to depend on this crate directly — [`awa`](https://crates.io/crates/awa) re-exports everything.
+## What's in here
+
+- **Client** — `Client` and `ClientBuilder` configure queues, register
+  handlers, attach lifecycle hooks, and start the runtime. `HealthCheck`,
+  `QueueHealth`, `QueueCapacity`, and `TransitionWorkerRole` expose the
+  observability and transition-aware capabilities.
+- **Job context** — `JobContext` (with cancellation, structured
+  progress, and callback registration), `CallbackToken`,
+  `CallbackGuard`.
+- **Handler results** — `JobResult` (`Completed`, `RetryAfter`,
+  `Snooze`, `Cancel`, `WaitForCallback`) and `JobError`. Implement
+  the `Worker` trait directly or register typed closures with
+  `register_handler`.
+- **Queue configuration** — `QueueConfig` (concurrency, weighted mode,
+  rate limiting, per-claim deadlines), `RateLimit`.
+- **Lifecycle hooks** — `JobEvent<T>` and `UntypedJobEvent` fire after
+  guarded finalization commits, useful for cache invalidation,
+  notifications, and metrics emission.
+- **HTTP worker** — `HttpWorker`, `HttpWorkerConfig`, `HttpWorkerMode`
+  dispatch jobs to serverless endpoints over HTTP with HMAC-BLAKE3
+  signing. See [ADR-018](../docs/adr/018-http-worker.md).
+- **Maintenance** — `RetentionPolicy` controls retention sweeps; the
+  maintenance leader also rotates the receipt-ring partitions
+  introduced in 0.6.
+- **Metrics** — `AwaMetrics` exposes the runtime metric surface for
+  Prometheus / OTel scrapers.
+
+## Capabilities
+
+- **Vacuum-aware queue storage** — workers default to the queue-storage
+  engine and rotating receipt ring described in
+  [ADR-019](../docs/adr/019-queue-storage-redesign.md) and
+  [ADR-023](../docs/adr/023-receipt-plane-ring-partitioning.md).
+- **Dead Letter Queue** — terminal failures land in `dlq_entries` for
+  any queue with `dlq_enabled` set. Per-queue policy is configured
+  through `QueueConfig` and the `dlq_enabled_by_default` builder
+  setting; see [`docs/dead-letter-queue.md`](../docs/dead-letter-queue.md).
+- **Descriptor catalog** — `ClientBuilder::queue_descriptor` and
+  `job_kind_descriptor` declare display name, owner, tags, and docs
+  URL alongside the worker. The runtime syncs these to
+  `queue_descriptors` / `job_kind_descriptors` on start
+  ([ADR-022](../docs/adr/022-descriptor-catalog.md)).
+- **Per-claim deadlines** — `QueueConfig::deadline_duration` writes
+  `lease_claims.deadline_at` on claim. Expired claims are force-closed
+  by the rescue path with `'deadline_expired'`.
+- **Priority aging** — applied at claim time on the queue-storage engine
+  ([ADR-005](../docs/adr/005-priority-aging.md)).
+- **Heartbeat + deadline rescue** — two independent rescue paths cover
+  crash and runaway failure modes
+  ([ADR-003](../docs/adr/003-heartbeat-deadline-hybrid.md)).
 
 ## Cancellation Semantics
 
@@ -40,6 +89,12 @@ There is an important distinction between:
 
 If a running job is cancelled in storage and the handler keeps running, its
 later completion/retry/cancel attempt is treated as stale and ignored.
+
+## See also
+
+- [Architecture overview](../docs/architecture.md)
+- [Configuration reference](../docs/configuration.md)
+- [Deployment](../docs/deployment.md)
 
 ## License
 


### PR DESCRIPTION
## Summary

Three-commit doc pass for the 0.6.0-alpha.0 release.

### 1. `CHANGELOG.md` (new)

First entry covers the queue-storage engine (ADR-019), receipt-plane
ring partitioning (ADR-023), DLQ (ADR-020), descriptor catalog
(ADR-022), per-claim deadlines, the `awa storage` CLI surface, and the
upgrade-path notes for existing 0.5.x clusters. Header explains the
format and points to `docs/upgrade-0.5-to-0.6.md` for migration
detail.

### 2. Sub-project READMEs

Refreshed every crate README except those already updated this
session (`awa/`, `awa-python/`, top-level `README.md`):

- `awa-model` — foundation crate framing, full module list, DLQ +
  descriptor + queue-storage coverage, enqueue-only example.
- `awa-worker` — runtime surface, queue-storage / DLQ / descriptor /
  per-claim-deadline / HTTP-worker capabilities, cancellation
  semantics retained.
- `awa-cli` — complete command table (`migrate`, `job`, `queue`,
  `cron`, `dlq`, `storage`, `serve`), worked storage-transition
  example, bulk-DLQ guard note, distribution paragraph (PyPI + cargo).
- `awa-ui` — six tabs plus DLQ browser, storage-transition card on
  Runtime, read-only mode behavior, REST surface pointer, frontend
  stack.
- `awa-testing` — TestClient surface, WorkResult predicates, full
  copy-pasteable example.
- `awa-macros` — `#[derive(JobArgs)]` defaults, `#[awa(kind = "...")]`
  override, dual-crate path resolution note.

Two corrections found while reading the code:

- The audit suggested `register_queue_descriptor` /
  `register_job_kind_descriptor` as worker-builder method names; the
  actual `ClientBuilder` methods are `queue_descriptor` /
  `job_kind_descriptor`. README now uses the real names.
- DLQ is a route in the UI (`/dlq`, `/dlq/$id`) but is not in the
  Shell sidebar nav. README documents it as a tab reachable from the
  Jobs tab via row links — matches the actual `job-detail.tsx`
  redirect behavior.

### 3. Python docstring final pass

The audit-flagged spots in `client.py` (lines 9, 142, 164, 778) were
already cleaned up in earlier audit batches. One residual was found
and fixed: the DLQ section block comment in `client.py` referenced
`awa-model/src/dlq.rs` (an internal source path that PyPI readers
don't have) — trimmed.

Sweep across `client.py`, `__init__.py`, `__main__.py`, `bridge.py`,
and `testing.py` found no remaining "0.4.x" / "0.5 → 0.6" arrows,
"WIP" / "TODO" / "for now" comments, ADR-NNN references in public
docstrings, or commit-SHA / issue-# pointers.

## Validation

- `cargo fmt --all -- --check` clean
- `SQLX_OFFLINE=true cargo clippy --workspace --all-targets --all-features -- -D warnings` clean
- `SQLX_OFFLINE=true cargo build --workspace` clean

## Reviewer checklist

- [ ] CHANGELOG bullets land on the right ADRs
- [ ] Sub-project READMEs match the public API surface (especially
      `awa-worker` `queue_descriptor` / `job_kind_descriptor` builder
      methods, `awa-cli` storage subcommand list)
- [ ] `awa-ui` README's tab list matches `Shell.tsx` nav + `/dlq`
      route
- [ ] No version arrows in the Python docstrings
- [ ] Cross-links (`docs/dead-letter-queue.md`,
      `docs/upgrade-0.5-to-0.6.md`, ADR pages) resolve

Not merging — leaving for review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive changelog documenting 0.6.0-alpha.0 release with new queue storage, DLQ support, and storage transition capabilities.
  * Expanded CLI, testing, and library documentation with detailed usage examples and feature descriptions.
  * Updated UI documentation to highlight DLQ management, storage-transition visualization, and read-only mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->