### PR TITLE
deps: combined dependabot bumps (2026-05-01)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1791,9 +1791,9 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "openssl"
-version = "0.10.76"
+version = "0.10.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "951c002c75e16ea2c65b8c7e4d3d51d5530d8dfa7d060b4776828c88cfb18ecf"
+checksum = "f38c4372413cdaaf3cc79dd92d29d7d9f5ab09b51b10dded508fb90bb70b9222"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -1823,9 +1823,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.112"
+version = "0.9.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57d55af3b3e226502be1526dfdba67ab0e9c96fc293004e79576b2b9edb0dbdb"
+checksum = "13ce1245cd07fcc4cfdb438f7507b0c7e4f3849a69fd84d52374c66d83741bb6"
 dependencies = [
  "cc",
  "libc",
@@ -2506,9 +2506,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",

--- a/awa-python/Cargo.lock
+++ b/awa-python/Cargo.lock
@@ -95,7 +95,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "awa-macros"
-version = "0.5.6"
+version = "0.6.0"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -105,7 +105,7 @@ dependencies = [
 
 [[package]]
 name = "awa-model"
-version = "0.5.6"
+version = "0.6.0"
 dependencies = [
  "awa-macros",
  "blake3",
@@ -125,7 +125,7 @@ dependencies = [
 
 [[package]]
 name = "awa-python"
-version = "0.5.6"
+version = "0.6.0"
 dependencies = [
  "async-trait",
  "awa-model",
@@ -148,7 +148,7 @@ dependencies = [
 
 [[package]]
 name = "awa-worker"
-version = "0.5.6"
+version = "0.6.0"
 dependencies = [
  "async-trait",
  "awa-macros",
@@ -1157,7 +1157,7 @@ dependencies = [
  "num-integer",
  "num-iter",
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
  "smallvec",
  "zeroize",
 ]
@@ -1582,9 +1582,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -1779,9 +1779,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -2084,7 +2084,7 @@ dependencies = [
  "memchr",
  "once_cell",
  "percent-encoding",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rsa",
  "serde",
  "sha1",
@@ -2124,7 +2124,7 @@ dependencies = [
  "md-5",
  "memchr",
  "once_cell",
- "rand 0.8.5",
+ "rand 0.8.6",
  "serde",
  "serde_json",
  "sha2",

--- a/awa-ui/frontend/package-lock.json
+++ b/awa-ui/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "awa-ui-frontend",
-  "version": "0.1.0",
+  "version": "0.5.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "awa-ui-frontend",
-      "version": "0.1.0",
+      "version": "0.5.6",
       "dependencies": {
         "@heroicons/react": "^2",
         "@tanstack/react-query": "^5",
@@ -4607,9 +4607,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "version": "8.5.12",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
+      "integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
       "dev": true,
       "funding": [
         {

--- a/examples/rust-app-demo/Cargo.lock
+++ b/examples/rust-app-demo/Cargo.lock
@@ -78,7 +78,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "awa"
-version = "0.4.0"
+version = "0.6.0"
 dependencies = [
  "awa-macros",
  "awa-model",
@@ -87,8 +87,9 @@ dependencies = [
 
 [[package]]
 name = "awa-macros"
-version = "0.4.0"
+version = "0.6.0"
 dependencies = [
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
  "syn",
@@ -96,7 +97,7 @@ dependencies = [
 
 [[package]]
 name = "awa-model"
-version = "0.4.0"
+version = "0.6.0"
 dependencies = [
  "awa-macros",
  "blake3",
@@ -133,7 +134,7 @@ dependencies = [
 
 [[package]]
 name = "awa-worker"
-version = "0.4.0"
+version = "0.6.0"
 dependencies = [
  "async-trait",
  "awa-macros",
@@ -1102,9 +1103,9 @@ checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "opentelemetry"
-version = "0.29.1"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e87237e2775f74896f9ad219d26a2081751187eb7c9f5c58dde20a23b95d16c"
+checksum = "b84bcd6ae87133e903af7ef497404dda70c60d0ea14895fc8a5e6722754fc2a0"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1250,6 +1251,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-crate"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
+dependencies = [
+ "toml_edit",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1275,9 +1285,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha",
@@ -1397,9 +1407,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -1959,6 +1969,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.25.11+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "toml_parser",
+ "winnow",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+dependencies = [
+ "winnow",
+]
+
+[[package]]
 name = "tower"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2484,6 +2524,15 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winnow"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wit-bindgen"


### PR DESCRIPTION
## Summary

Combined dependabot dependency bumps to avoid retriggering CI on each individual PR.

### Cargo bumps

| Crate | From | To | Lockfiles | Supersedes |
|---|---|---|---|---|
| openssl | 0.10.76 | 0.10.78 | root | #190 |
| openssl-sys | 0.9.112 | 0.9.114 | root (transitive of openssl) | — |
| rustls-webpki | 0.103.10 | 0.103.13 | root, awa-python, examples/rust-app-demo | #194, #199, #202 |
| rand | 0.8.5 | 0.8.6 | awa-python, examples/rust-app-demo | #191, #192 |

### Frontend bumps

| Package | From | To | Lockfile | Supersedes |
|---|---|---|---|---|
| postcss | 8.5.8 | 8.5.12 | awa-ui/frontend/package-lock.json | #201 |

### Skipped bumps

None.

## Side-effect lockfile syncs

The `awa-python/Cargo.lock` and `examples/rust-app-demo/Cargo.lock` had drifted from their Cargo.toml versions; running `cargo update` resyncs them. These appeared in dependabot's individual PRs too:
- `awa-python`: awa-* crates pinned 0.5.6 -> 0.6.0
- `examples/rust-app-demo`: awa-* crates 0.4.0 -> 0.6.0, opentelemetry 0.29.1 -> 0.31.0, plus new transitive `proc-macro-crate`/`toml_*` entries

## Local verification

- [x] `cargo fmt --all -- --check` — clean
- [x] `SQLX_OFFLINE=true cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
- [x] `SQLX_OFFLINE=true cargo build --workspace` — passes
- [x] `SQLX_OFFLINE=true cargo test --workspace --tests` (with Postgres at `postgres://postgres:postgres@localhost:5432/awa_test`) — passes
- [x] `awa-python`: `cargo build --release` + `cargo clippy --all-targets --all-features -- -D warnings` — passes
- [x] `examples/rust-app-demo`: `cargo build` — passes
- [x] `awa-ui/frontend`: `npm install` + `npm run lint` (tsc) + `npm run build` — passes

## Reviewer notes

After this PR merges, please close the superseded individual dependabot PRs (#190, #191, #192, #194, #199, #201, #202).

## Test plan

- [ ] CI green
- [ ] Spot-check Cargo.lock diffs match dependabot's proposed PRs (no surprise crates added)
- [ ] After merge, close superseded dependabot PRs