### PR TITLE
Reduce empty dispatcher claims after capacity wakes

### DIFF
--- a/awa-worker/src/dispatcher.rs
+++ b/awa-worker/src/dispatcher.rs
@@ -17,6 +17,7 @@ const CLAIM_BATCH_LIMIT: usize = 128;
 const MAX_CLAIMERS_PER_QUEUE: i16 = 4;
 const CLAIMER_LEASE_TTL: Duration = Duration::from_secs(3);
 const CLAIMER_IDLE_THRESHOLD: Duration = Duration::from_millis(500);
+const MAX_FALLBACK_POLL_BACKOFF: Duration = Duration::from_secs(300);
 
 fn max_claimers_per_queue() -> i16 {
     static MAX_CLAIMERS: OnceLock<i16> = OnceLock::new();
@@ -62,6 +63,61 @@ impl WakeReason {
             WakeReason::Capacity => "capacity",
             WakeReason::Poll => "poll",
         }
+    }
+}
+
+#[derive(Debug, Default)]
+struct CapacityWakeState {
+    recheck_on_capacity: bool,
+}
+
+impl CapacityWakeState {
+    fn should_drain_on_capacity(&self) -> bool {
+        self.recheck_on_capacity
+    }
+
+    fn mark_wake_deferred_for_capacity(&mut self) {
+        self.recheck_on_capacity = true;
+    }
+
+    fn record_claim_result(&mut self, claimed: usize, batch_size: usize, unused_permits: usize) {
+        // A capacity wake is only a useful claim signal if the previous
+        // claim filled the whole available batch. Empty or partial claims
+        // already proved that freed permits alone do not imply DB work.
+        self.recheck_on_capacity = claimed > 0 && claimed == batch_size && unused_permits == 0;
+    }
+}
+
+#[derive(Debug, Clone)]
+struct PollBackoff {
+    base: Duration,
+    current: Duration,
+    max: Duration,
+}
+
+impl PollBackoff {
+    fn new(base: Duration) -> Self {
+        Self {
+            base,
+            current: base,
+            max: MAX_FALLBACK_POLL_BACKOFF.max(base),
+        }
+    }
+
+    fn current_interval(&self) -> Duration {
+        self.current
+    }
+
+    fn reset(&mut self) {
+        self.current = self.base;
+    }
+
+    fn record_empty_poll(&mut self) {
+        self.current = self
+            .current
+            .checked_mul(2)
+            .unwrap_or(self.max)
+            .min(self.max);
     }
 }
 
