### PR TITLE
Restore fixed dispatcher polling

### DIFF
--- a/awa-worker/src/dispatcher.rs
+++ b/awa-worker/src/dispatcher.rs
@@ -17,7 +17,6 @@ const CLAIM_BATCH_LIMIT: usize = 128;
 const MAX_CLAIMERS_PER_QUEUE: i16 = 4;
 const CLAIMER_LEASE_TTL: Duration = Duration::from_secs(3);
 const CLAIMER_IDLE_THRESHOLD: Duration = Duration::from_millis(500);
-const MAX_FALLBACK_POLL_BACKOFF: Duration = Duration::from_secs(300);
 
 fn max_claimers_per_queue() -> i16 {
     static MAX_CLAIMERS: OnceLock<i16> = OnceLock::new();
@@ -63,39 +62,6 @@ impl WakeReason {
             WakeReason::Capacity => "capacity",
             WakeReason::Poll => "poll",
         }
-    }
-}
-
-#[derive(Debug, Clone)]
-struct PollBackoff {
-    base: Duration,
-    current: Duration,
-    max: Duration,
-}
-
-impl PollBackoff {
-    fn new(base: Duration) -> Self {
-        Self {
-            base,
-            current: base,
-            max: MAX_FALLBACK_POLL_BACKOFF.max(base),
-        }
-    }
-
-    fn current_interval(&self) -> Duration {
-        self.current
-    }
-
-    fn reset(&mut self) {
-        self.current = self.base;
-    }
-
-    fn record_empty_poll(&mut self) {
-        self.current = self
-            .current
-            .checked_mul(2)
-            .unwrap_or(self.max)
-            .min(self.max);
     }
 }
 
