### PR TITLE
TLA+: trace witnesses for receipt-only cancel, callback wait, DLQ purge

### DIFF
--- a/.github/workflows/nightly-chaos.yml
+++ b/.github/workflows/nightly-chaos.yml
@@ -53,6 +53,66 @@ jobs:
           fi
           cat /tmp/tlc-trace.log
           exit 1
+      - name: AwaSegmentedStorageTrace (receipt rescue accepted)
+        run: |
+          set +e
+          ./correctness/run-tlc.sh storage/AwaSegmentedStorageTrace.tla storage/AwaSegmentedStorageTraceReceiptRescue.cfg > /tmp/tlc-trace-rescue.log 2>&1
+          if grep -q "ReceiptRescueTraceIncomplete is violated" /tmp/tlc-trace-rescue.log; then
+            echo "receipt-rescue trace fully consumed (positive witness)"
+            exit 0
+          fi
+          cat /tmp/tlc-trace-rescue.log
+          exit 1
+      - name: AwaSegmentedStorageTrace (running cancel accepted)
+        run: |
+          set +e
+          ./correctness/run-tlc.sh storage/AwaSegmentedStorageTrace.tla storage/AwaSegmentedStorageTraceRunningCancel.cfg > /tmp/tlc-trace-running-cancel.log 2>&1
+          if grep -q "RunningCancelTraceIncomplete is violated" /tmp/tlc-trace-running-cancel.log; then
+            echo "running-cancel trace fully consumed (positive witness)"
+            exit 0
+          fi
+          cat /tmp/tlc-trace-running-cancel.log
+          exit 1
+      - name: AwaSegmentedStorageTrace (receipt-only cancel accepted)
+        run: |
+          set +e
+          ./correctness/run-tlc.sh storage/AwaSegmentedStorageTrace.tla storage/AwaSegmentedStorageTraceReceiptOnlyCancel.cfg > /tmp/tlc-trace-receipt-cancel.log 2>&1
+          if grep -q "ReceiptOnlyCancelTraceIncomplete is violated" /tmp/tlc-trace-receipt-cancel.log; then
+            echo "receipt-only-cancel trace fully consumed (positive witness)"
+            exit 0
+          fi
+          cat /tmp/tlc-trace-receipt-cancel.log
+          exit 1
+      - name: AwaSegmentedStorageTrace (callback wait/resume accepted)
+        run: |
+          set +e
+          ./correctness/run-tlc.sh storage/AwaSegmentedStorageTrace.tla storage/AwaSegmentedStorageTraceCallbackWait.cfg > /tmp/tlc-trace-callback-wait.log 2>&1
+          if grep -q "CallbackWaitTraceIncomplete is violated" /tmp/tlc-trace-callback-wait.log; then
+            echo "callback-wait trace fully consumed (positive witness)"
+            exit 0
+          fi
+          cat /tmp/tlc-trace-callback-wait.log
+          exit 1
+      - name: AwaSegmentedStorageTrace (DLQ retry accepted)
+        run: |
+          set +e
+          ./correctness/run-tlc.sh storage/AwaSegmentedStorageTrace.tla storage/AwaSegmentedStorageTraceDlqRetry.cfg > /tmp/tlc-trace-dlq-retry.log 2>&1
+          if grep -q "DlqRetryTraceIncomplete is violated" /tmp/tlc-trace-dlq-retry.log; then
+            echo "dlq-retry trace fully consumed (positive witness)"
+            exit 0
+          fi
+          cat /tmp/tlc-trace-dlq-retry.log
+          exit 1
+      - name: AwaSegmentedStorageTrace (DLQ purge accepted)
+        run: |
+          set +e
+          ./correctness/run-tlc.sh storage/AwaSegmentedStorageTrace.tla storage/AwaSegmentedStorageTraceDlqPurge.cfg > /tmp/tlc-trace-dlq-purge.log 2>&1
+          if grep -q "DlqPurgeTraceIncomplete is violated" /tmp/tlc-trace-dlq-purge.log; then
+            echo "dlq-purge trace fully consumed (positive witness)"
+            exit 0
+          fi
+          cat /tmp/tlc-trace-dlq-purge.log
+          exit 1
       - name: AwaSegmentedStorageTrace (broken trace rejected)
         run: |
           set +e

