### PR TITLE
Doc cross-consistency sweep: ADR-019 historical pass + queue_lanes.available_count narrative

### DIFF
--- a/correctness/storage/AwaDeadTupleContract.tla
+++ b/correctness/storage/AwaDeadTupleContract.tla
@@ -158,7 +158,6 @@ TableSpec == [
     \* schema changes), not job throughput. RowVacuum is fine.
     queue_lanes            |-> [kind |-> "RowVacuum", hot |-> "cold", bounded_by |-> ""],
     queue_terminal_rollups |-> [kind |-> "RowVacuum", hot |-> "cold", bounded_by |-> ""],
-    queue_count_snapshots  |-> [kind |-> "RowVacuum", hot |-> "cold", bounded_by |-> ""],
     queue_claimer_state    |-> [kind |-> "RowVacuum", hot |-> "cold", bounded_by |-> ""],
 
     \* ---- Ring-state singletons ----

--- a/correctness/storage/MAPPING.md
+++ b/correctness/storage/MAPPING.md
@@ -93,7 +93,7 @@ for backfill / fallback reads during upgrades.
 | `PrunedClaimSegmentsAreEmpty` (ADR-023) | `prune_oldest_claims` requires no open claim in the partition before TRUNCATE; rescue-before-truncate closes stragglers in the same transaction |
 | `NoLostClaim` (ADR-023) | receipts and their closures both live in `claim_slot`-partitioned tables; partitions only truncate once all their receipts are closed, so no open claim is physically dropped |
 | `ClaimOpenAndClosedDisjoint` (ADR-023) | closure insertion and receipt-clearing are a single transaction; a partition's receipt+closure pair is either both present or both dropped by `TRUNCATE` |
-| `LaneStateConsistent` | live availability is derived from `{schema}.ready_entries` plus `{schema}.queue_claim_heads`; completed totals are *not* maintained as hot counters. Rust derives them from live `done_entries` plus the cold `{schema}.queue_terminal_rollups` cache, with `queue_lanes.pruned_completed_count` read only as a transitional legacy fallback |
+| `LaneStateConsistent` | live availability reads `sum({schema}.queue_lanes.available_count)`; the queue-storage SQL functions keep that counter in lockstep with `ready_entries` inserts, claim-head advances, and rescue paths. Completed totals are *not* maintained as hot counters — Rust derives them from live `done_entries` plus the cold `{schema}.queue_terminal_rollups` cache, with `queue_lanes.pruned_completed_count` read only as a transitional legacy fallback |
 
 ## Storage-transition model mapping
 

--- a/docs/adr/019-queue-storage-redesign.md
+++ b/docs/adr/019-queue-storage-redesign.md
@@ -95,9 +95,12 @@ The implementation and migrations use these physical names:
 
 - The common path still records every claim, but the implementation can now do
   that in two stages:
-  - append-only `lease_claims` receipts for zero-deadline short jobs
-  - a bounded `open_receipt_claims` frontier for currently-live receipt-backed
-    attempts
+  - append-only `lease_claims` receipts for every claim (the receipt path is
+    now the default, not a zero-deadline-only short cut)
+  - **historical:** a bounded `open_receipt_claims` frontier for currently-live
+    receipt-backed attempts. ADR-023 replaces this with partitioned
+    `lease_claims` / `lease_claim_closures`; "currently open" is derived as an
+    anti-join over the active claim partitions.
   - lazy materialization into `active_leases` when the attempt needs the
     mutable execution path
 - Leases keep only dispatch and rescue-critical fields: ready reference,
@@ -144,8 +147,13 @@ The implementation and migrations use these physical names:
 - `lane_state` itself is reduced to stable per-lane identity and legacy
   fallback fields. The mutable enqueue cursor lives in `queue_enqueue_heads`
   and the mutable claim cursor lives in `queue_claim_heads`.
-- Availability is derived from `ready_entries` plus the claim head, not from a
-  hot cached `available_count` field on `lane_state`.
+- **historical:** the original ADR-019 design derived availability from
+  `ready_entries` plus the claim head, deliberately avoiding a hot cached
+  counter on `lane_state`. Long-horizon validation showed that scan was the
+  dispatcher hot-path bottleneck under multi-million-row backlogs; the
+  current implementation reads `sum(queue_lanes.available_count)`, which the
+  queue-storage SQL functions keep in lockstep with `ready_entries` inserts
+  and claim-head advances. `lane_state` itself remains cold.
 - Completed-history rollups live in a separate cold cache table so prune can
   preserve queue counts without serializing on the hot `lane_state` rows.
 - Completion must not update `lane_state` on every terminal transition; the
@@ -184,8 +192,11 @@ The implementation and migrations use these physical names:
   append-only and requeue it without first materializing a mutable
   `active_leases` row.
 - Runtime reads that need the current live receipt-backed set (`queue_counts`,
-  receipt rescue, and receipt-backed `load_job`) read
-  `open_receipt_claims`, not the full append-only claim history.
+  receipt rescue, and receipt-backed `load_job`) consult only the active
+  claim-ring partitions, not the full append-only claim history. **historical:**
+  ADR-019 used a bounded `open_receipt_claims` table for this; ADR-023 derives
+  the same set as an anti-join over partitioned `lease_claims` /
+  `lease_claim_closures`.
 - First heartbeat or progress flush for a receipt-backed attempt: lazily
   materialize the claim into `attempt_state` while keeping the claim on the
   append-only receipt path.
