### PR TITLE
Hotfix 0.5.x cron evaluation starvation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,7 +171,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "awa"
-version = "0.5.6"
+version = "0.5.7"
 dependencies = [
  "async-trait",
  "awa-macros",
@@ -196,7 +196,7 @@ dependencies = [
 
 [[package]]
 name = "awa-cli"
-version = "0.5.6"
+version = "0.5.7"
 dependencies = [
  "assert_cmd",
  "awa-model",
@@ -217,7 +217,7 @@ dependencies = [
 
 [[package]]
 name = "awa-macros"
-version = "0.5.6"
+version = "0.5.7"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -227,7 +227,7 @@ dependencies = [
 
 [[package]]
 name = "awa-model"
-version = "0.5.6"
+version = "0.5.7"
 dependencies = [
  "awa-macros",
  "blake3",
@@ -248,7 +248,7 @@ dependencies = [
 
 [[package]]
 name = "awa-testing"
-version = "0.5.6"
+version = "0.5.7"
 dependencies = [
  "async-trait",
  "awa-model",
@@ -263,7 +263,7 @@ dependencies = [
 
 [[package]]
 name = "awa-ui"
-version = "0.5.6"
+version = "0.5.7"
 dependencies = [
  "awa-model",
  "awa-testing",
@@ -285,7 +285,7 @@ dependencies = [
 
 [[package]]
 name = "awa-worker"
-version = "0.5.6"
+version = "0.5.7"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 exclude = ["awa-python", "spike", "benchmarks/portable/awa-bench"]
 
 [workspace.package]
-version = "0.5.6"
+version = "0.5.7"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "Postgres-native background job queue — transactional enqueue, heartbeat crash recovery, SKIP LOCKED dispatch"
@@ -23,9 +23,9 @@ categories = ["database", "asynchronous", "web-programming"]
 
 [workspace.dependencies]
 # Internal crates
-awa-model = { path = "awa-model", version = "0.5.6" }
-awa-macros = { path = "awa-macros", version = "0.5.6" }
-awa-worker = { path = "awa-worker", version = "0.5.6" }
+awa-model = { path = "awa-model", version = "0.5.7" }
+awa-macros = { path = "awa-macros", version = "0.5.7" }
+awa-worker = { path = "awa-worker", version = "0.5.7" }
 
 # Database
 sqlx = { version = "0.8", features = ["runtime-tokio-rustls", "postgres", "chrono", "json", "migrate", "uuid"] }

--- a/awa-cli/Cargo.toml
+++ b/awa-cli/Cargo.toml
@@ -13,7 +13,7 @@ path = "src/main.rs"
 
 [dependencies]
 awa-model.workspace = true
-awa-ui = { path = "../awa-ui", version = "0.5.6" }
+awa-ui = { path = "../awa-ui", version = "0.5.7" }
 axum.workspace = true
 sqlx.workspace = true
 tokio.workspace = true
@@ -25,7 +25,7 @@ chrono.workspace = true
 hex.workspace = true
 
 [dev-dependencies]
-awa-testing = { path = "../awa-testing", version = "0.5.6" }
+awa-testing = { path = "../awa-testing", version = "0.5.7" }
 assert_cmd = "2"
 serde.workspace = true
 uuid.workspace = true

--- a/awa-cli/pyproject.toml
+++ b/awa-cli/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "awa-cli"
-version = "0.5.6"
+version = "0.5.7"
 description = "CLI for the Awa Postgres-native job queue (migrations, admin, serve)"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/awa-python/Cargo.toml
+++ b/awa-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "awa-python"
-version = "0.5.6"
+version = "0.5.7"
 edition = "2021"
 
 [lib]
@@ -12,8 +12,8 @@ default = ["cel"]
 cel = ["awa-model/cel"]
 
 [dependencies]
-awa-model = { path = "../awa-model", version = "0.5.6" }
-awa-worker = { path = "../awa-worker", version = "0.5.6", features = ["__python-bridge"] }
+awa-model = { path = "../awa-model", version = "0.5.7" }
+awa-worker = { path = "../awa-worker", version = "0.5.7", features = ["__python-bridge"] }
 pyo3 = { version = "0.28", features = ["macros", "abi3-py310"] }
 pyo3-async-runtimes = { version = "0.28", features = ["tokio-runtime"] }
 sqlx = { version = "0.8", features = ["runtime-tokio-rustls", "postgres", "chrono", "json"] }

--- a/awa-python/pyproject.toml
+++ b/awa-python/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "maturin"
 [project]
 name = "awa-pg"
 requires-python = ">=3.10"
-version = "0.5.6"
+version = "0.5.7"
 description = "Postgres-native background job queue — Python SDK with async/sync workers, transactional enqueue, progress tracking, and web UI"
 readme = {file = "../README.md", content-type = "text/markdown"}
 license = {text = "MIT OR Apache-2.0"}

--- a/awa-worker/src/maintenance.rs
+++ b/awa-worker/src/maintenance.rs
@@ -73,7 +73,6 @@ pub struct MaintenanceService {
 
 const PROMOTE_BATCH_SIZE: i64 = 4_096;
 const PROMOTE_MAX_BATCHES_PER_TICK: usize = 32;
-const CRON_CATCH_UP_LIMIT: usize = 1_000;
 
 impl MaintenanceService {
     pub(crate) fn new(
@@ -434,10 +433,9 @@ impl MaintenanceService {
 
     /// Evaluate all cron schedules and enqueue any that are due.
     ///
-    /// For each schedule, computes due fire times ≤ now that are after
-    /// `last_enqueued_at`. If fires are due, executes the atomic CTE for each
-    /// fire in order so delayed evaluation catches up instead of collapsing
-    /// intermediate fires.
+    /// For each schedule, computes the latest fire time ≤ now that is after
+    /// `last_enqueued_at`. If a fire is due, executes the atomic CTE to
+    /// mark + insert in one statement.
     #[tracing::instrument(skip(pool), name = "maintenance.cron_eval")]
     async fn evaluate_cron_schedules(pool: &PgPool) {
         let cron_rows = match list_cron_jobs(pool).await {
@@ -455,43 +453,30 @@ impl MaintenanceService {
         let now = Utc::now();
 
         for row in &cron_rows {
-            let fire_times = compute_fire_times(row, now, CRON_CATCH_UP_LIMIT);
-            if fire_times.is_empty() {
-                continue;
-            }
-            if fire_times.len() == CRON_CATCH_UP_LIMIT {
-                warn!(
-                    cron_name = %row.name,
-                    catch_up_limit = CRON_CATCH_UP_LIMIT,
-                    "Cron catch-up limit reached; remaining due fires will be retried on the next evaluation"
-                );
-            }
+            let fire_time = match compute_fire_time(row, now) {
+                Some(time) => time,
+                None => continue,
+            };
 
-            let mut previous_enqueued_at = row.last_enqueued_at;
-            for fire_time in fire_times {
-                match atomic_enqueue(pool, &row.name, fire_time, previous_enqueued_at).await {
-                    Ok(Some(job)) => {
-                        previous_enqueued_at = Some(fire_time);
-                        info!(
-                            cron_name = %row.name,
-                            job_id = job.id,
-                            fire_time = %fire_time,
-                            "Enqueued periodic job"
-                        );
-                    }
-                    Ok(None) => {
-                        // Another leader already claimed this fire — not an error
-                        debug!(cron_name = %row.name, "Cron fire already claimed");
-                        break;
-                    }
-                    Err(err) => {
-                        error!(
-                            cron_name = %row.name,
-                            error = %err,
-                            "Failed to enqueue periodic job"
-                        );
-                        break;
-                    }
+            match atomic_enqueue(pool, &row.name, fire_time, row.last_enqueued_at).await {
+                Ok(Some(job)) => {
+                    info!(
+                        cron_name = %row.name,
+                        job_id = job.id,
+                        fire_time = %fire_time,
+                        "Enqueued periodic job"
+                    );
+                }
+                Ok(None) => {
+                    // Another leader already claimed this fire — not an error
+                    debug!(cron_name = %row.name, "Cron fire already claimed");
+                }
+                Err(err) => {
+                    error!(
+                        cron_name = %row.name,
+                        error = %err,
+                        "Failed to enqueue periodic job"
+                    );
                 }
             }
         }
@@ -975,21 +960,18 @@ impl Drop for MaintenanceAliveGuard {
     }
 }
 
-/// Compute due fire times for a cron job row, using its expression and timezone.
+/// Compute the latest fire time for a cron job row, using its expression and timezone.
 ///
-/// Existing schedules catch up missed fires up to `limit`. First registration
-/// still enqueues only the latest due fire to avoid backfilling before the
-/// schedule was known to AWA.
-fn compute_fire_times(
+/// Returns `None` if no fire is due (next occurrence is in the future).
+fn compute_fire_time(
     row: &CronJobRow,
     now: chrono::DateTime<Utc>,
-    limit: usize,
-) -> Vec<chrono::DateTime<Utc>> {
+) -> Option<chrono::DateTime<Utc>> {
     let cron = match Cron::new(&row.cron_expr).with_seconds_optional().parse() {
         Ok(c) => c,
         Err(err) => {
             error!(cron_name = %row.name, error = %err, "Invalid cron expression in database");
-            return Vec::new();
+            return None;
         }
     };
 
@@ -997,7 +979,7 @@ fn compute_fire_times(
         Ok(tz) => tz,
         Err(err) => {
             error!(cron_name = %row.name, error = %err, "Invalid timezone in database");
-            return Vec::new();
+            return None;
         }
     };
 
@@ -1010,7 +992,6 @@ fn compute_fire_times(
         None => (row.created_at - chrono::Duration::minutes(1)).with_timezone(&tz),
     };
 
-    let mut fire_times = Vec::new();
     let mut latest_fire: Option<chrono::DateTime<Utc>> = None;
 
     for fire_time in cron.iter_from(search_start) {
@@ -1026,22 +1007,10 @@ fn compute_fire_times(
             }
         }
 
-        if row.last_enqueued_at.is_none() {
-            latest_fire = Some(fire_utc);
-            continue;
-        }
-
-        fire_times.push(fire_utc);
-        if fire_times.len() >= limit {
-            break;
-        }
+        latest_fire = Some(fire_utc);
     }
 
-    if row.last_enqueued_at.is_none() {
-        latest_fire.into_iter().collect()
-    } else {
-        fire_times
-    }
+    latest_fire
 }
 
 #[cfg(test)]
@@ -1072,52 +1041,41 @@ mod tests {
     }
 
     #[test]
-    fn compute_fire_times_catches_up_missed_existing_fires() {
+    fn compute_fire_time_coalesces_missed_existing_fires() {
         let last = Utc.with_ymd_and_hms(2026, 5, 7, 12, 0, 0).unwrap();
         let now = Utc.with_ymd_and_hms(2026, 5, 7, 12, 0, 20).unwrap();
         let row = cron_row("*/5 * * * * *", last, Some(last));
 
-        let fires = compute_fire_times(&row, now, CRON_CATCH_UP_LIMIT);
+        let fire = compute_fire_time(&row, now);
 
         assert_eq!(
-            fires,
-            vec![
-                Utc.with_ymd_and_hms(2026, 5, 7, 12, 0, 5).unwrap(),
-                Utc.with_ymd_and_hms(2026, 5, 7, 12, 0, 10).unwrap(),
-                Utc.with_ymd_and_hms(2026, 5, 7, 12, 0, 15).unwrap(),
-                Utc.with_ymd_and_hms(2026, 5, 7, 12, 0, 20).unwrap(),
-            ]
+            fire,
+            Some(Utc.with_ymd_and_hms(2026, 5, 7, 12, 0, 20).unwrap())
         );
     }
 
     #[test]
-    fn compute_fire_times_limits_catch_up_work() {
+    fn compute_fire_time_returns_none_when_no_fire_is_due() {
         let last = Utc.with_ymd_and_hms(2026, 5, 7, 12, 0, 0).unwrap();
-        let now = Utc.with_ymd_and_hms(2026, 5, 7, 12, 0, 30).unwrap();
+        let now = Utc.with_ymd_and_hms(2026, 5, 7, 12, 0, 2).unwrap();
         let row = cron_row("*/5 * * * * *", last, Some(last));
 
-        let fires = compute_fire_times(&row, now, 2);
+        let fire = compute_fire_time(&row, now);
 
-        assert_eq!(
-            fires,
-            vec![
-                Utc.with_ymd_and_hms(2026, 5, 7, 12, 0, 5).unwrap(),
-                Utc.with_ymd_and_hms(2026, 5, 7, 12, 0, 10).unwrap(),
-            ]
-        );
+        assert_eq!(fire, None);
     }
 
     #[test]
-    fn compute_fire_times_keeps_first_registration_latest_only() {
+    fn compute_fire_time_keeps_first_registration_latest_only() {
         let created_at = Utc.with_ymd_and_hms(2026, 5, 7, 12, 0, 30).unwrap();
         let now = Utc.with_ymd_and_hms(2026, 5, 7, 12, 0, 55).unwrap();
         let row = cron_row("*/5 * * * * *", created_at, None);
 
-        let fires = compute_fire_times(&row, now, CRON_CATCH_UP_LIMIT);
+        let fire = compute_fire_time(&row, now);
 
         assert_eq!(
-            fires,
-            vec![Utc.with_ymd_and_hms(2026, 5, 7, 12, 0, 55).unwrap()]
+            fire,
+            Some(Utc.with_ymd_and_hms(2026, 5, 7, 12, 0, 55).unwrap())
         );
     }
 }

--- a/awa-worker/src/maintenance.rs
+++ b/awa-worker/src/maintenance.rs
@@ -1013,73 +1013,6 @@ fn compute_fire_time(
     latest_fire
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use chrono::TimeZone;
-
-    fn cron_row(
-        cron_expr: &str,
-        created_at: chrono::DateTime<Utc>,
-        last_enqueued_at: Option<chrono::DateTime<Utc>>,
-    ) -> CronJobRow {
-        CronJobRow {
-            name: "test_cron".to_string(),
-            cron_expr: cron_expr.to_string(),
-            timezone: "UTC".to_string(),
-            kind: "test_job".to_string(),
-            queue: "default".to_string(),
-            args: serde_json::json!({}),
-            priority: 2,
-            max_attempts: 25,
-            tags: Vec::new(),
-            metadata: serde_json::json!({}),
-            last_enqueued_at,
-            created_at,
-            updated_at: created_at,
-        }
-    }
-
-    #[test]
-    fn compute_fire_time_coalesces_missed_existing_fires() {
-        let last = Utc.with_ymd_and_hms(2026, 5, 7, 12, 0, 0).unwrap();
-        let now = Utc.with_ymd_and_hms(2026, 5, 7, 12, 0, 20).unwrap();
-        let row = cron_row("*/5 * * * * *", last, Some(last));
-
-        let fire = compute_fire_time(&row, now);
-
-        assert_eq!(
-            fire,
-            Some(Utc.with_ymd_and_hms(2026, 5, 7, 12, 0, 20).unwrap())
-        );
-    }
-
-    #[test]
-    fn compute_fire_time_returns_none_when_no_fire_is_due() {
-        let last = Utc.with_ymd_and_hms(2026, 5, 7, 12, 0, 0).unwrap();
-        let now = Utc.with_ymd_and_hms(2026, 5, 7, 12, 0, 2).unwrap();
-        let row = cron_row("*/5 * * * * *", last, Some(last));
-
-        let fire = compute_fire_time(&row, now);
-
-        assert_eq!(fire, None);
-    }
-
-    #[test]
-    fn compute_fire_time_keeps_first_registration_latest_only() {
-        let created_at = Utc.with_ymd_and_hms(2026, 5, 7, 12, 0, 30).unwrap();
-        let now = Utc.with_ymd_and_hms(2026, 5, 7, 12, 0, 55).unwrap();
-        let row = cron_row("*/5 * * * * *", created_at, None);
-
-        let fire = compute_fire_time(&row, now);
-
-        assert_eq!(
-            fire,
-            Some(Utc.with_ymd_and_hms(2026, 5, 7, 12, 0, 55).unwrap())
-        );
-    }
-}
-
 impl MaintenanceService {
     /// Clean up runtime snapshots older than 24 hours.
     /// Runs as part of the leader's cleanup cycle (not on every snapshot publish).
@@ -1177,5 +1110,72 @@ impl MaintenanceService {
                 self.metrics.record_queue_lag(queue, lag_seconds);
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+
+    fn cron_row(
+        cron_expr: &str,
+        created_at: chrono::DateTime<Utc>,
+        last_enqueued_at: Option<chrono::DateTime<Utc>>,
+    ) -> CronJobRow {
+        CronJobRow {
+            name: "test_cron".to_string(),
+            cron_expr: cron_expr.to_string(),
+            timezone: "UTC".to_string(),
+            kind: "test_job".to_string(),
+            queue: "default".to_string(),
+            args: serde_json::json!({}),
+            priority: 2,
+            max_attempts: 25,
+            tags: Vec::new(),
+            metadata: serde_json::json!({}),
+            last_enqueued_at,
+            created_at,
+            updated_at: created_at,
+        }
+    }
+
+    #[test]
+    fn compute_fire_time_coalesces_missed_existing_fires() {
+        let last = Utc.with_ymd_and_hms(2026, 5, 7, 12, 0, 0).unwrap();
+        let now = Utc.with_ymd_and_hms(2026, 5, 7, 12, 0, 20).unwrap();
+        let row = cron_row("*/5 * * * * *", last, Some(last));
+
+        let fire = compute_fire_time(&row, now);
+
+        assert_eq!(
+            fire,
+            Some(Utc.with_ymd_and_hms(2026, 5, 7, 12, 0, 20).unwrap())
+        );
+    }
+
+    #[test]
+    fn compute_fire_time_returns_none_when_no_fire_is_due() {
+        let last = Utc.with_ymd_and_hms(2026, 5, 7, 12, 0, 0).unwrap();
+        let now = Utc.with_ymd_and_hms(2026, 5, 7, 12, 0, 2).unwrap();
+        let row = cron_row("*/5 * * * * *", last, Some(last));
+
+        let fire = compute_fire_time(&row, now);
+
+        assert_eq!(fire, None);
+    }
+
+    #[test]
+    fn compute_fire_time_keeps_first_registration_latest_only() {
+        let created_at = Utc.with_ymd_and_hms(2026, 5, 7, 12, 0, 30).unwrap();
+        let now = Utc.with_ymd_and_hms(2026, 5, 7, 12, 0, 55).unwrap();
+        let row = cron_row("*/5 * * * * *", created_at, None);
+
+        let fire = compute_fire_time(&row, now);
+
+        assert_eq!(
+            fire,
+            Some(Utc.with_ymd_and_hms(2026, 5, 7, 12, 0, 55).unwrap())
+        );
     }
 }

--- a/awa-worker/src/maintenance.rs
+++ b/awa-worker/src/maintenance.rs
@@ -9,6 +9,7 @@ use std::collections::{HashMap, HashSet};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
+use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, info, warn};
 
@@ -72,6 +73,7 @@ pub struct MaintenanceService {
 
 const PROMOTE_BATCH_SIZE: i64 = 4_096;
 const PROMOTE_MAX_BATCHES_PER_TICK: usize = 32;
+const CRON_CATCH_UP_LIMIT: usize = 1_000;
 
 impl MaintenanceService {
     pub(crate) fn new(
@@ -269,7 +271,6 @@ impl MaintenanceService {
             let mut promote_timer = tokio::time::interval(self.promote_interval);
             let mut cleanup_timer = tokio::time::interval(self.cleanup_interval);
             let mut cron_sync_timer = tokio::time::interval(self.cron_sync_interval);
-            let mut cron_eval_timer = tokio::time::interval(self.cron_eval_interval);
             let mut leader_check_timer = tokio::time::interval(self.leader_check_interval);
             let mut queue_stats_timer = tokio::time::interval(self.queue_stats_interval);
             let mut dirty_key_timer = tokio::time::interval(self.dirty_key_recompute_interval);
@@ -284,7 +285,6 @@ impl MaintenanceService {
             promote_timer.tick().await;
             cleanup_timer.tick().await;
             cron_sync_timer.tick().await;
-            cron_eval_timer.tick().await;
             leader_check_timer.tick().await;
             queue_stats_timer.tick().await;
             dirty_key_timer.tick().await;
@@ -293,12 +293,19 @@ impl MaintenanceService {
 
             // Do an initial sync immediately on becoming leader
             self.sync_periodic_jobs_to_db().await;
+            let cron_eval_cancel = self.cancel.child_token();
+            let cron_eval_task = tokio::spawn(Self::run_cron_evaluator(
+                self.pool.clone(),
+                cron_eval_cancel.clone(),
+                self.cron_eval_interval,
+            ));
 
             loop {
                 tokio::select! {
                     _ = self.cancel.cancelled() => {
                         debug!("Maintenance service shutting down");
                         self.leader.store(false, Ordering::SeqCst);
+                        Self::stop_cron_evaluator(&cron_eval_cancel, &cron_eval_task);
                         // Release leader lock on the same connection that acquired it.
                         // If this fails, dropping the connection will release the lock anyway.
                         let _ = Self::release_leader(&mut leader_conn).await;
@@ -324,9 +331,6 @@ impl MaintenanceService {
                     _ = cron_sync_timer.tick() => {
                         self.sync_periodic_jobs_to_db().await;
                     }
-                    _ = cron_eval_timer.tick() => {
-                        self.evaluate_cron_schedules().await;
-                    }
                     _ = queue_stats_timer.tick() => {
                         self.publish_queue_health_metrics().await;
                     }
@@ -346,6 +350,7 @@ impl MaintenanceService {
                         if sqlx::query("SELECT 1").execute(&mut *leader_conn).await.is_err() {
                             warn!("Leader connection lost, re-entering election loop");
                             self.leader.store(false, Ordering::SeqCst);
+                            Self::stop_cron_evaluator(&cron_eval_cancel, &cron_eval_task);
                             break;
                         }
                     }
@@ -387,6 +392,25 @@ impl MaintenanceService {
         Ok(())
     }
 
+    async fn run_cron_evaluator(pool: PgPool, cancel: CancellationToken, interval: Duration) {
+        let mut timer = tokio::time::interval(interval);
+        timer.tick().await;
+
+        loop {
+            tokio::select! {
+                _ = cancel.cancelled() => return,
+                _ = timer.tick() => {
+                    Self::evaluate_cron_schedules(&pool).await;
+                }
+            }
+        }
+    }
+
+    fn stop_cron_evaluator(cancel: &CancellationToken, task: &JoinHandle<()>) {
+        cancel.cancel();
+        task.abort();
+    }
+
     /// Sync all registered periodic job schedules to `awa.cron_jobs` via UPSERT.
     ///
     /// Additive only — does NOT delete schedules not in the local set (multi-deployment safe).
@@ -410,12 +434,13 @@ impl MaintenanceService {
 
     /// Evaluate all cron schedules and enqueue any that are due.
     ///
-    /// For each schedule, computes the latest fire time ≤ now that is after
-    /// `last_enqueued_at`. If a fire is due, executes the atomic CTE to
-    /// mark + insert in one statement.
-    #[tracing::instrument(skip(self), name = "maintenance.cron_eval")]
-    async fn evaluate_cron_schedules(&self) {
-        let cron_rows = match list_cron_jobs(&self.pool).await {
+    /// For each schedule, computes due fire times ≤ now that are after
+    /// `last_enqueued_at`. If fires are due, executes the atomic CTE for each
+    /// fire in order so delayed evaluation catches up instead of collapsing
+    /// intermediate fires.
+    #[tracing::instrument(skip(pool), name = "maintenance.cron_eval")]
+    async fn evaluate_cron_schedules(pool: &PgPool) {
+        let cron_rows = match list_cron_jobs(pool).await {
             Ok(rows) => rows,
             Err(err) => {
                 error!(error = %err, "Failed to load cron jobs for evaluation");
@@ -430,30 +455,43 @@ impl MaintenanceService {
         let now = Utc::now();
 
         for row in &cron_rows {
-            let fire_time = match compute_fire_time(row, now) {
-                Some(time) => time,
-                None => continue,
-            };
+            let fire_times = compute_fire_times(row, now, CRON_CATCH_UP_LIMIT);
+            if fire_times.is_empty() {
+                continue;
+            }
+            if fire_times.len() == CRON_CATCH_UP_LIMIT {
+                warn!(
+                    cron_name = %row.name,
+                    catch_up_limit = CRON_CATCH_UP_LIMIT,
+                    "Cron catch-up limit reached; remaining due fires will be retried on the next evaluation"
+                );
+            }
 
-            match atomic_enqueue(&self.pool, &row.name, fire_time, row.last_enqueued_at).await {
-                Ok(Some(job)) => {
-                    info!(
-                        cron_name = %row.name,
-                        job_id = job.id,
-                        fire_time = %fire_time,
-                        "Enqueued periodic job"
-                    );
-                }
-                Ok(None) => {
-                    // Another leader already claimed this fire — not an error
-                    debug!(cron_name = %row.name, "Cron fire already claimed");
-                }
-                Err(err) => {
-                    error!(
-                        cron_name = %row.name,
-                        error = %err,
-                        "Failed to enqueue periodic job"
-                    );
+            let mut previous_enqueued_at = row.last_enqueued_at;
+            for fire_time in fire_times {
+                match atomic_enqueue(pool, &row.name, fire_time, previous_enqueued_at).await {
+                    Ok(Some(job)) => {
+                        previous_enqueued_at = Some(fire_time);
+                        info!(
+                            cron_name = %row.name,
+                            job_id = job.id,
+                            fire_time = %fire_time,
+                            "Enqueued periodic job"
+                        );
+                    }
+                    Ok(None) => {
+                        // Another leader already claimed this fire — not an error
+                        debug!(cron_name = %row.name, "Cron fire already claimed");
+                        break;
+                    }
+                    Err(err) => {
+                        error!(
+                            cron_name = %row.name,
+                            error = %err,
+                            "Failed to enqueue periodic job"
+                        );
+                        break;
+                    }
                 }
             }
         }
@@ -937,18 +975,21 @@ impl Drop for MaintenanceAliveGuard {
     }
 }
 
-/// Compute the latest fire time for a cron job row, using its expression and timezone.
+/// Compute due fire times for a cron job row, using its expression and timezone.
 ///
-/// Returns `None` if no fire is due (next occurrence is in the future).
-fn compute_fire_time(
+/// Existing schedules catch up missed fires up to `limit`. First registration
+/// still enqueues only the latest due fire to avoid backfilling before the
+/// schedule was known to AWA.
+fn compute_fire_times(
     row: &CronJobRow,
     now: chrono::DateTime<Utc>,
-) -> Option<chrono::DateTime<Utc>> {
+    limit: usize,
+) -> Vec<chrono::DateTime<Utc>> {
     let cron = match Cron::new(&row.cron_expr).with_seconds_optional().parse() {
         Ok(c) => c,
         Err(err) => {
             error!(cron_name = %row.name, error = %err, "Invalid cron expression in database");
-            return None;
+            return Vec::new();
         }
     };
 
@@ -956,7 +997,7 @@ fn compute_fire_time(
         Ok(tz) => tz,
         Err(err) => {
             error!(cron_name = %row.name, error = %err, "Invalid timezone in database");
-            return None;
+            return Vec::new();
         }
     };
 
@@ -969,6 +1010,7 @@ fn compute_fire_time(
         None => (row.created_at - chrono::Duration::minutes(1)).with_timezone(&tz),
     };
 
+    let mut fire_times = Vec::new();
     let mut latest_fire: Option<chrono::DateTime<Utc>> = None;
 
     for fire_time in cron.iter_from(search_start) {
@@ -984,10 +1026,100 @@ fn compute_fire_time(
             }
         }
 
-        latest_fire = Some(fire_utc);
+        if row.last_enqueued_at.is_none() {
+            latest_fire = Some(fire_utc);
+            continue;
+        }
+
+        fire_times.push(fire_utc);
+        if fire_times.len() >= limit {
+            break;
+        }
     }
 
-    latest_fire
+    if row.last_enqueued_at.is_none() {
+        latest_fire.into_iter().collect()
+    } else {
+        fire_times
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+
+    fn cron_row(
+        cron_expr: &str,
+        created_at: chrono::DateTime<Utc>,
+        last_enqueued_at: Option<chrono::DateTime<Utc>>,
+    ) -> CronJobRow {
+        CronJobRow {
+            name: "test_cron".to_string(),
+            cron_expr: cron_expr.to_string(),
+            timezone: "UTC".to_string(),
+            kind: "test_job".to_string(),
+            queue: "default".to_string(),
+            args: serde_json::json!({}),
+            priority: 2,
+            max_attempts: 25,
+            tags: Vec::new(),
+            metadata: serde_json::json!({}),
+            last_enqueued_at,
+            created_at,
+            updated_at: created_at,
+        }
+    }
+
+    #[test]
+    fn compute_fire_times_catches_up_missed_existing_fires() {
+        let last = Utc.with_ymd_and_hms(2026, 5, 7, 12, 0, 0).unwrap();
+        let now = Utc.with_ymd_and_hms(2026, 5, 7, 12, 0, 20).unwrap();
+        let row = cron_row("*/5 * * * * *", last, Some(last));
+
+        let fires = compute_fire_times(&row, now, CRON_CATCH_UP_LIMIT);
+
+        assert_eq!(
+            fires,
+            vec![
+                Utc.with_ymd_and_hms(2026, 5, 7, 12, 0, 5).unwrap(),
+                Utc.with_ymd_and_hms(2026, 5, 7, 12, 0, 10).unwrap(),
+                Utc.with_ymd_and_hms(2026, 5, 7, 12, 0, 15).unwrap(),
+                Utc.with_ymd_and_hms(2026, 5, 7, 12, 0, 20).unwrap(),
+            ]
+        );
+    }
+
+    #[test]
+    fn compute_fire_times_limits_catch_up_work() {
+        let last = Utc.with_ymd_and_hms(2026, 5, 7, 12, 0, 0).unwrap();
+        let now = Utc.with_ymd_and_hms(2026, 5, 7, 12, 0, 30).unwrap();
+        let row = cron_row("*/5 * * * * *", last, Some(last));
+
+        let fires = compute_fire_times(&row, now, 2);
+
+        assert_eq!(
+            fires,
+            vec![
+                Utc.with_ymd_and_hms(2026, 5, 7, 12, 0, 5).unwrap(),
+                Utc.with_ymd_and_hms(2026, 5, 7, 12, 0, 10).unwrap(),
+            ]
+        );
+    }
+
+    #[test]
+    fn compute_fire_times_keeps_first_registration_latest_only() {
+        let created_at = Utc.with_ymd_and_hms(2026, 5, 7, 12, 0, 30).unwrap();
+        let now = Utc.with_ymd_and_hms(2026, 5, 7, 12, 0, 55).unwrap();
+        let row = cron_row("*/5 * * * * *", created_at, None);
+
+        let fires = compute_fire_times(&row, now, CRON_CATCH_UP_LIMIT);
+
+        assert_eq!(
+            fires,
+            vec![Utc.with_ymd_and_hms(2026, 5, 7, 12, 0, 55).unwrap()]
+        );
+    }
 }
 
 impl MaintenanceService {

--- a/awa/Cargo.toml
+++ b/awa/Cargo.toml
@@ -20,7 +20,7 @@ awa-macros.workspace = true
 awa-worker.workspace = true
 
 [dev-dependencies]
-awa-testing = { path = "../awa-testing", version = "0.5.6" }
+awa-testing = { path = "../awa-testing", version = "0.5.7" }
 sqlx.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/docs/security.md
+++ b/docs/security.md
@@ -87,15 +87,17 @@ GRANT USAGE, SELECT ON SEQUENCE awa.jobs_id_seq TO awa_runtime;
 
 -- All tables: the runtime needs full DML because triggers run as the
 -- invoking role (SECURITY INVOKER), so inserting a job also writes to
--- the admin metadata cache tables via triggers.
-GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA awa TO awa_runtime;
+-- the admin metadata cache tables via triggers. The maintenance leader
+-- also calls refresh_admin_metadata(), which truncates dirty-key tables
+-- after taking the metadata advisory lock.
+GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE ON ALL TABLES IN SCHEMA awa TO awa_runtime;
 
 -- Functions (trigger functions execute with invoker privileges)
 GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA awa TO awa_runtime;
 
 -- Default privileges for future migrations
 ALTER DEFAULT PRIVILEGES FOR ROLE awa_owner IN SCHEMA awa
-  GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO awa_runtime;
+  GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE ON TABLES TO awa_runtime;
 ALTER DEFAULT PRIVILEGES FOR ROLE awa_owner IN SCHEMA awa
   GRANT USAGE, SELECT ON SEQUENCES TO awa_runtime;
 ALTER DEFAULT PRIVILEGES FOR ROLE awa_owner IN SCHEMA awa
@@ -121,7 +123,7 @@ This allows creating temporary staging tables for the `COPY` bulk insert path.
 
 ## What the runtime role needs and why
 
-The runtime grants look broad (`SELECT, INSERT, UPDATE, DELETE ON ALL TABLES`) because AWA's internal tables are maintained by `SECURITY INVOKER` trigger functions. When a worker inserts a job, triggers automatically update:
+The runtime grants look broad (`SELECT, INSERT, UPDATE, DELETE, TRUNCATE ON ALL TABLES`) because AWA's internal tables are maintained by `SECURITY INVOKER` trigger functions. When a worker inserts a job, triggers automatically update:
 
 - `awa.queue_state_counts` — per-queue job state tallies
 - `awa.job_kind_catalog` — distinct job kinds
@@ -129,6 +131,8 @@ The runtime grants look broad (`SELECT, INSERT, UPDATE, DELETE ON ALL TABLES`) b
 - `awa.job_unique_claims` — unique key deduplication
 
 Since these triggers run with the caller's privileges, the runtime role needs write access to these internal tables even though application code never touches them directly.
+
+The maintenance leader also calls `awa.refresh_admin_metadata()` as a full reconciliation safety net. That function runs with invoker privileges and uses `TRUNCATE` on `awa.admin_dirty_queues` and `awa.admin_dirty_kinds` after taking the metadata advisory lock, so `awa_runtime` needs the `TRUNCATE` table privilege too.
 
 The runtime also directly upserts into the descriptor catalogs on startup and on each runtime snapshot tick:
 
@@ -158,14 +162,14 @@ profiles:
       - on: { type: schema }
         privileges: [USAGE]
       - on: { type: table, name: "*" }
-        privileges: [SELECT, INSERT, UPDATE, DELETE]
+        privileges: [SELECT, INSERT, UPDATE, DELETE, TRUNCATE]
       - on: { type: sequence, name: "*" }
         privileges: [USAGE, SELECT]
       - on: { type: function, name: "*" }
         privileges: [EXECUTE]
     default_privileges:
       - on_type: table
-        privileges: [SELECT, INSERT, UPDATE, DELETE]
+        privileges: [SELECT, INSERT, UPDATE, DELETE, TRUNCATE]
       - on_type: sequence
         privileges: [USAGE, SELECT]
       - on_type: function


### PR DESCRIPTION
## Summary

- backport cron-evaluator isolation to the 0.5.x release branch so unrelated maintenance work cannot starve cron evaluation
- preserve 0.5.x cron semantics: delayed evaluation still coalesces to the latest due fire, with no catch-up behavior change in the hotfix
- document that the runtime role needs `TRUNCATE` on AWA tables because `refresh_admin_metadata()` truncates dirty-key tables under invoker privileges

Refs #239

## Testing

- `cargo test -p awa-worker maintenance::tests::compute_fire_time --lib`
- `cargo clippy --all-targets --all-features -- -D warnings`
