### PR TITLE
release: bump versions to 0.6.0-alpha.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,7 +171,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "awa"
-version = "0.6.0"
+version = "0.6.0-alpha.0"
 dependencies = [
  "async-trait",
  "awa-macros",
@@ -196,7 +196,7 @@ dependencies = [
 
 [[package]]
 name = "awa-cli"
-version = "0.6.0"
+version = "0.6.0-alpha.0"
 dependencies = [
  "assert_cmd",
  "awa-model",
@@ -218,7 +218,7 @@ dependencies = [
 
 [[package]]
 name = "awa-macros"
-version = "0.6.0"
+version = "0.6.0-alpha.0"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -228,7 +228,7 @@ dependencies = [
 
 [[package]]
 name = "awa-model"
-version = "0.6.0"
+version = "0.6.0-alpha.0"
 dependencies = [
  "awa-macros",
  "blake3",
@@ -249,7 +249,7 @@ dependencies = [
 
 [[package]]
 name = "awa-testing"
-version = "0.6.0"
+version = "0.6.0-alpha.0"
 dependencies = [
  "async-trait",
  "awa-model",
@@ -264,7 +264,7 @@ dependencies = [
 
 [[package]]
 name = "awa-ui"
-version = "0.6.0"
+version = "0.6.0-alpha.0"
 dependencies = [
  "awa-model",
  "awa-testing",
@@ -287,7 +287,7 @@ dependencies = [
 
 [[package]]
 name = "awa-worker"
-version = "0.6.0"
+version = "0.6.0-alpha.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 exclude = ["awa-python", "spike"]
 
 [workspace.package]
-version = "0.6.0"
+version = "0.6.0-alpha.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "Postgres-native background job queue — transactional enqueue, heartbeat crash recovery, SKIP LOCKED dispatch"
@@ -23,9 +23,9 @@ categories = ["database", "asynchronous", "web-programming"]
 
 [workspace.dependencies]
 # Internal crates
-awa-model = { path = "awa-model", version = "0.6.0" }
-awa-macros = { path = "awa-macros", version = "0.6.0" }
-awa-worker = { path = "awa-worker", version = "0.6.0" }
+awa-model = { path = "awa-model", version = "0.6.0-alpha.0" }
+awa-macros = { path = "awa-macros", version = "0.6.0-alpha.0" }
+awa-worker = { path = "awa-worker", version = "0.6.0-alpha.0" }
 
 # Database
 sqlx = { version = "0.8", features = ["runtime-tokio-rustls", "postgres", "chrono", "json", "migrate", "uuid"] }

--- a/awa-cli/Cargo.toml
+++ b/awa-cli/Cargo.toml
@@ -14,7 +14,7 @@ path = "src/main.rs"
 [dependencies]
 awa-model.workspace = true
 awa-worker.workspace = true
-awa-ui = { path = "../awa-ui", version = "0.6.0" }
+awa-ui = { path = "../awa-ui", version = "0.6.0-alpha.0" }
 axum.workspace = true
 sqlx.workspace = true
 tokio.workspace = true
@@ -26,7 +26,7 @@ chrono.workspace = true
 hex.workspace = true
 
 [dev-dependencies]
-awa-testing = { path = "../awa-testing", version = "0.6.0" }
+awa-testing = { path = "../awa-testing", version = "0.6.0-alpha.0" }
 assert_cmd = "2"
 serde.workspace = true
 uuid.workspace = true

--- a/awa-cli/pyproject.toml
+++ b/awa-cli/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "awa-cli"
-version = "0.6.0"
+version = "0.6.0-alpha.0"
 description = "CLI for the Awa Postgres-native job queue (migrations, admin, serve)"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/awa-python/Cargo.lock
+++ b/awa-python/Cargo.lock
@@ -95,7 +95,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "awa-macros"
-version = "0.6.0"
+version = "0.6.0-alpha.0"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -105,7 +105,7 @@ dependencies = [
 
 [[package]]
 name = "awa-model"
-version = "0.6.0"
+version = "0.6.0-alpha.0"
 dependencies = [
  "awa-macros",
  "blake3",
@@ -125,7 +125,7 @@ dependencies = [
 
 [[package]]
 name = "awa-python"
-version = "0.6.0"
+version = "0.6.0-alpha.0"
 dependencies = [
  "async-trait",
  "awa-model",
@@ -148,7 +148,7 @@ dependencies = [
 
 [[package]]
 name = "awa-worker"
-version = "0.6.0"
+version = "0.6.0-alpha.0"
 dependencies = [
  "async-trait",
  "awa-macros",

--- a/awa-python/Cargo.toml
+++ b/awa-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "awa-python"
-version = "0.6.0"
+version = "0.6.0-alpha.0"
 edition = "2021"
 
 [lib]
@@ -12,8 +12,8 @@ default = ["cel"]
 cel = ["awa-model/cel"]
 
 [dependencies]
-awa-model = { path = "../awa-model", version = "0.6.0" }
-awa-worker = { path = "../awa-worker", version = "0.6.0", features = ["__python-bridge"] }
+awa-model = { path = "../awa-model", version = "0.6.0-alpha.0" }
+awa-worker = { path = "../awa-worker", version = "0.6.0-alpha.0", features = ["__python-bridge"] }
 pyo3 = { version = "0.28", features = ["macros", "abi3-py310", "chrono"] }
 pyo3-async-runtimes = { version = "0.28", features = ["tokio-runtime"] }
 sqlx = { version = "0.8", features = ["runtime-tokio-rustls", "postgres", "chrono", "json"] }

--- a/awa-python/pyproject.toml
+++ b/awa-python/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "maturin"
 [project]
 name = "awa-pg"
 requires-python = ">=3.10"
-version = "0.6.0"
+version = "0.6.0-alpha.0"
 description = "Postgres-native background job queue — Python SDK with async/sync workers, transactional enqueue, progress tracking, and web UI"
 readme = {file = "../README.md", content-type = "text/markdown"}
 license = {text = "MIT OR Apache-2.0"}

--- a/awa/Cargo.toml
+++ b/awa/Cargo.toml
@@ -20,7 +20,7 @@ awa-macros.workspace = true
 awa-worker.workspace = true
 
 [dev-dependencies]
-awa-testing = { path = "../awa-testing", version = "0.6.0" }
+awa-testing = { path = "../awa-testing", version = "0.6.0-alpha.0" }
 sqlx.workspace = true
 serde.workspace = true
 serde_json.workspace = true


### PR DESCRIPTION
The `release.yml` workflow's version-consistency check requires the
git tag and `Cargo.toml` versions to match exactly. The earlier bump
on the 0.6 merge set `0.6.0` across the workspace; for an alpha
pre-release the SemVer form is `0.6.0-alpha.0`.

This was caught when `v0.6.0-alpha.0` was first pushed — see workflow
run [25186436983](https://github.com/hardbyte/awa/actions/runs/25186436983):

```
##[error]version mismatch: Cargo.toml says '0.6.0', tag says '0.6.0-alpha.0'
##[error]version mismatch: awa-python/Cargo.toml says '0.6.0', tag says '0.6.0-alpha.0'
##[error]version mismatch: awa-python/pyproject.toml says '0.6.0', tag says '0.6.0-alpha.0'
```

The bad tag has been deleted (local + remote). After this merges,
re-tag `v0.6.0-alpha.0` on the merge commit and push.

## What changed

- `Cargo.toml` (workspace.package + workspace.dependencies inter-crate version pins)
- `awa-cli/Cargo.toml` (awa-testing pin)
- `awa-cli/pyproject.toml`
- `awa/Cargo.toml` (awa-testing pin)
- `awa-python/Cargo.toml`
- `awa-python/pyproject.toml`
- `Cargo.lock` and `awa-python/Cargo.lock` (auto-regenerated by `cargo build`)

## Verified

- `cargo build --workspace` clean
- `cargo build` for awa-python clean

## Test plan
- [ ] CI green