### PR TITLE
Make admin cancel signal running handlers

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,9 +281,11 @@ Cancellation is cooperative for running handlers:
 - Rust handlers can poll `ctx.is_cancelled()`.
 - Python handlers can poll `job.is_cancelled()`.
 - Shutdown and runtime rescue paths flip that flag.
-- Admin cancel (`awa::admin::cancel`, `client.cancel`) always updates job state
-  in storage, but a running handler is not currently guaranteed to observe an
-  in-memory cancellation signal from admin cancel alone.
+- Admin cancel (`awa::admin::cancel`, `client.cancel`) updates job state in
+  storage and signals the matching in-flight handler, when that exact running
+  attempt is still alive on a worker process.
+- If a handler ignores the signal or returns too late, stale completion/retry
+  results remain no-ops because the job is already cancelled in storage.
 
 ## Installation
 

--- a/awa-model/src/admin.rs
+++ b/awa-model/src/admin.rs
@@ -311,6 +311,19 @@ fn queue_storage_current_jobs_cte(schema: &str) -> String {
     )
 }
 
+async fn notify_cancellation_tx<'a>(
+    tx: &mut sqlx::Transaction<'a, sqlx::Postgres>,
+    job_id: i64,
+    run_lease: i64,
+) -> Result<(), AwaError> {
+    let payload = serde_json::json!({ "job_id": job_id, "run_lease": run_lease }).to_string();
+    sqlx::query("SELECT pg_notify('awa:cancel', $1)")
+        .bind(payload)
+        .execute(tx.as_mut())
+        .await?;
+    Ok(())
+}
+
 async fn list_queue_storage_jobs(
     store: &QueueStorage,
     pool: &PgPool,
@@ -471,12 +484,7 @@ pub async fn cancel(pool: &PgPool, job_id: i64) -> Result<Option<JobRow>, AwaErr
     };
 
     if matches!(prior_state, JobState::Running | JobState::WaitingExternal) {
-        let payload =
-            serde_json::json!({ "job_id": job.id, "run_lease": job.run_lease }).to_string();
-        sqlx::query("SELECT pg_notify('awa:cancel', $1)")
-            .bind(payload)
-            .execute(tx.as_mut())
-            .await?;
+        notify_cancellation_tx(&mut tx, job.id, job.run_lease).await?;
     }
 
     tx.commit().await?;
@@ -507,12 +515,10 @@ pub async fn cancel(pool: &PgPool, job_id: i64) -> Result<Option<JobRow>, AwaErr
 ///
 /// Queries `jobs_hot` and `scheduled_jobs` directly rather than the `awa.jobs`
 /// UNION ALL view, because PostgreSQL does not support `FOR UPDATE` on UNION
-/// views. The CTE selects candidate IDs without row locks; blocking on a
-/// concurrently-locked row (e.g., one being processed by a worker) happens
-/// implicitly during the UPDATE phase via the writable view trigger. If the
-/// worker completes the job before the UPDATE acquires the lock, the state
-/// check (`NOT IN ('completed', 'failed', 'cancelled')`) causes the cancel
-/// to no-op and return `None`.
+/// views. The CTE selects the oldest candidate ID without row locks, then
+/// delegates to `cancel(...)` so running jobs also emit the cooperative
+/// in-flight cancellation notification. If the selected job completes before
+/// `cancel(...)` locks it, the cancel becomes a no-op and returns `None`.
 ///
 /// The lookup scans `unique_key` on both physical tables without a dedicated
 /// index. This is acceptable for low-volume use cases. For high-volume tables,
@@ -570,10 +576,10 @@ pub async fn cancel_by_unique_key(
         };
     }
 
