### PR TITLE
Perf bundle: multi-queue notify fanout + completion CTE merge

### DIFF
--- a/awa-model/src/queue_storage.rs
+++ b/awa-model/src/queue_storage.rs
@@ -4773,17 +4773,8 @@ impl QueueStorage {
         let mut tx = pool.begin().await.map_err(map_sqlx_error)?;
         let total_rows = self.insert_ready_rows_tx(&mut tx, rows.clone()).await?;
 
-        let queues_to_notify: BTreeSet<String> = rows
-            .iter()
-            .map(|row| self.logical_queue_name(&row.queue).to_string())
-            .collect();
-        for queue in queues_to_notify {
-            sqlx::query("SELECT pg_notify($1, '')")
-                .bind(format!("awa:{queue}"))
-                .execute(tx.as_mut())
-                .await
-                .map_err(map_sqlx_error)?;
-        }
+        let queues_to_notify: Vec<String> = rows.iter().map(|row| row.queue.clone()).collect();
+        self.notify_queues_tx(&mut tx, queues_to_notify).await?;
 
         tx.commit().await.map_err(map_sqlx_error)?;
         Ok(total_rows)
@@ -4892,10 +4883,8 @@ impl QueueStorage {
             }
         }
 
-        let queues_to_notify: BTreeSet<String> = ready_rows
-            .iter()
-            .map(|row| self.logical_queue_name(&row.queue).to_string())
-            .collect();
+        let queues_to_notify: Vec<String> =
+            ready_rows.iter().map(|row| row.queue.clone()).collect();
 
         let mut tx = pool.begin().await.map_err(map_sqlx_error)?;
         let mut total = 0usize;
@@ -4916,13 +4905,7 @@ impl QueueStorage {
                 .await?;
         }
 
-        for queue in queues_to_notify {
-            sqlx::query("SELECT pg_notify($1, '')")
-                .bind(format!("awa:{queue}"))
-                .execute(tx.as_mut())
-                .await
-                .map_err(map_sqlx_error)?;
-        }
+        self.notify_queues_tx(&mut tx, queues_to_notify).await?;
 
         tx.commit().await.map_err(map_sqlx_error)?;
         Ok(total)
@@ -4998,10 +4981,8 @@ impl QueueStorage {
             }
         }
 
-        let queues_to_notify: BTreeSet<String> = ready_rows
-            .iter()
-            .map(|row| self.logical_queue_name(&row.queue).to_string())
-            .collect();
+        let queues_to_notify: Vec<String> =
+            ready_rows.iter().map(|row| row.queue.clone()).collect();
 
         let mut tx = pool.begin().await.map_err(map_sqlx_error)?;
         let mut total = 0usize;
@@ -5025,13 +5006,7 @@ impl QueueStorage {
                 .await?;
         }
 
-        for queue in queues_to_notify {
-            sqlx::query("SELECT pg_notify($1, '')")
-                .bind(format!("awa:{queue}"))
-                .execute(tx.as_mut())
-                .await
-                .map_err(map_sqlx_error)?;
-        }
+        self.notify_queues_tx(&mut tx, queues_to_notify).await?;
 
         tx.commit().await.map_err(map_sqlx_error)?;
         Ok(total)
