### PR TITLE
Harden smoke CI and expose completion batch tuning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt, clippy
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
         with:
@@ -62,7 +62,7 @@ jobs:
           --health-timeout 5s
           --health-retries 5
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
         with:
@@ -94,7 +94,7 @@ jobs:
           --health-timeout 5s
           --health-retries 5
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
         with:
@@ -132,12 +132,12 @@ jobs:
       run:
         working-directory: awa-python
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: "awa-python -> awa-python/target"
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
       - name: Install uv
@@ -173,8 +173,8 @@ jobs:
       run:
         working-directory: awa-ui/frontend
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: "22"
       - name: Install dependencies
@@ -212,12 +212,12 @@ jobs:
       run:
         working-directory: awa-ui/frontend
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: ". -> target"
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: "22"
       - name: Install frontend dependencies
@@ -246,12 +246,12 @@ jobs:
       run:
         working-directory: spike/pyo3-async
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: "spike/pyo3-async -> spike/pyo3-async/target"
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
       - name: Install uv
@@ -271,8 +271,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
       - name: Build CLI wheel (maturin)
@@ -306,7 +306,7 @@ jobs:
           --health-timeout 5s
           --health-retries 5
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
         with:
@@ -356,12 +356,12 @@ jobs:
           --health-timeout 5s
           --health-retries 5
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: ". -> target"
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
       - name: Create Python venv for mixed-fleet test
@@ -380,6 +380,7 @@ jobs:
             -- --exact --ignored --nocapture
         env:
           DATABASE_URL: postgres://postgres:postgres@localhost:5432/awa_test
+          PYTHONFAULTHANDLER: "1"
 
   # ─── Telemetry validation ─────────────────────────────────────
   telemetry-validation:
@@ -412,7 +413,7 @@ jobs:
           --health-timeout 5s
           --health-retries 12
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
         with:

--- a/.github/workflows/nightly-chaos.yml
+++ b/.github/workflows/nightly-chaos.yml
@@ -20,7 +20,7 @@ jobs:
       run:
         shell: bash
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Show Docker version
         run: docker --version
       - name: AwaSegmentedStorage (1 worker)
@@ -88,7 +88,7 @@ jobs:
       run:
         shell: bash
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
         with:
@@ -121,12 +121,12 @@ jobs:
           --health-timeout 5s
           --health-retries 5
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: ". -> target"
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
       - name: Create Python venv for Rust chaos suite
@@ -150,6 +150,8 @@ jobs:
             | tee artifacts/nightly/rust-hot.txt
       - name: Run Rust chaos suite
         timeout-minutes: 5
+        env:
+          PYTHONFAULTHANDLER: "1"
         run: |
           set -o pipefail
           export AWA_PYTHON_BIN="$PWD/awa-python/.venv/bin/python"
@@ -271,7 +273,7 @@ jobs:
         run: python .github/scripts/check-bench-regression.py artifacts/nightly benchmarks/baseline.json
       - name: Upload Rust nightly artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: nightly-rust
           path: artifacts/nightly/
@@ -299,12 +301,12 @@ jobs:
         shell: bash
         working-directory: awa-python
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: "awa-python -> awa-python/target"
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
       - name: Install uv
@@ -373,7 +375,7 @@ jobs:
         run: python .github/scripts/check-bench-regression.py awa-python/artifacts/nightly benchmarks/baseline.json
       - name: Upload Python nightly artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: nightly-python
           path: awa-python/artifacts/nightly/
@@ -388,7 +390,7 @@ jobs:
     permissions:
       issues: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Build issue body
         id: body
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
     name: Verify version consistency
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Tag matches Cargo.toml versions
         shell: bash
         # Real TOML parse via stdlib `tomllib` (Python 3.11+). Ubuntu runners
@@ -100,7 +100,7 @@ jobs:
             release_asset: true
             docker_asset: false
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: dtolnay/rust-toolchain@stable
         with:
@@ -123,7 +123,7 @@ jobs:
 
       # Frontend must be built before cargo so rust-embed in awa-ui picks it up.
       # Without this the binary ships the "Frontend not built" placeholder (#162).
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: "22"
           cache: npm
