### PR TITLE
Fix cron evaluation starvation

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,8 @@ client.periodic(
     "daily_report", "0 9 * * *",
     GenerateReport, GenerateReport(format="pdf"),
     timezone="Pacific/Auckland",
+    # missed_fire_policy="coalesce" by default; use "catch_up" for
+    # idempotent reconciliation jobs that need every missed fire.
 )
 ```
 

--- a/awa-cli/src/main.rs
+++ b/awa-cli/src/main.rs
@@ -661,13 +661,18 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                             println!("No cron job schedules found.");
                         } else {
                             println!(
-                                "{:<25} {:<20} {:<12} {:<25} {:<10}",
-                                "NAME", "CRON", "TIMEZONE", "KIND", "QUEUE"
+                                "{:<25} {:<20} {:<12} {:<12} {:<25} {:<10}",
+                                "NAME", "CRON", "TIMEZONE", "MISSED", "KIND", "QUEUE"
                             );
                             for s in &schedules {
                                 println!(
-                                    "{:<25} {:<20} {:<12} {:<25} {:<10}",
-                                    s.name, s.cron_expr, s.timezone, s.kind, s.queue,
+                                    "{:<25} {:<20} {:<12} {:<12} {:<25} {:<10}",
+                                    s.name,
+                                    s.cron_expr,
+                                    s.timezone,
+                                    s.missed_fire_policy,
+                                    s.kind,
+                                    s.queue,
                                 );
                             }
                             println!("\n{} schedules listed.", schedules.len());

--- a/awa-model/migrations/v001_canonical_schema.sql
+++ b/awa-model/migrations/v001_canonical_schema.sql
@@ -106,6 +106,8 @@ CREATE TABLE awa.cron_jobs (
     max_attempts     SMALLINT    NOT NULL DEFAULT 25,
     tags             TEXT[]      NOT NULL DEFAULT '{}',
     metadata         JSONB       NOT NULL DEFAULT '{}',
+    missed_fire_policy TEXT      NOT NULL DEFAULT 'coalesce'
+        CHECK (missed_fire_policy IN ('coalesce', 'catch_up')),
     last_enqueued_at TIMESTAMPTZ,
     created_at       TIMESTAMPTZ NOT NULL DEFAULT now(),
     updated_at       TIMESTAMPTZ NOT NULL DEFAULT now()

--- a/awa-model/migrations/v015_cron_missed_fire_policy.sql
+++ b/awa-model/migrations/v015_cron_missed_fire_policy.sql
@@ -1,0 +1,25 @@
+-- Add explicit cron missed-fire policy.
+--
+-- Existing schedules keep the historical coalesced/latest-only behavior.
+-- New schedules can opt into catch_up to enqueue missed fire times in order.
+
+ALTER TABLE awa.cron_jobs
+  ADD COLUMN IF NOT EXISTS missed_fire_policy TEXT NOT NULL DEFAULT 'coalesce';
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'cron_jobs_missed_fire_policy_check'
+      AND conrelid = 'awa.cron_jobs'::regclass
+  ) THEN
+    ALTER TABLE awa.cron_jobs
+      ADD CONSTRAINT cron_jobs_missed_fire_policy_check
+      CHECK (missed_fire_policy IN ('coalesce', 'catch_up'));
+  END IF;
+END$$;
+
+INSERT INTO awa.schema_version (version, description)
+VALUES (15, 'Cron missed-fire policy')
+ON CONFLICT (version) DO NOTHING;

--- a/awa-model/src/cron.rs
+++ b/awa-model/src/cron.rs
@@ -10,6 +10,35 @@ use croner::Cron;
 use serde::Serialize;
 use sqlx::PgExecutor;
 
+/// How AWA handles cron fires missed because evaluation was delayed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CronMissedFirePolicy {
+    /// Enqueue only the latest due fire. This preserves pre-existing behavior.
+    Coalesce,
+    /// Enqueue each missed fire in timestamp order, subject to worker catch-up limits.
+    CatchUp,
+}
+
+impl CronMissedFirePolicy {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Coalesce => "coalesce",
+            Self::CatchUp => "catch_up",
+        }
+    }
+
+    pub fn parse(value: &str) -> Result<Self, AwaError> {
+        match value {
+            "coalesce" => Ok(Self::Coalesce),
+            "catch_up" => Ok(Self::CatchUp),
+            other => Err(AwaError::Validation(format!(
+                "invalid cron missed fire policy '{other}'"
+            ))),
+        }
+    }
+}
+
 /// A periodic job schedule definition.
 ///
 /// Created via `PeriodicJob::builder(name, cron_expr).build(args)`.
@@ -35,6 +64,8 @@ pub struct PeriodicJob {
     pub tags: Vec<String>,
     /// Extra metadata merged into created jobs.
     pub metadata: serde_json::Value,
+    /// How delayed cron evaluation handles missed scheduled fire times.
+    pub missed_fire_policy: CronMissedFirePolicy,
 }
 
 impl PeriodicJob {
@@ -52,6 +83,7 @@ impl PeriodicJob {
             max_attempts: 25,
             tags: Vec::new(),
             metadata: serde_json::json!({}),
+            missed_fire_policy: CronMissedFirePolicy::Coalesce,
         }
     }
 
@@ -122,6 +154,7 @@ pub struct PeriodicJobBuilder {
     max_attempts: i16,
     tags: Vec<String>,
     metadata: serde_json::Value,
+    missed_fire_policy: CronMissedFirePolicy,
 }
 
 impl PeriodicJobBuilder {
@@ -158,6 +191,12 @@ impl PeriodicJobBuilder {
     /// Set extra metadata for created jobs.
     pub fn metadata(mut self, metadata: serde_json::Value) -> Self {
         self.metadata = metadata;
+        self
+    }
+
+    /// Set how delayed cron evaluation handles missed scheduled fire times.
+    pub fn missed_fire_policy(mut self, policy: CronMissedFirePolicy) -> Self {
+        self.missed_fire_policy = policy;
         self
     }
 
@@ -209,6 +248,7 @@ impl PeriodicJobBuilder {
             max_attempts: self.max_attempts,
             tags: self.tags,
             metadata: self.metadata,
+            missed_fire_policy: self.missed_fire_policy,
         })
     }
 }
@@ -226,6 +266,7 @@ pub struct CronJobRow {
     pub max_attempts: i16,
     pub tags: Vec<String>,
     pub metadata: serde_json::Value,
+    pub missed_fire_policy: String,
     pub last_enqueued_at: Option<DateTime<Utc>>,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
@@ -240,8 +281,8 @@ where
 {
     sqlx::query(
         r#"
-        INSERT INTO awa.cron_jobs (name, cron_expr, timezone, kind, queue, args, priority, max_attempts, tags, metadata)
-        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+        INSERT INTO awa.cron_jobs (name, cron_expr, timezone, kind, queue, args, priority, max_attempts, tags, metadata, missed_fire_policy)
+        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
         ON CONFLICT (name) DO UPDATE SET
             cron_expr = EXCLUDED.cron_expr,
             timezone = EXCLUDED.timezone,
@@ -252,6 +293,7 @@ where
             max_attempts = EXCLUDED.max_attempts,
             tags = EXCLUDED.tags,
             metadata = EXCLUDED.metadata,
+            missed_fire_policy = EXCLUDED.missed_fire_policy,
             updated_at = now()
         "#,
     )
@@ -265,6 +307,7 @@ where
     .bind(job.max_attempts)
     .bind(&job.tags)
     .bind(&job.metadata)
+    .bind(job.missed_fire_policy.as_str())
     .execute(executor)
     .await?;
 
@@ -427,6 +470,7 @@ mod tests {
             max_attempts: 25,
             tags: vec![],
             metadata: serde_json::json!({}),
+            missed_fire_policy: CronMissedFirePolicy::Coalesce,
         }
     }
 

--- a/awa-model/src/lib.rs
+++ b/awa-model/src/lib.rs
@@ -25,7 +25,7 @@ pub use admin::{
 /// additional descriptor fields this alias predates.
 #[deprecated(since = "0.5.4", note = "use `QueueOverview` instead")]
 pub type QueueStats = QueueOverview;
-pub use cron::{CronJobRow, PeriodicJob, PeriodicJobBuilder};
+pub use cron::{CronJobRow, CronMissedFirePolicy, PeriodicJob, PeriodicJobBuilder};
 pub use dlq::{DlqMetadata, DlqRow, ListDlqFilter, RetryFromDlqOpts};
 pub use error::AwaError;
 pub use insert::{insert, insert_many, insert_many_copy, insert_many_copy_from_pool, insert_with};

--- a/awa-model/src/migrations.rs
+++ b/awa-model/src/migrations.rs
@@ -4,7 +4,7 @@ use sqlx::PgPool;
 use tracing::info;
 
 /// Current schema version.
-pub const CURRENT_VERSION: i32 = 14;
+pub const CURRENT_VERSION: i32 = 15;
 
 /// All migrations in order. SQL lives in `awa-model/migrations/*.sql`
 /// for easy inspection by users who run their own migration tooling.
@@ -62,6 +62,7 @@ const MIGRATIONS: &[(i32, &str, &[&str])] = &[
         "Storage transition role tracking and tightened mixed-transition gate",
         &[V14_UP],
     ),
+    (15, "Cron missed-fire policy", &[V15_UP]),
 ];
 
 const V1_UP: &str = include_str!("../migrations/v001_canonical_schema.sql");
@@ -77,6 +78,7 @@ const V11_UP: &str = include_str!("../migrations/v011_storage_transition_self_he
 const V12_UP: &str = include_str!("../migrations/v012_queue_storage_compat.sql");
 const V13_UP: &str = include_str!("../migrations/v013_storage_auto_finalize.sql");
 const V14_UP: &str = include_str!("../migrations/v014_storage_transition_role.sql");
+const V15_UP: &str = include_str!("../migrations/v015_cron_missed_fire_policy.sql");
 
 /// Old version numbers from pre-0.4 releases that used V3/V4/V5 numbering.
 /// Also tolerates the unreleased inline-V6 branch numbering used during review.

--- a/awa-python/python/awa/__main__.py
+++ b/awa-python/python/awa/__main__.py
@@ -469,10 +469,14 @@ async def _dispatch_cron(client: "awa.AsyncClient", args: argparse.Namespace) ->
         if not rows:
             print("No cron job schedules found.")
             return
-        print(f"{'NAME':<25} {'CRON':<20} {'TIMEZONE':<12} {'KIND':<25} {'QUEUE':<10}")
+        print(
+            f"{'NAME':<25} {'CRON':<20} {'TIMEZONE':<12} "
+            f"{'MISSED':<12} {'KIND':<25} {'QUEUE':<10}"
+        )
         for s in rows:
             print(
                 f"{s['name']:<25} {s['cron_expr']:<20} {s['timezone']:<12} "
+                f"{s.get('missed_fire_policy', 'coalesce'):<12} "
                 f"{s['kind']:<25} {s['queue']:<10}"
             )
         print(f"\n{len(rows)} schedules listed.")

--- a/awa-python/python/awa/client.py
+++ b/awa-python/python/awa/client.py
@@ -535,8 +535,14 @@ class AsyncClient:
         max_attempts: int = 25,
         tags: list[str] | None = None,
         metadata: dict[str, Any] | None = None,
+        missed_fire_policy: str = "coalesce",
     ) -> None:
-        """Register a periodic (cron) job schedule."""
+        """Register a periodic (cron) job schedule.
+
+        ``missed_fire_policy`` controls delayed evaluation: ``"coalesce"``
+        enqueues only the latest due fire, while ``"catch_up"`` enqueues each
+        missed fire in order.
+        """
         return self._raw.periodic(
             name,
             cron_expr,
@@ -548,6 +554,7 @@ class AsyncClient:
             max_attempts=max_attempts,
             tags=tags if tags is not None else [],
             metadata=metadata,
+            missed_fire_policy=missed_fire_policy,
         )
 
     def queue_descriptor(

--- a/awa-python/src/client.rs
+++ b/awa-python/src/client.rs
@@ -7,7 +7,8 @@ use crate::transaction::{
 use crate::worker::PythonWorker;
 use awa_model::admin::{JobKindDescriptor, ListJobsFilter, QueueDescriptor};
 use awa_model::{
-    InsertOpts, InsertParams, JobState, PeriodicJob, QueueStorage, QueueStorageConfig,
+    CronMissedFirePolicy, InsertOpts, InsertParams, JobState, PeriodicJob, QueueStorage,
+    QueueStorageConfig,
 };
 use chrono::{DateTime, Utc};
 use pyo3::prelude::*;
@@ -681,7 +682,7 @@ impl PyClient {
     ///
     /// The schedule is synced to the database by the leader and evaluated
     /// every second to enqueue jobs when they're due.
-    #[pyo3(signature = (name, cron_expr, args_type, args, *, timezone="UTC".to_string(), queue="default".to_string(), priority=2, max_attempts=25, tags=vec![], metadata=None))]
+    #[pyo3(signature = (name, cron_expr, args_type, args, *, timezone="UTC".to_string(), queue="default".to_string(), priority=2, max_attempts=25, tags=vec![], metadata=None, missed_fire_policy="coalesce".to_string()))]
     #[allow(clippy::too_many_arguments)]
     fn periodic(
         &self,
@@ -696,6 +697,7 @@ impl PyClient {
         max_attempts: i16,
         tags: Vec<String>,
         metadata: Option<Py<PyAny>>,
+        missed_fire_policy: String,
     ) -> PyResult<()> {
         let args_bound = args.bind(py);
         let kind = {
@@ -708,6 +710,8 @@ impl PyClient {
             .map(|value| py_to_json(py, value.bind(py)))
             .transpose()?
             .unwrap_or(serde_json::json!({}));
+        let missed_fire_policy =
+            CronMissedFirePolicy::parse(&missed_fire_policy).map_err(map_awa_error)?;
 
         let periodic_job = PeriodicJob::builder(&name, &cron_expr)
             .timezone(&timezone)
@@ -716,6 +720,7 @@ impl PyClient {
             .max_attempts(max_attempts)
             .tags(tags)
             .metadata(metadata_json)
+            .missed_fire_policy(missed_fire_policy)
             .build_raw(kind, args_json)
             .map_err(map_awa_error)?;
 

--- a/awa-python/tests/test_periodic.py
+++ b/awa-python/tests/test_periodic.py
@@ -38,7 +38,7 @@ async def _wait_for_cron_job(client, name: str, timeout_seconds: float = 5.0):
     while asyncio.get_running_loop().time() < deadline:
         tx = await client.transaction()
         row = await tx.fetch_optional(
-            "SELECT name, cron_expr, timezone, kind, queue, args, priority, max_attempts, tags, metadata "
+            "SELECT name, cron_expr, timezone, kind, queue, args, priority, max_attempts, tags, metadata, missed_fire_policy "
             "FROM awa.cron_jobs WHERE name = $1",
             name,
         )
@@ -88,6 +88,7 @@ async def test_periodic_registration(client):
     assert row is not None, "cron job should be synced to database"
     assert row["cron_expr"] == "0 9 * * *"
     assert row["timezone"] == "Pacific/Auckland"
+    assert row["missed_fire_policy"] == "coalesce"
     assert row["kind"] == "daily_report"
     assert row["queue"] == queue
 
@@ -111,6 +112,7 @@ async def test_periodic_with_metadata_and_tags(client):
         max_attempts=3,
         tags=["sync", "hourly"],
         metadata={"team": "platform"},
+        missed_fire_policy="catch_up",
     )
 
     await client.start([(queue, 1)], **RUNTIME_START_KWARGS)
@@ -122,6 +124,7 @@ async def test_periodic_with_metadata_and_tags(client):
     assert row["max_attempts"] == 3
     assert row["tags"] == ["sync", "hourly"]
     assert row["metadata"]["team"] == "platform"
+    assert row["missed_fire_policy"] == "catch_up"
 
 
 @pytest.mark.asyncio

--- a/awa-worker/src/lib.rs
+++ b/awa-worker/src/lib.rs
@@ -14,7 +14,7 @@ mod runtime;
 mod storage;
 
 // Re-exports
-pub use awa_model::{CallbackConfig, PeriodicJob, PeriodicJobBuilder};
+pub use awa_model::{CallbackConfig, CronMissedFirePolicy, PeriodicJob, PeriodicJobBuilder};
 pub use client::{
     BuildError, Client, ClientBuilder, HealthCheck, QueueCapacity, QueueHealth,
     TransitionWorkerRole,

--- a/awa-worker/src/maintenance.rs
+++ b/awa-worker/src/maintenance.rs
@@ -1482,9 +1482,13 @@ fn compute_fire_times(
     let should_catch_up =
         row.last_enqueued_at.is_some() && missed_fire_policy == CronMissedFirePolicy::CatchUp;
 
-    let mut fire_times = Vec::new();
-    let mut latest_fire: Option<chrono::DateTime<Utc>> = None;
+    if !should_catch_up {
+        return latest_due_fire(&cron, tz, search_start, row.last_enqueued_at, now)
+            .into_iter()
+            .collect();
+    }
 
+    let mut fire_times = Vec::new();
     for fire_time in cron.iter_from(search_start) {
         let fire_utc = fire_time.with_timezone(&Utc);
 
@@ -1498,22 +1502,90 @@ fn compute_fire_times(
             }
         }
 
-        if !should_catch_up {
-            latest_fire = Some(fire_utc);
-            continue;
-        }
-
         fire_times.push(fire_utc);
         if fire_times.len() >= limit {
             break;
         }
     }
 
-    if should_catch_up {
-        fire_times
-    } else {
-        latest_fire.into_iter().collect()
+    fire_times
+}
+
+fn latest_due_fire(
+    cron: &Cron,
+    tz: chrono_tz::Tz,
+    search_start: chrono::DateTime<chrono_tz::Tz>,
+    last_enqueued_at: Option<chrono::DateTime<Utc>>,
+    now: chrono::DateTime<Utc>,
+) -> Option<chrono::DateTime<Utc>> {
+    let first_due = first_due_fire(cron, search_start, last_enqueued_at, now)?;
+    let total_span_seconds = now.signed_duration_since(first_due).num_seconds().max(1);
+    let mut lookback_seconds = 1_i64;
+
+    loop {
+        // Croner has no previous-occurrence iterator. Search backward from
+        // `now` with an exponentially growing window, then scan only that
+        // small window to preserve coalesced/latest-only semantics.
+        let window_start_utc = (now - chrono::Duration::seconds(lookback_seconds)).max(first_due);
+        let window_start = window_start_utc.with_timezone(&tz);
+        let next_in_window = cron
+            .iter_from(window_start)
+            .next()
+            .map(|fire_time| fire_time.with_timezone(&Utc));
+
+        if next_in_window.is_some_and(|fire_utc| {
+            fire_utc <= now && last_enqueued_at.is_none_or(|last| fire_utc > last)
+        }) {
+            return latest_due_fire_in_window(cron, window_start, last_enqueued_at, now)
+                .or(Some(first_due));
+        }
+
+        if lookback_seconds >= total_span_seconds {
+            return Some(first_due);
+        }
+
+        lookback_seconds = lookback_seconds.saturating_mul(2).min(total_span_seconds);
     }
+}
+
+fn first_due_fire(
+    cron: &Cron,
+    search_start: chrono::DateTime<chrono_tz::Tz>,
+    last_enqueued_at: Option<chrono::DateTime<Utc>>,
+    now: chrono::DateTime<Utc>,
+) -> Option<chrono::DateTime<Utc>> {
+    for fire_time in cron.iter_from(search_start) {
+        let fire_utc = fire_time.with_timezone(&Utc);
+        if fire_utc > now {
+            return None;
+        }
+        if last_enqueued_at.is_none_or(|last| fire_utc > last) {
+            return Some(fire_utc);
+        }
+    }
+
+    None
+}
+
+fn latest_due_fire_in_window(
+    cron: &Cron,
+    window_start: chrono::DateTime<chrono_tz::Tz>,
+    last_enqueued_at: Option<chrono::DateTime<Utc>>,
+    now: chrono::DateTime<Utc>,
+) -> Option<chrono::DateTime<Utc>> {
+    let mut latest_fire = None;
+
+    for fire_time in cron.iter_from(window_start) {
+        let fire_utc = fire_time.with_timezone(&Utc);
+        if fire_utc > now {
+            break;
+        }
+        if last_enqueued_at.is_none_or(|last| fire_utc > last) {
+            latest_fire = Some(fire_utc);
+        }
+    }
+
+    latest_fire
 }
 
 impl MaintenanceService {
@@ -1796,6 +1868,25 @@ mod tests {
         );
 
         let fires = compute_fire_times(&row, now, CRON_CATCH_UP_LIMIT);
+
+        assert_eq!(
+            fires,
+            vec![Utc.with_ymd_and_hms(2026, 5, 7, 12, 0, 20).unwrap()]
+        );
+    }
+
+    #[test]
+    fn compute_fire_times_coalesces_to_latest_fire_after_long_outage() {
+        let last = Utc.with_ymd_and_hms(2026, 5, 6, 12, 0, 0).unwrap();
+        let now = Utc.with_ymd_and_hms(2026, 5, 7, 12, 0, 20).unwrap();
+        let row = cron_row(
+            "*/1 * * * * *",
+            last,
+            Some(last),
+            CronMissedFirePolicy::Coalesce,
+        );
+
+        let fires = compute_fire_times(&row, now, 2);
 
         assert_eq!(
             fires,

--- a/awa-worker/src/maintenance.rs
+++ b/awa-worker/src/maintenance.rs
@@ -11,6 +11,7 @@ use std::collections::{HashMap, HashSet};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
+use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, info, warn};
 
