### PR TITLE
queue_storage: fold multi-queue notify into a single round-trip

### DIFF
--- a/awa-model/src/queue_storage.rs
+++ b/awa-model/src/queue_storage.rs
@@ -4773,17 +4773,8 @@ impl QueueStorage {
         let mut tx = pool.begin().await.map_err(map_sqlx_error)?;
         let total_rows = self.insert_ready_rows_tx(&mut tx, rows.clone()).await?;
 
-        let queues_to_notify: BTreeSet<String> = rows
-            .iter()
-            .map(|row| self.logical_queue_name(&row.queue).to_string())
-            .collect();
-        for queue in queues_to_notify {
-            sqlx::query("SELECT pg_notify($1, '')")
-                .bind(format!("awa:{queue}"))
-                .execute(tx.as_mut())
-                .await
-                .map_err(map_sqlx_error)?;
-        }
+        let queues_to_notify: Vec<String> = rows.iter().map(|row| row.queue.clone()).collect();
+        self.notify_queues_tx(&mut tx, queues_to_notify).await?;
 
         tx.commit().await.map_err(map_sqlx_error)?;
         Ok(total_rows)
@@ -4892,10 +4883,8 @@ impl QueueStorage {
             }
         }
 
-        let queues_to_notify: BTreeSet<String> = ready_rows
-            .iter()
-            .map(|row| self.logical_queue_name(&row.queue).to_string())
-            .collect();
+        let queues_to_notify: Vec<String> =
+            ready_rows.iter().map(|row| row.queue.clone()).collect();
 
         let mut tx = pool.begin().await.map_err(map_sqlx_error)?;
         let mut total = 0usize;
@@ -4916,13 +4905,7 @@ impl QueueStorage {
                 .await?;
         }
 
-        for queue in queues_to_notify {
-            sqlx::query("SELECT pg_notify($1, '')")
-                .bind(format!("awa:{queue}"))
-                .execute(tx.as_mut())
-                .await
-                .map_err(map_sqlx_error)?;
-        }
+        self.notify_queues_tx(&mut tx, queues_to_notify).await?;
 
         tx.commit().await.map_err(map_sqlx_error)?;
         Ok(total)
@@ -4998,10 +4981,8 @@ impl QueueStorage {
             }
         }
 
-        let queues_to_notify: BTreeSet<String> = ready_rows
-            .iter()
-            .map(|row| self.logical_queue_name(&row.queue).to_string())
-            .collect();
+        let queues_to_notify: Vec<String> =
+            ready_rows.iter().map(|row| row.queue.clone()).collect();
 
         let mut tx = pool.begin().await.map_err(map_sqlx_error)?;
         let mut total = 0usize;
@@ -5025,13 +5006,7 @@ impl QueueStorage {
                 .await?;
         }
 
-        for queue in queues_to_notify {
-            sqlx::query("SELECT pg_notify($1, '')")
-                .bind(format!("awa:{queue}"))
-                .execute(tx.as_mut())
-                .await
-                .map_err(map_sqlx_error)?;
-        }
+        self.notify_queues_tx(&mut tx, queues_to_notify).await?;
 
         tx.commit().await.map_err(map_sqlx_error)?;
         Ok(total)
@@ -7026,17 +7001,23 @@ impl QueueStorage {
         tx: &mut sqlx::Transaction<'a, sqlx::Postgres>,
         queues: impl IntoIterator<Item = String>,
     ) -> Result<(), AwaError> {
-        let queues: BTreeSet<String> = queues
+        // BTreeSet dedups so we never emit the same NOTIFY twice per
+        // transaction. Multi-queue enqueues fold into a single round-trip via
+        // `unnest($1::text[])` rather than one round-trip per channel.
+        let channels: Vec<String> = queues
             .into_iter()
-            .map(|queue| self.logical_queue_name(&queue).to_string())
+            .map(|queue| format!("awa:{}", self.logical_queue_name(&queue)))
+            .collect::<BTreeSet<String>>()
+            .into_iter()
             .collect();
-        for queue in queues {
-            sqlx::query("SELECT pg_notify($1, '')")
-                .bind(format!("awa:{queue}"))
-                .execute(tx.as_mut())
-                .await
-                .map_err(map_sqlx_error)?;
+        if channels.is_empty() {
+            return Ok(());
         }
+        sqlx::query("SELECT pg_notify(channel, '') FROM unnest($1::text[]) AS channel")
+            .bind(&channels)
+            .execute(tx.as_mut())
+            .await
+            .map_err(map_sqlx_error)?;
         Ok(())
     }
 


### PR DESCRIPTION
## Summary

The three queue-storage enqueue paths (`enqueue_runtime_rows`, `enqueue_params_batch`, `enqueue_params_copy`) each contained an inline loop that issued one `pg_notify(channel, '')` query per distinct destination queue inside the enqueue transaction. With N distinct queues this was N round-trips for work that's independent.

This PR routes them through the existing private `notify_queues_tx` helper, and updates the helper to do a single `SELECT pg_notify(channel, '') FROM unnest($1::text[]) AS channel` — any number of queues collapses to one round-trip.

Two side benefits:

- The notify pattern (logical-queue mapping + dedup + emission) now lives in one place. Three call sites that were near-duplicates are gone.
- Single-queue enqueue (the common case) is byte-for-byte unchanged: still one statement, still one NOTIFY.

## Behaviour

- Same NOTIFY semantics: one `awa:<logical-queue>` notification per distinct queue per transaction.
- Dedup preserved by collecting channels through a `BTreeSet` before binding.
- Notifications still fire on commit (PG semantics for `pg_notify` inside a tx).

## Validation

- `SQLX_OFFLINE=true cargo build --workspace --tests` — clean
- `SQLX_OFFLINE=true cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo fmt --all`
- `cargo test -p awa-model --release` — 7 passed
- `DATABASE_URL=... cargo test -p awa --test queue_storage_runtime_test --release` — **53/53 passed**, including `..._two_clients_drain_without_duplicate_execution`, `..._striped_runtime_claims_do_not_deadlock_with_enqueues`, and the receipt-claim suite that exercise the wakeup → claim path.
- `cargo test -p awa --release --test benchmark_test test_throughput_rust_workers_queue_storage` ×3 at `AWA_VA_RUNTIME_TOTAL_JOBS=5000` — within run-to-run noise of the baseline. Expected: this is a single-queue benchmark, so the multi-queue fanout improvement doesn't show up here. The win is on multi-queue batches.

## Test plan

- [x] Workspace builds clean
- [x] Clippy clean
- [x] queue-storage runtime test suite green
- [x] awa-model unit tests green
- [ ] CI green