@@ -320,7 +286,6 @@ pub struct Dispatcher {
     rate_limiter: Option<TokenBucket>,
     storage: RuntimeStorage,
     capacity_wake: Arc<Notify>,
-    poll_backoff: PollBackoff,
 }
 
 impl Dispatcher {
@@ -342,7 +307,6 @@ impl Dispatcher {
             semaphore: Arc::new(Semaphore::new(config.max_workers as usize)),
         };
         let rate_limiter = config.rate_limit.as_ref().map(TokenBucket::new);
-        let poll_backoff = PollBackoff::new(config.poll_interval);
         Self {
             queue,
             runtime_instance_id,
@@ -358,7 +322,6 @@ impl Dispatcher {
             rate_limiter,
             storage,
             capacity_wake: Arc::new(Notify::new()),
-            poll_backoff,
         }
     }
 
@@ -379,7 +342,6 @@ impl Dispatcher {
         storage: RuntimeStorage,
     ) -> Self {
         let rate_limiter = config.rate_limit.as_ref().map(TokenBucket::new);
-        let poll_backoff = PollBackoff::new(config.poll_interval);
         Self {
             queue,
             runtime_instance_id,
@@ -395,7 +357,6 @@ impl Dispatcher {
             rate_limiter,
             storage,
             capacity_wake: Arc::new(Notify::new()),
-            poll_backoff,
         }
     }
 
@@ -442,7 +403,6 @@ impl Dispatcher {
                     match notification {
                         Ok(_) => {
                             debug!(queue = %self.queue, "Woken by NOTIFY");
-                            self.poll_backoff.reset();
                             self.drain_ready(WakeReason::Notify, Instant::now()).await;
                         }
                         Err(err) => {
@@ -454,7 +414,7 @@ impl Dispatcher {
                 _ = self.capacity_wake.notified() => {
                     self.drain_ready(WakeReason::Capacity, Instant::now()).await;
                 }
-                _ = tokio::time::sleep(self.poll_backoff.current_interval()) => {
+                _ = tokio::time::sleep(self.config.poll_interval) => {
                     self.drain_ready(WakeReason::Poll, Instant::now()).await;
                 }
             }
@@ -474,7 +434,7 @@ impl Dispatcher {
                 _ = self.capacity_wake.notified() => {
                     self.drain_ready(WakeReason::Capacity, Instant::now()).await;
                 }
-                _ = tokio::time::sleep(self.poll_backoff.current_interval()) => {
+                _ = tokio::time::sleep(self.config.poll_interval) => {
                     self.drain_ready(WakeReason::Poll, Instant::now()).await;
                 }
             }
@@ -540,9 +500,6 @@ impl Dispatcher {
         // Phase 1: Pre-acquire permits (non-blocking)
         let mut permits = self.acquire_permits();
         if permits.is_empty() {
-            if let Some((WakeReason::Poll, _)) = wake_context {
-                self.poll_backoff.record_empty_poll();
-            }
             return false;
         }
         if let Some((reason, woke_at)) = wake_context {
@@ -677,7 +634,6 @@ impl Dispatcher {
         self.metrics
             .record_claim_batch(&self.queue, jobs.len() as u64, claim_start.elapsed());
         if !jobs.is_empty() {
-            self.poll_backoff.reset();
             self.metrics
                 .record_job_claimed(&self.queue, jobs.len() as u64);
             // Wait duration = created_at → now() (claim moment).
@@ -715,9 +671,6 @@ impl Dispatcher {
         // Phase 5: Clear overflow demand if no jobs found
         if jobs.is_empty() {
             if let Some((reason, _)) = wake_context {
-                if matches!(reason, WakeReason::Poll) {
-                    self.poll_backoff.record_empty_poll();
-                }
                 self.metrics
                     .record_dispatch_empty_claim(&self.queue, reason.as_str());
             }
@@ -759,35 +712,5 @@ impl Dispatcher {
         }
 
         true
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::PollBackoff;
-    use std::time::Duration;
-
-    #[test]
-    fn poll_backoff_doubles_after_empty_poll_until_cap() {
-        let mut backoff = PollBackoff::new(Duration::from_millis(200));
-
-        backoff.record_empty_poll();
-        assert_eq!(backoff.current_interval(), Duration::from_millis(400));
-
-        for _ in 0..20 {
-            backoff.record_empty_poll();
-        }
-        assert_eq!(backoff.current_interval(), Duration::from_secs(300));
-    }
-
-    #[test]
-    fn poll_backoff_resets_after_work_signal() {
-        let mut backoff = PollBackoff::new(Duration::from_millis(200));
-
-        backoff.record_empty_poll();
-        backoff.record_empty_poll();
-        backoff.reset();
-
-        assert_eq!(backoff.current_interval(), Duration::from_millis(200));
     }
 }

--- a/awa-worker/src/dispatcher.rs
+++ b/awa-worker/src/dispatcher.rs
@@ -66,28 +66,6 @@ impl WakeReason {
     }
 }
 
-#[derive(Debug, Default)]
-struct CapacityWakeState {
-    recheck_on_capacity: bool,
-}
-
-impl CapacityWakeState {
-    fn should_drain_on_capacity(&self) -> bool {
-        self.recheck_on_capacity
-    }
-
-    fn mark_wake_deferred_for_capacity(&mut self) {
-        self.recheck_on_capacity = true;
-    }
-
-    fn record_claim_result(&mut self, claimed: usize) {
-        // A non-empty claim is enough evidence that capacity release may
-        // expose more ready work. Empty claims proved the opposite and should
-        // suppress completion-driven rechecks until another signal arrives.
-        self.recheck_on_capacity = claimed > 0;
-    }
-}
-
 #[derive(Debug, Clone)]
 struct PollBackoff {
     base: Duration,
@@ -342,7 +320,6 @@ pub struct Dispatcher {
     rate_limiter: Option<TokenBucket>,
     storage: RuntimeStorage,
     capacity_wake: Arc<Notify>,
-    capacity_wake_state: CapacityWakeState,
     poll_backoff: PollBackoff,
 }
 
@@ -381,7 +358,6 @@ impl Dispatcher {
             rate_limiter,
             storage,
             capacity_wake: Arc::new(Notify::new()),
-            capacity_wake_state: CapacityWakeState::default(),
             poll_backoff,
         }
     }
@@ -419,7 +395,6 @@ impl Dispatcher {
             rate_limiter,
             storage,
             capacity_wake: Arc::new(Notify::new()),
-            capacity_wake_state: CapacityWakeState::default(),
             poll_backoff,
         }
     }
@@ -477,9 +452,7 @@ impl Dispatcher {
                     }
                 }
                 _ = self.capacity_wake.notified() => {
-                    if self.capacity_wake_state.should_drain_on_capacity() {
-                        self.drain_ready(WakeReason::Capacity, Instant::now()).await;
-                    }
+                    self.drain_ready(WakeReason::Capacity, Instant::now()).await;
                 }
                 _ = tokio::time::sleep(self.poll_backoff.current_interval()) => {
                     self.drain_ready(WakeReason::Poll, Instant::now()).await;
@@ -499,9 +472,7 @@ impl Dispatcher {
                     break;
                 }
                 _ = self.capacity_wake.notified() => {
-                    if self.capacity_wake_state.should_drain_on_capacity() {
-                        self.drain_ready(WakeReason::Capacity, Instant::now()).await;
-                    }
+                    self.drain_ready(WakeReason::Capacity, Instant::now()).await;
                 }
                 _ = tokio::time::sleep(self.poll_backoff.current_interval()) => {
                     self.drain_ready(WakeReason::Poll, Instant::now()).await;
@@ -569,11 +540,8 @@ impl Dispatcher {
         // Phase 1: Pre-acquire permits (non-blocking)
         let mut permits = self.acquire_permits();
         if permits.is_empty() {
-            if let Some((reason @ (WakeReason::Notify | WakeReason::Poll), _)) = wake_context {
-                if matches!(reason, WakeReason::Poll) {
-                    self.poll_backoff.record_empty_poll();
-                }
-                self.capacity_wake_state.mark_wake_deferred_for_capacity();
+            if let Some((WakeReason::Poll, _)) = wake_context {
+                self.poll_backoff.record_empty_poll();
             }
             return false;
         }
@@ -743,7 +711,6 @@ impl Dispatcher {
             self.metrics
                 .record_dispatch_unused_permits(&self.queue, unused_permits as u64);
         }
-        self.capacity_wake_state.record_claim_result(jobs.len());
 
         // Phase 5: Clear overflow demand if no jobs found
         if jobs.is_empty() {
@@ -797,44 +764,8 @@ impl Dispatcher {
 
 #[cfg(test)]
 mod tests {
-    use super::{CapacityWakeState, PollBackoff};
+    use super::PollBackoff;
     use std::time::Duration;
-
-    #[test]
-    fn capacity_wake_state_rechecks_after_full_capacity_claim() {
-        let mut state = CapacityWakeState::default();
-
-        state.record_claim_result(4);
-
-        assert!(state.should_drain_on_capacity());
-    }
-
-    #[test]
-    fn capacity_wake_state_skips_after_empty_claim() {
-        let mut state = CapacityWakeState::default();
-
-        state.mark_wake_deferred_for_capacity();
-        state.record_claim_result(0);
-        assert!(!state.should_drain_on_capacity());
-    }
-
-    #[test]
-    fn capacity_wake_state_rechecks_after_partial_non_empty_claim() {
-        let mut state = CapacityWakeState::default();
-
-        state.mark_wake_deferred_for_capacity();
-        state.record_claim_result(2);
-        assert!(state.should_drain_on_capacity());
-    }
-
-    #[test]
-    fn capacity_wake_state_rechecks_when_wake_arrived_without_capacity() {
-        let mut state = CapacityWakeState::default();
-
-        state.mark_wake_deferred_for_capacity();
-
-        assert!(state.should_drain_on_capacity());
-    }
 
     #[test]
     fn poll_backoff_doubles_after_empty_poll_until_cap() {

--- a/awa/tests/benchmark_test.rs
+++ b/awa/tests/benchmark_test.rs
@@ -706,7 +706,6 @@ async fn test_throughput_rust_workers_queue_storage() {
         queue_stripe_count,
         lease_claim_receipts: true,
         claim_slot_count: 2,
-        ..Default::default()
     };
     let store =
         QueueStorage::new(store_config.clone()).expect("Failed to build queue storage store");

--- a/awa/tests/benchmark_test.rs
+++ b/awa/tests/benchmark_test.rs
@@ -363,6 +363,10 @@ fn env_usize(name: &str, default: usize) -> usize {
         .unwrap_or(default)
 }
 
+fn env_string(name: &str, default: &str) -> String {
+    std::env::var(name).unwrap_or_else(|_| default.to_string())
+}
+
 #[derive(Debug, Clone, Copy)]
 enum EnqueueMode {
     Insert,
@@ -690,10 +694,13 @@ async fn test_throughput_rust_workers_queue_storage() {
     let queue_slot_count = env_usize("AWA_VA_RUNTIME_QUEUE_SLOTS", 16);
     let lease_slot_count = env_usize("AWA_VA_RUNTIME_LEASE_SLOTS", 4);
     let queue_stripe_count = env_usize("AWA_VA_RUNTIME_QUEUE_STRIPES", 1);
+    let storage_schema = env_string("AWA_VA_RUNTIME_STORAGE_SCHEMA", "awa_queue_storage");
+    let max_workers = env_usize("AWA_VA_RUNTIME_MAX_WORKERS", 100);
     let queue_rotate_ms = env_i64("AWA_VA_RUNTIME_QUEUE_ROTATE_MS", 1_000);
     let lease_rotate_ms = env_i64("AWA_VA_RUNTIME_LEASE_ROTATE_MS", 50);
 
     let store_config = QueueStorageConfig {
+        schema: storage_schema,
         queue_slot_count,
         lease_slot_count,
         queue_stripe_count,
@@ -718,7 +725,7 @@ async fn test_throughput_rust_workers_queue_storage() {
         .queue(
             queue,
             QueueConfig {
-                max_workers: 100,
+                max_workers: max_workers.try_into().expect("max workers must fit in u32"),
                 poll_interval: Duration::from_millis(50),
                 deadline_duration: Duration::ZERO,
                 ..QueueConfig::default()

--- a/awa/tests/queue_storage_runtime_test.rs
+++ b/awa/tests/queue_storage_runtime_test.rs
@@ -2551,7 +2551,7 @@ async fn test_queue_storage_short_jobs_complete_via_lease_claim_receipts() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-async fn test_queue_storage_capacity_wake_skips_empty_claim_after_partial_drain() {
+async fn test_queue_storage_capacity_wake_drains_after_partial_drain() {
     let _guard = QUEUE_STORAGE_RUNTIME_LOCK.lock().await;
     let (exporter, meter_provider) = install_in_memory_metrics();
     let pool = setup_pool(10).await;
@@ -2638,9 +2638,9 @@ async fn test_queue_storage_capacity_wake_skips_empty_claim_after_partial_drain(
         "awa.dispatch.reason",
         "capacity",
     );
-    assert_eq!(
-        capacity_empty_claims, 0,
-        "partial-drain completion wake should not immediately issue an empty capacity claim"
+    assert!(
+        capacity_empty_claims > 0,
+        "partial-drain completion wake should immediately drain capacity again"
     );
 }
 


### PR DESCRIPTION
## Summary
- restore fixed `config.poll_interval` fallback polling by removing the #216 `PollBackoff` path
- keep completion/capacity wakes unsuppressed so released worker capacity drains ready work immediately
- update the capacity-wake runtime test to assert the restored drain behavior
- make the queue-storage throughput benchmark configurable enough to run against a non-canonical storage schema and variable worker counts

Closes #223.
Follow-up to #224.

## Why
PR #216 introduced capacity-wake suppression and geometric fallback-poll backoff to reduce empty-claim churn. The capacity-wake part was partially repaired by #220/#224, but the remaining `PollBackoff` still suppressed useful claim attempts under high concurrency: empty polls and permit-saturated polls doubled the fallback sleep up to the 300s cap, and successful claims / NOTIFY wakeups did not reset it often enough to keep the dispatcher near the configured poll interval.

This PR keeps the useful capacity-wake repair and removes the backoff, returning the dispatcher to fixed fallback polling while preserving the simpler wake-drain behavior.

## Validation
- `cargo test -p awa --test queue_storage_runtime_test test_queue_storage_capacity_wake_drains_after_partial_drain -- --exact --nocapture`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo fmt --check`
- `git diff --check`
- benchmark comparison: #225 recovers the 128-worker queue-storage throughput shape to within the alpha.3 baseline envelope; 64-worker results are also healthy
