### PR TITLE
Stabilize striped queue-storage runtime claims

### DIFF
--- a/awa-model/src/queue_storage.rs
+++ b/awa-model/src/queue_storage.rs
@@ -5109,27 +5109,71 @@ impl QueueStorage {
             return Ok(Vec::new());
         }
 
+        let stripe_queues = self.physical_queues_for_logical(queue);
+        if stripe_queues.len() > 1 {
+            let mut claimed = Vec::new();
+            let start = self.stripe_probe_start(stripe_queues.len());
+            for offset in 0..stripe_queues.len() {
+                if claimed.len() >= max_batch as usize {
+                    break;
+                }
+                let stripe_queue = &stripe_queues[(start + offset) % stripe_queues.len()];
+                let remaining = max_batch - claimed.len() as i64;
+                match self
+                    .claim_runtime_batch_with_aging_physical(
+                        pool,
+                        stripe_queue,
+                        remaining,
+                        deadline_duration,
+                        aging_interval,
+                    )
+                    .await
+                {
+                    Ok(stripe_claims) => claimed.extend(stripe_claims),
+                    Err(err) if claimed.is_empty() => return Err(err),
+                    Err(err) => {
+                        tracing::warn!(
+                            queue = %queue,
+                            stripe_queue = %stripe_queue,
+                            claimed = claimed.len(),
+                            error = ?err,
+                            "returning already-claimed runtime jobs after striped claim error"
+                        );
+                        break;
+                    }
+                }
+            }
+            return Ok(claimed);
+        }
+
+        self.claim_runtime_batch_with_aging_physical(
+            pool,
+            &stripe_queues[0],
+            max_batch,
+            deadline_duration,
+            aging_interval,
+        )
+        .await
+    }
+
+    async fn claim_runtime_batch_with_aging_physical(
+        &self,
+        pool: &PgPool,
+        queue: &str,
+        max_batch: i64,
+        deadline_duration: Duration,
+        aging_interval: Duration,
+    ) -> Result<Vec<ClaimedRuntimeJob>, AwaError> {
+        if max_batch <= 0 {
+            return Ok(Vec::new());
+        }
+
         let mut tx = pool.begin().await.map_err(map_sqlx_error)?;
         let mut claimed = Vec::new();
-        let stripe_queues = self.physical_queues_for_logical(queue);
-        let start = self.stripe_probe_start(stripe_queues.len());
-        for offset in 0..stripe_queues.len() {
-            if claimed.len() >= max_batch as usize {
-                break;
-            }
-            let stripe_queue = &stripe_queues[(start + offset) % stripe_queues.len()];
-            let remaining = max_batch - claimed.len() as i64;
-            claimed.extend(
-                self.claim_ready_rows_tx(
-                    &mut tx,
-                    stripe_queue,
-                    remaining,
-                    deadline_duration,
-                    aging_interval,
-                )
+        claimed.extend(
+            self.claim_ready_rows_tx(&mut tx, queue, max_batch, deadline_duration, aging_interval)
                 .await?,
-            );
-        }
+        );
 
         for row in &claimed {
             self.sync_unique_claim(
@@ -5143,13 +5187,14 @@ impl QueueStorage {
             .await?;
         }
 
-        tx.commit().await.map_err(map_sqlx_error)?;
-
         let use_lease_claim_receipts = self.use_lease_claim_receipts_for_runtime(deadline_duration);
-        claimed
+        let claimed = claimed
             .into_iter()
             .map(|row| row.into_claimed_runtime_job(use_lease_claim_receipts))
-            .collect()
+            .collect::<Result<Vec<_>, _>>()?;
+
+        tx.commit().await.map_err(map_sqlx_error)?;
+        Ok(claimed)
     }
 
     #[tracing::instrument(skip(self, pool), fields(queue = %queue, instance_id = %instance_id), name = "queue_storage.acquire_queue_claimer")]

--- a/awa-python/python/awa/_awa.pyi
+++ b/awa-python/python/awa/_awa.pyi
@@ -487,6 +487,7 @@ class Client:
         queue_storage_queue_slot_count: int = 16,
         queue_storage_lease_slot_count: int = 8,
         queue_storage_claim_slot_count: int = 8,
+        queue_storage_queue_stripe_count: int = 1,
         queue_storage_queue_rotate_interval_ms: int = 1000,
         queue_storage_lease_rotate_interval_ms: int = 50,
         queue_storage_claim_rotate_interval_ms: int | None = None,

--- a/awa-python/python/awa/client.py
+++ b/awa-python/python/awa/client.py
@@ -32,6 +32,7 @@ DEFAULT_QUEUE_STORAGE_SCHEMA = "awa"
 DEFAULT_QUEUE_STORAGE_QUEUE_SLOT_COUNT = 16
 DEFAULT_QUEUE_STORAGE_LEASE_SLOT_COUNT = 8
 DEFAULT_QUEUE_STORAGE_CLAIM_SLOT_COUNT = 8
+DEFAULT_QUEUE_STORAGE_QUEUE_STRIPE_COUNT = 1
 
 
 class AsyncClient:
@@ -653,6 +654,7 @@ class AsyncClient:
         queue_storage_queue_slot_count: int = DEFAULT_QUEUE_STORAGE_QUEUE_SLOT_COUNT,
         queue_storage_lease_slot_count: int = DEFAULT_QUEUE_STORAGE_LEASE_SLOT_COUNT,
         queue_storage_claim_slot_count: int = DEFAULT_QUEUE_STORAGE_CLAIM_SLOT_COUNT,
+        queue_storage_queue_stripe_count: int = DEFAULT_QUEUE_STORAGE_QUEUE_STRIPE_COUNT,
         queue_storage_queue_rotate_interval_ms: int = 1000,
         queue_storage_lease_rotate_interval_ms: int = 50,
         queue_storage_claim_rotate_interval_ms: int | None = None,
@@ -703,6 +705,7 @@ class AsyncClient:
             queue_storage_queue_slot_count=queue_storage_queue_slot_count,
             queue_storage_lease_slot_count=queue_storage_lease_slot_count,
             queue_storage_claim_slot_count=queue_storage_claim_slot_count,
+            queue_storage_queue_stripe_count=queue_storage_queue_stripe_count,
             queue_storage_queue_rotate_interval_ms=queue_storage_queue_rotate_interval_ms,
             queue_storage_lease_rotate_interval_ms=queue_storage_lease_rotate_interval_ms,
             queue_storage_claim_rotate_interval_ms=queue_storage_claim_rotate_interval_ms,

--- a/awa-python/src/client.rs
+++ b/awa-python/src/client.rs
@@ -1481,7 +1481,7 @@ impl PyClient {
         })
     }
 
