### PR TITLE
Bump version to 0.6.0-alpha.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ transitions live in [`docs/upgrade-0.5-to-0.6.md`](docs/upgrade-0.5-to-0.6.md).
 
 ## Unreleased
 
+## [0.6.0-alpha.5] — 2026-05-04
+
 ### Added
 
 - **`awa-pg[ui]` optional extra** ([#186](https://github.com/hardbyte/awa/issues/186)).
@@ -17,6 +19,31 @@ transitions live in [`docs/upgrade-0.5-to-0.6.md`](docs/upgrade-0.5-to-0.6.md).
   in `sys.prefix/{bin,Scripts}` (where `awa-cli`'s wheel installs it) and
   forwards the full argument tail verbatim. If the extra isn't installed,
   it exits with a `pip install 'awa-pg[ui]'` hint.
+
+### Fixed
+
+- **Restored queue-storage dispatcher throughput under high concurrency**
+  ([#223](https://github.com/hardbyte/awa/issues/223)). Capacity-release wakes
+  still drain ready work immediately, but the dispatcher now uses the configured
+  fixed fallback poll interval instead of geometrically backing off after empty
+  or permit-saturated polls.
+
+### Changed
+
+- Queue-storage throughput benchmarks can run against a non-canonical storage
+  schema and configurable worker count, making local A/B checks safer and
+  easier to reproduce.
+- Added TLA+ trace witnesses for receipt-only cancel, callback wait, and DLQ
+  purge paths, plus documentation alignment for the queue-storage design.
+
+## [0.6.0-alpha.4] — 2026-05-03
+
+### Changed
+
+- Added capacity-wake suppression to reduce empty claim churn in quiet queues.
+  This improved some operational churn metrics but regressed high-concurrency
+  queue-storage throughput; alpha.5 keeps the useful wake-drain repair while
+  restoring fixed fallback polling.
 
 ## [0.6.0-alpha.3] — 2026-05-02
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,7 +171,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "awa"
-version = "0.6.0-alpha.4"
+version = "0.6.0-alpha.5"
 dependencies = [
  "async-trait",
  "awa-macros",
@@ -196,7 +196,7 @@ dependencies = [
 
 [[package]]
 name = "awa-cli"
-version = "0.6.0-alpha.4"
+version = "0.6.0-alpha.5"
 dependencies = [
  "assert_cmd",
  "awa-model",
@@ -218,7 +218,7 @@ dependencies = [
 
 [[package]]
 name = "awa-macros"
-version = "0.6.0-alpha.4"
+version = "0.6.0-alpha.5"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -228,7 +228,7 @@ dependencies = [
 
 [[package]]
 name = "awa-model"
-version = "0.6.0-alpha.4"
+version = "0.6.0-alpha.5"
 dependencies = [
  "awa-macros",
  "blake3",
@@ -249,7 +249,7 @@ dependencies = [
 
 [[package]]
 name = "awa-testing"
-version = "0.6.0-alpha.4"
+version = "0.6.0-alpha.5"
 dependencies = [
  "async-trait",
  "awa-model",
@@ -264,7 +264,7 @@ dependencies = [
 
 [[package]]
 name = "awa-ui"
-version = "0.6.0-alpha.4"
+version = "0.6.0-alpha.5"
 dependencies = [
  "awa-model",
  "awa-testing",
@@ -287,7 +287,7 @@ dependencies = [
 
 [[package]]
 name = "awa-worker"
-version = "0.6.0-alpha.4"
+version = "0.6.0-alpha.5"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 exclude = ["awa-python", "spike"]
 
 [workspace.package]
-version = "0.6.0-alpha.4"
+version = "0.6.0-alpha.5"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "Postgres-native background job queue — transactional enqueue, heartbeat crash recovery, SKIP LOCKED dispatch"
@@ -23,9 +23,9 @@ categories = ["database", "asynchronous", "web-programming"]
 
 [workspace.dependencies]
 # Internal crates
-awa-model = { path = "awa-model", version = "0.6.0-alpha.4" }
-awa-macros = { path = "awa-macros", version = "0.6.0-alpha.4" }
-awa-worker = { path = "awa-worker", version = "0.6.0-alpha.4" }
+awa-model = { path = "awa-model", version = "0.6.0-alpha.5" }
+awa-macros = { path = "awa-macros", version = "0.6.0-alpha.5" }
+awa-worker = { path = "awa-worker", version = "0.6.0-alpha.5" }
 
 # Database
 sqlx = { version = "0.8", features = ["runtime-tokio-rustls", "postgres", "chrono", "json", "migrate", "uuid"] }

--- a/awa-cli/Cargo.toml
+++ b/awa-cli/Cargo.toml
@@ -14,7 +14,7 @@ path = "src/main.rs"
 [dependencies]
 awa-model.workspace = true
 awa-worker.workspace = true
-awa-ui = { path = "../awa-ui", version = "0.6.0-alpha.4" }
+awa-ui = { path = "../awa-ui", version = "0.6.0-alpha.5" }
 axum.workspace = true
 sqlx.workspace = true
 tokio.workspace = true
@@ -26,7 +26,7 @@ chrono.workspace = true
 hex.workspace = true
 
 [dev-dependencies]
-awa-testing = { path = "../awa-testing", version = "0.6.0-alpha.4" }
+awa-testing = { path = "../awa-testing", version = "0.6.0-alpha.5" }
 assert_cmd = "2"
 serde.workspace = true
 uuid.workspace = true

--- a/awa-cli/pyproject.toml
+++ b/awa-cli/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "awa-cli"
-version = "0.6.0-alpha.4"
+version = "0.6.0-alpha.5"
 description = "CLI for the Awa Postgres-native job queue (migrations, admin, serve)"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/awa-python/Cargo.toml
+++ b/awa-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "awa-python"
-version = "0.6.0-alpha.4"
+version = "0.6.0-alpha.5"
 edition = "2021"
 
 [lib]
@@ -12,8 +12,8 @@ default = ["cel"]
 cel = ["awa-model/cel"]
 
 [dependencies]
-awa-model = { path = "../awa-model", version = "0.6.0-alpha.4" }
-awa-worker = { path = "../awa-worker", version = "0.6.0-alpha.4", features = ["__python-bridge"] }
+awa-model = { path = "../awa-model", version = "0.6.0-alpha.5" }
+awa-worker = { path = "../awa-worker", version = "0.6.0-alpha.5", features = ["__python-bridge"] }
 pyo3 = { version = "0.28", features = ["macros", "abi3-py310", "chrono"] }
 pyo3-async-runtimes = { version = "0.28", features = ["tokio-runtime"] }
 sqlx = { version = "0.8", features = ["runtime-tokio-rustls", "postgres", "chrono", "json"] }

--- a/awa-python/pyproject.toml
+++ b/awa-python/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "maturin"
 [project]
 name = "awa-pg"
 requires-python = ">=3.10"
-version = "0.6.0-alpha.4"
+version = "0.6.0-alpha.5"
 description = "Postgres-native background job queue — Python SDK with async/sync workers, transactional enqueue, and progress tracking. Install awa-pg[ui] to add the bundled web dashboard."
 readme = {file = "../README.md", content-type = "text/markdown"}
 license = {text = "MIT OR Apache-2.0"}
@@ -32,7 +32,7 @@ classifiers = [
 #
 # Kept opt-in so the default `awa-pg` install stays small — workers and
 # producers don't need the ~10 MB UI bundle.
-ui = ["awa-cli==0.6.0-alpha.4"]
+ui = ["awa-cli==0.6.0-alpha.5"]
 
 [project.urls]
 Homepage = "https://github.com/hardbyte/awa"

--- a/awa/Cargo.toml
+++ b/awa/Cargo.toml
@@ -20,7 +20,7 @@ awa-macros.workspace = true
 awa-worker.workspace = true
 
 [dev-dependencies]
-awa-testing = { path = "../awa-testing", version = "0.6.0-alpha.4" }
+awa-testing = { path = "../awa-testing", version = "0.6.0-alpha.5" }
 sqlx.workspace = true
 serde.workspace = true
 serde_json.workspace = true


### PR DESCRIPTION
## Summary
- bump Rust workspace, internal crate constraints, CLI wheel, and Python SDK versions to 0.6.0-alpha.5
- add alpha.5 changelog notes for the dispatcher polling recovery, awa-pg[ui], benchmark harness, and model/docs follow-up
- record alpha.4 as the short-lived release that introduced the wake-suppression throughput regression fixed by alpha.5

## Validation
- cargo check --workspace
- cargo fmt --check
- git diff --check