@@ -238,6 +249,8 @@ The leader-elected maintenance service owns:
 - rescuing stale heartbeats, deadlines, and callback timeouts
 - rotating and pruning queue partitions
 - rotating and pruning lease partitions
+- rotating and pruning claim-ring partitions (added by ADR-023; replaces the
+  ADR-019 `open_receipt_claims` cleanup path)
 - queue depth publication
 - DLQ retention cleanup
 
@@ -254,6 +267,11 @@ lock contract is:
 - prune-leases derives the oldest initialized slot from `lease_ring_state`,
   locks the child partition `ACCESS EXCLUSIVE`, rechecks that the slot is not
   current, then truncates if it is empty
+- prune-claim-ring (added by ADR-023) takes `FOR UPDATE` on `claim_ring_state`,
+  `FOR UPDATE` on the target `claim_ring_slots` row, and `ACCESS EXCLUSIVE` on
+  both the matching `lease_claims_*` and `lease_claim_closures_*` partitions,
+  rescues any still-open claims in the slot, then `TRUNCATE`s both partitions
+  in lockstep
 
 That order is deliberate. The TLA+ storage race / lock-order models exist to
 prove that claim, rotate, and prune cannot interleave into “claim lands in a
@@ -261,8 +279,8 @@ pruned segment” behavior.
 
 Rotation and prune policy is also part of this decision:
 
-- lease segments rotate quickly because lease churn is the remaining hot-path
-  source
+- lease and claim-ring segments rotate quickly because their churn is the
+  remaining hot-path source
 - ready / deferred / waiting / terminal / dlq segments rotate more slowly and
   are primarily retention-driven
 - prune walks sealed segments oldest-first


### PR DESCRIPTION
## Summary

Closes the remaining doc items from #197's TLA+ / Documentation accuracy gate:

> - [ ] Make ADR-019 readable as historical where superseded by ADR-023; remove or clearly annotate current-sounding `open_receipt_claims` lifecycle text.
> - [ ] Final cross-consistency sweep after the SQL gate / transition-role decision: ADR-023, ADR-019, `docs/architecture.md`, `docs/migrations.md`, `docs/configuration.md`, and `correctness/storage/MAPPING.md` should tell the same story about claim-ring, lease-ring, rotate/prune, receipt rescue, transition roles, and `queue_lanes.available_count`.

## Drift found

Two pieces of text were claiming things the implementation no longer does:

1. **ADR-019 \"availability is derived from `ready_entries` plus the claim head, not from a hot cached `available_count` field on `lane_state`\"** — the queue_counts fix shipped in #197's P0 work landed `queue_lanes.available_count` as the live signal source. Long-horizon multi-million-row validation showed the original \`ready_entries\`-scan was the dispatcher hot-path bottleneck.
2. **MAPPING.md `LaneStateConsistent`** told the same pre-fix story.

Plus a smaller gap:

3. **`AwaDeadTupleContract.tla`** still classified `queue_count_snapshots` even though the table was dropped by the queue_counts fix.

## Edits

### ADR-019

- Lifecycle and physical-layout bullets that referenced `open_receipt_claims` as the live frontier now carry `**historical:**` markers pointing at ADR-023's anti-join design. The status note at the top already covered the supersession; this makes the body usable as a reference instead of pure history.
- The \`available_count\` bullet is annotated as superseded with the queue_counts story.
- Maintenance-ownership and lock-contract sections list claim-ring rotation/prune (added by ADR-023) alongside the original lease-ring and queue-ring entries.

### MAPPING.md

- `LaneStateConsistent` implementation column reflects \`sum(queue_lanes.available_count)\` instead of the pre-fix ready_entries-plus-claim-head story.

### AwaDeadTupleContract.tla

- Drop the `queue_count_snapshots` row from \`Tables\`. Re-ran TLC; contract still passes (1 distinct state, no violations).

### architecture.md, migrations.md, configuration.md, ADR-023

Verified — no edits needed. Already use the current vocabulary throughout: `queue_lanes.available_count`, partitioned `lease_claims` / `lease_claim_closures`, `transition_role = queue_storage_target`, `claim_slot_count`, `claim_rotate_interval`, claim-ring rotation.

## Test plan

- [x] ADR-019 reads as historical where ADR-023 supersedes; current behaviour is sourced inline
- [x] All five docs (ADR-019, ADR-023, architecture, migrations, configuration) plus MAPPING.md tell the same story about claim-ring / lease-ring / rotate-prune / receipt rescue / transition roles / `queue_lanes.available_count`
- [x] No remaining \`open_receipt_claims\` / \`queue_counts_cached\` / \`queue_count_snapshots\` references in user-facing docs
- [x] \`AwaDeadTupleContract\` TLC still passes
- [ ] CI on this branch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated queue storage specifications to reflect optimized availability and completion metrics calculation.
  * Revised architectural decision records to align storage design patterns with latest maintenance and lock-ordering procedures.

* **Chores**
  * Removed outdated snapshot table reference from storage metadata specification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->