### PR TITLE
DLQ: regression test for #160 composite-cursor pagination

### DIFF
--- a/awa-python/tests/test_dlq.py
+++ b/awa-python/tests/test_dlq.py
@@ -317,6 +317,78 @@ def test_bulk_retry_and_purge_require_scope_unless_allow_all(sync_client):
     assert sync_client.dlq_depth(queue="pydlq_purge_all") == 0
 
 
+def test_list_dlq_composite_cursor_walks_non_monotonic_dlq_at(sync_client):
+    """Regression for #160. The pre-fix code paginated with `id < before_id`
+    while sorting by `(dlq_at DESC, id DESC)`, so a row with a larger id and
+    smaller dlq_at than the page boundary was silently skipped. With the
+    composite cursor `(dlq_at, id) < ($before_dlq_at, $before_id)`, walking
+    one row at a time must surface every DLQ entry exactly once in
+    `(dlq_at DESC, id DESC)` order regardless of how `dlq_at` lines up with
+    `id`."""
+    queue = "pydlq_composite_cursor"
+
+    # Insert four jobs in id order (so id_a < id_b < id_c < id_d), then
+    # backdate dlq_at on three of them to a permutation that is NOT
+    # monotonic with id. The pre-fix `id < before_id` cursor would skip
+    # rows in this layout; the composite cursor walks all four.
+    j_a = sync_client.insert(DlqPyJob(value="a"), queue=queue)
+    j_b = sync_client.insert(DlqPyJob(value="b"), queue=queue)
+    j_c = sync_client.insert(DlqPyJob(value="c"), queue=queue)
+    j_d = sync_client.insert(DlqPyJob(value="d"), queue=queue)
+    for j in (j_a, j_b, j_c, j_d):
+        _move_ready_to_failed_done(sync_client, j.id)
+        sync_client.move_failed_to_dlq(j.id, "composite")
+
+    # Resulting (dlq_at DESC, id DESC) order: [j_b, j_d, j_a, j_c].
+    # Notice that j_d's id > j_b's id but j_d's dlq_at < j_b's, and j_c's id
+    # > j_a's but j_c's dlq_at < j_a's — the failure mode #160 describes.
+    for offset_days, jid in [(0, j_b.id), (1, j_d.id), (3, j_a.id), (4, j_c.id)]:
+        tx = sync_client.transaction()
+        tx.execute(
+            f"UPDATE {SCHEMA}.dlq_entries "
+            f"SET dlq_at = now() - ($1::int * interval '1 day') "
+            f"WHERE job_id = $2",
+            offset_days,
+            jid,
+        )
+        tx.commit()
+
+    expected_order = [j_b.id, j_d.id, j_a.id, j_c.id]
+
+    # Sanity: a single full-page list returns the whole permutation.
+    full = sync_client.list_dlq(queue=queue)
+    assert [entry.job.id for entry in full] == expected_order
+
+    # Walk pagination one row at a time using BOTH cursor fields. Every row
+    # must surface exactly once and in `(dlq_at DESC, id DESC)` order — the
+    # exact property #160 says was broken under the id-only cursor.
+    walked: list[int] = []
+    cursor_id: int | None = None
+    cursor_dlq_at = None
+    while True:
+        kwargs = {"queue": queue, "limit": 1}
+        if cursor_id is not None and cursor_dlq_at is not None:
+            kwargs["before_id"] = cursor_id
+            kwargs["before_dlq_at"] = cursor_dlq_at
+        page = sync_client.list_dlq(**kwargs)
+        if not page:
+            break
+        assert len(page) == 1
+        walked.append(page[0].job.id)
+        cursor_id = page[0].job.id
+        cursor_dlq_at = page[0].dlq_at
+        # Defensive cap — the loop must terminate within len(rows) iterations.
+        assert len(walked) <= len(expected_order)
+
+    assert walked == expected_order, (
+        f"composite-cursor walk skipped or duplicated rows: "
+        f"got {walked}, expected {expected_order}"
+    )
+
+    # Cleanup so the queue's depth is back to zero for any later test.
+    sync_client.purge_dlq(queue=queue, allow_all=True)
+
+
 def test_list_and_purge_with_before_dlq_at_only(sync_client):
     queue = "pydlq_before_cursor"
     older = sync_client.insert(DlqPyJob(value="older"), queue=queue)


### PR DESCRIPTION
## Summary

Closes #160.

The implementation fix landed earlier — \`list_dlq\` already paginates with the composite \`(dlq_at, job_id) < (\$before_dlq_at, \$before_id)\` cursor when both are set, falls back to the single-cursor branches when only one is set. What was missing was a regression test that exercises the exact failure mode #160 describes: rows with non-monotonic \`dlq_at\` vs \`id\`, walked one page at a time using both cursor fields.

## What's in this PR

A single Python test, \`test_list_dlq_composite_cursor_walks_non_monotonic_dlq_at\`:

1. Inserts four jobs in id order, moves all to DLQ, then backdates \`dlq_at\` on each so the natural sort \`(dlq_at DESC, id DESC)\` is the permutation \`[j_b, j_d, j_a, j_c]\`. In this layout, the pre-fix id-only cursor would skip \`j_d\` and \`j_c\` (their ids are greater than \`j_b\`'s but their \`dlq_at\` is older).
2. Sanity-checks a single full-page list returns the whole permutation.
3. Walks pagination one row at a time, passing **both** \`before_id\` and \`before_dlq_at\` on every page after the first.
4. Asserts the walk produces every row exactly once in the expected order.

## Verifying it catches the bug

Temporarily reverted \`awa-model::dlq::list_dlq\`'s SQL to an id-only cursor (\`AND (\$4::bigint IS NULL OR job_id < \$4)\`) and re-ran:

\`\`\`
E       assert [2, 1] == [2, 4, 1, 3]
E         At index 1 diff: 1 != 4
E         Right contains 2 more items, first extra item: 1
\`\`\`

That's #160's exact failure mode: \`j_d\` (id 4) and \`j_c\` (id 3) silently skipped. Restoring the composite cursor turns the test green again.

## Surface verification

The composite cursor is wired through every surface mentioned in #160's acceptance — checked but not edited in this PR:

- \`awa-model/src/dlq.rs\` — composite SQL
- \`awa-model::ListDlqFilter\` — has both \`before_id\` and \`before_dlq_at\`
- \`awa-cli/src/main.rs\` — \`awa dlq list --before-id --before-dlq-at\`
- \`awa-ui/src/handlers/dlq.rs\` — \`GET /api/dlq?before_id=&before_dlq_at=\`
- \`awa-python\` — \`Client.list_dlq(before_id=..., before_dlq_at=...)\`

## Test plan

- [x] New test passes against the current main: \`pytest awa-python/tests/test_dlq.py::test_list_dlq_composite_cursor_walks_non_monotonic_dlq_at\`
- [x] New test fails against a synthetic id-only cursor revert (verifies it actually catches the bug)
- [x] All 9 DLQ tests still pass
- [ ] CI on this branch