-    #[pyo3(signature = (queues=None, *, poll_interval_ms=200, global_max_workers=None, completed_retention_hours=None, failed_retention_hours=None, descriptor_retention_days=None, cleanup_batch_size=None, leader_election_interval_ms=None, heartbeat_interval_ms=None, promote_interval_ms=None, heartbeat_rescue_interval_ms=None, heartbeat_staleness_ms=None, deadline_rescue_interval_ms=None, callback_rescue_interval_ms=None, queue_storage_schema=None, queue_storage_queue_slot_count=16, queue_storage_lease_slot_count=8, queue_storage_claim_slot_count=8, queue_storage_queue_rotate_interval_ms=1000, queue_storage_lease_rotate_interval_ms=50, queue_storage_claim_rotate_interval_ms=None, storage_transition_role=None))]
+    #[pyo3(signature = (queues=None, *, poll_interval_ms=200, global_max_workers=None, completed_retention_hours=None, failed_retention_hours=None, descriptor_retention_days=None, cleanup_batch_size=None, leader_election_interval_ms=None, heartbeat_interval_ms=None, promote_interval_ms=None, heartbeat_rescue_interval_ms=None, heartbeat_staleness_ms=None, deadline_rescue_interval_ms=None, callback_rescue_interval_ms=None, queue_storage_schema=None, queue_storage_queue_slot_count=16, queue_storage_lease_slot_count=8, queue_storage_claim_slot_count=8, queue_storage_queue_stripe_count=1, queue_storage_queue_rotate_interval_ms=1000, queue_storage_lease_rotate_interval_ms=50, queue_storage_claim_rotate_interval_ms=None, storage_transition_role=None))]
     #[allow(clippy::too_many_arguments)]
     fn start<'py>(
         &self,