--- a/correctness/storage/AwaSegmentedStorageTrace.tla
+++ b/correctness/storage/AwaSegmentedStorageTrace.tla
@@ -74,6 +74,46 @@ DlqRetryTrace == <<
     [action |-> "FastComplete", worker |-> "w1", job |-> "j1"]
 >>
 
+\* Receipt-only cancel trace. Models `awa::admin::cancel` racing with a
+\* freshly-opened receipt: the claim cursor has advanced and an open
+\* receipt exists, but the lease row hasn't materialized yet. Admin
+\* cancel closes the receipt and writes a terminal_entries row so the
+\* job's lifecycle is well-defined even if the worker never finishes
+\* materializing the lease. Distinct from RunningCancel (which targets
+\* an active lease) and from receipt rescue (which targets a stale
+\* receipt left behind by a vanished worker).
+ReceiptOnlyCancelTrace == <<
+    [action |-> "EnqueueReady",                job |-> "j1"],
+    [action |-> "SeedOpenReceiptOnlyClaim",    worker |-> "w1", job |-> "j1"],
+    [action |-> "CancelReceiptOnlyToTerminal", job |-> "j1"]
+>>
+
+\* Callback wait/resume trace: claim a job, materialize attempt_state,
+\* park into waiting_external (the `WaitForCallback` return path in the
+\* Rust executor), resume the same lease via the external callback, and
+\* finish via the stateful completion path. Covers the lifecycle the
+\* SnoozeTrace doesn't reach — snooze never enters waiting_external.
+CallbackWaitTrace == <<
+    [action |-> "EnqueueReady",            job |-> "j1"],
+    [action |-> "Claim",                   worker |-> "w1", job |-> "j1"],
+    [action |-> "MaterializeAttemptState", job |-> "j1"],
+    [action |-> "ParkToWaiting",           worker |-> "w1", job |-> "j1"],
+    [action |-> "ResumeWaitingToRunning",  job |-> "j1"],
+    [action |-> "StatefulComplete",        worker |-> "w1", job |-> "j1"]
+>>
+
+\* DLQ purge trace: an executor terminal failure moves the row into
+\* dlq_entries, then an operator-initiated purge removes it. Validates
+\* that PurgeDlq fires from a real DLQ-entry state and leaves the rest
+\* of the model invariants intact. Distinct from DlqRetry which revives
+\* the row back to ready_entries.
+DlqPurgeTrace == <<
+    [action |-> "EnqueueReady", job |-> "j1"],
+    [action |-> "Claim",        worker |-> "w1", job |-> "j1"],
+    [action |-> "FailToDlq",    worker |-> "w1", job |-> "j1"],
+    [action |-> "PurgeDlq",     job |-> "j1"]
+>>
+
 \* Deliberately-broken trace: steps 3 and 4 are swapped so PromoteDeferred
 \* fires before RetryToDeferred has moved the job into the deferred
 \* family. TLC is expected to report deadlock at traceIdx = 2 when
@@ -173,6 +213,9 @@ SpecSnooze == TraceInit /\ [][TraceNextFor(SnoozeTrace)]_<<vars, traceIdx>>
 SpecReceiptRescue == TraceInit /\ [][TraceNextFor(ReceiptRescueTrace)]_<<vars, traceIdx>>
 SpecRunningCancel == TraceInit /\ [][TraceNextFor(RunningCancelTrace)]_<<vars, traceIdx>>
 SpecDlqRetry == TraceInit /\ [][TraceNextFor(DlqRetryTrace)]_<<vars, traceIdx>>
