### PR TITLE
Bump version to 0.6.0-alpha.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,48 @@ transitions live in [`docs/upgrade-0.5-to-0.6.md`](docs/upgrade-0.5-to-0.6.md).
 
 ## Unreleased
 
+## [0.6.0-alpha.6] — 2026-05-07
+
+### Added
+
+- **`awa-metrics` crate** ([#176](https://github.com/hardbyte/awa/issues/176),
+  [#232](https://github.com/hardbyte/awa/pull/232)). The `AwaMetrics` type
+  and its `record_*` methods move from `awa-worker` into a dedicated
+  `awa-metrics` crate so non-runtime callers (`awa-ui`, `awa-cli`) can emit
+  the same OTel counters as the worker without depending on the
+  dispatcher/runtime crate graph. `awa-worker::AwaMetrics` re-exports for
+  source compatibility — no semver break for `awa-cli` or `awa-python`.
+  `awa-metrics::names` exposes public string constants for every metric, and
+  `AwaMetrics::new()` is built from those constants so registered
+  instruments and the public names can't drift.
+
+### Changed
+
+- **Multi-queue NOTIFY collapses to one round-trip per enqueue tx**
+  ([#235](https://github.com/hardbyte/awa/pull/235)). The three queue-storage
+  enqueue paths (`enqueue_runtime_rows`, `enqueue_params_batch`,
+  `enqueue_params_copy`) used to issue one `pg_notify($1, '')` per distinct
+  destination queue inside the enqueue transaction. Now routed through
+  `notify_queues_tx`, which uses
+  `SELECT pg_notify(channel, '') FROM unnest($1::text[])` so any number of
+  queues becomes one round-trip. Single-queue enqueue (the common case) is
+  unchanged.
+- **Completion path: lease delete and `attempt_state` cleanup merge into a
+  single CTE-as-DML statement** ([#235](https://github.com/hardbyte/awa/pull/235)).
+  `complete_runtime_batch` previously issued two consecutive DELETEs (leases,
+  then `attempt_state`) on the receipt-disabled path and on the materialized
+  fallback inside the receipt-enabled path. They now share one statement —
+  one fewer round-trip per completion batch, identical atomicity and
+  return shape.
+
+### Fixed
+
+- **`awa.job.dlq_retried` tagged with the source queue** ([#232](https://github.com/hardbyte/awa/pull/232)).
+  Single-job retry from `awa-ui` previously read `job.queue` from the
+  returned `JobRow`, which carries the *destination* queue if the request
+  body supplied a `queue` override. The metric now looks the source queue
+  up before retry runs (matching `record_dlq_purged`'s pattern).
+
 ## [0.6.0-alpha.5] — 2026-05-04
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,7 +171,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "awa"
-version = "0.6.0-alpha.5"
+version = "0.6.0-alpha.6"
 dependencies = [
  "async-trait",
  "awa-macros",
@@ -196,7 +196,7 @@ dependencies = [
 
 [[package]]
 name = "awa-cli"
-version = "0.6.0-alpha.5"
+version = "0.6.0-alpha.6"
 dependencies = [
  "assert_cmd",
  "awa-model",
@@ -218,7 +218,7 @@ dependencies = [
 
 [[package]]
 name = "awa-macros"
-version = "0.6.0-alpha.5"
+version = "0.6.0-alpha.6"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -228,7 +228,7 @@ dependencies = [
 
 [[package]]
 name = "awa-metrics"
-version = "0.6.0-alpha.5"
+version = "0.6.0-alpha.6"
 dependencies = [
  "awa-model",
  "opentelemetry",
@@ -236,7 +236,7 @@ dependencies = [
 
 [[package]]
 name = "awa-model"
-version = "0.6.0-alpha.5"
+version = "0.6.0-alpha.6"
 dependencies = [
  "awa-macros",
  "blake3",
@@ -257,7 +257,7 @@ dependencies = [
 
 [[package]]
 name = "awa-testing"
-version = "0.6.0-alpha.5"
+version = "0.6.0-alpha.6"
 dependencies = [
  "async-trait",
  "awa-model",
@@ -272,7 +272,7 @@ dependencies = [
 
 [[package]]
 name = "awa-ui"
-version = "0.6.0-alpha.5"
+version = "0.6.0-alpha.6"
 dependencies = [
  "awa-metrics",
  "awa-model",
@@ -295,7 +295,7 @@ dependencies = [
 
 [[package]]
 name = "awa-worker"
-version = "0.6.0-alpha.5"
+version = "0.6.0-alpha.6"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = [
 exclude = ["awa-python", "spike"]
 
 [workspace.package]
-version = "0.6.0-alpha.5"
+version = "0.6.0-alpha.6"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "Postgres-native background job queue — transactional enqueue, heartbeat crash recovery, SKIP LOCKED dispatch"
@@ -24,10 +24,10 @@ categories = ["database", "asynchronous", "web-programming"]
 
 [workspace.dependencies]
 # Internal crates
-awa-model = { path = "awa-model", version = "0.6.0-alpha.5" }
-awa-macros = { path = "awa-macros", version = "0.6.0-alpha.5" }
-awa-metrics = { path = "awa-metrics", version = "0.6.0-alpha.5" }
-awa-worker = { path = "awa-worker", version = "0.6.0-alpha.5" }
+awa-model = { path = "awa-model", version = "0.6.0-alpha.6" }
+awa-macros = { path = "awa-macros", version = "0.6.0-alpha.6" }
+awa-metrics = { path = "awa-metrics", version = "0.6.0-alpha.6" }
+awa-worker = { path = "awa-worker", version = "0.6.0-alpha.6" }
 
 # Database
 sqlx = { version = "0.8", features = ["runtime-tokio-rustls", "postgres", "chrono", "json", "migrate", "uuid"] }

--- a/awa-cli/Cargo.toml
+++ b/awa-cli/Cargo.toml
@@ -14,7 +14,7 @@ path = "src/main.rs"
 [dependencies]
 awa-model.workspace = true
 awa-worker.workspace = true
-awa-ui = { path = "../awa-ui", version = "0.6.0-alpha.5" }
+awa-ui = { path = "../awa-ui", version = "0.6.0-alpha.6" }
 axum.workspace = true
 sqlx.workspace = true
 tokio.workspace = true
@@ -26,7 +26,7 @@ chrono.workspace = true
 hex.workspace = true
 
 [dev-dependencies]
-awa-testing = { path = "../awa-testing", version = "0.6.0-alpha.5" }
+awa-testing = { path = "../awa-testing", version = "0.6.0-alpha.6" }
 assert_cmd = "2"
 serde.workspace = true
 uuid.workspace = true

--- a/awa-cli/pyproject.toml
+++ b/awa-cli/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "awa-cli"
-version = "0.6.0-alpha.5"
+version = "0.6.0-alpha.6"
 description = "CLI for the Awa Postgres-native job queue (migrations, admin, serve)"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/awa-python/Cargo.lock
+++ b/awa-python/Cargo.lock
@@ -95,7 +95,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "awa-macros"
-version = "0.6.0-alpha.4"
+version = "0.6.0-alpha.6"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -104,8 +104,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "awa-metrics"
+version = "0.6.0-alpha.6"
+dependencies = [
+ "awa-model",
+ "opentelemetry",
+]
+
+[[package]]
 name = "awa-model"
-version = "0.6.0-alpha.4"
+version = "0.6.0-alpha.6"
 dependencies = [
  "awa-macros",
  "blake3",
@@ -125,7 +133,7 @@ dependencies = [
 
 [[package]]
 name = "awa-python"
-version = "0.6.0-alpha.4"
+version = "0.6.0-alpha.6"
 dependencies = [
  "async-trait",
  "awa-model",
@@ -148,10 +156,11 @@ dependencies = [
 
 [[package]]
 name = "awa-worker"
-version = "0.6.0-alpha.4"
+version = "0.6.0-alpha.6"
 dependencies = [
  "async-trait",
  "awa-macros",
+ "awa-metrics",
  "awa-model",
  "chrono",
  "chrono-tz",

--- a/awa-python/Cargo.toml
+++ b/awa-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "awa-python"
-version = "0.6.0-alpha.5"
+version = "0.6.0-alpha.6"
 edition = "2021"
 
 [lib]
@@ -12,8 +12,8 @@ default = ["cel"]
 cel = ["awa-model/cel"]
 
 [dependencies]
-awa-model = { path = "../awa-model", version = "0.6.0-alpha.5" }
-awa-worker = { path = "../awa-worker", version = "0.6.0-alpha.5", features = ["__python-bridge"] }
+awa-model = { path = "../awa-model", version = "0.6.0-alpha.6" }
+awa-worker = { path = "../awa-worker", version = "0.6.0-alpha.6", features = ["__python-bridge"] }
 pyo3 = { version = "0.28", features = ["macros", "abi3-py310", "chrono"] }
 pyo3-async-runtimes = { version = "0.28", features = ["tokio-runtime"] }
 sqlx = { version = "0.8", features = ["runtime-tokio-rustls", "postgres", "chrono", "json"] }

--- a/awa-python/pyproject.toml
+++ b/awa-python/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "maturin"
 [project]
 name = "awa-pg"
 requires-python = ">=3.10"
-version = "0.6.0-alpha.5"
+version = "0.6.0-alpha.6"
 description = "Postgres-native background job queue — Python SDK with async/sync workers, transactional enqueue, and progress tracking. Install awa-pg[ui] to add the bundled web dashboard."
 readme = {file = "../README.md", content-type = "text/markdown"}
 license = {text = "MIT OR Apache-2.0"}
@@ -32,7 +32,7 @@ classifiers = [
 #
 # Kept opt-in so the default `awa-pg` install stays small — workers and
 # producers don't need the ~10 MB UI bundle.
-ui = ["awa-cli==0.6.0-alpha.5"]
+ui = ["awa-cli==0.6.0-alpha.6"]
 
 [project.urls]
 Homepage = "https://github.com/hardbyte/awa"


### PR DESCRIPTION
Release prep for `0.6.0-alpha.6`.

## What landed since alpha.5

- **#232** — Extract `awa-metrics` crate (closes #176). `AwaMetrics` moves to a dedicated crate so `awa-ui` and other non-runtime callers share the worker's OTel counter definitions; constants in `awa-metrics::names` drive `AwaMetrics::new()` so registered instruments and public names can't drift.
- **#235** — Two queue-storage round-trip reductions: multi-queue NOTIFY collapses to one statement, and completion `attempt_state` cleanup merges into the lease-delete CTE.
- **dlq_retried tagging fix** — single-job DLQ retry from `awa-ui` now tags `awa.job.dlq_retried` with the source queue, not the (possibly-overridden) destination queue.

## Version touch list

- `Cargo.toml` workspace package + four internal `[workspace.dependencies]` versions
- `awa-python/Cargo.toml` package + two internal deps
- `awa-python/pyproject.toml` `project.version` and the `[ui]` extra's `awa-cli==` pin
- `awa-cli/Cargo.toml` two internal deps
- `awa-cli/pyproject.toml` `project.version`
- Both `Cargo.lock`s
- CHANGELOG entry

## Validation

- `cargo build --workspace` clean
- `cargo clippy --workspace --all-targets -- -D warnings` clean
- `cargo fmt --all`
- `awa-python` builds against the new `0.6.0-alpha.6` Cargo path-deps
- The `version-check` job in `release.yml` parses every TOML field above; this commit was prepped to satisfy it