@@ -7026,17 +7001,23 @@ impl QueueStorage {
         tx: &mut sqlx::Transaction<'a, sqlx::Postgres>,
         queues: impl IntoIterator<Item = String>,
     ) -> Result<(), AwaError> {
-        let queues: BTreeSet<String> = queues
+        // BTreeSet dedups so we never emit the same NOTIFY twice per
+        // transaction. Multi-queue enqueues fold into a single round-trip via
+        // `unnest($1::text[])` rather than one round-trip per channel.
+        let channels: Vec<String> = queues
             .into_iter()
-            .map(|queue| self.logical_queue_name(&queue).to_string())
+            .map(|queue| format!("awa:{}", self.logical_queue_name(&queue)))
+            .collect::<BTreeSet<String>>()
+            .into_iter()
             .collect();
-        for queue in queues {
-            sqlx::query("SELECT pg_notify($1, '')")
-                .bind(format!("awa:{queue}"))
-                .execute(tx.as_mut())
-                .await
-                .map_err(map_sqlx_error)?;
+        if channels.is_empty() {
+            return Ok(());
         }
+        sqlx::query("SELECT pg_notify(channel, '') FROM unnest($1::text[]) AS channel")
+            .bind(&channels)
+            .execute(tx.as_mut())
+            .await
+            .map_err(map_sqlx_error)?;
         Ok(())
     }
 

--- a/awa-model/src/queue_storage.rs
+++ b/awa-model/src/queue_storage.rs
@@ -5814,34 +5814,63 @@ impl QueueStorage {
                     .map(|entry| entry.job.run_lease)
                     .collect();
 
+                // CTE-as-DML: delete the leases and the matching attempt_state
+                // rows in one round-trip. See the receipt-disabled branch
+                // below for the same pattern.
                 let deleted: Vec<DeletedLeaseRow> = sqlx::query_as(&format!(
                     r#"
                     WITH completed(lease_slot, queue, priority, lane_seq, run_lease) AS (
                         SELECT * FROM unnest($1::int[], $2::text[], $3::smallint[], $4::bigint[], $5::bigint[])
+                    ),
+                    deleted AS (
+                        DELETE FROM {schema}.leases AS leases
+                        USING completed
+                        WHERE leases.lease_slot = completed.lease_slot
+                          AND leases.queue = completed.queue
+                          AND leases.priority = completed.priority
+                          AND leases.lane_seq = completed.lane_seq
+                          AND leases.run_lease = completed.run_lease
+                        RETURNING
+                            leases.ready_slot,
+                            leases.ready_generation,
+                            leases.job_id,
+                            leases.queue,
+                            leases.state,
+                            leases.priority,
+                            leases.attempt,
+                            leases.run_lease,
+                            leases.max_attempts,
+                            leases.lane_seq,
+                            leases.heartbeat_at,
+                            leases.deadline_at,
+                            leases.attempted_at,
+                            leases.callback_id,
+                            leases.callback_timeout_at
+                    ),
+                    del_attempts AS (
+                        DELETE FROM {schema}.attempt_state AS attempt
+                        USING deleted
+                        WHERE attempt.job_id = deleted.job_id
+                          AND attempt.run_lease = deleted.run_lease
+                        RETURNING attempt.job_id
                     )
-                    DELETE FROM {schema}.leases AS leases
-                    USING completed
-                    WHERE leases.lease_slot = completed.lease_slot
-                      AND leases.queue = completed.queue
-                      AND leases.priority = completed.priority
-                      AND leases.lane_seq = completed.lane_seq
-                      AND leases.run_lease = completed.run_lease
-                    RETURNING
-                        leases.ready_slot,
-                        leases.ready_generation,
-                        leases.job_id,
-                        leases.queue,
-                        leases.state,
-                        leases.priority,
-                        leases.attempt,
-                        leases.run_lease,
-                        leases.max_attempts,
-                        leases.lane_seq,
-                        leases.heartbeat_at,
-                        leases.deadline_at,
-                        leases.attempted_at,
-                        leases.callback_id,
-                        leases.callback_timeout_at
+                    SELECT
+                        ready_slot,
+                        ready_generation,
+                        job_id,
+                        queue,
+                        state,
+                        priority,
+                        attempt,
+                        run_lease,
+                        max_attempts,
+                        lane_seq,
+                        heartbeat_at,
+                        deadline_at,
+                        attempted_at,
+                        callback_id,
+                        callback_timeout_at
+                    FROM deleted
                     "#
                 ))
                 .bind(&lease_slots)
@@ -5854,27 +5883,6 @@ impl QueueStorage {
                 .map_err(map_sqlx_error)?;
 
                 if !deleted.is_empty() {
-                    let deleted_job_ids: Vec<i64> = deleted.iter().map(|row| row.job_id).collect();
-                    let deleted_run_leases: Vec<i64> =
-                        deleted.iter().map(|row| row.run_lease).collect();
-
-                    sqlx::query(&format!(
-                        r#"
-                        WITH completed(job_id, run_lease) AS (
-                            SELECT * FROM unnest($1::bigint[], $2::bigint[])
-                        )
-                        DELETE FROM {schema}.attempt_state AS attempt
-                        USING completed
-                        WHERE attempt.job_id = completed.job_id
-                          AND attempt.run_lease = completed.run_lease
-                        "#
-                    ))
-                    .bind(&deleted_job_ids)
-                    .bind(&deleted_run_leases)
-                    .execute(tx.as_mut())
-                    .await
-                    .map_err(map_sqlx_error)?;
-
                     let finalized_at = Utc::now();
                     let mut done_rows = Vec::with_capacity(deleted.len());
                     for deleted_row in deleted {
@@ -5905,34 +5913,66 @@ impl QueueStorage {
         let lane_seqs: Vec<i64> = claimed.iter().map(|entry| entry.claim.lane_seq).collect();
         let run_leases: Vec<i64> = claimed.iter().map(|entry| entry.job.run_lease).collect();
 
+        // Single CTE-as-DML statement: delete the leases and the matching
+        // attempt_state rows in one round-trip. The `deleted` CTE materialises
+        // the lease deletion (so its RETURNING is observable to the
+        // attempt-state delete and to the final SELECT), and `del_attempts`
+        // hangs off it. Saves one round-trip per completion batch versus
+        // issuing the attempt-state delete as a separate statement.
         let deleted: Vec<DeletedLeaseRow> = sqlx::query_as(&format!(
             r#"
             WITH completed(lease_slot, queue, priority, lane_seq, run_lease) AS (
                 SELECT * FROM unnest($1::int[], $2::text[], $3::smallint[], $4::bigint[], $5::bigint[])
+            ),
+            deleted AS (
+                DELETE FROM {schema}.leases AS leases
+                USING completed
+                WHERE leases.lease_slot = completed.lease_slot
+                  AND leases.queue = completed.queue
+                  AND leases.priority = completed.priority
+                  AND leases.lane_seq = completed.lane_seq
+                  AND leases.run_lease = completed.run_lease
+                RETURNING
+                    leases.ready_slot,
+                    leases.ready_generation,
+                    leases.job_id,
+                    leases.queue,
+                    leases.state,
+                    leases.priority,
+                    leases.attempt,
+                    leases.run_lease,
+                    leases.max_attempts,
+                    leases.lane_seq,
+                    leases.heartbeat_at,
+                    leases.deadline_at,
+                    leases.attempted_at,
+                    leases.callback_id,
+                    leases.callback_timeout_at
+            ),
+            del_attempts AS (
+                DELETE FROM {schema}.attempt_state AS attempt
+                USING deleted
+                WHERE attempt.job_id = deleted.job_id
+                  AND attempt.run_lease = deleted.run_lease
+                RETURNING attempt.job_id
             )
-            DELETE FROM {schema}.leases AS leases
-            USING completed
-            WHERE leases.lease_slot = completed.lease_slot
-              AND leases.queue = completed.queue
-              AND leases.priority = completed.priority
-              AND leases.lane_seq = completed.lane_seq
-              AND leases.run_lease = completed.run_lease
-            RETURNING
-                leases.ready_slot,
-                leases.ready_generation,
-                leases.job_id,
-                leases.queue,
-                leases.state,
-                leases.priority,
-                leases.attempt,
-                leases.run_lease,
-                leases.max_attempts,
-                leases.lane_seq,
-                leases.heartbeat_at,
-                leases.deadline_at,
-                leases.attempted_at,
-                leases.callback_id,
-                leases.callback_timeout_at
+            SELECT
+                ready_slot,
+                ready_generation,
+                job_id,
+                queue,
+                state,
+                priority,
+                attempt,
+                run_lease,
+                max_attempts,
+                lane_seq,
+                heartbeat_at,
+                deadline_at,
+                attempted_at,
+                callback_id,
+                callback_timeout_at
+            FROM deleted
             "#
         ))
         .bind(&lease_slots)
@@ -5948,26 +5988,6 @@ impl QueueStorage {
             tx.commit().await.map_err(map_sqlx_error)?;
             return Ok(Vec::new());
         }
-
-        let deleted_job_ids: Vec<i64> = deleted.iter().map(|row| row.job_id).collect();
-        let deleted_run_leases: Vec<i64> = deleted.iter().map(|row| row.run_lease).collect();
-
-        sqlx::query(&format!(
-            r#"
-            WITH completed(job_id, run_lease) AS (
-                SELECT * FROM unnest($1::bigint[], $2::bigint[])
-            )
-            DELETE FROM {schema}.attempt_state AS attempt
-            USING completed
-            WHERE attempt.job_id = completed.job_id
-              AND attempt.run_lease = completed.run_lease
-            "#
-        ))
-        .bind(&deleted_job_ids)
-        .bind(&deleted_run_leases)
-        .execute(tx.as_mut())
-        .await
-        .map_err(map_sqlx_error)?;
 
         let finalized_at = Utc::now();
         let mut done_rows = Vec::with_capacity(deleted.len());


### PR DESCRIPTION
## Summary

Queue-storage performance bundle containing the remaining storage-path changes after `awa-metrics` landed separately in #232. Against current `main`, this PR only changes `awa-model/src/queue_storage.rs`.

Included changes:

- **Fold multi-queue NOTIFY fanout into one statement.** Ready enqueue paths now collect destination queues and call `notify_queues_tx`, which deduplicates logical channels and emits `pg_notify` through a single `unnest($1::text[])` query. Single-queue behavior remains one NOTIFY for one logical queue.
- **Merge `attempt_state` cleanup into runtime lease deletion.** `complete_runtime_batch` now deletes matching `attempt_state` rows inside the lease-delete CTE, removing one database round trip per completion batch while preserving the same transaction boundary and lease-delete `RETURNING` shape.

## Validation

- CI green on this bundle
- CodeRabbit review completed
- Constituent PRs #233 and #234 were CI green
- `git diff --check origin/main..pr/235` clean
- Existing queue-storage runtime coverage exercises completion cleanup, receipt fallback, stale-result guards, and striped runtime paths

## Notes

No end-user documentation update is needed: these changes do not add or change public configuration, API, schema, or operational semantics. The expected benefit is fewer database round trips in multi-queue enqueue batches and completion-heavy workloads.