@@ -242,7 +242,7 @@ jobs:
 
       - name: Upload release artifact
         if: matrix.release_asset
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: binary-${{ matrix.target }}
           path: ${{ env.ARCHIVE }}
@@ -258,7 +258,7 @@ jobs:
 
       - name: Upload Docker binary
         if: matrix.docker_asset
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: docker-binary-${{ matrix.target }}
           path: docker-dist/
@@ -273,11 +273,11 @@ jobs:
       IMAGE_REGISTRY: ghcr.io
       IMAGE_REPOSITORY: hardbyte
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_REPOSITORY }}/${{ env.IMAGE_NAME }}
           tags: |
@@ -295,7 +295,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Download Linux binaries
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: docker-binary-*
           path: dist
@@ -310,7 +310,7 @@ jobs:
       # not the "Frontend not built" placeholder (#162). We also check
       # `awa --version` matches the git tag.
       - name: Build local image for smoke test
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: docker/Dockerfile.runtime
@@ -378,7 +378,7 @@ jobs:
 
       - name: Build and push (multi-arch)
         id: build-and-push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: docker/Dockerfile.runtime
@@ -414,10 +414,10 @@ jobs:
     needs: [build-binaries, python-wheels, cli-wheels]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: "{binary-*,wheels-*,cli-wheels-*}"
           merge-multiple: true