+SpecReceiptOnlyCancel == TraceInit /\ [][TraceNextFor(ReceiptOnlyCancelTrace)]_<<vars, traceIdx>>
+SpecCallbackWait == TraceInit /\ [][TraceNextFor(CallbackWaitTrace)]_<<vars, traceIdx>>
+SpecDlqPurge == TraceInit /\ [][TraceNextFor(DlqPurgeTrace)]_<<vars, traceIdx>>
 SpecBroken == TraceInit /\ [][TraceNextFor(BrokenTrace)]_<<vars, traceIdx>>
 
 \* Positive witness invariants: negated so "violation" means acceptance.
@@ -185,6 +228,9 @@ SnoozeTraceIncomplete == traceIdx < Len(SnoozeTrace)
 ReceiptRescueTraceIncomplete == traceIdx < Len(ReceiptRescueTrace)
 RunningCancelTraceIncomplete == traceIdx < Len(RunningCancelTrace)
 DlqRetryTraceIncomplete == traceIdx < Len(DlqRetryTrace)
+ReceiptOnlyCancelTraceIncomplete == traceIdx < Len(ReceiptOnlyCancelTrace)
+CallbackWaitTraceIncomplete == traceIdx < Len(CallbackWaitTrace)
+DlqPurgeTraceIncomplete == traceIdx < Len(DlqPurgeTrace)
 BrokenTraceIncomplete == traceIdx < Len(BrokenTrace)
 
 \* All other safety invariants (TypeOK, DlqHasNoLiveRuntime, etc.) are

--- a/correctness/storage/AwaSegmentedStorageTraceCallbackWait.cfg
+++ b/correctness/storage/AwaSegmentedStorageTraceCallbackWait.cfg
@@ -1,0 +1,35 @@
+\* Callback wait/resume trace validation. TLC should report
+\* "Invariant CallbackWaitTraceIncomplete is violated" when the trace
+\* reaches Len(CallbackWaitTrace) = 6.
+CONSTANTS
+  Jobs = {"j1"}
+  Workers = {"w1"}
+  ReadySegmentCount = 2
+  LeaseSegmentCount = 2
+  TerminalSegmentCount = 2
+  ClaimSegmentCount = 2
+  MaxRunLease = 2
+  MaxAppendSeq = 2
+
+SPECIFICATION SpecCallbackWait
+
+INVARIANTS
+  TypeOK
+  ActiveLeasesSubsetReadyEntries
+  AttemptStateRequiresLiveLease
+  FreshHeartbeatRequiresLease
+  ProgressRequiresAttemptState
+  TerminalHasNoLiveRuntime
+  DlqHasNoLiveRuntime
+  DlqAndTerminalDisjoint
+  DeferredHasNoLiveRuntime
+  WaitingIsLeaseState
+  ReadyEntriesHaveLaneSeq
+  DeferredEntriesClearLaneSeq
+  ReadyLaneSeqUnique
+  ClaimCursorBounded
+  NoLostClaim
+  ClaimOpenAndClosedDisjoint
+  LaneStateConsistent
+  TaskLeaseBounded
+  CallbackWaitTraceIncomplete

--- a/correctness/storage/AwaSegmentedStorageTraceDlqPurge.cfg
+++ b/correctness/storage/AwaSegmentedStorageTraceDlqPurge.cfg
@@ -1,0 +1,35 @@
+\* DLQ purge trace validation. TLC should report
+\* "Invariant DlqPurgeTraceIncomplete is violated" when the trace
+\* reaches Len(DlqPurgeTrace) = 4.
+CONSTANTS
+  Jobs = {"j1"}
+  Workers = {"w1"}
+  ReadySegmentCount = 2
+  LeaseSegmentCount = 2
+  TerminalSegmentCount = 2
+  ClaimSegmentCount = 2
+  MaxRunLease = 2
+  MaxAppendSeq = 2
+
+SPECIFICATION SpecDlqPurge
+
+INVARIANTS
+  TypeOK
+  ActiveLeasesSubsetReadyEntries
+  AttemptStateRequiresLiveLease
+  FreshHeartbeatRequiresLease
+  ProgressRequiresAttemptState
+  TerminalHasNoLiveRuntime
+  DlqHasNoLiveRuntime
+  DlqAndTerminalDisjoint
+  DeferredHasNoLiveRuntime
+  WaitingIsLeaseState
+  ReadyEntriesHaveLaneSeq
+  DeferredEntriesClearLaneSeq
+  ReadyLaneSeqUnique
+  ClaimCursorBounded
+  NoLostClaim
+  ClaimOpenAndClosedDisjoint
+  LaneStateConsistent
+  TaskLeaseBounded
+  DlqPurgeTraceIncomplete