@@ -81,6 +82,7 @@ pub struct MaintenanceService {
 
 const PROMOTE_BATCH_SIZE: i64 = 4_096;
 const PROMOTE_MAX_BATCHES_PER_TICK: usize = 32;
+const CRON_CATCH_UP_LIMIT: usize = 1_000;
 type QueueStorageMetricRow = (String, i64, i64, i64, i64, i64, i64, i64, Option<f64>);
 
 impl MaintenanceService {
@@ -303,7 +305,6 @@ impl MaintenanceService {
             let mut promote_timer = tokio::time::interval(self.promote_interval);
             let mut cleanup_timer = tokio::time::interval(self.cleanup_interval);
             let mut cron_sync_timer = tokio::time::interval(self.cron_sync_interval);
-            let mut cron_eval_timer = tokio::time::interval(self.cron_eval_interval);
             let mut leader_check_timer = tokio::time::interval(self.leader_check_interval);
             let mut queue_stats_timer = tokio::time::interval(self.queue_stats_interval);
             let mut dirty_key_timer = tokio::time::interval(self.dirty_key_recompute_interval);
@@ -330,7 +331,6 @@ impl MaintenanceService {
             promote_timer.tick().await;
             cleanup_timer.tick().await;
             cron_sync_timer.tick().await;
-            cron_eval_timer.tick().await;
             leader_check_timer.tick().await;
             queue_stats_timer.tick().await;
             dirty_key_timer.tick().await;
@@ -348,12 +348,19 @@ impl MaintenanceService {
 
             // Do an initial sync immediately on becoming leader
             self.sync_periodic_jobs_to_db().await;
+            let cron_eval_cancel = self.cancel.child_token();
+            let cron_eval_task = tokio::spawn(Self::run_cron_evaluator(
+                self.pool.clone(),
+                cron_eval_cancel.clone(),
+                self.cron_eval_interval,
+            ));
 
             loop {
                 tokio::select! {
                     _ = self.cancel.cancelled() => {
                         debug!("Maintenance service shutting down");
                         self.leader.store(false, Ordering::SeqCst);
+                        Self::stop_cron_evaluator(&cron_eval_cancel, &cron_eval_task);
                         // Release leader lock on the same connection that acquired it.
                         // If this fails, dropping the connection will release the lock anyway.
                         let _ = Self::release_leader(&mut leader_conn).await;
@@ -379,9 +386,6 @@ impl MaintenanceService {
                     }
                     _ = cron_sync_timer.tick() => {
                         self.sync_periodic_jobs_to_db().await;
-                    }
-                    _ = cron_eval_timer.tick() => {
-                        self.evaluate_cron_schedules().await;
                     }
                     _ = queue_stats_timer.tick() => {
                         self.publish_queue_health_metrics().await;
@@ -429,6 +433,7 @@ impl MaintenanceService {
                         if sqlx::query("SELECT 1").execute(&mut *leader_conn).await.is_err() {
                             warn!("Leader connection lost, re-entering election loop");
                             self.leader.store(false, Ordering::SeqCst);
+                            Self::stop_cron_evaluator(&cron_eval_cancel, &cron_eval_task);
                             break;
                         }
                     }
@@ -470,6 +475,25 @@ impl MaintenanceService {
         Ok(())
     }
 
+    async fn run_cron_evaluator(pool: PgPool, cancel: CancellationToken, interval: Duration) {
+        let mut timer = tokio::time::interval(interval);
+        timer.tick().await;
+
+        loop {
+            tokio::select! {
+                _ = cancel.cancelled() => return,
+                _ = timer.tick() => {
+                    Self::evaluate_cron_schedules(&pool).await;
+                }
+            }
+        }
+    }
+
+    fn stop_cron_evaluator(cancel: &CancellationToken, task: &JoinHandle<()>) {
+        cancel.cancel();
+        task.abort();
+    }
+
     /// Sync all registered periodic job schedules to `awa.cron_jobs` via UPSERT.
     ///
     /// Additive only — does NOT delete schedules not in the local set (multi-deployment safe).
@@ -493,12 +517,13 @@ impl MaintenanceService {
 
     /// Evaluate all cron schedules and enqueue any that are due.
     ///
-    /// For each schedule, computes the latest fire time ≤ now that is after
-    /// `last_enqueued_at`. If a fire is due, executes the atomic CTE to
-    /// mark + insert in one statement.
-    #[tracing::instrument(skip(self), name = "maintenance.cron_eval")]
-    async fn evaluate_cron_schedules(&self) {
-        let cron_rows = match list_cron_jobs(&self.pool).await {
+    /// For each schedule, computes due fire times ≤ now that are after
+    /// `last_enqueued_at`. If fires are due, executes the atomic CTE for each
+    /// fire in order so delayed evaluation catches up instead of collapsing
+    /// intermediate fires.
+    #[tracing::instrument(skip(pool), name = "maintenance.cron_eval")]
+    async fn evaluate_cron_schedules(pool: &PgPool) {
+        let cron_rows = match list_cron_jobs(pool).await {
             Ok(rows) => rows,
             Err(err) => {
                 error!(error = %err, "Failed to load cron jobs for evaluation");
@@ -513,30 +538,43 @@ impl MaintenanceService {
         let now = Utc::now();
 
         for row in &cron_rows {
-            let fire_time = match compute_fire_time(row, now) {
-                Some(time) => time,
-                None => continue,
-            };
+            let fire_times = compute_fire_times(row, now, CRON_CATCH_UP_LIMIT);
+            if fire_times.is_empty() {
+                continue;
+            }
+            if fire_times.len() == CRON_CATCH_UP_LIMIT {
+                warn!(
+                    cron_name = %row.name,
+                    catch_up_limit = CRON_CATCH_UP_LIMIT,
+                    "Cron catch-up limit reached; remaining due fires will be retried on the next evaluation"
+                );
+            }
 
-            match atomic_enqueue(&self.pool, &row.name, fire_time, row.last_enqueued_at).await {
-                Ok(Some(job)) => {
-                    info!(
-                        cron_name = %row.name,
-                        job_id = job.id,
-                        fire_time = %fire_time,
-                        "Enqueued periodic job"
-                    );
-                }
-                Ok(None) => {
-                    // Another leader already claimed this fire — not an error
-                    debug!(cron_name = %row.name, "Cron fire already claimed");
-                }
-                Err(err) => {
-                    error!(
-                        cron_name = %row.name,
-                        error = %err,
-                        "Failed to enqueue periodic job"
-                    );
+            let mut previous_enqueued_at = row.last_enqueued_at;
+            for fire_time in fire_times {
+                match atomic_enqueue(pool, &row.name, fire_time, previous_enqueued_at).await {
+                    Ok(Some(job)) => {
+                        previous_enqueued_at = Some(fire_time);
+                        info!(
+                            cron_name = %row.name,
+                            job_id = job.id,
+                            fire_time = %fire_time,
+                            "Enqueued periodic job"
+                        );
+                    }
+                    Ok(None) => {
+                        // Another leader already claimed this fire — not an error
+                        debug!(cron_name = %row.name, "Cron fire already claimed");
+                        break;
+                    }
+                    Err(err) => {
+                        error!(
+                            cron_name = %row.name,
+                            error = %err,
+                            "Failed to enqueue periodic job"
+                        );
+                        break;
+                    }
                 }
             }
         }
@@ -1397,18 +1435,21 @@ impl Drop for MaintenanceAliveGuard {
     }
 }
 
-/// Compute the latest fire time for a cron job row, using its expression and timezone.
+/// Compute due fire times for a cron job row, using its expression and timezone.
 ///
-/// Returns `None` if no fire is due (next occurrence is in the future).
-fn compute_fire_time(
+/// Existing schedules catch up missed fires up to `limit`. First registration
+/// still enqueues only the latest due fire to avoid backfilling before the
+/// schedule was known to AWA.
+fn compute_fire_times(
     row: &CronJobRow,
     now: chrono::DateTime<Utc>,
-) -> Option<chrono::DateTime<Utc>> {
+    limit: usize,
+) -> Vec<chrono::DateTime<Utc>> {
     let cron = match Cron::new(&row.cron_expr).with_seconds_optional().parse() {
         Ok(c) => c,
         Err(err) => {
             error!(cron_name = %row.name, error = %err, "Invalid cron expression in database");
-            return None;
+            return Vec::new();
         }
     };
 
@@ -1416,7 +1457,7 @@ fn compute_fire_time(
         Ok(tz) => tz,
         Err(err) => {
             error!(cron_name = %row.name, error = %err, "Invalid timezone in database");
-            return None;
+            return Vec::new();
         }
     };
 
@@ -1429,6 +1470,7 @@ fn compute_fire_time(
         None => (row.created_at - chrono::Duration::minutes(1)).with_timezone(&tz),
     };
 
+    let mut fire_times = Vec::new();
     let mut latest_fire: Option<chrono::DateTime<Utc>> = None;
 
     for fire_time in cron.iter_from(search_start) {
@@ -1444,10 +1486,100 @@ fn compute_fire_time(
             }
         }
 
-        latest_fire = Some(fire_utc);
+        if row.last_enqueued_at.is_none() {
+            latest_fire = Some(fire_utc);
+            continue;
+        }
+
+        fire_times.push(fire_utc);
+        if fire_times.len() >= limit {
+            break;
+        }
     }
 
-    latest_fire
+    if row.last_enqueued_at.is_none() {
+        latest_fire.into_iter().collect()
+    } else {
+        fire_times
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+
+    fn cron_row(
+        cron_expr: &str,
+        created_at: chrono::DateTime<Utc>,
+        last_enqueued_at: Option<chrono::DateTime<Utc>>,
+    ) -> CronJobRow {
+        CronJobRow {
+            name: "test_cron".to_string(),
+            cron_expr: cron_expr.to_string(),
+            timezone: "UTC".to_string(),
+            kind: "test_job".to_string(),
+            queue: "default".to_string(),
+            args: serde_json::json!({}),
+            priority: 2,
+            max_attempts: 25,
+            tags: Vec::new(),
+            metadata: serde_json::json!({}),
+            last_enqueued_at,
+            created_at,
+            updated_at: created_at,
+        }
+    }
+
+    #[test]
+    fn compute_fire_times_catches_up_missed_existing_fires() {
+        let last = Utc.with_ymd_and_hms(2026, 5, 7, 12, 0, 0).unwrap();
+        let now = Utc.with_ymd_and_hms(2026, 5, 7, 12, 0, 20).unwrap();
+        let row = cron_row("*/5 * * * * *", last, Some(last));
+
+        let fires = compute_fire_times(&row, now, CRON_CATCH_UP_LIMIT);
+
+        assert_eq!(
+            fires,
+            vec![
+                Utc.with_ymd_and_hms(2026, 5, 7, 12, 0, 5).unwrap(),
+                Utc.with_ymd_and_hms(2026, 5, 7, 12, 0, 10).unwrap(),
+                Utc.with_ymd_and_hms(2026, 5, 7, 12, 0, 15).unwrap(),
+                Utc.with_ymd_and_hms(2026, 5, 7, 12, 0, 20).unwrap(),
+            ]
+        );
+    }
+
+    #[test]
+    fn compute_fire_times_limits_catch_up_work() {
+        let last = Utc.with_ymd_and_hms(2026, 5, 7, 12, 0, 0).unwrap();
+        let now = Utc.with_ymd_and_hms(2026, 5, 7, 12, 0, 30).unwrap();
+        let row = cron_row("*/5 * * * * *", last, Some(last));
+
+        let fires = compute_fire_times(&row, now, 2);
+
+        assert_eq!(
+            fires,
+            vec![
+                Utc.with_ymd_and_hms(2026, 5, 7, 12, 0, 5).unwrap(),
+                Utc.with_ymd_and_hms(2026, 5, 7, 12, 0, 10).unwrap(),
+            ]
+        );
+    }
+
+    #[test]
+    fn compute_fire_times_keeps_first_registration_latest_only() {
+        let created_at = Utc.with_ymd_and_hms(2026, 5, 7, 12, 0, 30).unwrap();
+        let now = Utc.with_ymd_and_hms(2026, 5, 7, 12, 0, 55).unwrap();
+        let row = cron_row("*/5 * * * * *", created_at, None);
+
+        let fires = compute_fire_times(&row, now, CRON_CATCH_UP_LIMIT);
+
+        assert_eq!(
+            fires,
+            vec![Utc.with_ymd_and_hms(2026, 5, 7, 12, 0, 55).unwrap()]
+        );
+    }
 }
 
 impl MaintenanceService {

--- a/awa-worker/src/maintenance.rs
+++ b/awa-worker/src/maintenance.rs
@@ -1516,120 +1516,6 @@ fn compute_fire_times(
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use chrono::TimeZone;
-
-    fn cron_row(
-        cron_expr: &str,
-        created_at: chrono::DateTime<Utc>,
-        last_enqueued_at: Option<chrono::DateTime<Utc>>,
-        missed_fire_policy: CronMissedFirePolicy,
-    ) -> CronJobRow {
-        CronJobRow {
-            name: "test_cron".to_string(),
-            cron_expr: cron_expr.to_string(),
-            timezone: "UTC".to_string(),
-            kind: "test_job".to_string(),
-            queue: "default".to_string(),
-            args: serde_json::json!({}),
-            priority: 2,
-            max_attempts: 25,
-            tags: Vec::new(),
-            metadata: serde_json::json!({}),
-            missed_fire_policy: missed_fire_policy.as_str().to_string(),
-            last_enqueued_at,
-            created_at,
-            updated_at: created_at,
-        }
-    }
-
-    #[test]
-    fn compute_fire_times_coalesces_missed_existing_fires_by_default() {
-        let last = Utc.with_ymd_and_hms(2026, 5, 7, 12, 0, 0).unwrap();
-        let now = Utc.with_ymd_and_hms(2026, 5, 7, 12, 0, 20).unwrap();
-        let row = cron_row(
-            "*/5 * * * * *",
-            last,
-            Some(last),
-            CronMissedFirePolicy::Coalesce,
-        );
-
-        let fires = compute_fire_times(&row, now, CRON_CATCH_UP_LIMIT);
-
-        assert_eq!(
-            fires,
-            vec![Utc.with_ymd_and_hms(2026, 5, 7, 12, 0, 20).unwrap()]
-        );
-    }
-
-    #[test]
-    fn compute_fire_times_catches_up_when_policy_requests_it() {
-        let last = Utc.with_ymd_and_hms(2026, 5, 7, 12, 0, 0).unwrap();
-        let now = Utc.with_ymd_and_hms(2026, 5, 7, 12, 0, 20).unwrap();
-        let row = cron_row(
-            "*/5 * * * * *",
-            last,
-            Some(last),
-            CronMissedFirePolicy::CatchUp,
-        );
-
-        let fires = compute_fire_times(&row, now, CRON_CATCH_UP_LIMIT);
-
-        assert_eq!(
-            fires,
-            vec![
-                Utc.with_ymd_and_hms(2026, 5, 7, 12, 0, 5).unwrap(),
-                Utc.with_ymd_and_hms(2026, 5, 7, 12, 0, 10).unwrap(),
-                Utc.with_ymd_and_hms(2026, 5, 7, 12, 0, 15).unwrap(),
-                Utc.with_ymd_and_hms(2026, 5, 7, 12, 0, 20).unwrap(),
-            ]
-        );
-    }
-
-    #[test]
-    fn compute_fire_times_limits_catch_up_work() {
-        let last = Utc.with_ymd_and_hms(2026, 5, 7, 12, 0, 0).unwrap();
-        let now = Utc.with_ymd_and_hms(2026, 5, 7, 12, 0, 30).unwrap();
-        let row = cron_row(
-            "*/5 * * * * *",
-            last,
-            Some(last),
-            CronMissedFirePolicy::CatchUp,
-        );
-
-        let fires = compute_fire_times(&row, now, 2);
-
-        assert_eq!(
-            fires,
-            vec![
-                Utc.with_ymd_and_hms(2026, 5, 7, 12, 0, 5).unwrap(),
-                Utc.with_ymd_and_hms(2026, 5, 7, 12, 0, 10).unwrap(),
-            ]
-        );
-    }
-
-    #[test]
-    fn compute_fire_times_keeps_first_registration_latest_only() {
-        let created_at = Utc.with_ymd_and_hms(2026, 5, 7, 12, 0, 30).unwrap();
-        let now = Utc.with_ymd_and_hms(2026, 5, 7, 12, 0, 55).unwrap();
-        let row = cron_row(
-            "*/5 * * * * *",
-            created_at,
-            None,
-            CronMissedFirePolicy::CatchUp,
-        );
-
-        let fires = compute_fire_times(&row, now, CRON_CATCH_UP_LIMIT);
-
-        assert_eq!(
-            fires,
-            vec![Utc.with_ymd_and_hms(2026, 5, 7, 12, 0, 55).unwrap()]
-        );
-    }
-}
-
 impl MaintenanceService {
     /// Clean up runtime snapshots older than 24 hours.
     /// Runs as part of the leader's cleanup cycle (not on every snapshot publish).
@@ -1866,5 +1752,119 @@ impl MaintenanceService {
                 self.metrics.record_queue_lag(&queue, lag_seconds);
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+
+    fn cron_row(
+        cron_expr: &str,
+        created_at: chrono::DateTime<Utc>,
+        last_enqueued_at: Option<chrono::DateTime<Utc>>,
+        missed_fire_policy: CronMissedFirePolicy,
+    ) -> CronJobRow {
+        CronJobRow {
+            name: "test_cron".to_string(),
+            cron_expr: cron_expr.to_string(),
+            timezone: "UTC".to_string(),
+            kind: "test_job".to_string(),
+            queue: "default".to_string(),
+            args: serde_json::json!({}),
+            priority: 2,
+            max_attempts: 25,
+            tags: Vec::new(),
+            metadata: serde_json::json!({}),
+            missed_fire_policy: missed_fire_policy.as_str().to_string(),
+            last_enqueued_at,
+            created_at,
+            updated_at: created_at,
+        }
+    }
+
+    #[test]
+    fn compute_fire_times_coalesces_missed_existing_fires_by_default() {
+        let last = Utc.with_ymd_and_hms(2026, 5, 7, 12, 0, 0).unwrap();
+        let now = Utc.with_ymd_and_hms(2026, 5, 7, 12, 0, 20).unwrap();
+        let row = cron_row(
+            "*/5 * * * * *",
+            last,
+            Some(last),
+            CronMissedFirePolicy::Coalesce,
+        );
+
+        let fires = compute_fire_times(&row, now, CRON_CATCH_UP_LIMIT);
+
+        assert_eq!(
+            fires,
+            vec![Utc.with_ymd_and_hms(2026, 5, 7, 12, 0, 20).unwrap()]
+        );
+    }
+
+    #[test]
+    fn compute_fire_times_catches_up_when_policy_requests_it() {
+        let last = Utc.with_ymd_and_hms(2026, 5, 7, 12, 0, 0).unwrap();
+        let now = Utc.with_ymd_and_hms(2026, 5, 7, 12, 0, 20).unwrap();
+        let row = cron_row(
+            "*/5 * * * * *",
+            last,
+            Some(last),
+            CronMissedFirePolicy::CatchUp,
+        );
+
+        let fires = compute_fire_times(&row, now, CRON_CATCH_UP_LIMIT);
+
+        assert_eq!(
+            fires,
+            vec![
+                Utc.with_ymd_and_hms(2026, 5, 7, 12, 0, 5).unwrap(),
+                Utc.with_ymd_and_hms(2026, 5, 7, 12, 0, 10).unwrap(),
+                Utc.with_ymd_and_hms(2026, 5, 7, 12, 0, 15).unwrap(),
+                Utc.with_ymd_and_hms(2026, 5, 7, 12, 0, 20).unwrap(),
+            ]
+        );
+    }
+
+    #[test]
+    fn compute_fire_times_limits_catch_up_work() {
+        let last = Utc.with_ymd_and_hms(2026, 5, 7, 12, 0, 0).unwrap();
+        let now = Utc.with_ymd_and_hms(2026, 5, 7, 12, 0, 30).unwrap();
+        let row = cron_row(
+            "*/5 * * * * *",
+            last,
+            Some(last),
+            CronMissedFirePolicy::CatchUp,
+        );
+
+        let fires = compute_fire_times(&row, now, 2);
+
+        assert_eq!(
+            fires,
+            vec![
+                Utc.with_ymd_and_hms(2026, 5, 7, 12, 0, 5).unwrap(),
+                Utc.with_ymd_and_hms(2026, 5, 7, 12, 0, 10).unwrap(),
+            ]
+        );
+    }
+
+    #[test]
+    fn compute_fire_times_keeps_first_registration_latest_only() {
+        let created_at = Utc.with_ymd_and_hms(2026, 5, 7, 12, 0, 30).unwrap();
+        let now = Utc.with_ymd_and_hms(2026, 5, 7, 12, 0, 55).unwrap();
+        let row = cron_row(
+            "*/5 * * * * *",
+            created_at,
+            None,
+            CronMissedFirePolicy::CatchUp,
+        );
+
+        let fires = compute_fire_times(&row, now, CRON_CATCH_UP_LIMIT);
+
+        assert_eq!(
+            fires,
+            vec![Utc.with_ymd_and_hms(2026, 5, 7, 12, 0, 55).unwrap()]
+        );
     }
 }

--- a/awa-worker/src/maintenance.rs
+++ b/awa-worker/src/maintenance.rs
@@ -1,7 +1,9 @@
 use crate::executor::DlqPolicy;
 use crate::runtime::InFlightMap;
 use crate::storage::RuntimeStorage;
-use awa_model::cron::{atomic_enqueue, list_cron_jobs, upsert_cron_job, CronJobRow};
+use awa_model::cron::{
+    atomic_enqueue, list_cron_jobs, upsert_cron_job, CronJobRow, CronMissedFirePolicy,
+};
 use awa_model::{JobRow, JobState, PeriodicJob, PruneOutcome, RotateOutcome};
 use chrono::Utc;
 use croner::Cron;
@@ -1437,9 +1439,9 @@ impl Drop for MaintenanceAliveGuard {
 
 /// Compute due fire times for a cron job row, using its expression and timezone.
 ///
-/// Existing schedules catch up missed fires up to `limit`. First registration
-/// still enqueues only the latest due fire to avoid backfilling before the
-/// schedule was known to AWA.
+/// Existing schedules can catch up missed fires up to `limit` when configured.
+/// First registration always enqueues only the latest due fire to avoid
+/// backfilling before the schedule was known to AWA.
 fn compute_fire_times(
     row: &CronJobRow,
     now: chrono::DateTime<Utc>,
@@ -1470,6 +1472,16 @@ fn compute_fire_times(
         None => (row.created_at - chrono::Duration::minutes(1)).with_timezone(&tz),
     };
 
+    let missed_fire_policy = match CronMissedFirePolicy::parse(&row.missed_fire_policy) {
+        Ok(policy) => policy,
+        Err(err) => {
+            error!(cron_name = %row.name, error = %err, "Invalid cron missed-fire policy in database");
+            return Vec::new();
+        }
+    };
+    let should_catch_up =
+        row.last_enqueued_at.is_some() && missed_fire_policy == CronMissedFirePolicy::CatchUp;
+
     let mut fire_times = Vec::new();
     let mut latest_fire: Option<chrono::DateTime<Utc>> = None;
 
@@ -1486,7 +1498,7 @@ fn compute_fire_times(
             }
         }
 
-        if row.last_enqueued_at.is_none() {
+        if !should_catch_up {
             latest_fire = Some(fire_utc);
             continue;
         }
@@ -1497,10 +1509,10 @@ fn compute_fire_times(
         }
     }
 
-    if row.last_enqueued_at.is_none() {
-        latest_fire.into_iter().collect()
-    } else {
+    if should_catch_up {
         fire_times
+    } else {
+        latest_fire.into_iter().collect()
     }
 }
 
@@ -1513,6 +1525,7 @@ mod tests {
         cron_expr: &str,
         created_at: chrono::DateTime<Utc>,
         last_enqueued_at: Option<chrono::DateTime<Utc>>,
+        missed_fire_policy: CronMissedFirePolicy,
     ) -> CronJobRow {
         CronJobRow {
             name: "test_cron".to_string(),
@@ -1525,6 +1538,7 @@ mod tests {
             max_attempts: 25,
             tags: Vec::new(),
             metadata: serde_json::json!({}),
+            missed_fire_policy: missed_fire_policy.as_str().to_string(),
             last_enqueued_at,
             created_at,
             updated_at: created_at,
@@ -1532,10 +1546,34 @@ mod tests {
     }
 
     #[test]
-    fn compute_fire_times_catches_up_missed_existing_fires() {
+    fn compute_fire_times_coalesces_missed_existing_fires_by_default() {
         let last = Utc.with_ymd_and_hms(2026, 5, 7, 12, 0, 0).unwrap();
         let now = Utc.with_ymd_and_hms(2026, 5, 7, 12, 0, 20).unwrap();
-        let row = cron_row("*/5 * * * * *", last, Some(last));
+        let row = cron_row(
+            "*/5 * * * * *",
+            last,
+            Some(last),
+            CronMissedFirePolicy::Coalesce,
+        );
+
+        let fires = compute_fire_times(&row, now, CRON_CATCH_UP_LIMIT);
+
+        assert_eq!(
+            fires,
+            vec![Utc.with_ymd_and_hms(2026, 5, 7, 12, 0, 20).unwrap()]
+        );
+    }
+
+    #[test]
+    fn compute_fire_times_catches_up_when_policy_requests_it() {
+        let last = Utc.with_ymd_and_hms(2026, 5, 7, 12, 0, 0).unwrap();
+        let now = Utc.with_ymd_and_hms(2026, 5, 7, 12, 0, 20).unwrap();
+        let row = cron_row(
+            "*/5 * * * * *",
+            last,
+            Some(last),
+            CronMissedFirePolicy::CatchUp,
+        );
 
         let fires = compute_fire_times(&row, now, CRON_CATCH_UP_LIMIT);
 
@@ -1554,7 +1592,12 @@ mod tests {
     fn compute_fire_times_limits_catch_up_work() {
         let last = Utc.with_ymd_and_hms(2026, 5, 7, 12, 0, 0).unwrap();
         let now = Utc.with_ymd_and_hms(2026, 5, 7, 12, 0, 30).unwrap();
-        let row = cron_row("*/5 * * * * *", last, Some(last));
+        let row = cron_row(
+            "*/5 * * * * *",
+            last,
+            Some(last),
+            CronMissedFirePolicy::CatchUp,
+        );
 
         let fires = compute_fire_times(&row, now, 2);
 
@@ -1571,7 +1614,12 @@ mod tests {
     fn compute_fire_times_keeps_first_registration_latest_only() {
         let created_at = Utc.with_ymd_and_hms(2026, 5, 7, 12, 0, 30).unwrap();
         let now = Utc.with_ymd_and_hms(2026, 5, 7, 12, 0, 55).unwrap();
-        let row = cron_row("*/5 * * * * *", created_at, None);
+        let row = cron_row(
+            "*/5 * * * * *",
+            created_at,
+            None,
+            CronMissedFirePolicy::CatchUp,
+        );
 
         let fires = compute_fire_times(&row, now, CRON_CATCH_UP_LIMIT);
 

--- a/awa/src/lib.rs
+++ b/awa/src/lib.rs
@@ -21,9 +21,9 @@ pub use awa_model::{
 // Re-export worker runtime
 pub use awa_worker::{
     self as worker, context::ProgressState, BuildError, CallbackGuard, CallbackToken, Client,
-    ClientBuilder, HealthCheck, JobContext, JobError, JobEvent, JobResult, PeriodicJob,
-    PeriodicJobBuilder, QueueCapacity, QueueConfig, QueueHealth, RateLimit, RetentionPolicy,
-    UntypedJobEvent, Worker,
+    ClientBuilder, CronMissedFirePolicy, HealthCheck, JobContext, JobError, JobEvent, JobResult,
+    PeriodicJob, PeriodicJobBuilder, QueueCapacity, QueueConfig, QueueHealth, RateLimit,
+    RetentionPolicy, UntypedJobEvent, Worker,
 };
 
 #[cfg(feature = "http-worker")]

--- a/awa/tests/cron_test.rs
+++ b/awa/tests/cron_test.rs
@@ -6,7 +6,10 @@ use awa::model::{
     cron::{atomic_enqueue, delete_cron_job, list_cron_jobs, upsert_cron_job},
     migrations,
 };
-use awa::{Client, JobArgs, JobContext, JobResult, JobState, PeriodicJob, QueueConfig};
+use awa::{
+    Client, CronMissedFirePolicy, JobArgs, JobContext, JobResult, JobState, PeriodicJob,
+    QueueConfig,
+};
 use chrono::Utc;
 use serde::{Deserialize, Serialize};
 use sqlx::postgres::PgPoolOptions;
@@ -147,6 +150,7 @@ async fn test_upsert_inserts_new_schedule() {
     assert_eq!(found.timezone, "UTC");
     assert_eq!(found.queue, "default");
     assert_eq!(found.priority, 2);
+    assert_eq!(found.missed_fire_policy, "coalesce");
     assert!(found.last_enqueued_at.is_none());
 }
 
@@ -167,6 +171,7 @@ async fn test_upsert_updates_existing_schedule() {
     let job_v2 = PeriodicJob::builder("test_upsert_update", "30 8 * * *")
         .timezone("Pacific/Auckland")
         .queue("reports")
+        .missed_fire_policy(CronMissedFirePolicy::CatchUp)
         .build_raw(
             "daily_report".to_string(),
             serde_json::json!({"format": "csv"}),
@@ -183,6 +188,7 @@ async fn test_upsert_updates_existing_schedule() {
     assert_eq!(found.timezone, "Pacific/Auckland");
     assert_eq!(found.queue, "reports");
     assert_eq!(found.args, serde_json::json!({"format": "csv"}));
+    assert_eq!(found.missed_fire_policy, "catch_up");
 }
 
 #[tokio::test]

--- a/awa/tests/migration_test.rs
+++ b/awa/tests/migration_test.rs
@@ -9,8 +9,9 @@
 use awa::model::{insert_many, insert_many_copy_from_pool, migrations, storage, QueueStorage};
 use awa::{InsertOpts, InsertParams, JobArgs, UniqueOpts};
 use serde::{Deserialize, Serialize};
-use sqlx::postgres::{PgConnection, PgPoolOptions};
+use sqlx::postgres::{PgConnectOptions, PgConnection, PgPoolOptions};
 use sqlx::{Connection, PgPool};
+use std::str::FromStr;
 use std::sync::OnceLock;
 use tokio::sync::Mutex;
 use uuid::Uuid;
@@ -218,6 +219,70 @@ async fn active_queue_storage_schema(pool: &PgPool) -> Option<String> {
         .expect("active queue storage schema query should succeed")
 }
 
+fn assert_safe_generated_role_name(role: &str) {
+    assert!(
+        role.chars()
+            .all(|ch| ch.is_ascii_lowercase() || ch.is_ascii_digit() || ch == '_'),
+        "generated test role contains unsafe characters: {role}"
+    );
+}
+
+async fn create_login_role(pool: &PgPool, role: &str) {
+    assert_safe_generated_role_name(role);
+    sqlx::query(&format!("DROP ROLE IF EXISTS {role}"))
+        .execute(pool)
+        .await
+        .expect("test role should be dropped before create");
+    sqlx::query(&format!(
+        "CREATE ROLE {role} LOGIN PASSWORD 'awa_test_password'"
+    ))
+    .execute(pool)
+    .await
+    .expect("test role should be created");
+}
+
+async fn drop_login_role(pool: &PgPool, role: &str) {
+    assert_safe_generated_role_name(role);
+    let _ = sqlx::query(&format!("DROP ROLE IF EXISTS {role}"))
+        .execute(pool)
+        .await;
+}
+
+async fn grant_runtime_privileges(pool: &PgPool, role: &str, include_truncate: bool) {
+    assert_safe_generated_role_name(role);
+    let table_privileges = if include_truncate {
+        "SELECT, INSERT, UPDATE, DELETE, TRUNCATE"
+    } else {
+        "SELECT, INSERT, UPDATE, DELETE"
+    };
+    sqlx::raw_sql(&format!(
+        r#"
+        GRANT CONNECT ON DATABASE awa_migration_test TO {role};
+        GRANT USAGE ON SCHEMA awa TO {role};
+        GRANT USAGE, SELECT ON SEQUENCE awa.jobs_id_seq TO {role};
+        GRANT {table_privileges} ON ALL TABLES IN SCHEMA awa TO {role};
+        GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA awa TO {role};
+        "#
+    ))
+    .execute(pool)
+    .await
+    .expect("runtime grants should apply");
+}
+
+async fn runtime_pool_for_role(role: &str) -> PgPool {
+    assert_safe_generated_role_name(role);
+    let options = PgConnectOptions::from_str(&migration_database_url())
+        .expect("migration database URL should parse")
+        .username(role)
+        .password("awa_test_password");
+    PgPoolOptions::new()
+        .max_connections(1)
+        .acquire_timeout(std::time::Duration::from_secs(5))
+        .connect_with(options)
+        .await
+        .expect("runtime role should connect")
+}
+
 async fn relation_exists(pool: &PgPool, qualified_relname: &str) -> bool {
     sqlx::query_scalar("SELECT to_regclass($1) IS NOT NULL")
         .bind(qualified_relname)
@@ -322,6 +387,44 @@ async fn test_migrations_are_idempotent() {
 
     let version = migrations::current_version(&pool).await.unwrap();
     assert_eq!(version, migrations::CURRENT_VERSION);
+}
+
+#[tokio::test]
+async fn test_documented_runtime_grants_cover_admin_refresh_truncate() {
+    let _guard = acquire_migration_guard().await;
+    let pool = pool().await;
+    reset_schema(&pool).await;
+    migrations::run(&pool).await.unwrap();
+
+    let suffix = Uuid::new_v4().simple().to_string();
+    let runtime_without_truncate = format!("awa_runtime_no_truncate_{suffix}");
+    let runtime_with_truncate = format!("awa_runtime_with_truncate_{suffix}");
+
+    create_login_role(&pool, &runtime_without_truncate).await;
+    create_login_role(&pool, &runtime_with_truncate).await;
+
+    grant_runtime_privileges(&pool, &runtime_without_truncate, false).await;
+    grant_runtime_privileges(&pool, &runtime_with_truncate, true).await;
+
+    let old_doc_pool = runtime_pool_for_role(&runtime_without_truncate).await;
+    let err = awa::model::admin::refresh_admin_metadata(&old_doc_pool)
+        .await
+        .expect_err("runtime grants without TRUNCATE should fail during metadata refresh");
+    assert_eq!(
+        sqlstate_from_awa_error(&err).as_deref(),
+        Some("42501"),
+        "missing TRUNCATE should surface as insufficient_privilege"
+    );
+    old_doc_pool.close().await;
+
+    let documented_pool = runtime_pool_for_role(&runtime_with_truncate).await;
+    awa::model::admin::refresh_admin_metadata(&documented_pool)
+        .await
+        .expect("documented runtime grants should allow metadata refresh");
+    documented_pool.close().await;
+
+    drop_login_role(&pool, &runtime_without_truncate).await;
+    drop_login_role(&pool, &runtime_with_truncate).await;
 }
 
 // ── Step-through upgrade with data survival ──────────────────────

--- a/correctness/races/AwaCron.tla
+++ b/correctness/races/AwaCron.tla
@@ -9,8 +9,14 @@ EXTENDS FiniteSets, Naturals
   produces at most one enqueued job, even under leader failover where
   multiple instances may concurrently attempt the CAS.
 
+  The cron evaluator can run either coalesced (enqueue only the latest
+  missed fire) or catch-up (enqueue every missed fire in timestamp order).
+  The safety argument is the same for both: every enqueue advances
+  last_enqueued_at with a compare-and-swap against the evaluator's snapshot.
+
   Maps to code:
     ReadCronState  -> maintenance.rs: evaluate_cron_schedules calls list_cron_jobs
+    ChosenFire     -> maintenance.rs: compute_fire_times
     AtomicEnqueue  -> cron.rs: atomic_enqueue CTE (UPDATE...WHERE last_enqueued_at
                      IS NOT DISTINCT FROM $3, then INSERT...FROM mark)
     CASFail        -> CTE UPDATE matches 0 rows, INSERT produces nothing
@@ -28,9 +34,11 @@ MaxFire == 2
 FireTimes == 1..MaxFire
 
 NoLeader == "none"
+Policies == {"coalesce", "catch_up"}
 
 VARIABLES
     leader,         \* Advisory lock holder: Instances \cup {NoLeader}
+    policy,         \* Cron missed-fire policy for this schedule
     lastEnqueued,   \* DB column cron_jobs.last_enqueued_at (0 = never)
     snapshot,       \* Per-instance: cached lastEnqueued from list_cron_jobs read
     hasSnapshot,    \* Per-instance: whether a valid snapshot exists
@@ -38,12 +46,13 @@ VARIABLES
     jobCount,       \* Per fire: count of jobs created (safety target)
     alive           \* Per-instance: whether the instance process is running
 
-vars == <<leader, lastEnqueued, snapshot, hasSnapshot, clock, jobCount, alive>>
+vars == <<leader, policy, lastEnqueued, snapshot, hasSnapshot, clock, jobCount, alive>>
 
 \* ─── Initial state ────────────────────────────────────────
 
 Init ==
     /\ leader = NoLeader
+    /\ policy \in Policies
     /\ lastEnqueued = 0
     /\ snapshot = [i \in Instances |-> 0]
     /\ hasSnapshot = [i \in Instances |-> FALSE]
@@ -57,21 +66,21 @@ Init ==
 AdvanceClock ==
     /\ clock < MaxFire
     /\ clock' = clock + 1
-    /\ UNCHANGED <<leader, lastEnqueued, snapshot, hasSnapshot, jobCount, alive>>
+    /\ UNCHANGED <<leader, policy, lastEnqueued, snapshot, hasSnapshot, jobCount, alive>>
 
 \* Acquire advisory lock (pg_try_advisory_lock succeeds).
 AcquireLeader(i) ==
     /\ alive[i]
     /\ leader = NoLeader
     /\ leader' = i
-    /\ UNCHANGED <<lastEnqueued, snapshot, hasSnapshot, clock, jobCount, alive>>
+    /\ UNCHANGED <<policy, lastEnqueued, snapshot, hasSnapshot, clock, jobCount, alive>>
 
 \* Lose advisory lock: connection dies, explicit release, or shutdown.
 \* The instance may still have a cached snapshot from a prior read.
 LoseLeader(i) ==
     /\ leader = i
     /\ leader' = NoLeader
-    /\ UNCHANGED <<lastEnqueued, snapshot, hasSnapshot, clock, jobCount, alive>>
+    /\ UNCHANGED <<policy, lastEnqueued, snapshot, hasSnapshot, clock, jobCount, alive>>
 
 \* Instance crashes: loses leadership, loses snapshot (stack unwound).
 Crash(i) ==
@@ -79,13 +88,13 @@ Crash(i) ==
     /\ alive' = [alive EXCEPT ![i] = FALSE]
     /\ hasSnapshot' = [hasSnapshot EXCEPT ![i] = FALSE]
     /\ leader' = IF leader = i THEN NoLeader ELSE leader
-    /\ UNCHANGED <<lastEnqueued, snapshot, clock, jobCount>>
+    /\ UNCHANGED <<policy, lastEnqueued, snapshot, clock, jobCount>>
 
 \* Instance recovers (restarts).
 Recover(i) ==
     /\ ~alive[i]
     /\ alive' = [alive EXCEPT ![i] = TRUE]
-    /\ UNCHANGED <<leader, lastEnqueued, snapshot, hasSnapshot, clock, jobCount>>
+    /\ UNCHANGED <<leader, policy, lastEnqueued, snapshot, hasSnapshot, clock, jobCount>>
 
 \* Leader reads cron state from DB (list_cron_jobs).
 \* Only the leader enters evaluate_cron_schedules.
@@ -94,43 +103,65 @@ ReadCronState(i) ==
     /\ leader = i
     /\ snapshot' = [snapshot EXCEPT ![i] = lastEnqueued]
     /\ hasSnapshot' = [hasSnapshot EXCEPT ![i] = TRUE]
-    /\ UNCHANGED <<leader, lastEnqueued, clock, jobCount, alive>>
+    /\ UNCHANGED <<leader, policy, lastEnqueued, clock, jobCount, alive>>
 
-\* The latest due fire from this instance's perspective.
-\* Maps to compute_fire_time: returns the largest fire <= clock that
-\* is strictly after the cached last_enqueued_at (snapshot).
-\* Returns 0 if no fire is due.
+\* Due fires from this instance's perspective.
+DueFires(i) == {f \in FireTimes : f <= clock /\ f > snapshot[i]}
+
+\* Coalesced policy: enqueue the latest due fire only.
 LatestDueFire(i) ==
-    LET candidates == {f \in FireTimes : f <= clock /\ f > snapshot[i]}
+    LET candidates == DueFires(i)
     IN IF candidates = {} THEN 0
        ELSE CHOOSE f \in candidates : \A g \in candidates : f >= g
+
+\* Catch-up policy: enqueue due fires in timestamp order.
+EarliestDueFire(i) ==
+    LET candidates == DueFires(i)
+    IN IF candidates = {} THEN 0
+       ELSE CHOOSE f \in candidates : \A g \in candidates : f <= g
+
+ChosenFire(i) ==
+    IF policy = "coalesce"
+    THEN LatestDueFire(i)
+    ELSE EarliestDueFire(i)
+
+MoreDueAfter(i, fire) ==
+    \E f \in FireTimes : f <= clock /\ f > fire
 
 \* Atomic CAS + insert (the atomic_enqueue CTE).
 \* CAS succeeds: DB lastEnqueued matches our snapshot.
 \* Precondition does NOT require current leadership — models the window
 \* where leadership was lost between ReadCronState and this action.
-\* Only attempts the latest due fire (compute_fire_time semantics).
+\* Coalesced mode attempts the latest due fire. Catch-up mode attempts
+\* one due fire at a time and advances the in-memory snapshot after each
+\* successful enqueue, matching evaluate_cron_schedules' previous_enqueued_at.
 AtomicEnqueue(i) ==
-    LET fire == LatestDueFire(i) IN
+    LET fire == ChosenFire(i) IN
     /\ alive[i]
     /\ hasSnapshot[i]
     /\ fire > 0                          \* a fire is due
     /\ lastEnqueued = snapshot[i]        \* CAS: DB matches what we read
     /\ lastEnqueued' = fire
     /\ jobCount' = [jobCount EXCEPT ![fire] = @ + 1]
-    /\ hasSnapshot' = [hasSnapshot EXCEPT ![i] = FALSE]
-    /\ UNCHANGED <<leader, snapshot, clock, alive>>
+    /\ IF policy = "catch_up" /\ MoreDueAfter(i, fire)
+       THEN
+           /\ snapshot' = [snapshot EXCEPT ![i] = fire]
+           /\ hasSnapshot' = hasSnapshot
+       ELSE
+           /\ snapshot' = snapshot
+           /\ hasSnapshot' = [hasSnapshot EXCEPT ![i] = FALSE]
+    /\ UNCHANGED <<leader, policy, clock, alive>>
 
 \* CAS fails: another instance already updated last_enqueued_at.
 \* The CTE UPDATE matches 0 rows, INSERT produces nothing.
 CASFail(i) ==
-    LET fire == LatestDueFire(i) IN
+    LET fire == ChosenFire(i) IN
     /\ alive[i]
     /\ hasSnapshot[i]
     /\ fire > 0
     /\ lastEnqueued # snapshot[i]        \* CAS fails — DB moved
     /\ hasSnapshot' = [hasSnapshot EXCEPT ![i] = FALSE]
-    /\ UNCHANGED <<leader, lastEnqueued, snapshot, clock, jobCount, alive>>
+    /\ UNCHANGED <<leader, policy, lastEnqueued, snapshot, clock, jobCount, alive>>
 
 \* ─── Specification ────────────────────────────────────────
 
@@ -150,6 +181,7 @@ Spec == Init /\ [][Next]_vars
 
 TypeOK ==
     /\ leader \in Instances \cup {NoLeader}
+    /\ policy \in Policies
     /\ lastEnqueued \in 0..MaxFire
     /\ snapshot \in [Instances -> 0..MaxFire]
     /\ hasSnapshot \in [Instances -> BOOLEAN]
@@ -204,12 +236,14 @@ FairSpec ==
     /\ SF_vars(\E i \in Instances : AtomicEnqueue(i))
     /\ SF_vars(\E i \in Instances : CASFail(i))
 
-\* The latest due fire is eventually enqueued.
-\* Note: earlier fires may be skipped (no-backfill design) — the code's
-\* compute_fire_time only returns the latest fire, so if fire 1 and 2
-\* are both due, only fire 2 is enqueued.
+\* Coalesced schedules eventually enqueue the latest due fire.
 \* Checked under FairSpec (stable cluster with no crashes).
-LatestFireEventuallyEnqueued ==
-    (clock = MaxFire) ~> (jobCount[MaxFire] = 1)
+CoalescedLatestFireEventuallyEnqueued ==
+    (policy = "coalesce" /\ clock = MaxFire) ~> (jobCount[MaxFire] = 1)
+
+\* Catch-up schedules eventually enqueue every missed fire in order.
+\* Checked under FairSpec (stable cluster with no crashes).
+CatchUpFiresEventuallyEnqueued ==
+    (policy = "catch_up" /\ clock = MaxFire) ~> (\A f \in FireTimes : jobCount[f] = 1)
 
 ====

--- a/correctness/races/AwaCronLiveness.cfg
+++ b/correctness/races/AwaCronLiveness.cfg
@@ -8,4 +8,5 @@ INVARIANTS
   NoDuplicateFire
 
 PROPERTIES
-  LatestFireEventuallyEnqueued
+  CoalescedLatestFireEventuallyEnqueued
+  CatchUpFiresEventuallyEnqueued

--- a/docs/adr/007-periodic-cron-jobs.md
+++ b/docs/adr/007-periodic-cron-jobs.md
@@ -50,9 +50,11 @@ A naive sync would `DELETE FROM awa.cron_jobs WHERE name NOT IN (...)` to remove
 
 Awa's sync is additive: UPSERT only, never DELETE. Stale schedules from decommissioned deployments can be cleaned up manually via `awa cron remove <name>` or direct SQL.
 
-### No backfill
+### Missed-fire policy
 
-When a worker starts after being down, the scheduler enqueues only the most recent missed fire time per schedule, not every missed occurrence. This avoids a thundering herd of jobs when a worker recovers from a long outage. This matches River's approach.
+By default, when evaluation is delayed or a worker starts after being down, the scheduler enqueues only the most recent missed fire time per schedule, not every missed occurrence. This `coalesce` policy avoids a thundering herd of jobs when a worker recovers from a long outage.
+
+Schedules that represent reconciliation or polling work can opt into `catch_up`, which enqueues each missed fire in timestamp order subject to the worker's bounded per-pass catch-up limit. Catch-up schedules should use idempotent handlers and expect several jobs to appear in quick succession after downtime.
 
 ### Leader liveness verification
 
@@ -73,4 +75,4 @@ The advisory lock is session-scoped: as long as the connection is alive, the loc
 - **1-second evaluation granularity.** Sub-second schedules are not supported. This is acceptable for cron-style workloads (hourly, daily, etc.).
 - **Leader bottleneck.** All cron evaluation happens on the leader. For thousands of schedules this could become a bottleneck, though in practice most deployments have dozens, not thousands.
 - **No automatic orphan cleanup.** Decommissioned schedules must be removed manually. This is an intentional trade-off for multi-deployment safety.
-- **No backfill.** If a schedule was down for 24 hours, only the most recent fire is recovered. Users who need guaranteed delivery of every missed fire must implement their own catch-up logic.
+- **Coalesced by default.** If a schedule was down for 24 hours, only the most recent fire is recovered unless the schedule explicitly opts into `catch_up`.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -887,6 +887,9 @@ let client = Client::builder(pool)
     .periodic(
         PeriodicJob::builder("daily_report", "0 9 * * *")
             .timezone("Pacific/Auckland")
+            // Default: coalesce delayed evaluation to the latest due fire.
+            // Use CronMissedFirePolicy::CatchUp for reconciliation jobs that
+            // should enqueue every missed fire in order.
             .build(&DailyReport { format: "pdf".into() })?
     )
     .build()?;
@@ -899,10 +902,16 @@ client.periodic(
     args_type=DailyReport,
     args=DailyReport(format="pdf"),
     timezone="Pacific/Auckland",
+    # Default missed_fire_policy="coalesce"; use "catch_up" when each
+    # missed scheduled fire must be enqueued.
 )
 ```
 
 Cron expressions and timezones are validated eagerly at registration time via the `croner` crate and `chrono-tz`.
+By default, delayed evaluation is coalesced to the latest due fire. Jobs that
+need every missed fire can opt into catch-up behavior with
+`CronMissedFirePolicy::CatchUp` in Rust or `missed_fire_policy="catch_up"` in
+Python.
 
 ### Lifecycle Hooks
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -945,10 +945,11 @@ MaintenanceService (leader)
     ├── Every 60s: sync_periodic_jobs_to_db()
     │   └── UPSERT all registered schedules (additive, no deletes)
     │
-    ├── Every 1s: evaluate_cron_schedules()
+    ├── Cron evaluator task (own leader-scoped lane, every 1s)
     │   ├── SELECT * FROM awa.cron_jobs
-    │   ├── For each: compute latest fire time ≤ now, after last_enqueued_at
-    │   └── If due: atomic CTE (mark last_enqueued_at + INSERT INTO awa.jobs)
+    │   ├── coalesce: compute one latest due fire after last_enqueued_at
+    │   ├── catch_up: compute bounded due fires in timestamp order
+    │   └── For each fire: atomic CTE (mark last_enqueued_at + INSERT INTO awa.jobs)
     │
     └── Every 30s: leader liveness check
         └── SELECT 1 on leader connection (break to re-election if dead)
@@ -984,18 +985,19 @@ Awa uses a hybrid approach with two independent crash recovery mechanisms, each 
 ### Leader Election
 
 Maintenance tasks (heartbeat rescue, deadline rescue, scheduled promotion,
-cleanup, cron evaluation, and canonical-table priority aging) run on a single
-leader instance elected via Postgres advisory lock
+cleanup, cron sync, cron evaluation, and canonical-table priority aging) run on
+a single leader instance elected via Postgres advisory lock
 (`pg_try_advisory_lock(0x4157415f4d41494e)`). The lock is session-scoped -- it
 auto-releases if the leader's connection drops. Non-leaders retry every 10
 seconds. The leader verifies its connection is still alive every 30 seconds; if
-the ping fails, it re-enters the election loop. Queue storage does not
-physically reprioritize ready rows; it applies effective priority aging at
-claim time.
+the ping fails, it re-enters the election loop and stops the leader-scoped cron
+evaluator task. Queue storage does not physically reprioritize ready rows; it
+applies effective priority aging at claim time.
 
 Scheduled and retryable promotion runs every 250ms by default, in bounded
 batches, and emits queue notifications after promotion. Cron evaluation remains
-on a 1-second tick.
+on a 1-second tick but runs in its own leader-scoped task so slower background
+hygiene cannot starve schedule evaluation.
 
 ## Python Integration
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -133,7 +133,7 @@ ALTER DEFAULT PRIVILEGES FOR ROLE awa_owner IN SCHEMA my_qs_schema
   GRANT EXECUTE ON FUNCTIONS TO awa_runtime;
 ```
 
-The queue-storage schema is migrated by `awa storage prepare-queue-storage-schema`, which runs as the migrator role and creates objects owned by `awa_migrator` / `awa_owner`. The runtime role needs read/write/execute plus `TRUNCATE` for ring-partition rotation; it never needs DDL.
+The queue-storage schema is migrated by `awa storage prepare-queue-storage-schema`, which runs as the migrator role and creates objects owned by `awa_migrator` / `awa_owner`. The runtime role needs read/write/execute privileges plus `TRUNCATE` for ring-partition rotation; it never needs DDL.
 
 ### 5. Configure your processes
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -123,17 +123,17 @@ the grant block against that schema:
 
 ```sql
 GRANT USAGE ON SCHEMA my_qs_schema TO awa_runtime;
-GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA my_qs_schema TO awa_runtime;
+GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE ON ALL TABLES IN SCHEMA my_qs_schema TO awa_runtime;
 GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA my_qs_schema TO awa_runtime;
 ALTER DEFAULT PRIVILEGES FOR ROLE awa_owner IN SCHEMA my_qs_schema
-  GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO awa_runtime;
+  GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE ON TABLES TO awa_runtime;
 ALTER DEFAULT PRIVILEGES FOR ROLE awa_owner IN SCHEMA my_qs_schema
   GRANT USAGE, SELECT ON SEQUENCES TO awa_runtime;
 ALTER DEFAULT PRIVILEGES FOR ROLE awa_owner IN SCHEMA my_qs_schema
   GRANT EXECUTE ON FUNCTIONS TO awa_runtime;
 ```
 
-The queue-storage schema is migrated by `awa storage prepare-queue-storage-schema`, which runs as the migrator role and creates objects owned by `awa_migrator` / `awa_owner`. The runtime role only needs read/write/execute, never DDL.
+The queue-storage schema is migrated by `awa storage prepare-queue-storage-schema`, which runs as the migrator role and creates objects owned by `awa_migrator` / `awa_owner`. The runtime role needs read/write/execute plus `TRUNCATE` for ring-partition rotation; it never needs DDL.
 
 ### 5. Configure your processes
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -87,15 +87,17 @@ GRANT USAGE, SELECT ON SEQUENCE awa.jobs_id_seq TO awa_runtime;
 
 -- All tables: the runtime needs full DML because triggers run as the
 -- invoking role (SECURITY INVOKER), so inserting a job also writes to
--- the admin metadata cache tables via triggers.
-GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA awa TO awa_runtime;
+-- the admin metadata cache tables via triggers. The maintenance leader
+-- also calls refresh_admin_metadata(), which truncates dirty-key tables
+-- after taking the metadata advisory lock.
+GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE ON ALL TABLES IN SCHEMA awa TO awa_runtime;
 
 -- Functions (trigger functions execute with invoker privileges)
 GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA awa TO awa_runtime;
 
 -- Default privileges for future migrations
 ALTER DEFAULT PRIVILEGES FOR ROLE awa_owner IN SCHEMA awa
-  GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO awa_runtime;
+  GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE ON TABLES TO awa_runtime;
 ALTER DEFAULT PRIVILEGES FOR ROLE awa_owner IN SCHEMA awa
   GRANT USAGE, SELECT ON SEQUENCES TO awa_runtime;
 ALTER DEFAULT PRIVILEGES FOR ROLE awa_owner IN SCHEMA awa
@@ -144,7 +146,7 @@ The queue-storage schema is migrated by `awa storage prepare-queue-storage-schem
 
 ## What the runtime role needs and why
 
-The runtime grants look broad (`SELECT, INSERT, UPDATE, DELETE ON ALL TABLES`) because AWA's internal tables are maintained by `SECURITY INVOKER` trigger functions. When a worker inserts a job, triggers automatically update:
+The runtime grants look broad (`SELECT, INSERT, UPDATE, DELETE, TRUNCATE ON ALL TABLES`) because AWA's internal tables are maintained by `SECURITY INVOKER` trigger functions. When a worker inserts a job, triggers automatically update:
 
 - `awa.queue_state_counts` — per-queue job state tallies
 - `awa.job_kind_catalog` — distinct job kinds
@@ -152,6 +154,8 @@ The runtime grants look broad (`SELECT, INSERT, UPDATE, DELETE ON ALL TABLES`) b
 - `awa.job_unique_claims` — unique key deduplication
 
 Since these triggers run with the caller's privileges, the runtime role needs write access to these internal tables even though application code never touches them directly.
+
+The maintenance leader also calls `awa.refresh_admin_metadata()` as a full reconciliation safety net. That function runs with invoker privileges and uses `TRUNCATE` on `awa.admin_dirty_queues` and `awa.admin_dirty_kinds` after taking the metadata advisory lock, so `awa_runtime` needs the `TRUNCATE` table privilege too.
 
 The runtime also directly upserts into the descriptor catalogs on startup and on each runtime snapshot tick:
 
@@ -181,14 +185,14 @@ profiles:
       - on: { type: schema }
         privileges: [USAGE]
       - on: { type: table, name: "*" }
-        privileges: [SELECT, INSERT, UPDATE, DELETE]
+        privileges: [SELECT, INSERT, UPDATE, DELETE, TRUNCATE]
       - on: { type: sequence, name: "*" }
         privileges: [USAGE, SELECT]
       - on: { type: function, name: "*" }
         privileges: [EXECUTE]
     default_privileges:
       - on_type: table
-        privileges: [SELECT, INSERT, UPDATE, DELETE]
+        privileges: [SELECT, INSERT, UPDATE, DELETE, TRUNCATE]
       - on_type: sequence
         privileges: [USAGE, SELECT]
       - on_type: function


### PR DESCRIPTION
## Summary

- run cron evaluation in its own leader-scoped task so unrelated maintenance branches cannot starve schedule evaluation
- preserve existing coalesced/latest-only behavior by default
- add an explicit persisted missed-fire policy: `coalesce` by default, `catch_up` for idempotent reconciliation jobs that need every missed fire in order
- expose the policy through Rust, Python, CLI/API output, docs, and migration v015
- document that the runtime role needs `TRUNCATE` on AWA/control-plane tables and custom queue-storage schemas where runtime maintenance issues TRUNCATE
- add a DB-backed regression test proving the old grants fail with insufficient_privilege and the documented grants allow `refresh_admin_metadata()`

Closes #239

## Testing

- `cargo test -p awa-worker maintenance::tests::compute_fire_times --lib`
- `cargo test -p awa-model cron::tests --lib`
- `cargo check -p awa-cli -p awa-worker`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test -p awa --test migration_test test_documented_runtime_grants_cover_admin_refresh_truncate -- --test-threads=1` compiled locally, but could not execute because local Postgres refused connections
- `cargo check --manifest-path awa-python/Cargo.toml` blocked locally because the available interpreter is Python 3.9 while `awa-python` uses `abi3-py310`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `missed_fire_policy` configuration for cron jobs, controlling how missed fires are handled when the scheduler is delayed. Supports two modes: "coalesce" (default, enqueues only the latest missed fire) and "catch_up" (enqueues all missed fires in order).
  * CLI list output now displays the missed fire policy for each schedule.

* **Documentation**
  * Updated guides and examples with missed-fire policy usage and behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->