@@ -286,6 +342,8 @@ pub struct Dispatcher {
     rate_limiter: Option<TokenBucket>,
     storage: RuntimeStorage,
     capacity_wake: Arc<Notify>,
+    capacity_wake_state: CapacityWakeState,
+    poll_backoff: PollBackoff,
 }
 
 impl Dispatcher {
@@ -307,6 +365,7 @@ impl Dispatcher {
             semaphore: Arc::new(Semaphore::new(config.max_workers as usize)),
         };
         let rate_limiter = config.rate_limit.as_ref().map(TokenBucket::new);
+        let poll_backoff = PollBackoff::new(config.poll_interval);
         Self {
             queue,
             runtime_instance_id,
@@ -322,6 +381,8 @@ impl Dispatcher {
             rate_limiter,
             storage,
             capacity_wake: Arc::new(Notify::new()),
+            capacity_wake_state: CapacityWakeState::default(),
+            poll_backoff,
         }
     }
 
@@ -342,6 +403,7 @@ impl Dispatcher {
         storage: RuntimeStorage,
     ) -> Self {
         let rate_limiter = config.rate_limit.as_ref().map(TokenBucket::new);
+        let poll_backoff = PollBackoff::new(config.poll_interval);
         Self {
             queue,
             runtime_instance_id,
@@ -357,6 +419,8 @@ impl Dispatcher {
             rate_limiter,
             storage,
             capacity_wake: Arc::new(Notify::new()),
+            capacity_wake_state: CapacityWakeState::default(),
+            poll_backoff,
         }
     }
 
@@ -403,6 +467,7 @@ impl Dispatcher {
                     match notification {
                         Ok(_) => {
                             debug!(queue = %self.queue, "Woken by NOTIFY");
+                            self.poll_backoff.reset();
                             self.drain_ready(WakeReason::Notify, Instant::now()).await;
                         }
                         Err(err) => {
@@ -412,9 +477,11 @@ impl Dispatcher {
                     }
                 }
                 _ = self.capacity_wake.notified() => {
-                    self.drain_ready(WakeReason::Capacity, Instant::now()).await;
+                    if self.capacity_wake_state.should_drain_on_capacity() {
+                        self.drain_ready(WakeReason::Capacity, Instant::now()).await;
+                    }
                 }
-                _ = tokio::time::sleep(self.config.poll_interval) => {
+                _ = tokio::time::sleep(self.poll_backoff.current_interval()) => {
                     self.drain_ready(WakeReason::Poll, Instant::now()).await;
                 }
             }
@@ -432,9 +499,11 @@ impl Dispatcher {
                     break;
                 }
                 _ = self.capacity_wake.notified() => {
-                    self.drain_ready(WakeReason::Capacity, Instant::now()).await;
+                    if self.capacity_wake_state.should_drain_on_capacity() {
+                        self.drain_ready(WakeReason::Capacity, Instant::now()).await;
+                    }
                 }
-                _ = tokio::time::sleep(self.config.poll_interval) => {
+                _ = tokio::time::sleep(self.poll_backoff.current_interval()) => {
                     self.drain_ready(WakeReason::Poll, Instant::now()).await;
                 }
             }
@@ -500,6 +569,12 @@ impl Dispatcher {
         // Phase 1: Pre-acquire permits (non-blocking)
         let mut permits = self.acquire_permits();
         if permits.is_empty() {
+            if let Some((reason @ (WakeReason::Notify | WakeReason::Poll), _)) = wake_context {
+                if matches!(reason, WakeReason::Poll) {
+                    self.poll_backoff.record_empty_poll();
+                }
+                self.capacity_wake_state.mark_wake_deferred_for_capacity();
+            }
             return false;
         }
         if let Some((reason, woke_at)) = wake_context {
@@ -634,6 +709,7 @@ impl Dispatcher {
         self.metrics
             .record_claim_batch(&self.queue, jobs.len() as u64, claim_start.elapsed());
         if !jobs.is_empty() {
+            self.poll_backoff.reset();
             self.metrics
                 .record_job_claimed(&self.queue, jobs.len() as u64);
             // Wait duration = created_at → now() (claim moment).
@@ -667,10 +743,15 @@ impl Dispatcher {
             self.metrics
                 .record_dispatch_unused_permits(&self.queue, unused_permits as u64);
         }
+        self.capacity_wake_state
+            .record_claim_result(jobs.len(), batch_size, unused_permits);
 
         // Phase 5: Clear overflow demand if no jobs found
         if jobs.is_empty() {
             if let Some((reason, _)) = wake_context {
+                if matches!(reason, WakeReason::Poll) {
+                    self.poll_backoff.record_empty_poll();
+                }
                 self.metrics
                     .record_dispatch_empty_claim(&self.queue, reason.as_str());
             }
@@ -712,5 +793,66 @@ impl Dispatcher {
         }
 
         true
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{CapacityWakeState, PollBackoff};
+    use std::time::Duration;
+
+    #[test]
+    fn capacity_wake_state_rechecks_after_full_capacity_claim() {
+        let mut state = CapacityWakeState::default();
+
+        state.record_claim_result(4, 4, 0);
+
+        assert!(state.should_drain_on_capacity());
+    }
+
+    #[test]
+    fn capacity_wake_state_skips_after_empty_or_partial_claim() {
+        let mut state = CapacityWakeState::default();
+
+        state.mark_wake_deferred_for_capacity();
+        state.record_claim_result(0, 4, 4);
+        assert!(!state.should_drain_on_capacity());
+
+        state.mark_wake_deferred_for_capacity();
+        state.record_claim_result(2, 4, 2);
+        assert!(!state.should_drain_on_capacity());
+    }
+
+    #[test]
+    fn capacity_wake_state_rechecks_when_wake_arrived_without_capacity() {
+        let mut state = CapacityWakeState::default();
+
+        state.mark_wake_deferred_for_capacity();
+
+        assert!(state.should_drain_on_capacity());
+    }
+
+    #[test]
+    fn poll_backoff_doubles_after_empty_poll_until_cap() {
+        let mut backoff = PollBackoff::new(Duration::from_millis(200));
+
+        backoff.record_empty_poll();
+        assert_eq!(backoff.current_interval(), Duration::from_millis(400));
+
+        for _ in 0..20 {
+            backoff.record_empty_poll();
+        }
+        assert_eq!(backoff.current_interval(), Duration::from_secs(300));
+    }
+
+    #[test]
+    fn poll_backoff_resets_after_work_signal() {
+        let mut backoff = PollBackoff::new(Duration::from_millis(200));
+
+        backoff.record_empty_poll();
+        backoff.record_empty_poll();
+        backoff.reset();
+
+        assert_eq!(backoff.current_interval(), Duration::from_millis(200));
     }
 }

--- a/awa/tests/queue_storage_runtime_test.rs
+++ b/awa/tests/queue_storage_runtime_test.rs
@@ -12,6 +12,8 @@ use awa::{
     UniqueOpts, Worker,
 };
 use chrono::{DateTime, Utc};
+use opentelemetry_sdk::metrics::data::{AggregatedMetrics, MetricData};
+use opentelemetry_sdk::metrics::{InMemoryMetricExporter, SdkMeterProvider};
 use serde::{Deserialize, Serialize};
 use sqlx::postgres::PgPoolOptions;
 use std::collections::HashSet;
@@ -23,6 +25,45 @@ use tokio::sync::Mutex;
 use uuid::Uuid;
 
 static QUEUE_STORAGE_RUNTIME_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
+
+fn install_in_memory_metrics() -> (InMemoryMetricExporter, SdkMeterProvider) {
+    let exporter = InMemoryMetricExporter::default();
+    let meter_provider = SdkMeterProvider::builder()
+        .with_periodic_exporter(exporter.clone())
+        .build();
+    opentelemetry::global::set_meter_provider(meter_provider.clone());
+    (exporter, meter_provider)
+}
+
+fn sum_counter_metric_with_attribute(
+    resource_metrics: &[opentelemetry_sdk::metrics::data::ResourceMetrics],
+    name: &str,
+    attr_name: &str,
+    attr_value: &str,
+) -> u64 {
+    let mut total = 0;
+    for rm in resource_metrics {
+        for scope_metrics in rm.scope_metrics() {
+            for metric in scope_metrics.metrics() {
+                if metric.name() != name {
+                    continue;
+                }
+                if let AggregatedMetrics::U64(MetricData::Sum(sum)) = metric.data() {
+                    total += sum
+                        .data_points()
+                        .filter(|dp| {
+                            dp.attributes().any(|kv| {
+                                kv.key.as_str() == attr_name && kv.value.as_str() == attr_value
+                            })
+                        })
+                        .map(|dp| dp.value())
+                        .sum::<u64>();
+                }
+            }
+        }
+    }
+    total
+}
 
 fn base_database_url() -> String {
     std::env::var("DATABASE_URL")
@@ -2465,6 +2506,95 @@ async fn test_queue_storage_short_jobs_complete_via_lease_claim_receipts() {
     assert_eq!(completed_counts.running, 0);
 
     client.shutdown(Duration::from_secs(5)).await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn test_queue_storage_capacity_wake_skips_empty_claim_after_partial_drain() {
+    let _guard = QUEUE_STORAGE_RUNTIME_LOCK.lock().await;
+    let (exporter, meter_provider) = install_in_memory_metrics();
+    let pool = setup_pool(10).await;
+    let queue = "qs_capacity_wake_partial_drain";
+    let schema = "awa_qs_capacity_wake_partial_drain";
+    let store_config = QueueStorageConfig {
+        schema: schema.to_string(),
+        queue_slot_count: 4,
+        lease_slot_count: 2,
+        lease_claim_receipts: true,
+        claim_slot_count: 2,
+        ..Default::default()
+    };
+    let store = create_store_with_config(&pool, store_config.clone()).await;
+    let client = Client::builder(pool.clone())
+        .queue(
+            queue,
+            QueueConfig {
+                max_workers: 8,
+                poll_interval: Duration::from_secs(5),
+                deadline_duration: Duration::ZERO,
+                ..QueueConfig::default()
+            },
+        )
+        .queue_storage(
+            store_config,
+            Duration::from_millis(1_000),
+            Duration::from_millis(50),
+        )
+        .claim_rotate_interval(Duration::from_secs(60))
+        .register_worker(CompleteWorker)
+        .promote_interval(Duration::from_millis(25))
+        .leader_election_interval(Duration::from_millis(100))
+        .leader_check_interval(Duration::from_millis(50))
+        .heartbeat_rescue_interval(Duration::from_millis(100))
+        .deadline_rescue_interval(Duration::from_millis(100))
+        .callback_rescue_interval(Duration::from_millis(25))
+        .build()
+        .expect("Failed to build capacity wake client");
+
+    client
+        .start()
+        .await
+        .expect("Failed to start capacity wake client");
+
+    let job_id = enqueue_job(
+        &pool,
+        &store,
+        &CompleteJob { id: 2003 },
+        InsertOpts {
+            queue: queue.to_string(),
+            ..Default::default()
+        },
+    )
+    .await;
+
+    let completed = wait_for_job_state(
+        &store,
+        &pool,
+        job_id,
+        &[JobState::Completed],
+        Duration::from_secs(5),
+    )
+    .await;
+    assert_eq!(completed.state, JobState::Completed);
+
+    tokio::time::sleep(Duration::from_millis(250)).await;
+    client.shutdown(Duration::from_secs(5)).await;
+    meter_provider
+        .force_flush()
+        .expect("Failed to flush metrics");
+    let resource_metrics = exporter
+        .get_finished_metrics()
+        .expect("Failed to get metrics");
+
+    let capacity_empty_claims = sum_counter_metric_with_attribute(
+        &resource_metrics,
+        "awa.dispatch.empty_claims",
+        "awa.dispatch.reason",
+        "capacity",
+    );
+    assert_eq!(
+        capacity_empty_claims, 0,
+        "partial-drain completion wake should not immediately issue an empty capacity claim"
+    );
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]


### PR DESCRIPTION
## Summary
- gate dispatcher capacity wakeups so completed jobs only trigger another DB claim when the previous claim showed possible backlog
- add exponential fallback poll backoff: empty poll wakes double from the configured base interval up to 300s, while NOTIFY and successful claims reset immediately
- preserve immediate recheck when a notify/poll arrives while no worker capacity is available
- add unit coverage for the capacity-wake and poll-backoff state machines plus an integration regression asserting partial-drain completion wakes do not emit empty capacity claims

## Investigation notes
The existing metrics already expose the key signals for this work: `awa.dispatch.claim_batches`, `awa.dispatch.empty_claims`, `awa.dispatch.claim_batch_size`, and `awa.dispatch.claim_duration`. The two local churn sources were:

1. completion-side `capacity_wake.notify_one()`: after a partial/empty claim, freeing a permit alone does not mean the DB has more work, yet the dispatcher still claimed again.
2. fallback polling: each dispatcher used the configured `poll_interval` on every idle loop. The default remains responsive at 200ms initially, but repeated empty poll wakes now back off up to 300s because LISTEN/NOTIFY is the normal fast path.

This keeps fast pickup for real work: NOTIFY resets the fallback poll interval immediately, successful claims reset it, full claims still arm capacity wake rechecks, and no-capacity notify/poll wakes still recheck when capacity is released.

## Verification
- `cargo fmt --check && git diff --check`
- `cargo check -p awa-worker -p awa-model -p awa`
- `cargo test -p awa-worker`
- `cargo test -p awa --test queue_storage_runtime_test -- --nocapture`
- `cargo test -p awa --test queue_storage_runtime_test test_queue_storage_two_clients_drain_without_duplicate_execution -- --nocapture`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced dispatcher efficiency with adaptive polling backoff and improved capacity-aware scheduling logic
  * Optimized job claim handling to reduce unnecessary database operations under load conditions

* **Tests**
  * Added integration test validating queue storage capacity wake behavior and empty claim detection

<!-- end of auto-generated comment: release notes by coderabbit.ai -->