### PR TITLE
Shorten queue-storage runtime claim transactions

### DIFF
--- a/awa-model/src/queue_storage.rs
+++ b/awa-model/src/queue_storage.rs
@@ -5163,13 +5163,27 @@ impl QueueStorage {
         }
 
         let use_lease_claim_receipts = self.use_lease_claim_receipts_for_runtime(deadline_duration);
-        let claimed = claimed
+        if !use_lease_claim_receipts && deadline_duration.is_zero() {
+            // Legacy zero-deadline claims have no heartbeat/deadline rescue
+            // timestamp, so a post-commit conversion error would strand the
+            // materialized lease indefinitely. Keep the old rollback semantics
+            // for that path.
+            let claimed = claimed
+                .into_iter()
+                .map(|row| row.into_claimed_runtime_job(use_lease_claim_receipts))
+                .collect::<Result<Vec<_>, _>>()?;
+            tx.commit().await.map_err(map_sqlx_error)?;
+            return Ok(claimed);
+        }
+
+        // Release claim locks before doing Rust-side payload conversion; this
+        // keeps the hot claim transaction focused on database state changes.
+        tx.commit().await.map_err(map_sqlx_error)?;
+
+        claimed
             .into_iter()
             .map(|row| row.into_claimed_runtime_job(use_lease_claim_receipts))
-            .collect::<Result<Vec<_>, _>>()?;
-
-        tx.commit().await.map_err(map_sqlx_error)?;
-        Ok(claimed)
+            .collect()
     }
 
     #[tracing::instrument(skip(self, pool), fields(queue = %queue, instance_id = %instance_id), name = "queue_storage.acquire_queue_claimer")]

--- a/awa/tests/queue_storage_runtime_test.rs
+++ b/awa/tests/queue_storage_runtime_test.rs
@@ -1705,6 +1705,59 @@ async fn test_lease_claim_rotation_isolation() {
     );
 }
 
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_legacy_zero_deadline_claim_conversion_error_rolls_back() {
+    let _guard = QUEUE_STORAGE_RUNTIME_LOCK.lock().await;
+    let pool = setup_pool(4).await;
+    let schema = "awa_qs_legacy_zero_deadline_claim_rollback";
+    let queue = "qs_legacy_zero_deadline_claim_rollback";
+    let store = create_store(&pool, schema).await;
+
+    let job_id = enqueue_job(
+        &pool,
+        &store,
+        &RetryJob { id: 1 },
+        InsertOpts {
+            queue: queue.to_string(),
+            ..Default::default()
+        },
+    )
+    .await;
+
+    sqlx::query(&format!(
+        "UPDATE {schema}.ready_entries SET payload = '{{\"metadata\":\"bad\"}}'::jsonb WHERE job_id = $1"
+    ))
+    .bind(job_id)
+    .execute(&pool)
+    .await
+    .expect("corrupt ready payload");
+
+    store
+        .claim_runtime_batch(&pool, queue, 1, Duration::ZERO)
+        .await
+        .expect_err("corrupt payload should fail runtime conversion");
+    assert_eq!(
+        lease_count(&pool, &store).await,
+        0,
+        "failed conversion must not leave an unrescueable legacy zero-deadline lease"
+    );
+
+    sqlx::query(&format!(
+        "UPDATE {schema}.ready_entries SET payload = '{{}}'::jsonb WHERE job_id = $1"
+    ))
+    .bind(job_id)
+    .execute(&pool)
+    .await
+    .expect("repair ready payload");
+
+    let claimed = store
+        .claim_runtime_batch(&pool, queue, 1, Duration::ZERO)
+        .await
+        .expect("claim should remain available after conversion rollback");
+    assert_eq!(claimed.len(), 1);
+    assert_eq!(claimed[0].job.id, job_id);
+}
+
 /// Receipt-plane partition-migration test (see ADR-023). Start from
 /// a schema that still has the legacy regular (non-partitioned)
 /// `lease_claims` + `lease_claim_closures`, seed some rows in them,


### PR DESCRIPTION
## Summary
- commit the runtime claim transaction before converting claimed rows into runtime job rows
- keep the #215 striped claim deadlock fix intact while shortening the single-stripe lock/transaction window
- document why the conversion must stay outside the hot claim transaction

## Why
The post-#220 benchmark still shows a high-concurrency gap versus alpha.3. One remaining single-stripe difference from #215 is that claimed rows were converted into runtime jobs before commit. That conversion deserializes the queue-storage runtime payload, so doing it under the claim transaction can extend row-lock lifetime under 64/128-worker contention.

## Behavior note
This intentionally changes the cold failure mode if runtime payload deserialization fails after a row has been claimed. Before this PR, that conversion error rolled back the claim transaction and the rows returned to Available immediately. With this PR, the claim commit has already landed, so a conversion error leaves those rows Running until the lease timeout/rescue path makes them claimable again. The payload is written by Awa, so this should only matter for corrupt data or payload-format upgrade mistakes, but it is worth calling out explicitly.

## Validation
- cargo test -p awa --test queue_storage_runtime_test test_queue_storage_striped_runtime_claims_do_not_deadlock_with_enqueues -- --exact --nocapture
- cargo test -p awa --test queue_storage_runtime_test test_queue_storage_claim_runtime_applies_priority_aging_dynamically -- --exact --nocapture
- cargo test -p awa-model queue_storage:: -- --nocapture
- cargo clippy -p awa-model --all-targets -- -D warnings
- cargo fmt --check
- git diff --check