@@ -1504,6 +1504,7 @@ impl PyClient {
         queue_storage_queue_slot_count: u32,
         queue_storage_lease_slot_count: u32,
         queue_storage_claim_slot_count: u32,
+        queue_storage_queue_stripe_count: u32,
         queue_storage_queue_rotate_interval_ms: u64,
         queue_storage_lease_rotate_interval_ms: u64,
         queue_storage_claim_rotate_interval_ms: Option<u64>,
@@ -1625,6 +1626,11 @@ impl PyClient {
                 "queue_storage_claim_slot_count must be > 0",
             ));
         }
+        if queue_storage_queue_stripe_count == 0 {
+            return Err(pyo3::exceptions::PyValueError::new_err(
+                "queue_storage_queue_stripe_count must be > 0",
+            ));
+        }
         if queue_storage_queue_rotate_interval_ms == 0 {
             return Err(pyo3::exceptions::PyValueError::new_err(
                 "queue_storage_queue_rotate_interval_ms must be > 0",
@@ -1650,6 +1656,7 @@ impl PyClient {
                 queue_slot_count: queue_storage_queue_slot_count as usize,
                 lease_slot_count: queue_storage_lease_slot_count as usize,
                 claim_slot_count: queue_storage_claim_slot_count as usize,
+                queue_stripe_count: queue_storage_queue_stripe_count as usize,
                 ..Default::default()
             },
             Duration::from_millis(queue_storage_queue_rotate_interval_ms),

--- a/awa-python/tests/test_start_config.py
+++ b/awa-python/tests/test_start_config.py
@@ -634,6 +634,13 @@ async def test_queue_storage_claim_ring_knobs_validate(client):
             queue_storage_claim_slot_count=0,
         )
 
+    with pytest.raises(ValueError, match="queue_storage_queue_stripe_count must be > 0"):
+        await client.start(
+            [(queue, 1)],
+            poll_interval_ms=25,
+            queue_storage_queue_stripe_count=0,
+        )
+
     with pytest.raises(ValueError, match="queue_storage_claim_rotate_interval_ms must be > 0"):
         await client.start(
             [(queue, 1)],

--- a/awa/tests/queue_storage_runtime_test.rs
+++ b/awa/tests/queue_storage_runtime_test.rs
@@ -3898,6 +3898,61 @@ async fn test_queue_storage_striped_claims_probe_stripes_round_robin() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn test_queue_storage_striped_runtime_claims_do_not_deadlock_with_enqueues() {
+    let _guard = QUEUE_STORAGE_RUNTIME_LOCK.lock().await;
+    let pool = setup_pool(20).await;
+    let queue = "qs_striped_claim_enqueue";
+    let schema = "awa_qs_striped_claim_enqueue";
+    let config = QueueStorageConfig {
+        schema: schema.to_string(),
+        queue_slot_count: 4,
+        lease_slot_count: 2,
+        queue_stripe_count: 2,
+        ..Default::default()
+    };
+    let store = Arc::new(create_store_with_config(&pool, config).await);
+
+    let producer_pool = pool.clone();
+    let producer_store = Arc::clone(&store);
+    let producer = tokio::spawn(async move {
+        for _ in 0..64 {
+            producer_store
+                .enqueue_batch(&producer_pool, queue, 1, 16)
+                .await
+                .expect("striped enqueue should not deadlock");
+            tokio::task::yield_now().await;
+        }
+    });
+
+    let claimer_pool = pool.clone();
+    let claimer_store = Arc::clone(&store);
+    let claimer = tokio::spawn(async move {
+        let mut claimed_total = 0usize;
+        for _ in 0..128 {
+            let claimed = claimer_store
+                .claim_runtime_batch(&claimer_pool, queue, 8, Duration::ZERO)
+                .await
+                .expect("striped runtime claim should not deadlock");
+            claimed_total += claimed.len();
+            tokio::task::yield_now().await;
+        }
+        claimed_total
+    });
+
+    let (_producer_done, claimed_total) = tokio::time::timeout(Duration::from_secs(20), async {
+        tokio::try_join!(producer, claimer)
+    })
+    .await
+    .expect("striped enqueue/claim workload timed out")
+    .expect("striped enqueue/claim task panicked");
+
+    assert!(
+        claimed_total > 0,
+        "expected concurrent striped runtime claims to claim at least one job"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn test_queue_storage_claim_runtime_does_not_wait_for_lease_rotation_lock() {
     let _guard = QUEUE_STORAGE_RUNTIME_LOCK.lock().await;
     let pool = setup_pool(10).await;

--- a/correctness/README.md
+++ b/correctness/README.md
@@ -77,14 +77,17 @@ What is intentionally not modeled:
   locks and busy checks, not `FOR SHARE` on `lease_ring_state` — see
   `storage/MAPPING.md` for the full analysis.
 - `storage/AwaStorageLockOrder.tla` / `storage/AwaStorageLockOrder.cfg` /
-  `storage/AwaStorageLockOrderDeadlockDemo.cfg`: lock-ordering protocol
-  spec. Models each storage-engine transaction (claim, rotate-leases,
-  prune-leases, rotate-ready, prune-ready) as an ordered sequence of
-  Postgres lock acquisitions with a shared/exclusive compatibility matrix.
-  Checks `NoDeadlock` via a waits-for cycle detector. The main config
-  passes cleanly (39,040 distinct states), confirming the current
-  lock ordering is deadlock-free. The demo config uses a deliberately
-  cycle-creating plan pair to prove the detector itself works.
+  `storage/AwaStorageLockOrderDeadlockDemo.cfg` /
+  `storage/AwaStorageLockOrderOldStripedClaimDeadlock.cfg`: lock-ordering protocol
+  spec. Models each storage-engine transaction (enqueue, claim,
+  complete, close-receipt, rescue-receipts, ensure-running, cancel,
+  rotate, and prune) as an ordered sequence of Postgres lock acquisitions
+  with a shared/exclusive compatibility matrix. The striped enqueue path
+  takes multiple physical queue lanes in stable order; the current striped
+  claim path takes at most one physical stripe per transaction. Checks
+  `NoDeadlock` via a waits-for cycle detector. The demo configs use a
+  deliberately cycle-creating plan pair and the historical old striped
+  logical-claim plan to prove the detector catches real cycles.
 - `storage/AwaStorageTransition.tla` /
   `storage/AwaStorageTransition.cfg` /
   `storage/AwaStorageTransitionCurrentGate.cfg`: focused model for the
@@ -149,6 +152,7 @@ From the repository root:
 ./correctness/run-tlc.sh storage/AwaSegmentedStorageRaces.tla storage/AwaSegmentedStorageRacesSafe.cfg
 ./correctness/run-tlc.sh storage/AwaStorageLockOrder.tla
 ./correctness/run-tlc.sh storage/AwaStorageLockOrder.tla storage/AwaStorageLockOrderDeadlockDemo.cfg
+./correctness/run-tlc.sh storage/AwaStorageLockOrder.tla storage/AwaStorageLockOrderOldStripedClaimDeadlock.cfg
 ./correctness/run-tlc.sh storage/AwaStorageTransition.tla
 ./correctness/run-tlc.sh storage/AwaStorageTransition.tla storage/AwaStorageTransitionCurrentGate.cfg
 ./correctness/run-tlc.sh storage/AwaSegmentedStorageTrace.tla

--- a/correctness/storage/AwaStorageLockOrder.cfg
+++ b/correctness/storage/AwaStorageLockOrder.cfg
@@ -4,7 +4,9 @@
 \* has broken the lock contract.
 CONSTANTS
   TxIds = {"t1", "t2"}
-  Queues = {"q1"}
+  Queues = {"q1", "q1#0", "q1#1"}
+  StripeA = "q1#0"
+  StripeB = "q1#1"
   Priorities = {1}
   LeaseSlots = {1, 2}
   ReadySlots = {1, 2}

--- a/correctness/storage/AwaStorageLockOrder.tla
+++ b/correctness/storage/AwaStorageLockOrder.tla
@@ -58,6 +58,8 @@ EXTENDS TLC, Naturals, FiniteSets, Sequences
 
 CONSTANTS TxIds,
           Queues,
+          StripeA,
+          StripeB,
           Priorities,
           LeaseSlots,
           ReadySlots,
@@ -134,8 +136,33 @@ Resources ==
 \* A plan step is [res, mode].
 Step(res, mode) == [res |-> res, mode |-> mode]
 
+\* A small, explicit two-stripe shape for the hot logical queue case.
+\* `StripeA` / `StripeB` are physical queue names such as `queue#0`
+\* and `queue#1`. The enqueue path processes grouped physical queues
+\* in a stable order inside one transaction. Runtime claim used to
+\* visit multiple physical stripes inside one claim transaction; the
+\* Rust implementation now claims each physical stripe in its own
+\* transaction, so the main spec only starts single-stripe claim plans.
+TwoStripeQueuesOK ==
+    /\ StripeA \in Queues
+    /\ StripeB \in Queues
+    /\ StripeA # StripeB
+
 \* Transaction kind plans. Each mirrors the actual SQL in
 \* awa-model/src/queue_storage.rs as noted inline.
+
+\* insert_ready_rows_tx / insert_ready_rows_copy_tx
+\*   UPDATE queue_enqueue_heads for each grouped physical queue
+\*   INSERT / COPY ready rows
+\*   UPDATE queue_lanes for each grouped physical queue
+\*
+\* The model collapses the queue_enqueue_heads and queue_lanes rows
+\* into LaneResource, because the deadlock class we care about is
+\* multi-stripe transactions taking lane-family locks in different
+\* physical-queue orders. Enqueue keeps a stable physical-stripe order.
+EnqueueTwoStripePlan(p) ==
+    << Step(LaneResource(StripeA, p), ModeExclusive),
+       Step(LaneResource(StripeB, p), ModeExclusive) >>
 
 \* The claim CTE
 \* (`claim_runtime_batch_with_aging_for_instance` in queue_storage.rs)
@@ -165,6 +192,20 @@ ClaimLegacyPlan(q, p, readySlot, leaseSlot) ==
     << Step(LaneResource(q, p), ModeExclusive),
        Step(ReadyChildResource(readySlot), ModeShared),
        Step(LeaseChildResource(leaseSlot), ModeShared) >>
+
+\* Historical unsafe logical-queue claim shape: one transaction walked
+\* multiple physical stripes starting at a rotating probe point. This
+\* can invert the stable enqueue order and form a waits-for cycle:
+\* enqueue holds StripeA then wants StripeB while claim holds StripeB
+\* then wants StripeA. The production path no longer uses this shape;
+\* it remains in the spec only as a negative regression harness.
+OldClaimTwoStripeReceiptsPlan(p, readySlot, claimSlot) ==
+    << Step(LaneResource(StripeB, p), ModeExclusive),
+       Step(ReadyChildResource(readySlot), ModeShared),
+       Step(ClaimChildResource(claimSlot), ModeShared),
+       Step(LaneResource(StripeA, p), ModeExclusive),
+       Step(ReadyChildResource(readySlot), ModeShared),
+       Step(ClaimChildResource(claimSlot), ModeShared) >>
 
 \* complete_runtime_batch receipt branch (ADR-023)
 \*   No queue_lanes lock (completion does not gate on a lane row)
@@ -299,6 +340,9 @@ Init ==
     /\ txPlan = [t \in TxIds |-> EmptyPlan]
     /\ txNextStep = [t \in TxIds |-> 0]
 
+ConfigOK ==
+    TwoStripeQueuesOK
+
 \* Does any other tx hold an incompatible lock on r wrt mode?
 Blocked(t, r, mode) ==
     \E u \in TxIds \ {t} :
@@ -339,6 +383,15 @@ StartClaimLegacy(t, q, p, readySlot, leaseSlot) ==
     /\ leaseSlot \in LeaseSlots
     /\ txState' = [txState EXCEPT ![t] = "running"]
     /\ txPlan' = [txPlan EXCEPT ![t] = ClaimLegacyPlan(q, p, readySlot, leaseSlot)]
+    /\ txNextStep' = [txNextStep EXCEPT ![t] = 1]
+    /\ UNCHANGED heldLocks
+
+StartEnqueueTwoStripe(t, p) ==
+    /\ t \in TxIds
+    /\ txState[t] = "idle"
+    /\ p \in Priorities
+    /\ txState' = [txState EXCEPT ![t] = "running"]
+    /\ txPlan' = [txPlan EXCEPT ![t] = EnqueueTwoStripePlan(p)]
     /\ txNextStep' = [txNextStep EXCEPT ![t] = 1]
     /\ UNCHANGED heldLocks
 
@@ -495,6 +548,7 @@ Recycle(t) ==
 Stutter == /\ UNCHANGED vars
 
 Next ==
+    \/ \E t \in TxIds, p \in Priorities : StartEnqueueTwoStripe(t, p)
     \/ \E t \in TxIds, q \in Queues, p \in Priorities,
          rs \in ReadySlots, cs \in ClaimSlots :
           StartClaimReceipts(t, q, p, rs, cs)
@@ -524,7 +578,7 @@ Next ==
     \/ \E t \in TxIds : Recycle(t)
     \/ Stutter
 
-Spec == Init /\ [][Next]_vars
+Spec == ConfigOK /\ Init /\ [][Next]_vars
 
 \* ---- Sanity check for the deadlock detector ----
 \*
@@ -566,11 +620,47 @@ NextDeadlockDemo ==
 
 SpecDeadlockDemo == Init /\ [][NextDeadlockDemo]_vars
 
+\* ---- Historical striped-claim deadlock harness ----
+\*
+\* This models the pre-fix shape where a single logical queue claim
+\* transaction could walk multiple physical stripes in an order opposite
+\* to the producer's stable grouped enqueue order. TLC is expected to
+\* flag NoDeadlock on this spec. If it passes, this harness no longer
+\* describes the bug class we fixed.
+
+StartOldClaimTwoStripeReceipts(t, p, readySlot, claimSlot) ==
+    /\ t \in TxIds
+    /\ txState[t] = "idle"
+    /\ p \in Priorities
+    /\ readySlot \in ReadySlots
+    /\ claimSlot \in ClaimSlots
+    /\ txState' = [txState EXCEPT ![t] = "running"]
+    /\ txPlan' = [txPlan EXCEPT ![t] =
+        OldClaimTwoStripeReceiptsPlan(p, readySlot, claimSlot)]
+    /\ txNextStep' = [txNextStep EXCEPT ![t] = 1]
+    /\ UNCHANGED heldLocks
+
+NextOldStripedClaimDeadlockDemo ==
+    \/ \E t \in TxIds, p \in Priorities : StartEnqueueTwoStripe(t, p)
+    \/ \E t \in TxIds, p \in Priorities, rs \in ReadySlots,
+         cs \in ClaimSlots :
+          StartOldClaimTwoStripeReceipts(t, p, rs, cs)
+    \/ \E t \in TxIds : AcquireNext(t)
+    \/ \E t \in TxIds : Commit(t)
+    \/ \E t \in TxIds : Recycle(t)
+    \/ Stutter
+
+SpecOldStripedClaimDeadlockDemo ==
+    ConfigOK /\ Init /\ [][NextOldStripedClaimDeadlockDemo]_vars
+
 \* ---- Invariants ----
 
 TypeOK ==
     /\ TxIds # {}
     /\ Queues # {}
+    /\ StripeA \in Queues
+    /\ StripeB \in Queues
+    /\ StripeA # StripeB
     /\ Priorities # {}
     /\ LeaseSlots # {}
     /\ ReadySlots # {}

--- a/correctness/storage/AwaStorageLockOrderDeadlockDemo.cfg
+++ b/correctness/storage/AwaStorageLockOrderDeadlockDemo.cfg
@@ -5,7 +5,9 @@
 \* is broken and the main spec's "no deadlock" result cannot be trusted.
 CONSTANTS
   TxIds = {"t1", "t2"}
-  Queues = {"q1"}
+  Queues = {"q1", "q1#0", "q1#1"}
+  StripeA = "q1#0"
+  StripeB = "q1#1"
   Priorities = {1}
   LeaseSlots = {1}
   ReadySlots = {1}

--- a/correctness/storage/AwaStorageLockOrderOldStripedClaimDeadlock.cfg
+++ b/correctness/storage/AwaStorageLockOrderOldStripedClaimDeadlock.cfg
@@ -1,0 +1,22 @@
+\* Historical striped logical-claim harness. This uses the old shape
+\* where a single runtime claim transaction could walk more than one
+\* physical stripe. TLC is expected to flag NoDeadlock: producer enqueue
+\* takes q1#0 then q1#1, while the old claim shape can take q1#1 then
+\* q1#0.
+CONSTANTS
+  TxIds = {"t1", "t2"}
+  Queues = {"q1#0", "q1#1"}
+  StripeA = "q1#0"
+  StripeB = "q1#1"
+  Priorities = {1}
+  LeaseSlots = {1}
+  ReadySlots = {1}
+  ClaimSlots = {1}
+
+SPECIFICATION SpecOldStripedClaimDeadlockDemo
+
+INVARIANTS
+  TypeOK
+  LockCompatibility
+  HeldOnlyByRunningTxs
+  NoDeadlock

--- a/correctness/storage/MAPPING.md
+++ b/correctness/storage/MAPPING.md
@@ -232,10 +232,13 @@ directly and checks that no interleaving of claim / complete /
 close-receipt / rescue-receipts / ensure-running / cancel /
 rotate-leases / prune-leases / rotate-ready / prune-ready /
 rotate-claims / prune-claims transactions produces a waits-for cycle.
-Current result: 39,040 distinct states, no deadlock. A
-deliberately-broken demo config
-(`AwaStorageLockOrderDeadlockDemo.cfg`) confirms the deadlock
-detector fires when a cycle exists.
+It also models the striped producer path that updates multiple physical
+queue lanes in a stable order, while the current runtime claim path claims
+only one physical stripe per transaction. A deliberately-broken demo config
+(`AwaStorageLockOrderDeadlockDemo.cfg`) confirms the deadlock detector fires
+when a cycle exists, and `AwaStorageLockOrderOldStripedClaimDeadlock.cfg`
+captures the historical unsafe shape where one logical claim transaction
+walked multiple physical stripes in the opposite order from enqueue.
 
 Together the two specs cover complementary risks:
 - `AwaSegmentedStorageRaces` catches data-level races that would

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -415,6 +415,7 @@ await client.start(
     queue_storage_queue_slot_count=16,
     queue_storage_lease_slot_count=8,
     queue_storage_claim_slot_count=8,
+    queue_storage_queue_stripe_count=1,
     queue_storage_queue_rotate_interval_ms=1000,
     queue_storage_lease_rotate_interval_ms=50,
     queue_storage_claim_rotate_interval_ms=1000,
@@ -428,7 +429,7 @@ await client.start(
 | `queue_slot_count` | `16` | Number of rotating ready/terminal queue partitions |
 | `lease_slot_count` | `8` | Number of rotating lease partitions |
 | `claim_slot_count` | `8` | Number of rotating ADR-023 claim-ring partitions (`lease_claims` + `lease_claim_closures` children). Both tables share the same `claim_slot` so each partition's claims and closures are reclaimed together by `TRUNCATE`. |
-| `queue_stripe_count` | `1` | Rust `QueueStorageConfig` only in the current API. Number of physical stripes behind each logical queue. `1` is the normal unstriped path. For a single very hot queue on many small replicas, `2` is the current release-shape candidate; higher values should be benchmarked before use. |
+| `queue_stripe_count` / `queue_storage_queue_stripe_count` | `1` | Number of physical stripes behind each logical queue. `1` is the normal unstriped path. For a single very hot queue on many small replicas, `2` is the current release-shape candidate; higher values should be benchmarked before use. |
 | `lease_claim_receipts` | `true` | Use the receipt-plane short path (claim writes a row into `lease_claims`; completion writes a closure tombstone into `lease_claim_closures`; both reclaimed by claim-ring rotation). Receipts mode supports per-claim deadlines: when `QueueConfig.deadline_duration > 0`, the claim writes `clock_timestamp() + interval` onto `lease_claims.deadline_at` and the maintenance rescue path force-closes expired claims with a `'deadline_expired'` closure. Set to `false` to force every claim through the legacy `leases` materialization path. See ADR-023. |
 | `queue_rotate_interval` | `1000ms` | How often ready/terminal segments rotate |
 | `lease_rotate_interval` | `50ms` | How often lease segments rotate |


### PR DESCRIPTION
## Summary

- Claim each physical queue stripe in its own transaction for striped queue-storage runtime claims.
- Extend the TLA+ lock-order model with striped enqueue and old multi-stripe claim transaction coverage.
- Add a concurrent striped enqueue/claim regression test.
- Expose `queue_storage_queue_stripe_count` through the Python start API and docs.

## Benchmark evidence

256 workers, depth-target producer, copy producer path, clean phase medians:

| Run | Throughput/s | Depth | p95 ms | p99 ms |
| --- | ---: | ---: | ---: | ---: |
| Old main, 1 stripe, DB depth 4000 | 20,588 | 5,532 | 529 | 627 |
| This branch, 1 stripe, DB depth 4000 | 18,734 | 6,960 | 557 | 647 |
| This branch, 2 stripes, DB depth 4000 | 18,790 | 5,748 | 497 | 594 |
| Main + harness local-started controller, 1 stripe, depth 1500 | 16,802 | 1,180 | 116 | 269 |
| This branch + harness local-started controller, 2 stripes, depth 1500 | 17,440 | 1,244 | 105 | 143 |

The first attempted 2-stripe run on main produced `queue_storage` deadlocks and then pool starvation; this branch completed the same 2-stripe shape cleanly.

The local-started controller is still a benchmark-harness experiment and is not part of this PR.

## Tests

```bash
cargo check -p awa-model -p awa-worker

PYO3_PYTHON="/Users/brian/.local/share/uv/python/cpython-3.14.3-macos-aarch64-none/bin/python" \
  cargo check --manifest-path awa-python/Cargo.toml

cargo test -p awa --test queue_storage_runtime_test striped -- --nocapture

uv run pytest tests/test_start_config.py -k 'claim_ring_knobs_validate'

./correctness/run-tlc.sh \
  storage/AwaStorageLockOrder.tla \
  storage/AwaStorageLockOrder.cfg

./correctness/run-tlc.sh \
  storage/AwaStorageLockOrder.tla \
  storage/AwaStorageLockOrderDeadlockDemo.cfg
# expected: NoDeadlock violation

./correctness/run-tlc.sh \
  storage/AwaStorageLockOrder.tla \
  storage/AwaStorageLockOrderOldStripedClaimDeadlock.cfg
# expected: NoDeadlock violation