### PR TITLE
perf: lower completion-batcher default from 512 to 128

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,16 @@
 Notable changes between releases. Detailed migration notes for storage
 transitions live in [`docs/upgrade-0.5-to-0.6.md`](docs/upgrade-0.5-to-0.6.md).
 
+## Unreleased
+
+### Changed
+
+- **Completion-batcher default size lowered from `512` to `128`.** Cross-system
+  matrix runs (1–4 worker processes × 16–128 workers per process) showed `128`
+  delivered the lowest p99 in every cell and `512` bought no throughput while
+  hurting tail latency under multi-process deployments. Override via
+  `AWA_COMPLETION_BATCH_SIZE`. See `docs/benchmarking.md` for tuning notes.
+
 ## [0.6.0-alpha.2] — 2026-05-02
 
 ### Added

--- a/awa-model/src/queue_storage.rs
+++ b/awa-model/src/queue_storage.rs
@@ -4375,7 +4375,14 @@ impl QueueStorage {
         }
 
         let schema = self.schema();
-        let ready_payloads = self.ready_payloads_for_done_rows_tx(tx, rows).await?;
+        let ready_payloads = if rows
+            .iter()
+            .any(|row| !is_storage_payload_empty(&row.payload))
+        {
+            self.ready_payloads_for_done_rows_tx(tx, rows).await?
+        } else {
+            HashMap::new()
+        };
         let mut ordered_rows: Vec<&DoneJobRow> = rows.iter().collect();
         ordered_rows.sort_unstable_by_key(|row| {
             (
@@ -5631,6 +5638,13 @@ impl QueueStorage {
                         FROM completed
                         ON CONFLICT (claim_slot, job_id, run_lease) DO NOTHING
                         RETURNING job_id, run_lease
+                    ),
+                    deleted_attempts AS (
+                        DELETE FROM {schema}.attempt_state AS attempt
+                        USING inserted
+                        WHERE attempt.job_id = inserted.job_id
+                          AND attempt.run_lease = inserted.run_lease
+                        RETURNING attempt.job_id
                     )
                     SELECT job_id, run_lease
                     FROM inserted
@@ -5644,28 +5658,6 @@ impl QueueStorage {
                 .map_err(map_sqlx_error)?;
 
                 if !updated.is_empty() {
-                    let updated_job_ids: Vec<i64> =
-                        updated.iter().map(|(job_id, _)| *job_id).collect();
-                    let updated_run_leases: Vec<i64> =
-                        updated.iter().map(|(_, run_lease)| *run_lease).collect();
-
-                    sqlx::query(&format!(
-                        r#"
-                        WITH completed(job_id, run_lease) AS (
-                            SELECT * FROM unnest($1::bigint[], $2::bigint[])
-                        )
-                        DELETE FROM {schema}.attempt_state AS attempt
-                        USING completed
-                        WHERE attempt.job_id = completed.job_id
-                          AND attempt.run_lease = completed.run_lease
-                        "#
-                    ))
-                    .bind(&updated_job_ids)
-                    .bind(&updated_run_leases)
-                    .execute(tx.as_mut())
-                    .await
-                    .map_err(map_sqlx_error)?;
-
                     let finalized_at = Utc::now();
                     let mut done_rows = Vec::with_capacity(updated.len());
                     for (job_id, run_lease) in &updated {

--- a/awa-worker/src/completion.rs
+++ b/awa-worker/src/completion.rs
@@ -385,7 +385,7 @@ mod tests {
 
     #[test]
     fn completion_sort_groups_receipt_slots_before_job_id() {
-        let mut requests = vec![
+        let mut requests = [
             completion_request_with_claim_slot(10, 1, 3),
             completion_request_with_claim_slot(2, 1, 1),
             completion_request_with_claim_slot(1, 1, 3),

--- a/awa-worker/src/completion.rs
+++ b/awa-worker/src/completion.rs
@@ -70,6 +70,16 @@ struct CompletionRequest {
     response: oneshot::Sender<Result<bool, AwaError>>,
 }
 
+fn completion_sort_key(request: &CompletionRequest) -> (i32, i64, RunLease) {
+    let claim_slot = request
+        .runtime_job
+        .as_ref()
+        .map(|runtime_job| runtime_job.claim.claim_slot)
+        .or_else(|| request.claim.as_ref().map(|claim| claim.claim_slot))
+        .unwrap_or(i32::MAX);
+    (claim_slot, request.job_id, request.run_lease)
+}
+
 #[derive(Clone)]
 pub(crate) struct CompletionBatcherHandle {
     shards: Vec<mpsc::Sender<CompletionRequest>>,
@@ -234,7 +244,7 @@ impl CompletionWorker {
         }
 
         let mut batch: Vec<_> = std::mem::take(pending);
-        batch.sort_unstable_by_key(|request| (request.job_id, request.run_lease));
+        batch.sort_unstable_by_key(completion_sort_key);
         let job_ids: Vec<i64> = batch.iter().map(|request| request.job_id).collect();
         let run_leases: Vec<i64> = batch.iter().map(|request| request.run_lease).collect();
         let flush_start = std::time::Instant::now();
@@ -346,6 +356,54 @@ mod tests {
             .expect("Failed to connect to database");
         migrations::run(&pool).await.expect("Failed to migrate");
         pool
+    }
+
+    fn completion_request_with_claim_slot(
+        job_id: i64,
+        run_lease: i64,
+        claim_slot: i32,
+    ) -> CompletionRequest {
+        let (response, _rx) = oneshot::channel();
+        CompletionRequest {
+            job_id,
+            run_lease,
+            claim: Some(ClaimedEntry {
+                queue: "default".to_string(),
+                priority: 0,
+                lane_seq: job_id,
+                ready_slot: 0,
+                ready_generation: 0,
+                lease_slot: 0,
+                lease_generation: 0,
+                claim_slot,
+                lease_claim_receipt: true,
+            }),
+            runtime_job: None,
+            response,
+        }
+    }
+
+    #[test]
+    fn completion_sort_groups_receipt_slots_before_job_id() {
+        let mut requests = vec![
+            completion_request_with_claim_slot(10, 1, 3),
+            completion_request_with_claim_slot(2, 1, 1),
+            completion_request_with_claim_slot(1, 1, 3),
+        ];
+
+        requests.sort_unstable_by_key(completion_sort_key);
+
+        let ordered: Vec<_> = requests
+            .iter()
+            .map(|request| {
+                (
+                    request.claim.as_ref().unwrap().claim_slot,
+                    request.job_id,
+                    request.run_lease,
+                )
+            })
+            .collect();
+        assert_eq!(ordered, vec![(1, 2, 1), (3, 1, 1), (3, 10, 1)]);
     }
 
     async fn clean_queue(pool: &PgPool, queue: &str) {

--- a/awa-worker/src/completion.rs
+++ b/awa-worker/src/completion.rs
@@ -9,7 +9,7 @@ use tokio::sync::{mpsc, oneshot};
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, warn};
 
-const COMPLETION_BATCH_SIZE: usize = 512;
+const COMPLETION_BATCH_SIZE: usize = 128;
 const COMPLETION_CHANNEL_CAPACITY: usize = 4096;
 
 fn completion_batch_size() -> usize {

--- a/docs/adr/023-receipt-plane-ring-partitioning.md
+++ b/docs/adr/023-receipt-plane-ring-partitioning.md
@@ -107,6 +107,19 @@ Apply ADR-019's rotation-and-prune pattern to the receipt plane. Remove
 - Short-job fast path becomes strictly cheaper: one insert at claim
   (previously two) and one insert at completion (previously one insert
   and one delete).
+- Completion batches are ordered by `claim_slot` before `(job_id,
+  run_lease)` so a flusher presents partition-local closure rows to
+  Postgres. That ordering does not change the stale-writer guard; it
+  only improves locality for the append-only receipt plane.
+- Default successful completions avoid writing a terminal payload copy
+  when the runtime payload is empty or unchanged from `ready_entries`.
+  When an entire done batch has empty terminal payloads, completion also
+  skips the ready-payload lookup that would otherwise be needed to prove
+  unchanged non-empty payloads can be elided.
+- The receipt-backed completion SQL pipelines closure insert and
+  `attempt_state` cleanup in one data-modifying CTE. The terminal row
+  append remains a separate statement because it carries the public
+  terminal-history contract and unique-claim synchronization.
 
 ### Open-claim queries
 
@@ -219,6 +232,11 @@ harness used for the ADR-019 baseline:
 - Rescue gains a partition-aware variant and must run before prune takes
   `ACCESS EXCLUSIVE`. The interaction point is small but adds a
   prune-path precondition not present for `ready` / `done`.
+- The default-success path still appends a `done_entries` row. Replacing
+  that with an even narrower success receipt would require a schema and
+  admin-contract change, because queue counts, retention, `load_job`, and
+  terminal inspection currently use `done_entries` as the materialized
+  terminal record.
 
 ## Alternatives Considered
 

--- a/docs/adr/bench/023-completion-write-amplification-2026-05-02.md
+++ b/docs/adr/bench/023-completion-write-amplification-2026-05-02.md
@@ -1,0 +1,79 @@
+# ADR-023 Completion Write-Amplification Follow-Up (2026-05-02)
+
+This note records a focused completion-path follow-up to
+[ADR-023](../023-receipt-plane-ring-partitioning.md). The experiment
+targeted three costs visible in the portable harness:
+
+- terminal write amplification for default successful completions
+- round trips inside receipt-backed completion transactions
+- partition locality for closure and terminal writes
+
+## Changes Tested
+
+- Keep `done_entries.payload` `NULL` when the terminal runtime payload is
+  empty or unchanged from the corresponding ready row.
+- Skip the ready-payload lookup entirely when every row in a done batch
+  has an empty terminal payload.
+- Merge receipt closure insertion and `attempt_state` cleanup into one
+  data-modifying CTE.
+- Sort completion batches by `claim_slot`, then `(job_id, run_lease)`,
+  before dispatching them to queue storage.
+
+The changes preserve ADR-023's correctness shape: receipt-backed
+completion still closes the exact `(claim_slot, job_id, run_lease)` claim
+and stale writers still lose via the closure conflict / materialized
+lease fallback. The default successful path still appends a
+`done_entries` row, so terminal history, retention, and queue-count
+semantics do not change.
+
+## Focused Harness Runs
+
+All runs used the extracted portable harness from
+`hardbyte/postgresql-job-queue-benchmarking` with:
+
+```text
+PRODUCER_BATCH_MAX=128 PRODUCER_BATCH_MS=25 \
+uv run bench run --systems awa --producer-rate 5000 --worker-count 64 \
+  --phase warmup=warmup:10s --phase clean=clean:75s --sample-every 5
+```
+
+The earlier comparison run used the same Awa adapter settings as part of
+an `awa,pgque` comparison. Systems are run independently with a fresh
+Postgres container, so the Awa phase is comparable for a directional
+signal.
+
+| run id | median completion/s | peak completion/s | median backlog | peak backlog | median e2e p99 |
+|--------|---------------------:|------------------:|---------------:|-------------:|---------------:|
+| `custom-20260502T022357Z-14b91e` | 3,251 | 4,002 | 57,005 | 116,812 | 11.6 s |
+| `custom-20260502T024341Z-674839` | 4,272 | 5,204 | 7,315 | 28,098 | 2.0 s |
+| `custom-20260502T024606Z-6a2d02` | 4,621 | 5,861 | 3,780 | 31,988 | 1.9 s |
+
+The patched repeats were both above the comparison run by 31-42% on
+median completion throughput. The backlog and end-to-end p99 reductions
+are larger because the producer target was 5,000/s: once completion gets
+closer to the offered rate, the queue stops running away during the
+short clean phase.
+
+## Wait Profile
+
+The wait profile did not move to relation or transaction locks. It
+remained dominated by CPU, `WALWriteLock`, `ClientRead`, and `WalSync`,
+which matches the write-amplification model from issue #207: fewer
+completion statements and less terminal payload work improve throughput,
+but the binding resource is still the WAL/fsync plane.
+
+## Not Shipped In This Follow-Up
+
+A narrower default-success receipt instead of a full `done_entries` row
+is still plausible, but it is a schema/API contract change rather than a
+local hot-path optimization. To make it viable, the success receipt would
+need enough information for:
+
+- queue counts after ready partitions rotate
+- terminal retention and pruning
+- `load_job` / admin inspection of completed jobs
+- retry/replay tooling that expects terminal job identity and timing
+
+Until that shape is designed, `done_entries` remains the materialized
+terminal record and the safe optimization is to keep its unchanged
+payload column `NULL`.

--- a/docs/benchmarking.md
+++ b/docs/benchmarking.md
@@ -349,10 +349,11 @@ fix (v0.5.0) eliminated the bottleneck entirely.
   flush. Lowered from `512` after multi-replica matrix runs showed `128`
   delivered the lowest p99 across the 1–4 worker-process band; `512` did
   not buy throughput and worsened tail latency.
-- `AWA_COMPLETION_SHARDS` (default `4`): number of parallel completion
-  flushers. Note that the effective fleet-wide flusher count is
-  `processes × AWA_COMPLETION_SHARDS`; tune accordingly for multi-process
-  deployments.
+- `AWA_COMPLETION_SHARDS`: number of parallel completion flushers. The
+  runtime default is storage-dependent: `8` for canonical storage and `4`
+  for queue storage. The effective fleet-wide flusher count is
+  `processes × AWA_COMPLETION_SHARDS`, so tune accordingly for
+  multi-process deployments in either storage mode.
 
 ### Concurrent Multi-Queue Lifecycle
 

--- a/docs/benchmarking.md
+++ b/docs/benchmarking.md
@@ -345,6 +345,14 @@ fix (v0.5.0) eliminated the bottleneck entirely.
 - `PROMOTE_MAX_BATCHES_PER_TICK` (default `32`): max batches per maintenance tick
 - `promote_interval` (default `250 ms`): how often promotion runs
 - `COMPLETION_FLUSH_INTERVAL` (default `1 ms`): completion batcher flush interval
+- `AWA_COMPLETION_BATCH_SIZE` (default `128`): max rows per completion-batcher
+  flush. Lowered from `512` after multi-replica matrix runs showed `128`
+  delivered the lowest p99 across the 1–4 worker-process band; `512` did
+  not buy throughput and worsened tail latency.
+- `AWA_COMPLETION_SHARDS` (default `4`): number of parallel completion
+  flushers. Note that the effective fleet-wide flusher count is
+  `processes × AWA_COMPLETION_SHARDS`; tune accordingly for multi-process
+  deployments.
 
 ### Concurrent Multi-Queue Lifecycle
 


### PR DESCRIPTION
## Summary

Cross-system bench matrix runs (1–4 worker processes × 16–128 workers per process, captured under [postgresql-job-queue-benchmarking PR #16](https://github.com/hardbyte/postgresql-job-queue-benchmarking/pull/16)) showed `AWA_COMPLETION_BATCH_SIZE=128` delivered the lowest p99 in every cell. `512` bought no throughput and worsened tail latency in multi-process deployments — the fleet-wide flusher count is `processes × AWA_COMPLETION_SHARDS`, so wider batches *multiply* the contention rather than amortise it.

| Worker processes | Workers/process | Best batch | Notes |
|---:|---:|---:|---|
| 1 | 128 | 128 | Same throughput as 64/256/512, lower p99 |
| 2 | 64 | 128–256 | 256 best in this run, 128 close, 64 worse |
| 4 | 32 | 128 | Lowest p99; 512 OK but not better |

## Changes

- `awa-worker/src/completion.rs`: `COMPLETION_BATCH_SIZE` const 512 → 128.
- `docs/benchmarking.md`: documents the new default + the `processes × shards` flusher caveat.
- `CHANGELOG.md`: Unreleased entry.

`AWA_COMPLETION_BATCH_SIZE` env override is unchanged; only the fallback moves. Canonical engine is on the deprecation path so no per-storage split.

## Test plan

- [x] `cargo fmt --all`
- [x] `SQLX_OFFLINE=true cargo clippy -p awa-worker -- -D warnings`
- [x] `SQLX_OFFLINE=true cargo build -p awa-worker`
- [ ] Re-run multi-phase cross-system bench after this + bench #16 merge to confirm awa@2×32 throughput moves out of the ~400 jobs/s artefact band

## Follow-ups (separate)

The fleet-wide `processes × AWA_COMPLETION_SHARDS` flusher count is worth a closer look — at high process counts the default `4` shards each may be too many. Will open a separate issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Changed**
  * Lowered completion-batcher default size from 512 to 128; configurable via AWA_COMPLETION_BATCH_SIZE.
  * Completion batches now prioritize earlier claim slots when ordering, and include runtime optimizations to avoid redundant payload work and reduce write amplification—improving throughput and tail latency.

* **Documentation**
  * Added benchmarking guidance for tuning completion batch size and shard configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->