--- a/correctness/storage/AwaSegmentedStorageTraceReceiptOnlyCancel.cfg
+++ b/correctness/storage/AwaSegmentedStorageTraceReceiptOnlyCancel.cfg
@@ -1,0 +1,35 @@
+\* Receipt-only cancel trace validation. TLC should report
+\* "Invariant ReceiptOnlyCancelTraceIncomplete is violated" when the
+\* trace reaches Len(ReceiptOnlyCancelTrace) = 3.
+CONSTANTS
+  Jobs = {"j1"}
+  Workers = {"w1"}
+  ReadySegmentCount = 2
+  LeaseSegmentCount = 2
+  TerminalSegmentCount = 2
+  ClaimSegmentCount = 2
+  MaxRunLease = 2
+  MaxAppendSeq = 2
+
+SPECIFICATION SpecReceiptOnlyCancel
+
+INVARIANTS
+  TypeOK
+  ActiveLeasesSubsetReadyEntries
+  AttemptStateRequiresLiveLease
+  FreshHeartbeatRequiresLease
+  ProgressRequiresAttemptState
+  TerminalHasNoLiveRuntime
+  DlqHasNoLiveRuntime
+  DlqAndTerminalDisjoint
+  DeferredHasNoLiveRuntime
+  WaitingIsLeaseState
+  ReadyEntriesHaveLaneSeq
+  DeferredEntriesClearLaneSeq
+  ReadyLaneSeqUnique
+  ClaimCursorBounded
+  NoLostClaim
+  ClaimOpenAndClosedDisjoint
+  LaneStateConsistent
+  TaskLeaseBounded
+  ReceiptOnlyCancelTraceIncomplete

--- a/correctness/storage/MAPPING.md
+++ b/correctness/storage/MAPPING.md
@@ -323,6 +323,21 @@ optionally a retry-from-deferred or retry-from-dlq round trip.
   CancelRunningToTerminal. Accepts cleanly with 4 states.
 - `DlqRetryTrace`: 6 events — EnqueueReady → Claim → FailToDlq →
   RetryFromDlq → Claim → FastComplete. Accepts cleanly with 7 states.