-    // Find the oldest matching job across both physical tables. CTE selects
-    // candidate IDs without row locks; blocking on concurrently-locked rows
-    // happens implicitly during the UPDATE via the writable view trigger.
-    let row = sqlx::query_as::<_, JobRow>(
+    // Find the oldest matching job across both physical tables, then route
+    // through `cancel(...)` so running jobs emit the same cooperative
+    // cancellation notification as ID-based admin cancels.
+    let candidate: Option<i64> = sqlx::query_scalar(
         r#"
         WITH candidates AS (
             SELECT id FROM awa.jobs_hot
@@ -584,21 +590,22 @@ pub async fn cancel_by_unique_key(
             ORDER BY id ASC
             LIMIT 1
         )
-        UPDATE awa.jobs
-        SET state = 'cancelled', finalized_at = now(),
-            callback_id = NULL, callback_timeout_at = NULL,
-            callback_filter = NULL, callback_on_complete = NULL,
-            callback_on_fail = NULL, callback_transform = NULL
+        SELECT id
         FROM candidates
-        WHERE awa.jobs.id = candidates.id
-        RETURNING awa.jobs.*
         "#,
     )
     .bind(&unique_key)
     .fetch_optional(pool)
     .await?;
 
-    Ok(row)
+    match candidate {
+        Some(job_id) => match cancel(pool, job_id).await {
+            Ok(row) => Ok(row),
+            Err(AwaError::JobNotFound { .. }) => Ok(None),
+            Err(err) => Err(err),
+        },
+        None => Ok(None),
+    }
 }
 
 /// Retry all failed jobs of a given kind.

--- a/awa-python/python/awa/client.py
+++ b/awa-python/python/awa/client.py
@@ -218,9 +218,9 @@ class AsyncClient:
         """Cancel a job.
 
         Pending/waiting jobs transition to ``cancelled`` immediately.
-        Running jobs are also cancelled in storage, but handler-visible
-        ``job.is_cancelled()`` is primarily driven by shutdown/rescue signals,
-        not by admin cancel alone.
+        Running jobs are cancelled in storage and, if the exact attempt is
+        still in-flight on a worker process, the handler can observe
+        ``job.is_cancelled()`` and exit cooperatively.
         """
         return await self._raw.cancel(job_id)
 
@@ -861,9 +861,9 @@ class Client:
         """Cancel a job.
 
         Pending/waiting jobs transition to ``cancelled`` immediately.
-        Running jobs are also cancelled in storage, but handler-visible
-        ``job.is_cancelled()`` is primarily driven by shutdown/rescue signals,
-        not by admin cancel alone.
+        Running jobs are cancelled in storage and, if the exact attempt is
+        still in-flight on a worker process, the handler can observe
+        ``job.is_cancelled()`` and exit cooperatively.
         """
         return self._raw.cancel_sync(job_id)
 

--- a/awa-python/tests/test_worker_dispatch.py
+++ b/awa-python/tests/test_worker_dispatch.py
@@ -183,6 +183,36 @@ async def test_worker_dispatch_shutdown_signals_cancellation(client):
 
 
 @pytest.mark.asyncio
+async def test_worker_dispatch_admin_cancel_signals_cancellation(client):
+    """Admin cancel flips job.is_cancelled() for an in-flight Python handler."""
+    queue = "dispatch_admin_cancel_signal"
+    started = asyncio.Event()
+    observed = asyncio.Event()
+
+    @client.task(DispatchEmail, queue=queue)
+    async def handle(job):
+        started.set()
+        while not job.is_cancelled():
+            await asyncio.sleep(0.02)
+        observed.set()
+        return awa.Cancel(reason="admin cancel")
+
+    await client.start([(queue, 1)], **RUNTIME_START_KWARGS)
+    job = await client.insert(
+        DispatchEmail(to="admin-cancel@test.com", subject="Signal"),
+        queue=queue,
+    )
+
+    await asyncio.wait_for(started.wait(), timeout=1.0)
+    cancelled = await client.cancel(job.id)
+    assert cancelled.state == awa.JobState.Cancelled
+    await asyncio.wait_for(observed.wait(), timeout=1.0)
+
+    stored = await client.get_job(job.id)
+    assert stored.state == awa.JobState.Cancelled
+
+
+@pytest.mark.asyncio
 async def test_worker_dispatch_health_check(client):
     """Health check reflects the Rust runtime state while workers are running."""
     queue = "dispatch_health"

--- a/awa-worker/README.md
+++ b/awa-worker/README.md
@@ -78,14 +78,14 @@ result like `JobResult::Cancel(...)`, `JobResult::RetryAfter(...)`, or
 
 There is an important distinction between:
 
-- **handler/runtime cancellation signals**
+- **handler cancellation signals**
   - the in-memory cancellation flag becomes `true`
   - the handler can observe cancellation while it is still running
 - **admin/job-state cancellation**
   - `admin::cancel(...)` / `client.cancel(...)` marks the job `cancelled` in storage
   - pending or waiting jobs transition immediately
-  - a running handler is not currently guaranteed to see its in-memory
-    cancellation flag flipped by admin cancel alone
+  - if the exact running attempt is still alive on a worker process, the
+    matching handler also sees its in-memory cancellation flag flip
 
 If a running job is cancelled in storage and the handler keeps running, its
 later completion/retry/cancel attempt is treated as stale and ignored.

--- a/awa-worker/src/cancel_listener.rs
+++ b/awa-worker/src/cancel_listener.rs
@@ -23,6 +23,7 @@ use serde::Deserialize;
 use sqlx::postgres::PgListener;
 use sqlx::PgPool;
 use std::sync::atomic::Ordering;
+use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, warn};
 
@@ -49,7 +50,7 @@ impl CancelListener {
         }
     }
 
