### PR TITLE
queue_storage: merge attempt_state cleanup into the lease-delete CTE

### DIFF
--- a/awa-model/src/queue_storage.rs
+++ b/awa-model/src/queue_storage.rs
@@ -5814,34 +5814,63 @@ impl QueueStorage {
                     .map(|entry| entry.job.run_lease)
                     .collect();
 
+                // CTE-as-DML: delete the leases and the matching attempt_state
+                // rows in one round-trip. See the receipt-disabled branch
+                // below for the same pattern.
                 let deleted: Vec<DeletedLeaseRow> = sqlx::query_as(&format!(
                     r#"
                     WITH completed(lease_slot, queue, priority, lane_seq, run_lease) AS (
                         SELECT * FROM unnest($1::int[], $2::text[], $3::smallint[], $4::bigint[], $5::bigint[])
+                    ),
+                    deleted AS (
+                        DELETE FROM {schema}.leases AS leases
+                        USING completed
+                        WHERE leases.lease_slot = completed.lease_slot
+                          AND leases.queue = completed.queue
+                          AND leases.priority = completed.priority
+                          AND leases.lane_seq = completed.lane_seq
+                          AND leases.run_lease = completed.run_lease
+                        RETURNING
+                            leases.ready_slot,
+                            leases.ready_generation,
+                            leases.job_id,
+                            leases.queue,
+                            leases.state,
+                            leases.priority,
+                            leases.attempt,
+                            leases.run_lease,
+                            leases.max_attempts,
+                            leases.lane_seq,
+                            leases.heartbeat_at,
+                            leases.deadline_at,
+                            leases.attempted_at,
+                            leases.callback_id,
+                            leases.callback_timeout_at
+                    ),
+                    del_attempts AS (
+                        DELETE FROM {schema}.attempt_state AS attempt
+                        USING deleted
+                        WHERE attempt.job_id = deleted.job_id
+                          AND attempt.run_lease = deleted.run_lease
+                        RETURNING attempt.job_id
                     )
-                    DELETE FROM {schema}.leases AS leases
-                    USING completed
-                    WHERE leases.lease_slot = completed.lease_slot
-                      AND leases.queue = completed.queue
-                      AND leases.priority = completed.priority
-                      AND leases.lane_seq = completed.lane_seq
-                      AND leases.run_lease = completed.run_lease
-                    RETURNING
-                        leases.ready_slot,
-                        leases.ready_generation,
-                        leases.job_id,
-                        leases.queue,
-                        leases.state,
-                        leases.priority,
-                        leases.attempt,
-                        leases.run_lease,
-                        leases.max_attempts,
-                        leases.lane_seq,
-                        leases.heartbeat_at,
-                        leases.deadline_at,
-                        leases.attempted_at,
-                        leases.callback_id,
-                        leases.callback_timeout_at
+                    SELECT
+                        ready_slot,
+                        ready_generation,
+                        job_id,
+                        queue,
+                        state,
+                        priority,
+                        attempt,
+                        run_lease,
+                        max_attempts,
+                        lane_seq,
+                        heartbeat_at,
+                        deadline_at,
+                        attempted_at,
+                        callback_id,
+                        callback_timeout_at
+                    FROM deleted
                     "#
                 ))
                 .bind(&lease_slots)
@@ -5854,27 +5883,6 @@ impl QueueStorage {
                 .map_err(map_sqlx_error)?;
 
                 if !deleted.is_empty() {
-                    let deleted_job_ids: Vec<i64> = deleted.iter().map(|row| row.job_id).collect();
-                    let deleted_run_leases: Vec<i64> =
-                        deleted.iter().map(|row| row.run_lease).collect();
-
-                    sqlx::query(&format!(
-                        r#"
-                        WITH completed(job_id, run_lease) AS (
-                            SELECT * FROM unnest($1::bigint[], $2::bigint[])
-                        )
-                        DELETE FROM {schema}.attempt_state AS attempt
-                        USING completed
-                        WHERE attempt.job_id = completed.job_id
-                          AND attempt.run_lease = completed.run_lease
-                        "#
-                    ))
-                    .bind(&deleted_job_ids)
-                    .bind(&deleted_run_leases)
-                    .execute(tx.as_mut())
-                    .await
-                    .map_err(map_sqlx_error)?;
-
                     let finalized_at = Utc::now();
                     let mut done_rows = Vec::with_capacity(deleted.len());
                     for deleted_row in deleted {
@@ -5905,34 +5913,66 @@ impl QueueStorage {
         let lane_seqs: Vec<i64> = claimed.iter().map(|entry| entry.claim.lane_seq).collect();
         let run_leases: Vec<i64> = claimed.iter().map(|entry| entry.job.run_lease).collect();
 
+        // Single CTE-as-DML statement: delete the leases and the matching
+        // attempt_state rows in one round-trip. The `deleted` CTE materialises
+        // the lease deletion (so its RETURNING is observable to the
+        // attempt-state delete and to the final SELECT), and `del_attempts`
+        // hangs off it. Saves one round-trip per completion batch versus
+        // issuing the attempt-state delete as a separate statement.
         let deleted: Vec<DeletedLeaseRow> = sqlx::query_as(&format!(
             r#"
             WITH completed(lease_slot, queue, priority, lane_seq, run_lease) AS (
                 SELECT * FROM unnest($1::int[], $2::text[], $3::smallint[], $4::bigint[], $5::bigint[])
+            ),
+            deleted AS (
+                DELETE FROM {schema}.leases AS leases
+                USING completed
+                WHERE leases.lease_slot = completed.lease_slot
+                  AND leases.queue = completed.queue
+                  AND leases.priority = completed.priority
+                  AND leases.lane_seq = completed.lane_seq
+                  AND leases.run_lease = completed.run_lease
+                RETURNING
+                    leases.ready_slot,
+                    leases.ready_generation,
+                    leases.job_id,
+                    leases.queue,
+                    leases.state,
+                    leases.priority,
+                    leases.attempt,
+                    leases.run_lease,
+                    leases.max_attempts,
+                    leases.lane_seq,
+                    leases.heartbeat_at,
+                    leases.deadline_at,
+                    leases.attempted_at,
+                    leases.callback_id,
+                    leases.callback_timeout_at
+            ),
+            del_attempts AS (
+                DELETE FROM {schema}.attempt_state AS attempt
+                USING deleted
+                WHERE attempt.job_id = deleted.job_id
+                  AND attempt.run_lease = deleted.run_lease
+                RETURNING attempt.job_id
             )
-            DELETE FROM {schema}.leases AS leases
-            USING completed
-            WHERE leases.lease_slot = completed.lease_slot
-              AND leases.queue = completed.queue
-              AND leases.priority = completed.priority
-              AND leases.lane_seq = completed.lane_seq
-              AND leases.run_lease = completed.run_lease
-            RETURNING
-                leases.ready_slot,
-                leases.ready_generation,
-                leases.job_id,
-                leases.queue,
-                leases.state,
-                leases.priority,
-                leases.attempt,
-                leases.run_lease,
-                leases.max_attempts,
-                leases.lane_seq,
-                leases.heartbeat_at,
-                leases.deadline_at,
-                leases.attempted_at,
-                leases.callback_id,
-                leases.callback_timeout_at
+            SELECT
+                ready_slot,
+                ready_generation,
+                job_id,
+                queue,
+                state,
+                priority,
+                attempt,
+                run_lease,
+                max_attempts,
+                lane_seq,
+                heartbeat_at,
+                deadline_at,
+                attempted_at,
+                callback_id,
+                callback_timeout_at
+            FROM deleted
             "#
         ))
         .bind(&lease_slots)
@@ -5948,26 +5988,6 @@ impl QueueStorage {
             tx.commit().await.map_err(map_sqlx_error)?;
             return Ok(Vec::new());
         }
-
-        let deleted_job_ids: Vec<i64> = deleted.iter().map(|row| row.job_id).collect();
-        let deleted_run_leases: Vec<i64> = deleted.iter().map(|row| row.run_lease).collect();
-
-        sqlx::query(&format!(
-            r#"
-            WITH completed(job_id, run_lease) AS (
-                SELECT * FROM unnest($1::bigint[], $2::bigint[])
-            )
-            DELETE FROM {schema}.attempt_state AS attempt
-            USING completed
-            WHERE attempt.job_id = completed.job_id
-              AND attempt.run_lease = completed.run_lease
-            "#
-        ))
-        .bind(&deleted_job_ids)
-        .bind(&deleted_run_leases)
-        .execute(tx.as_mut())
-        .await
-        .map_err(map_sqlx_error)?;
 
         let finalized_at = Utc::now();
         let mut done_rows = Vec::with_capacity(deleted.len());


### PR DESCRIPTION
## Summary

`complete_runtime_batch` historically issued two consecutive `DELETE` statements on the completion path:

1. `DELETE FROM leases ... RETURNING` (so the caller can hydrate `DeletedLeaseRow`s into done-rows)
2. `DELETE FROM attempt_state USING <ids from #1>`

This applied both on the receipt-disabled branch and on the materialized fallback inside the receipt-enabled branch — i.e. on every call that actually closes leases.

This PR folds the second DELETE into the first as a CTE-as-DML so the completion shape is **one statement / one round-trip** per call:

```sql
WITH completed(...) AS (unnest of bound arrays),
     deleted AS (DELETE FROM leases ... RETURNING ...),
     del_attempts AS (
         DELETE FROM attempt_state AS attempt
         USING deleted
         WHERE attempt.job_id = deleted.job_id
           AND attempt.run_lease = deleted.run_lease
         RETURNING attempt.job_id
     )
SELECT * FROM deleted
```

## Semantics — unchanged

- Lease-delete `RETURNING` is still observable as `DeletedLeaseRow` (same shape).
- `attempt_state` rows are removed only for leases that actually got deleted, since `del_attempts` joins through `deleted`. Un-matched attempt rows (e.g. already gone) are unaffected.
- Both CTEs commit/roll back atomically within the same outer transaction — identical to before.
- Empty `claimed` short-circuit and empty-deleted early return are preserved.

## Validation

- `cargo build --workspace --tests` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo fmt --all`
- `cargo test -p awa --test queue_storage_runtime_test --release` — **53/53 passed**, including:
  - `test_queue_storage_runtime_*` (snooze, retry_after, complete_external, callback_timeout, terminal_failure, stale_heartbeat_rescue)
  - the full receipt-claim suite
  - `test_queue_storage_two_clients_drain_without_duplicate_execution`
  - `test_queue_storage_striped_runtime_claims_do_not_deadlock_with_enqueues`
  - `test_queue_storage_short_jobs_complete_via_lease_claim_receipts`
  - `test_queue_storage_late_completion_*` guards
- Local throughput bench (`test_throughput_rust_workers_queue_storage`, `AWA_VA_RUNTIME_TOTAL_JOBS=20000`, 8 runs each):
    - baseline post-insert: 17600..18351, median ~18228 jobs/s
    - cte-merge post-insert: 17928..19782, median ~18156 jobs/s
  Within run-to-run noise — completion is not the bottleneck on this loopback-Postgres bench. The win is one fewer round-trip per completion batch, which matters under high-contention or network-bound deployments rather than this test environment.

## Test plan

- [x] Workspace builds clean
- [x] Clippy clean
- [x] queue-storage runtime suite green
- [ ] CI green (especially nightly chaos / queue-storage soak)