+- `ReceiptOnlyCancelTrace`: 3 events — EnqueueReady →
+  SeedOpenReceiptOnlyClaim → CancelReceiptOnlyToTerminal. Accepts
+  cleanly with 4 states. Models `awa::admin::cancel` racing with a
+  freshly-opened receipt before the lease row materialises;
+  complements `RunningCancelTrace` (active lease) and
+  `ReceiptRescueTrace` (stale receipt left by a vanished worker).
+- `CallbackWaitTrace`: 6 events — EnqueueReady → Claim →
+  MaterializeAttemptState → ParkToWaiting → ResumeWaitingToRunning →
+  StatefulComplete. Accepts cleanly with 7 states. Covers the
+  external-callback `WaitForCallback` round-trip; distinct from
+  `SnoozeTrace`, which never enters `waiting_external`.
+- `DlqPurgeTrace`: 4 events — EnqueueReady → Claim → FailToDlq →
+  PurgeDlq. Accepts cleanly with 5 states. Validates the operator
+  `awa dlq purge` path; complements `DlqRetryTrace` which revives the
+  row instead of removing it.
 - `BrokenTrace`: same 6 events but with steps 3 and 4 swapped so
   PromoteDeferred fires before RetryToDeferred. TLC reports deadlock
   at traceIdx = 2 (after EnqueueReady + Claim, before the


### PR DESCRIPTION
## Summary

Closes the remaining trace-validation items from #197's release-readiness checklist:

> - [ ] Add trace-validation coverage for receipt-only cancel
> - [ ] Add trace-validation coverage for callback wait/resume
> - [ ] Add trace-validation coverage for DLQ purge

The base spec already modelled the relevant actions (\`CancelReceiptOnlyToTerminal\`, \`ParkToWaiting\` / \`ResumeWaitingToRunning\`, \`PurgeDlq\`) and \`TraceStep\` already dispatched on their action names — only the trace sequences and configs were missing.

## Three new traces

| Trace | Events | Lifecycle |
|---|---|---|
| \`ReceiptOnlyCancelTrace\` | 3 | EnqueueReady → SeedOpenReceiptOnlyClaim → CancelReceiptOnlyToTerminal |
| \`CallbackWaitTrace\` | 6 | EnqueueReady → Claim → MaterializeAttemptState → ParkToWaiting → ResumeWaitingToRunning → StatefulComplete |
| \`DlqPurgeTrace\` | 4 | EnqueueReady → Claim → FailToDlq → PurgeDlq |

All three accepted by TLC — the per-trace \`*Incomplete\` invariants fire when the trace is fully consumed (the positive-witness convention used by the existing traces).

## Distinguishing from existing coverage

- \`ReceiptOnlyCancelTrace\` complements \`RunningCancelTrace\` (active lease) and \`ReceiptRescueTrace\` (stale receipt from a vanished worker). It's the cancel-races-receipt-creation case.
- \`CallbackWaitTrace\` is distinct from \`SnoozeTrace\`, which never enters \`waiting_external\`. This one exercises the \`WaitForCallback\` round-trip the Rust executor uses for external completion.
- \`DlqPurgeTrace\` complements \`DlqRetryTrace\` which revives the row instead of removing it.

## CI

The nightly-chaos workflow now runs every positive-witness trace (previously only \`SnoozeTrace\` was gated; \`ReceiptRescue\`, \`RunningCancel\`, \`DlqRetry\` were locally runnable but not in CI). Six positive witnesses + the broken-trace deadlock check.

## Verification

\`\`\`
$ ./correctness/run-tlc.sh storage/AwaSegmentedStorageTrace.tla \\
    storage/AwaSegmentedStorageTraceReceiptOnlyCancel.cfg
… Invariant ReceiptOnlyCancelTraceIncomplete is violated.   # ← positive witness
4 states generated, 4 distinct states found.

$ ./correctness/run-tlc.sh storage/AwaSegmentedStorageTrace.tla \\
    storage/AwaSegmentedStorageTraceCallbackWait.cfg
… Invariant CallbackWaitTraceIncomplete is violated.
7 states generated, 7 distinct states found.

$ ./correctness/run-tlc.sh storage/AwaSegmentedStorageTrace.tla \\
    storage/AwaSegmentedStorageTraceDlqPurge.cfg
… Invariant DlqPurgeTraceIncomplete is violated.
5 states generated, 5 distinct states found.
\`\`\`

All existing traces still pass; broken trace still deadlocks at step 3 as expected.

## Test plan

- [x] All three new traces accepted by TLC
- [x] Existing traces (snooze, receipt-rescue, running-cancel, DLQ-retry, broken) regression-checked
- [x] MAPPING.md entries added
- [x] Nightly-chaos workflow extended to gate every positive witness
- [ ] CI on this branch

## Files

- \`correctness/storage/AwaSegmentedStorageTrace.tla\` — three new \`*Trace\` constants, \`Spec*\` definitions, \`*Incomplete\` invariants
- \`correctness/storage/AwaSegmentedStorageTraceReceiptOnlyCancel.cfg\` — new
- \`correctness/storage/AwaSegmentedStorageTraceCallbackWait.cfg\` — new
- \`correctness/storage/AwaSegmentedStorageTraceDlqPurge.cfg\` — new
- \`correctness/storage/MAPPING.md\` — \"Current traces\" section gets the three new entries
- \`.github/workflows/nightly-chaos.yml\` — gate every positive-witness trace