### PR TITLE
Make queue claimer cap configurable

### DIFF
--- a/awa-worker/src/dispatcher.rs
+++ b/awa-worker/src/dispatcher.rs
@@ -5,7 +5,7 @@ use awa_model::JobRow;
 use sqlx::PgPool;
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 use std::time::{Duration, Instant};
 use tokio::sync::{Mutex, Notify, Semaphore};
 use tokio::task::JoinSet;
@@ -17,6 +17,36 @@ const CLAIM_BATCH_LIMIT: usize = 128;
 const MAX_CLAIMERS_PER_QUEUE: i16 = 4;
 const CLAIMER_LEASE_TTL: Duration = Duration::from_secs(3);
 const CLAIMER_IDLE_THRESHOLD: Duration = Duration::from_millis(500);
+
+fn max_claimers_per_queue() -> i16 {
+    static MAX_CLAIMERS: OnceLock<i16> = OnceLock::new();
+    *MAX_CLAIMERS.get_or_init(|| {
+        let Ok(raw) = std::env::var("AWA_MAX_CLAIMERS_PER_QUEUE") else {
+            return MAX_CLAIMERS_PER_QUEUE;
+        };
+
+        match raw.parse::<i16>() {
+            Ok(value) if value > 0 => value,
+            Ok(value) => {
+                warn!(
+                    value,
+                    default = MAX_CLAIMERS_PER_QUEUE,
+                    "AWA_MAX_CLAIMERS_PER_QUEUE must be positive; using default"
+                );
+                MAX_CLAIMERS_PER_QUEUE
+            }
+            Err(error) => {
+                warn!(
+                    raw = %raw,
+                    %error,
+                    default = MAX_CLAIMERS_PER_QUEUE,
+                    "Failed to parse AWA_MAX_CLAIMERS_PER_QUEUE; using default"
+                );
+                MAX_CLAIMERS_PER_QUEUE
+            }
+        }
+    })
+}
 
 #[derive(Debug, Clone, Copy)]
 enum WakeReason {
@@ -577,7 +607,7 @@ impl Dispatcher {
                     self.config.deadline_duration,
                     self.config.priority_aging_interval,
                     self.runtime_instance_id,
-                    MAX_CLAIMERS_PER_QUEUE,
+                    max_claimers_per_queue(),
                     CLAIMER_LEASE_TTL,
                     CLAIMER_IDLE_THRESHOLD,
                 )


### PR DESCRIPTION
## Summary
- add AWA_MAX_CLAIMERS_PER_QUEUE to override the queue-storage dispatcher claimer cap
- preserve the existing default of 4 claimers per queue
- keep the tuning knob runtime-only so benchmark sweeps do not need source edits

## Validation
- cargo check -p awa-worker

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for configuring the maximum number of claimers per queue via the AWA_MAX_CLAIMERS_PER_QUEUE environment variable. The value must be a positive integer; if unset or invalid, the system falls back to the built-in default. The setting is validated and cached for consistent runtime behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->