-    pub async fn run(self) {
+    pub async fn spawn(self) -> Option<JoinHandle<()>> {
         let mut listener = match PgListener::connect_with(&self.pool).await {
             Ok(listener) => listener,
             Err(err) => {
@@ -58,7 +59,7 @@ impl CancelListener {
                     "Failed to create PG listener for admin cancel; admin cancels will \
                      only take effect via heartbeat/deadline rescue"
                 );
-                return;
+                return None;
             }
         };
 
@@ -69,11 +70,16 @@ impl CancelListener {
                 "Failed to LISTEN on cancel channel; admin cancels will only take \
                  effect via heartbeat/deadline rescue"
             );
-            return;
+            return None;
         }
 
         debug!(channel = CANCEL_CHANNEL, "Cancel listener started");
+        Some(tokio::spawn(async move {
+            self.run(listener).await;
+        }))
+    }
 
+    async fn run(self, mut listener: PgListener) {
         loop {
             tokio::select! {
                 _ = self.cancel.cancelled() => {

--- a/awa-worker/src/client.rs
+++ b/awa-worker/src/client.rs
@@ -1123,9 +1123,23 @@ impl Client {
             self.dlq_policy.clone(),
         ));
 
+        // Admin cancellation listener: fires the in-flight cancel flag
+        // for any locally-running attempt when an admin issues
+        // `cancel(job_id)` on the DB. Listen before dispatchers start
+        // claiming so an early admin cancel cannot race listener setup.
+        let cancel_listener = crate::cancel_listener::CancelListener::new(
+            self.pool.clone(),
+            self.in_flight.clone(),
+            self.service_cancel.clone(),
+        );
+        let cancel_listener_handle = cancel_listener.spawn().await;
+
         let mut service_handles = self.service_handles.write().await;
 
         service_handles.extend(completion_batcher.spawn());
+        if let Some(handle) = cancel_listener_handle {
+            service_handles.push(handle);
+        }
 
         // Start heartbeat service (uses service_cancel — stays alive during drain)
         let heartbeat = HeartbeatService::new(
@@ -1265,19 +1279,6 @@ impl Client {
         let reporter = self.runtime_reporter_state();
         service_handles.push(tokio::spawn(async move {
             reporter.run().await;
-        }));
-
-        // Admin cancellation listener: fires the in-flight cancel flag
-        // for any locally-running attempt when an admin issues
-        // `cancel(job_id)` on the DB. Uses `service_cancel` so it
-        // shuts down alongside the other background services.
-        let cancel_listener = crate::cancel_listener::CancelListener::new(
-            self.pool.clone(),
-            self.in_flight.clone(),
-            self.service_cancel.clone(),
-        );
-        service_handles.push(tokio::spawn(async move {
-            cancel_listener.run().await;
         }));
 
         info!("Awa worker runtime started");

--- a/awa/tests/integration_test.rs
+++ b/awa/tests/integration_test.rs
@@ -9,7 +9,7 @@ use awa::{
 };
 use awa_testing::{TestClient, WorkResult};
 use serde::{Deserialize, Serialize};
-use sqlx::postgres::PgPoolOptions;
+use sqlx::postgres::{PgListener, PgPoolOptions};
 use std::sync::OnceLock;
 use std::time::Duration;
 use tokio::sync::Mutex;
@@ -528,6 +528,68 @@ async fn test_admin_cancel() {
 
     let cancelled = client.get_job(job.id).await.unwrap();
     assert_eq!(cancelled.state, JobState::Cancelled);
+}
+
+#[tokio::test]
+async fn test_admin_cancel_by_unique_key_emits_canonical_running_cancel_notification() {
+    let _guard = test_lock().lock().await;
+    let client = setup_with_connections(4).await;
+    let queue = "integ_cancel_by_unique_key_notify";
+    awa_testing::setup::reset_runtime_backend(client.pool()).await;
+    clean_queue(client.pool(), queue).await;
+
+    let mut listener = PgListener::connect_with(client.pool()).await.unwrap();
+    listener.listen("awa:cancel").await.unwrap();
+
+    let args = SendEmail {
+        to: "cancel-by-key-running@example.com".into(),
+        subject: "Cancel running by key".into(),
+    };
+    let job = insert_with(
+        client.pool(),
+        &args,
+        InsertOpts {
+            queue: queue.into(),
+            unique: Some(UniqueOpts {
+                by_queue: true,
+                by_args: true,
+                ..Default::default()
+            }),
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+
+    sqlx::query(
+        "UPDATE awa.jobs \
+         SET state = 'running', attempt = 1, run_lease = 42, attempted_at = now(), heartbeat_at = now() \
+         WHERE id = $1",
+    )
+    .bind(job.id)
+    .execute(client.pool())
+    .await
+    .unwrap();
+
+    let cancelled = admin::cancel_by_unique_key(
+        client.pool(),
+        SendEmail::kind(),
+        Some(queue),
+        Some(&serde_json::to_value(&args).unwrap()),
+        None,
+    )
+    .await
+    .unwrap()
+    .expect("running job should be cancelled by unique key");
+    assert_eq!(cancelled.id, job.id);
+
+    let notification = tokio::time::timeout(Duration::from_secs(3), listener.recv())
+        .await
+        .expect("cancel notification should be emitted")
+        .expect("cancel listener should receive notification");
+    let payload: serde_json::Value = serde_json::from_str(notification.payload()).unwrap();
+    assert_eq!(payload["job_id"].as_i64(), Some(job.id));
+    assert_eq!(payload["run_lease"].as_i64(), Some(42));
 }
 
 #[tokio::test]

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -193,8 +193,9 @@ stateDiagram-v2
 - DLQ is opt-in per queue. It is stored in `dlq_entries`; it is not a
   dispatchable `job_state`.
 - Cancellation is cooperative for live handlers. Runtime-driven shutdown,
-  stale-heartbeat rescue, and deadline rescue signal the local in-memory
-  cancellation flag when the rescuing process still has that handler registered.
+  admin cancel, stale-heartbeat rescue, and deadline rescue signal the local
+  in-memory cancellation flag when the process still has that handler
+  registered.
   A process that has panicked has no live handler left to signal; storage rescue
   and the `run_lease` guard are what let another worker recover the attempt.
 
@@ -858,17 +859,18 @@ Cancellation is cooperative:
 
 - Rust handlers observe `ctx.is_cancelled()`.
 - Python handlers observe `job.is_cancelled()`.
-- Shutdown and runtime rescue paths set that in-memory flag so long-running
-  handlers can notice cancellation and exit gracefully.
+- Shutdown, admin cancel, and runtime rescue paths set that in-memory flag so
+  long-running handlers can notice cancellation and exit gracefully.
 
-That is distinct from **admin cancellation**:
+Admin cancellation has both a storage effect and, for live local attempts, a
+handler-visible cooperative signal:
 
 - `admin::cancel(...)` / `client.cancel(...)` transitions the job row to
   `cancelled` in storage.
 - Pending and `waiting_external` jobs cancel immediately.
-- Running jobs are also cancelled in storage, but that storage transition does
-  not currently imply that the in-memory handler cancellation flag has been
-  signalled.
+- Running jobs are also cancelled in storage, and the worker runtime listens
+  for that cancellation so the matching `(job_id, run_lease)` handler sees
+  `ctx.is_cancelled()` / `job.is_cancelled()`.
 - If a running handler continues after an admin cancel, its later
   completion/retry/cancel result is treated as stale and ignored.
 

--- a/docs/test-plan.md
+++ b/docs/test-plan.md
@@ -30,6 +30,7 @@ All tests are automated and run in CI.
 | B4 | Heartbeat alive during shutdown drain | ✓ | |
 | B5 | Deadline rescue signals ctx.is_cancelled() | ✓ | |
 | B6 | UniqueConflict.constraint field | ✓ | |
+| B7 | Admin cancel signals in-flight handler cancellation | ✓ | ✓ |
 | T75 | Priority aging maintenance task promotes long-waiting low-priority jobs | ✓ | |
 
 ### Uniqueness (Python)


### PR DESCRIPTION
## Summary
- start the admin cancel listener before dispatchers claim work so early cancels cannot race LISTEN setup
- route canonical cancel-by-unique-key through the notifying cancel path for running jobs
- document the user-facing cooperative cancellation contract for Rust and Python handlers
- add Rust and Python coverage for admin cancel signalling running attempts

Closes #193

## Test plan
- rustfmt --edition 2021 --check awa-model/src/admin.rs awa-worker/src/cancel_listener.rs awa-worker/src/client.rs awa/tests/integration_test.rs
- git diff --check
- cargo test -p awa --test integration_test test_admin_cancel_by_unique_key_emits_canonical_running_cancel_notification -- --exact --nocapture
- cargo test -p awa --test queue_storage_runtime_test test_admin_cancel_wakes_in_flight_handler -- --exact --nocapture
- cargo test -p awa --test integration_test test_admin_cancel_by_unique_key -- --exact --nocapture
- cargo test -p awa-model -p awa-worker
- cd awa-python && uv run maturin develop
- cd awa-python && DATABASE_URL=${DATABASE_URL:-postgres://postgres:test@localhost:15432/awa_test} uv run pytest tests/test_worker_dispatch.py::test_worker_dispatch_admin_cancel_signals_cancellation -q
- cd awa-python && DATABASE_URL=${DATABASE_URL:-postgres://postgres:test@localhost:15432/awa_test} uv run pytest tests/test_worker_dispatch.py::test_worker_dispatch_shutdown_signals_cancellation tests/test_worker_dispatch.py::test_worker_dispatch_admin_cancel_signals_cancellation -q