### PR TITLE
release.yml: crates.io Trusted Publishing via OIDC

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -619,6 +619,15 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
 
   # ─── Publish Rust crates ─────────────────────────────────────────────
+  #
+  # Authentication: crates.io Trusted Publishing via GitHub OIDC.
+  # `rust-lang/crates-io-auth-action` exchanges the workflow's OIDC token
+  # for a short-lived crates.io token (~30 minutes). No long-lived
+  # CARGO_REGISTRY_TOKEN secret needed. Each crate must have a Trusted
+  # Publisher entry configured on crates.io (Settings → Trusted
+  # Publishing) matching this repo + workflow filename. New crates use
+  # the "Pending Publisher" flow on crates.io to bootstrap before the
+  # first publish.
   publish-crates:
     name: Publish to crates.io
     needs: [version-check]
@@ -626,6 +635,10 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
+
+      - name: Authenticate to crates.io (OIDC)
+        id: crates-io-auth
+        uses: rust-lang/crates-io-auth-action@v1
 
       # awa-ui embeds `awa-ui/static/` via rust-embed; without building the
       # frontend first, the crate published to crates.io carries no assets and
@@ -664,7 +677,7 @@ jobs:
       - name: Publish awa-macros
         run: cargo publish --package awa-macros --no-verify
         env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ steps.crates-io-auth.outputs.token }}
 
       - name: Wait for index
         run: sleep 30
@@ -672,7 +685,7 @@ jobs:
       - name: Publish awa-model
         run: cargo publish --package awa-model --no-verify
         env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ steps.crates-io-auth.outputs.token }}
 
       - name: Wait for index
         run: sleep 30
@@ -680,7 +693,7 @@ jobs:
       - name: Publish awa-worker
         run: cargo publish --package awa-worker --no-verify
         env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ steps.crates-io-auth.outputs.token }}
 
       - name: Wait for index
         run: sleep 30
@@ -688,7 +701,7 @@ jobs:
       - name: Publish awa-testing
         run: cargo publish --package awa-testing --no-verify
         env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ steps.crates-io-auth.outputs.token }}
 
       - name: Wait for index
         run: sleep 30
@@ -704,7 +717,7 @@ jobs:
       - name: Publish awa-ui
         run: cargo publish --package awa-ui --no-verify --allow-dirty
         env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ steps.crates-io-auth.outputs.token }}
 
       - name: Wait for index
         run: sleep 30
@@ -712,7 +725,7 @@ jobs:
       - name: Publish awa-cli
         run: cargo publish --package awa-cli --no-verify
         env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ steps.crates-io-auth.outputs.token }}
 
       - name: Wait for index
         run: sleep 30
@@ -720,4 +733,4 @@ jobs:
       - name: Publish awa (facade)
         run: cargo publish --package awa --no-verify
         env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ steps.crates-io-auth.outputs.token }}


### PR DESCRIPTION
## Summary

Replace the long-lived \`CARGO_REGISTRY_TOKEN\` secret with crates.io [Trusted Publishing](https://crates.io/docs/trusted-publishing) via GitHub Actions OIDC. The workflow already declares \`id-token: write\`, so no permission change is needed.

## How it works

- One auth step at the top of \`publish-crates\` exchanges the workflow's OIDC token for a short-lived crates.io API token (~30 min) via [\`rust-lang/crates-io-auth-action@v1\`](https://github.com/rust-lang/crates-io-auth-action). The job's 7 \`cargo publish\` steps + 30 s index waits run comfortably inside that window.
- Each publish step reads the token from \`steps.crates-io-auth.outputs.token\` instead of \`secrets.CARGO_REGISTRY_TOKEN\`.
- The \`CARGO_REGISTRY_TOKEN\` repo secret can be deleted after the next successful release.

## One-time setup per crate (manual)

Trusted Publishing needs a per-crate "Trusted Publisher" entry on crates.io (Settings → Trusted Publishing) matching this repo + workflow filename:

| Field | Value |
|---|---|
| Repository owner | \`hardbyte\` |
| Repository name | \`awa\` |
| Workflow filename | \`release.yml\` |
| Environment | (leave empty unless you wire up an environment) |

Per-crate, do this for: \`awa-macros\`, \`awa-model\`, \`awa-worker\`, \`awa-testing\`, \`awa-ui\`, \`awa-cli\`, \`awa\` — and \`awa-metrics\` (which lands in #232/#235).

For **new** crates (\`awa-metrics\`), use crates.io's "Pending Publisher" flow: configure the trusted publisher under your account *before* the first publish; the bootstrap publish from this workflow auto-creates the crate under the configured owner. Without the pending-publisher entry the first \`cargo publish\` for a non-existent crate will fail OIDC validation.

## Validation

- YAML structure unchanged apart from the new auth step + token source. Same step ordering, same publish targets, same \`--no-verify\` / \`--allow-dirty\` flags where they applied.
- Auth token TTL (30 min) safely covers the entire publish job (~5 min of actual work in the existing flow).

## Test plan

- [ ] Configure Trusted Publisher on crates.io for each existing crate under hardbyte/awa
- [ ] Configure Pending Publisher for \`awa-metrics\` (when #232 lands)
- [ ] Cut a tag, watch the release run authenticate without the long-lived secret
- [ ] After a successful release, remove the \`CARGO_REGISTRY_TOKEN\` repo secret