@@ -471,9 +471,9 @@ jobs:
           - os: macos-latest
             target: aarch64
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 
@@ -488,7 +488,7 @@ jobs:
             apt-get update && apt-get install -y libpq-dev || true
 
       - name: Upload wheels
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: wheels-${{ matrix.os }}-${{ matrix.target }}
           path: dist/*.whl
@@ -513,16 +513,16 @@ jobs:
           - os: macos-latest
             target: aarch64
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 
       # Frontend must be built before maturin invokes cargo so rust-embed in
       # awa-ui picks it up — the CLI wheel otherwise ships the "Frontend not
       # built" placeholder (#162).
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: "22"
           cache: npm
@@ -562,7 +562,7 @@ jobs:
             apt-get update && apt-get install -y libpq-dev || true
 
       - name: Upload CLI wheels
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: cli-wheels-${{ matrix.os }}-${{ matrix.target }}
           path: dist/*.whl
@@ -577,7 +577,7 @@ jobs:
       id-token: write
     steps:
       - name: Download SDK wheels
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: wheels-*
           merge-multiple: true
@@ -596,7 +596,7 @@ jobs:
       id-token: write
     steps:
       - name: Download CLI wheels
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: cli-wheels-*
           merge-multiple: true
@@ -611,14 +611,14 @@ jobs:
     needs: [version-check]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
 
       # awa-ui embeds `awa-ui/static/` via rust-embed; without building the
       # frontend first, the crate published to crates.io carries no assets and
       # every downstream `cargo install awa-cli` bakes in the placeholder HTML
       # (#162).
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: "22"
           cache: npm

--- a/awa-model/src/queue_storage.rs
+++ b/awa-model/src/queue_storage.rs
@@ -4376,10 +4376,21 @@ impl QueueStorage {
 
         let schema = self.schema();
         let ready_payloads = self.ready_payloads_for_done_rows_tx(tx, rows).await?;
+        let mut ordered_rows: Vec<&DoneJobRow> = rows.iter().collect();
+        ordered_rows.sort_unstable_by_key(|row| {
+            (
+                row.ready_slot,
+                row.ready_generation,
+                row.queue.as_str(),
+                row.priority,
+                row.lane_seq,
+                row.job_id,
+            )
+        });
         let mut builder = QueryBuilder::<Postgres>::new(format!(
             "INSERT INTO {schema}.done_entries (ready_slot, ready_generation, job_id, kind, queue, args, state, priority, attempt, run_lease, max_attempts, lane_seq, run_at, attempted_at, finalized_at, created_at, unique_key, unique_states, payload) "
         ));
-        builder.push_values(rows.iter(), |mut b, row| {
+        builder.push_values(ordered_rows, |mut b, row| {
             let ready_key = (
                 row.ready_slot,
                 row.ready_generation,

--- a/awa-worker/src/completion.rs
+++ b/awa-worker/src/completion.rs
@@ -12,6 +12,14 @@ use tracing::{debug, warn};
 const COMPLETION_BATCH_SIZE: usize = 512;
 const COMPLETION_CHANNEL_CAPACITY: usize = 4096;
 
+fn completion_batch_size() -> usize {
+    env::var("AWA_COMPLETION_BATCH_SIZE")
+        .ok()
+        .and_then(|value| value.parse::<usize>().ok())
+        .filter(|value| *value > 0)
+        .unwrap_or(COMPLETION_BATCH_SIZE)
+}
+
 fn completion_flush_interval() -> Duration {
     env::var("AWA_COMPLETION_FLUSH_MS")
         .ok()
@@ -123,6 +131,7 @@ impl CompletionBatcher {
         storage: RuntimeStorage,
     ) -> (Self, CompletionBatcherHandle) {
         let shard_count = completion_shards(&storage);
+        let batch_size = completion_batch_size();
         let flush_interval = completion_flush_interval();
         let mut shards = Vec::with_capacity(shard_count);
         let mut workers = Vec::with_capacity(shard_count);
@@ -137,6 +146,7 @@ impl CompletionBatcher {
                 cancel: cancel.clone(),
                 metrics: metrics.clone(),
                 storage: storage.clone(),
+                batch_size,
                 flush_interval,
             });
         }
@@ -159,12 +169,13 @@ struct CompletionWorker {
     cancel: CancellationToken,
     metrics: crate::metrics::AwaMetrics,
     storage: RuntimeStorage,
+    batch_size: usize,
     flush_interval: Duration,
 }
 
 impl CompletionWorker {
     async fn run(mut self) {
-        let mut pending = Vec::with_capacity(COMPLETION_BATCH_SIZE);
+        let mut pending = Vec::with_capacity(self.batch_size);
 
         loop {
             if pending.is_empty() {
@@ -190,7 +201,7 @@ impl CompletionWorker {
                         match request {
                             Some(request) => {
                                 pending.push(request);
-                                if pending.len() >= COMPLETION_BATCH_SIZE {
+                                if pending.len() >= self.batch_size {
                                     self.flush(&mut pending).await;
                                 }
                             }
@@ -203,7 +214,7 @@ impl CompletionWorker {
 
         while let Ok(request) = self.rx.try_recv() {
             pending.push(request);
-            if pending.len() >= COMPLETION_BATCH_SIZE {
+            if pending.len() >= self.batch_size {
                 self.flush(&mut pending).await;
             }
         }


### PR DESCRIPTION
## Summary
- upgrade GitHub Actions and Docker action majors that have Node 24-ready releases
- enable Python faulthandler on mixed Rust/Python chaos smoke paths so a repeat SIGSEGV leaves useful diagnostics
- expose `AWA_COMPLETION_BATCH_SIZE` for shard/batch/worker matrix experiments
- insert queue-storage terminal rows grouped by ready slot/generation/queue/priority/lane sequence to improve locality for cross-slot completion batches

## Smoke failure notes
- The failed CI job was the mixed Rust/Python chaos smoke on commit `629ccd3` with the Python insert helper exiting via SIGSEGV.
- Local rebuild of the Python extension plus the exact ignored smoke test passed twice, so I could not reproduce a deterministic crash. The added `PYTHONFAULTHANDLER=1` should make any recurrence actionable instead of only reporting signal 11.

## Validation
- `cargo fmt --check`
- `cargo test -p awa-worker completion::tests:: --lib`
- `cargo test -p awa-model --lib`
- `DATABASE_URL=postgres://postgres:test@localhost:15432/awa_test cargo test -p awa-model --test queue_storage_copy_test -- --nocapture`
- `DATABASE_URL=postgres://postgres:test@localhost:15432/awa_test AWA_PYTHON_BIN="$PWD/awa-python/.venv/bin/python" PYTHONFAULTHANDLER=1 cargo test --package awa --test chaos_suite_test test_mixed_rust_and_python_workers_share_same_queue -- --exact --ignored --nocapture`
- `cargo check -p awa-worker -p awa-model`
