### PR TITLE
Spike queue-storage enqueue throughput

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,7 +171,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "awa"
-version = "0.6.0-alpha.0"
+version = "0.6.0-alpha.1"
 dependencies = [
  "async-trait",
  "awa-macros",
@@ -196,7 +196,7 @@ dependencies = [
 
 [[package]]
 name = "awa-cli"
-version = "0.6.0-alpha.0"
+version = "0.6.0-alpha.1"
 dependencies = [
  "assert_cmd",
  "awa-model",
@@ -218,7 +218,7 @@ dependencies = [
 
 [[package]]
 name = "awa-macros"
-version = "0.6.0-alpha.0"
+version = "0.6.0-alpha.1"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -228,7 +228,7 @@ dependencies = [
 
 [[package]]
 name = "awa-model"
-version = "0.6.0-alpha.0"
+version = "0.6.0-alpha.1"
 dependencies = [
  "awa-macros",
  "blake3",
@@ -249,7 +249,7 @@ dependencies = [
 
 [[package]]
 name = "awa-testing"
-version = "0.6.0-alpha.0"
+version = "0.6.0-alpha.1"
 dependencies = [
  "async-trait",
  "awa-model",
@@ -264,7 +264,7 @@ dependencies = [
 
 [[package]]
 name = "awa-ui"
-version = "0.6.0-alpha.0"
+version = "0.6.0-alpha.1"
 dependencies = [
  "awa-model",
  "awa-testing",
@@ -287,7 +287,7 @@ dependencies = [
 
 [[package]]
 name = "awa-worker"
-version = "0.6.0-alpha.0"
+version = "0.6.0-alpha.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 exclude = ["awa-python", "spike"]
 
 [workspace.package]
-version = "0.6.0-alpha.0"
+version = "0.6.0-alpha.1"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "Postgres-native background job queue — transactional enqueue, heartbeat crash recovery, SKIP LOCKED dispatch"
@@ -23,9 +23,9 @@ categories = ["database", "asynchronous", "web-programming"]
 
 [workspace.dependencies]
 # Internal crates
-awa-model = { path = "awa-model", version = "0.6.0-alpha.0" }
-awa-macros = { path = "awa-macros", version = "0.6.0-alpha.0" }
-awa-worker = { path = "awa-worker", version = "0.6.0-alpha.0" }
+awa-model = { path = "awa-model", version = "0.6.0-alpha.1" }
+awa-macros = { path = "awa-macros", version = "0.6.0-alpha.1" }
+awa-worker = { path = "awa-worker", version = "0.6.0-alpha.1" }
 
 # Database
 sqlx = { version = "0.8", features = ["runtime-tokio-rustls", "postgres", "chrono", "json", "migrate", "uuid"] }

--- a/awa-cli/Cargo.toml
+++ b/awa-cli/Cargo.toml
@@ -14,7 +14,7 @@ path = "src/main.rs"
 [dependencies]
 awa-model.workspace = true
 awa-worker.workspace = true
-awa-ui = { path = "../awa-ui", version = "0.6.0-alpha.0" }
+awa-ui = { path = "../awa-ui", version = "0.6.0-alpha.1" }
 axum.workspace = true
 sqlx.workspace = true
 tokio.workspace = true
@@ -26,7 +26,7 @@ chrono.workspace = true
 hex.workspace = true
 
 [dev-dependencies]
-awa-testing = { path = "../awa-testing", version = "0.6.0-alpha.0" }
+awa-testing = { path = "../awa-testing", version = "0.6.0-alpha.1" }
 assert_cmd = "2"
 serde.workspace = true
 uuid.workspace = true

--- a/awa-model/src/queue_storage.rs
+++ b/awa-model/src/queue_storage.rs
@@ -7,7 +7,7 @@ use chrono::TimeDelta;
 use chrono::{DateTime, Utc};
 use sqlx::{PgPool, Postgres, QueryBuilder};
 use std::collections::hash_map::DefaultHasher;
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::{BTreeMap, BTreeSet, HashSet};
 use std::hash::{Hash, Hasher};
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Duration;
@@ -1594,6 +1594,87 @@ impl QueueStorage {
         }
 
         Ok(())
+    }
+
+    async fn sync_enqueue_unique_claims<'a>(
+        &self,
+        tx: &mut sqlx::Transaction<'a, sqlx::Postgres>,
+        claims: Vec<(Vec<u8>, i64)>,
+    ) -> Result<(), AwaError> {
+        if claims.is_empty() {
+            return Ok(());
+        }
+
+        let mut seen: HashSet<&[u8]> = HashSet::with_capacity(claims.len());
+        for (key, _) in &claims {
+            if !seen.insert(key.as_slice()) {
+                return Err(AwaError::UniqueConflict {
+                    constraint: Some("idx_awa_jobs_unique".to_string()),
+                });
+            }
+        }
+
+        let (keys, job_ids): (Vec<Vec<u8>>, Vec<i64>) = claims.into_iter().unzip();
+        let (requested, applied): (i64, i64) = sqlx::query_as(
+            r#"
+            WITH input(unique_key, job_id) AS (
+                SELECT * FROM unnest($1::bytea[], $2::bigint[])
+            ),
+            inserted AS (
+                INSERT INTO awa.job_unique_claims (unique_key, job_id)
+                SELECT unique_key, job_id FROM input
+                ON CONFLICT (unique_key)
+                DO UPDATE SET job_id = EXCLUDED.job_id
+                WHERE awa.job_unique_claims.job_id = EXCLUDED.job_id
+                RETURNING unique_key
+            )
+            SELECT
+                (SELECT count(*)::bigint FROM input) AS requested,
+                (SELECT count(*)::bigint FROM inserted) AS applied
+            "#,
+        )
+        .bind(keys)
+        .bind(job_ids)
+        .fetch_one(tx.as_mut())
+        .await
+        .map_err(map_sqlx_error)?;
+
+        if applied != requested {
+            return Err(AwaError::UniqueConflict {
+                constraint: Some("idx_awa_jobs_unique".to_string()),
+            });
+        }
+
+        Ok(())
+    }
+
+    // Enqueue inserts have no prior storage state, so uniqueness only needs to
+    // add claims for states included in the row's unique-state bitmask. State
+    // transitions still use `sync_unique_claim`, which can release old claims.
+    async fn sync_ready_enqueue_unique_claims<'a>(
+        &self,
+        tx: &mut sqlx::Transaction<'a, sqlx::Postgres>,
+        rows: &[RuntimeReadyInsert],
+    ) -> Result<(), AwaError> {
+        let claims = rows
+            .iter()
+            .filter(|row| unique_state_claims(row.unique_states.as_deref(), JobState::Available))
+            .filter_map(|row| row.unique_key.as_ref().map(|key| (key.clone(), row.job_id)))
+            .collect();
+        self.sync_enqueue_unique_claims(tx, claims).await
+    }
+
+    async fn sync_deferred_enqueue_unique_claims<'a>(
+        &self,
+        tx: &mut sqlx::Transaction<'a, sqlx::Postgres>,
+        rows: &[DeferredJobRow],
+    ) -> Result<(), AwaError> {
+        let claims = rows
+            .iter()
+            .filter(|row| unique_state_claims(row.unique_states.as_deref(), row.state))
+            .filter_map(|row| row.unique_key.as_ref().map(|key| (key.clone(), row.job_id)))
+            .collect();
+        self.sync_enqueue_unique_claims(tx, claims).await
     }
 
     #[tracing::instrument(skip(self, pool), name = "queue_storage.prepare_schema")]
@@ -3823,15 +3904,6 @@ impl QueueStorage {
                 let job_id = job_id_iter.next().ok_or_else(|| {
                     AwaError::Validation("queue storage job id allocation underflow".to_string())
                 })?;
-                self.sync_unique_claim(
-                    tx,
-                    job_id,
-                    &row.unique_key,
-                    row.unique_states.as_deref(),
-                    None,
-                    Some(JobState::Available),
-                )
-                .await?;
                 ready_rows.push(RuntimeReadyInsert {
                     job_id,
                     kind: row.kind,
@@ -3852,6 +3924,8 @@ impl QueueStorage {
             }
         }
 
+        self.sync_ready_enqueue_unique_claims(tx, &ready_rows)
+            .await?;
         self.execute_ready_inserts_tx(tx, &ready_rows).await?;
         let mut count_deltas: BTreeMap<(String, i16), i64> = BTreeMap::new();
         for row in &ready_rows {
@@ -3921,15 +3995,6 @@ impl QueueStorage {
                 let job_id = job_id_iter.next().ok_or_else(|| {
                     AwaError::Validation("queue storage job id allocation underflow".to_string())
                 })?;
-                self.sync_unique_claim(
-                    tx,
-                    job_id,
-                    &row.unique_key,
-                    row.unique_states.as_deref(),
-                    None,
-                    Some(JobState::Available),
-                )
-                .await?;
                 ready_rows.push(RuntimeReadyInsert {
                     job_id,
                     kind: row.kind,
@@ -3950,6 +4015,8 @@ impl QueueStorage {
             }
         }
 
+        self.sync_ready_enqueue_unique_claims(tx, &ready_rows)
+            .await?;
         self.execute_ready_copy_tx(tx, &ready_rows).await?;
         let mut count_deltas: BTreeMap<(String, i16), i64> = BTreeMap::new();
         for row in &ready_rows {
@@ -4065,16 +4132,20 @@ impl QueueStorage {
             return Ok(0);
         }
 
-        for row in &rows {
-            self.sync_unique_claim(
-                tx,
-                row.job_id,
-                &row.unique_key,
-                row.unique_states.as_deref(),
-                old_state,
-                Some(row.state),
-            )
-            .await?;
+        if old_state.is_none() {
+            self.sync_deferred_enqueue_unique_claims(tx, &rows).await?;
+        } else {
+            for row in &rows {
+                self.sync_unique_claim(
+                    tx,
+                    row.job_id,
+                    &row.unique_key,
+                    row.unique_states.as_deref(),
+                    old_state,
+                    Some(row.state),
+                )
+                .await?;
+            }
         }
 
         let schema = self.schema();
@@ -4117,17 +4188,7 @@ impl QueueStorage {
             return Ok(0);
         }
 
-        for row in &rows {
-            self.sync_unique_claim(
-                tx,
-                row.job_id,
-                &row.unique_key,
-                row.unique_states.as_deref(),
-                None,
-                Some(row.state),
-            )
-            .await?;
-        }
+        self.sync_deferred_enqueue_unique_claims(tx, &rows).await?;
 
         let schema = self.schema();
         let copy_sql = format!(

--- a/awa-model/tests/queue_storage_copy_test.rs
+++ b/awa-model/tests/queue_storage_copy_test.rs
@@ -97,6 +97,14 @@ fn copy_job_with_opts(
     }
 }
 
+fn bench_env_usize(name: &str, default: usize) -> usize {
+    std::env::var(name)
+        .ok()
+        .and_then(|value| value.parse::<usize>().ok())
+        .filter(|value| *value > 0)
+        .unwrap_or(default)
+}
+
 #[tokio::test]
 async fn queue_storage_copy_enqueues_ready_and_deferred_rows() {
     let _guard = QUEUE_STORAGE_COPY_LOCK.lock().await;
@@ -228,6 +236,114 @@ async fn queue_storage_copy_rolls_back_on_unique_conflict() {
     .await
     .expect("count lane availability");
     assert_eq!(lane_available, 0);
+}
+
+#[tokio::test]
+async fn queue_storage_batch_rolls_back_on_batched_unique_conflict() {
+    let _guard = QUEUE_STORAGE_COPY_LOCK.lock().await;
+    let (pool, store) = setup_store("awa_qs_batch_unique_conflict").await;
+    let queue = "qs_batch_unique_conflict";
+
+    let opts = InsertOpts {
+        queue: queue.to_string(),
+        unique: Some(UniqueOpts::default()),
+        ..Default::default()
+    };
+    let jobs = vec![
+        InsertParams {
+            kind: "batch_unique".to_string(),
+            args: serde_json::json!({"same": true}),
+            opts: opts.clone(),
+        },
+        InsertParams {
+            kind: "batch_unique".to_string(),
+            args: serde_json::json!({"same": true}),
+            opts,
+        },
+    ];
+
+    let err = store
+        .enqueue_params_batch(&pool, &jobs)
+        .await
+        .expect_err("duplicate unique batch should fail");
+    assert!(
+        matches!(err, AwaError::UniqueConflict { .. }),
+        "unexpected error: {err:?}"
+    );
+
+    let ready_count: i64 = sqlx::query_scalar(&format!(
+        "SELECT count(*)::bigint FROM {}.ready_entries WHERE queue = $1",
+        store.schema()
+    ))
+    .bind(queue)
+    .fetch_one(&pool)
+    .await
+    .expect("count ready rows");
+    assert_eq!(ready_count, 0);
+
+    let lane_available: i64 = sqlx::query_scalar(&format!(
+        "SELECT COALESCE(sum(available_count), 0)::bigint FROM {}.queue_lanes WHERE queue = $1",
+        store.schema()
+    ))
+    .bind(queue)
+    .fetch_one(&pool)
+    .await
+    .expect("count lane availability");
+    assert_eq!(lane_available, 0);
+}
+
+#[tokio::test]
+async fn queue_storage_copy_rolls_back_on_existing_unique_conflict() {
+    let _guard = QUEUE_STORAGE_COPY_LOCK.lock().await;
+    let (pool, store) = setup_store("awa_qs_copy_existing_unique_conflict").await;
+    let queue = "qs_copy_existing_unique_conflict";
+
+    let opts = InsertOpts {
+        queue: queue.to_string(),
+        unique: Some(UniqueOpts::default()),
+        ..Default::default()
+    };
+    let job = InsertParams {
+        kind: "copy_existing_unique".to_string(),
+        args: serde_json::json!({"same": true}),
+        opts,
+    };
+
+    assert_eq!(
+        store
+            .enqueue_params_batch(&pool, std::slice::from_ref(&job))
+            .await
+            .expect("seed unique job"),
+        1
+    );
+    let err = store
+        .enqueue_params_copy(&pool, std::slice::from_ref(&job))
+        .await
+        .expect_err("existing unique claim should fail");
+    assert!(
+        matches!(err, AwaError::UniqueConflict { .. }),
+        "unexpected error: {err:?}"
+    );
+
+    let ready_count: i64 = sqlx::query_scalar(&format!(
+        "SELECT count(*)::bigint FROM {}.ready_entries WHERE queue = $1",
+        store.schema()
+    ))
+    .bind(queue)
+    .fetch_one(&pool)
+    .await
+    .expect("count ready rows");
+    assert_eq!(ready_count, 1);
+
+    let lane_available: i64 = sqlx::query_scalar(&format!(
+        "SELECT COALESCE(sum(available_count), 0)::bigint FROM {}.queue_lanes WHERE queue = $1",
+        store.schema()
+    ))
+    .bind(queue)
+    .fetch_one(&pool)
+    .await
+    .expect("count lane availability");
+    assert_eq!(lane_available, 1);
 }
 
 #[tokio::test]
@@ -425,14 +541,8 @@ async fn queue_storage_copy_escapes_csv_special_values() {
 #[ignore = "benchmark; requires local Postgres and is not part of the default suite"]
 async fn queue_storage_copy_benchmark_batch_vs_copy() {
     let _guard = QUEUE_STORAGE_COPY_LOCK.lock().await;
-    let total_jobs: usize = std::env::var("AWA_QS_COPY_BENCH_JOBS")
-        .ok()
-        .and_then(|value| value.parse().ok())
-        .unwrap_or(8192);
-    let batch_size: usize = std::env::var("AWA_QS_COPY_BENCH_BATCH")
-        .ok()
-        .and_then(|value| value.parse().ok())
-        .unwrap_or(128);
+    let total_jobs = bench_env_usize("AWA_QS_COPY_BENCH_JOBS", 8192);
+    let batch_size = bench_env_usize("AWA_QS_COPY_BENCH_BATCH", 128);
 
     let (batch_pool, batch_store) = setup_store_with_config(
         QueueStorageConfig {
@@ -504,6 +614,88 @@ async fn queue_storage_copy_benchmark_batch_vs_copy() {
     );
     println!(
         "[bench] queue_storage COPY speedup: {:.2}x",
+        copy_rate / batch_rate
+    );
+}
+
+#[tokio::test]
+#[ignore = "benchmark; set DATABASE_URL and AWA_QS_COPY_BENCH_* to tune"]
+async fn queue_storage_copy_benchmark_unique_batch_vs_copy() {
+    let _guard = QUEUE_STORAGE_COPY_LOCK.lock().await;
+    let total_jobs = bench_env_usize("AWA_QS_COPY_BENCH_JOBS", 4096);
+    let batch_size = bench_env_usize("AWA_QS_COPY_BENCH_BATCH", 128);
+
+    let (batch_pool, batch_store) = setup_store_with_config(
+        QueueStorageConfig {
+            schema: "awa_qs_copy_unique_bench_batch".to_string(),
+            queue_slot_count: 4,
+            lease_slot_count: 2,
+            claim_slot_count: 2,
+            ..Default::default()
+        },
+        8,
+    )
+    .await;
+    let (copy_pool, copy_store) = setup_store_with_config(
+        QueueStorageConfig {
+            schema: "awa_qs_copy_unique_bench_copy".to_string(),
+            queue_slot_count: 4,
+            lease_slot_count: 2,
+            claim_slot_count: 2,
+            ..Default::default()
+        },
+        8,
+    )
+    .await;
+
+    let jobs: Vec<_> = (0..total_jobs)
+        .map(|seq| {
+            copy_job_with_opts(
+                "copy_unique_bench",
+                "qs_copy_unique_bench",
+                seq as i64,
+                InsertOpts {
+                    metadata: serde_json::json!({"bench": true, "seq": seq}),
+                    tags: vec!["bench".to_string(), "unique".to_string()],
+                    unique: Some(UniqueOpts::default()),
+                    ..Default::default()
+                },
+            )
+        })
+        .collect();
+
+    let batch_start = Instant::now();
+    for chunk in jobs.chunks(batch_size) {
+        batch_store
+            .enqueue_params_batch(&batch_pool, chunk)
+            .await
+            .expect("batch enqueue");
+    }
+    let batch_elapsed = batch_start.elapsed();
+
+    let copy_start = Instant::now();
+    for chunk in jobs.chunks(batch_size) {
+        copy_store
+            .enqueue_params_copy(&copy_pool, chunk)
+            .await
+            .expect("copy enqueue");
+    }
+    let copy_elapsed = copy_start.elapsed();
+
+    let batch_rate = total_jobs as f64 / batch_elapsed.as_secs_f64();
+    let copy_rate = total_jobs as f64 / copy_elapsed.as_secs_f64();
+    println!(
+        "[bench] queue_storage unique batch: {total_jobs} jobs in {:.3}s ({:.0} jobs/sec), batch_size={batch_size}",
+        batch_elapsed.as_secs_f64(),
+        batch_rate
+    );
+    println!(
+        "[bench] queue_storage unique COPY:  {total_jobs} jobs in {:.3}s ({:.0} jobs/sec), batch_size={batch_size}",
+        copy_elapsed.as_secs_f64(),
+        copy_rate
+    );
+    println!(
+        "[bench] queue_storage unique COPY speedup: {:.2}x",
         copy_rate / batch_rate
     );
 }

--- a/awa-python/Cargo.lock
+++ b/awa-python/Cargo.lock
@@ -95,7 +95,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "awa-macros"
-version = "0.6.0-alpha.0"
+version = "0.6.0-alpha.1"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -105,7 +105,7 @@ dependencies = [
 
 [[package]]
 name = "awa-model"
-version = "0.6.0-alpha.0"
+version = "0.6.0-alpha.1"
 dependencies = [
  "awa-macros",
  "blake3",
@@ -125,7 +125,7 @@ dependencies = [
 
 [[package]]
 name = "awa-python"
-version = "0.6.0-alpha.0"
+version = "0.6.0-alpha.1"
 dependencies = [
  "async-trait",
  "awa-model",
@@ -148,7 +148,7 @@ dependencies = [
 
 [[package]]
 name = "awa-worker"
-version = "0.6.0-alpha.0"
+version = "0.6.0-alpha.1"
 dependencies = [
  "async-trait",
  "awa-macros",

--- a/awa-python/Cargo.toml
+++ b/awa-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "awa-python"
-version = "0.6.0-alpha.0"
+version = "0.6.0-alpha.1"
 edition = "2021"
 
 [lib]
@@ -12,8 +12,8 @@ default = ["cel"]
 cel = ["awa-model/cel"]
 
 [dependencies]
-awa-model = { path = "../awa-model", version = "0.6.0-alpha.0" }
-awa-worker = { path = "../awa-worker", version = "0.6.0-alpha.0", features = ["__python-bridge"] }
+awa-model = { path = "../awa-model", version = "0.6.0-alpha.1" }
+awa-worker = { path = "../awa-worker", version = "0.6.0-alpha.1", features = ["__python-bridge"] }
 pyo3 = { version = "0.28", features = ["macros", "abi3-py310", "chrono"] }
 pyo3-async-runtimes = { version = "0.28", features = ["tokio-runtime"] }
 sqlx = { version = "0.8", features = ["runtime-tokio-rustls", "postgres", "chrono", "json"] }

--- a/awa-python/pyproject.toml
+++ b/awa-python/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "maturin"
 [project]
 name = "awa-pg"
 requires-python = ">=3.10"
-version = "0.6.0-alpha.0"
+version = "0.6.0-alpha.1"
 description = "Postgres-native background job queue — Python SDK with async/sync workers, transactional enqueue, progress tracking, and web UI"
 readme = {file = "../README.md", content-type = "text/markdown"}
 license = {text = "MIT OR Apache-2.0"}

--- a/awa/Cargo.toml
+++ b/awa/Cargo.toml
@@ -20,7 +20,7 @@ awa-macros.workspace = true
 awa-worker.workspace = true
 
 [dev-dependencies]
-awa-testing = { path = "../awa-testing", version = "0.6.0-alpha.0" }
+awa-testing = { path = "../awa-testing", version = "0.6.0-alpha.1" }
 sqlx.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/correctness/storage/MAPPING.md
+++ b/correctness/storage/MAPPING.md
@@ -42,8 +42,8 @@ for backfill / fallback reads during upgrades.
 
 | TLA+ action | Rust function | SQL / DDL |
 |---|---|---|
-| `EnqueueReady(j)` | `QueueStorage::insert_ready_rows_tx` and `QueueStorage::insert_ready_rows_copy_tx`; producer entry points include `enqueue_batch`, `enqueue_runtime_rows`, `enqueue_params_batch`, and `enqueue_params_copy` | reserve `{schema}.queue_enqueue_heads.next_seq`, sync uniqueness, append to `{schema}.ready_entries` via INSERT or COPY, update lane counters, and notify logical queues in one tx |
-| `EnqueueDeferred(j)` | `QueueStorage::insert_deferred_rows_tx` and `QueueStorage::insert_deferred_rows_copy_tx`; producer entry points include `enqueue_params_batch` and `enqueue_params_copy` | allocate job ids, sync uniqueness, append to `{schema}.deferred_jobs` via INSERT or COPY in one tx |
+| `EnqueueReady(j)` | `QueueStorage::insert_ready_rows_tx` and `QueueStorage::insert_ready_rows_copy_tx`; producer entry points include `enqueue_batch`, `enqueue_runtime_rows`, `enqueue_params_batch`, and `enqueue_params_copy` | reserve `{schema}.queue_enqueue_heads.next_seq`, sync enqueue-time uniqueness claims, append to `{schema}.ready_entries` via INSERT or COPY, update lane counters, and notify logical queues in one tx |
+| `EnqueueDeferred(j)` | `QueueStorage::insert_deferred_rows_tx` and `QueueStorage::insert_deferred_rows_copy_tx`; producer entry points include `enqueue_params_batch` and `enqueue_params_copy` | allocate job ids, sync enqueue-time uniqueness claims, append to `{schema}.deferred_jobs` via INSERT or COPY in one tx |
 | `PromoteDeferred(j)` | maintenance promote loop in `awa-worker/src/maintenance.rs::promote_due_state` | `DELETE FROM deferred_jobs ... INSERT INTO ready_entries ...` in one tx |
 | `AdvanceClaimCursor` | claim path gap-skipping after rescue/prune holes | inside the inline claim CTE; logical `UPDATE queue_claim_heads SET claim_seq = claim_seq + 1 WHERE no row at claim_seq` |
 | `Claim(w, j)` | `QueueStorage::claim_runtime_batch` (`queue_storage.rs:4145`) → `claim_runtime_batch_with_aging_for_instance` (`:4504`) → dispatcher (`awa-worker/src/dispatcher.rs`) | inline claim CTE: lane selection via `FOR UPDATE OF queue_claim_heads SKIP LOCKED`; bare reads of `lease_ring_state` and `claim_ring_state` (no FOR SHARE/UPDATE — rotate's CAS UPDATE on `(current_slot, generation)` plus the partition busy-check provides the conflict detection); INSERT into `lease_claims_<claim_slot>` (receipts mode) or `leases_<lease_slot>` (legacy mode); UPDATE `queue_claim_heads` |
@@ -144,6 +144,23 @@ progress snapshotting, while durable completion continues asynchronously
 through the completion batcher. That changes throughput and scheduling
 behavior, but it does not change the modeled storage safety boundary because
 the `run_lease`-guarded finalization and rescue semantics are unchanged.
+
+## Producer batching note
+
+The TLA+ storage model treats `EnqueueReady` and `EnqueueDeferred` as
+logical per-job state transitions. Rust may batch the SQL implementation
+of producer side effects: allocating a contiguous lane sequence range,
+syncing enqueue-time `job_unique_claims` with one array-backed statement,
+and inserting rows with multi-row `INSERT` or COPY. Those batching choices
+refine the same logical actions as long as they commit in the same
+transaction as the ready/deferred append.
+
+Uniqueness itself is intentionally outside this storage model: duplicate
+rejection is covered by Rust integration tests around `job_unique_claims`.
+The model's enqueue preconditions start after a job has been admitted to
+the storage state, so batching uniqueness claims changes implementation
+granularity rather than the modeled lifecycle, lane, lease, or prune
+invariants.
 
 ## Known modelling gaps with implementation implications
 

--- a/docs/adr/008-copy-batch-ingestion.md
+++ b/docs/adr/008-copy-batch-ingestion.md
@@ -41,7 +41,8 @@ For queue storage producers, add a direct COPY path:
 
 1. Prepare `InsertParams` with the same code as `enqueue_params_batch`
 2. Apply queue striping, allocate job ids, reserve per-lane sequence ranges,
-   sync uniqueness claims, and update lane counters inside one transaction
+   sync uniqueness claims in one statement for new enqueues, and update lane
+   counters inside one transaction
 3. Stream available jobs into
    `{schema}.ready_entries (ready_slot, ready_generation, job_id, kind, queue,
    args, priority, attempt, run_lease, max_attempts, lane_seq, run_at,
@@ -113,6 +114,11 @@ and dispatchers handle duplicates gracefully.
   compatibility view/function and COPY directly into `ready_entries` and
   `deferred_jobs` while preserving job id, lane, counter, uniqueness, and
   notification invariants.
+- **Batched queue-storage uniqueness:** direct queue-storage producers batch
+  enqueue-time uniqueness claims with one `unnest(bytea[], bigint[])` driven
+  `INSERT ... ON CONFLICT` statement. Duplicate keys inside the request are
+  rejected before COPY; conflicts against existing claims abort the transaction
+  before any ready/deferred rows are copied.
 - **Python support:** Python bindings expose `insert_many_copy` /
   `insert_many_copy_sync` for compatibility COPY and `enqueue_many_copy` /
   `enqueue_many_copy_sync` for direct queue-storage COPY.
@@ -127,6 +133,11 @@ and dispatchers handle duplicates gracefully.
 - **Staging overhead remains:** COPY still pays for staging and a final insert
   into the real Awa tables, so it is not automatically faster than chunked
   multi-row `INSERT` in every workload.
+- **Lane counters remain online:** queue-storage enqueue still updates
+  `queue_lanes.available_count` once per touched lane and transaction. Deferring
+  those writes would reduce hot-lane churn further, but the dispatcher scaling
+  path reads the counters as online state, so lazy reconciliation needs a
+  separate design.
 
 ## Relationship to ADR-019
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -305,7 +305,7 @@ enqueue_params_copy(pool, jobs)
     │
     ├── prepare InsertParams and queue stripes
     ├── allocate job ids and reserve per-lane seq ranges
-    ├── sync uniqueness claims and lane counters in the same transaction
+    ├── sync enqueue-time uniqueness claims and lane counters in the same transaction
     ├── COPY ready rows into `{schema}.ready_entries`
     ├── COPY scheduled rows into `{schema}.deferred_jobs`
     └── notify logical queues with newly-ready work
@@ -313,7 +313,9 @@ enqueue_params_copy(pool, jobs)
 
 The COPY producer refines the same storage actions as the normal queue-storage
 batch producer: append ready/deferred rows atomically with the corresponding
-sequence, uniqueness, counter, and notification side effects.
+sequence, uniqueness, counter, and notification side effects. The
+enqueue-time uniqueness claim sync may be batched internally; state transitions
+that move existing jobs still use the transition-aware claim sync.
 
 ### Poll and Claim (Dispatcher)
 


### PR DESCRIPTION
## Summary
- Batch new queue-storage uniqueness claim sync into one array-backed INSERT ... ON CONFLICT statement for batch and COPY enqueue paths.
- Preserve per-row uniqueness sync for state transitions where old_state matters.
- Add conflict rollback coverage for batch/COPY uniqueness and an ignored unique-heavy COPY benchmark.
- Update ADR-008 to document batched queue-storage uniqueness and why online lane counters remain eager.

Stacked on #206 / codex/queue-storage-copy-producer.

## Measurements
Local Postgres, 8192 jobs, chunk size 128, unique jobs:
- batch: 0.576s, 14,223 jobs/sec
- COPY: 0.626s, 13,083 jobs/sec
- COPY speedup: 0.92x

This reduces per-job uniqueness round trips but does not yet beat batch for this unique-heavy workload. Lane-counter writes are already coalesced once per touched lane per transaction; making them lazy needs a separate dispatcher-counter design because queue scaling reads available_count online.

## Validation
- cargo fmt --check
- cargo test -p awa-model --lib
- DATABASE_URL=postgres://postgres:test@localhost:15432/awa_test cargo test -p awa-model --test queue_storage_copy_test
- DATABASE_URL=postgres://postgres:test@localhost:15432/awa_test AWA_QS_COPY_BENCH_JOBS=8192 AWA_QS_COPY_BENCH_BATCH=128 cargo test -p awa-model --test queue_storage_copy_test queue_storage_copy_benchmark_unique_batch_vs_copy -- --ignored --nocapture
- DATABASE_URL=postgres://postgres:test@localhost:15432/awa_test cargo test --workspace

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Optimized uniqueness validation for batch queue operations, consolidating multiple per-row checks into single database operations for faster processing.

* **Tests**
  * Added comprehensive test coverage for batch-based uniqueness conflict scenarios and performance benchmarking.

* **Documentation**
  * Updated queue-storage ingestion documentation to reflect new batch validation approach and online lane counter updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->