### PR TITLE
Recover capacity wake refill after partial claims

### DIFF
--- a/awa-worker/src/dispatcher.rs
+++ b/awa-worker/src/dispatcher.rs
@@ -80,11 +80,11 @@ impl CapacityWakeState {
         self.recheck_on_capacity = true;
     }
 
-    fn record_claim_result(&mut self, claimed: usize, batch_size: usize, unused_permits: usize) {
-        // A capacity wake is only a useful claim signal if the previous
-        // claim filled the whole available batch. Empty or partial claims
-        // already proved that freed permits alone do not imply DB work.
-        self.recheck_on_capacity = claimed > 0 && claimed == batch_size && unused_permits == 0;
+    fn record_claim_result(&mut self, claimed: usize, _batch_size: usize, _unused_permits: usize) {
+        // A non-empty claim is enough evidence that capacity release may
+        // expose more ready work. Empty claims proved the opposite and should
+        // suppress completion-driven rechecks until another signal arrives.
+        self.recheck_on_capacity = claimed > 0;
     }
 }
 
@@ -817,10 +817,15 @@ mod tests {
         state.mark_wake_deferred_for_capacity();
         state.record_claim_result(0, 4, 4);
         assert!(!state.should_drain_on_capacity());
+    }
+
+    #[test]
+    fn capacity_wake_state_rechecks_after_partial_non_empty_claim() {
+        let mut state = CapacityWakeState::default();
 
         state.mark_wake_deferred_for_capacity();
         state.record_claim_result(2, 4, 2);
-        assert!(!state.should_drain_on_capacity());
+        assert!(state.should_drain_on_capacity());
     }
 
     #[test]

--- a/awa-worker/src/dispatcher.rs
+++ b/awa-worker/src/dispatcher.rs
@@ -80,7 +80,7 @@ impl CapacityWakeState {
         self.recheck_on_capacity = true;
     }
 
-    fn record_claim_result(&mut self, claimed: usize, _batch_size: usize, _unused_permits: usize) {
+    fn record_claim_result(&mut self, claimed: usize) {
         // A non-empty claim is enough evidence that capacity release may
         // expose more ready work. Empty claims proved the opposite and should
         // suppress completion-driven rechecks until another signal arrives.
@@ -743,8 +743,7 @@ impl Dispatcher {
             self.metrics
                 .record_dispatch_unused_permits(&self.queue, unused_permits as u64);
         }
-        self.capacity_wake_state
-            .record_claim_result(jobs.len(), batch_size, unused_permits);
+        self.capacity_wake_state.record_claim_result(jobs.len());
 
         // Phase 5: Clear overflow demand if no jobs found
         if jobs.is_empty() {
@@ -805,17 +804,17 @@ mod tests {
     fn capacity_wake_state_rechecks_after_full_capacity_claim() {
         let mut state = CapacityWakeState::default();
 
-        state.record_claim_result(4, 4, 0);
+        state.record_claim_result(4);
 
         assert!(state.should_drain_on_capacity());
     }
 
     #[test]
-    fn capacity_wake_state_skips_after_empty_or_partial_claim() {
+    fn capacity_wake_state_skips_after_empty_claim() {
         let mut state = CapacityWakeState::default();
 
         state.mark_wake_deferred_for_capacity();
-        state.record_claim_result(0, 4, 4);
+        state.record_claim_result(0);
         assert!(!state.should_drain_on_capacity());
     }
 
@@ -824,7 +823,7 @@ mod tests {
         let mut state = CapacityWakeState::default();
 
         state.mark_wake_deferred_for_capacity();
-        state.record_claim_result(2, 4, 2);
+        state.record_claim_result(2);
         assert!(state.should_drain_on_capacity());
     }
 


### PR DESCRIPTION
## Summary
- allow capacity-release wakes after any non-empty claim, not only full-batch claims
- keep suppressing completion-driven rechecks after true empty claims
- update dispatcher unit coverage for the partial non-empty claim case

## Why
alpha.4/#216 reduced empty capacity wake claims, but benchmark data suggests it also made the dispatcher too quiet after partial claims. A partial non-empty claim still proves there was ready work recently; suppressing capacity wakes in that state can leave workers idle until NOTIFY or fallback poll. This keeps the empty-claim suppression while restoring work-conserving refill behavior for active queues.

## Test plan
- cargo fmt --all
- git diff --check
- cargo test -p awa-worker dispatcher::tests::capacity_wake_state -- --nocapture
- cargo test -p awa --test queue_storage_runtime_test test_queue_storage_capacity_wake_skips_empty_claim_after_partial_drain -- --exact --nocapture
- cargo clippy -p awa-worker --all-targets -- -D warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved capacity drain recheck logic to trigger whenever claims are successfully processed. Updated unit tests to validate the enhanced capacity handling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->