### PR TITLE
Fix Python helper teardown in subprocess tests

### DIFF
--- a/awa-python/tests/_subprocess_exit.py
+++ b/awa-python/tests/_subprocess_exit.py
@@ -1,0 +1,21 @@
+import asyncio
+import os
+import signal
+from collections.abc import Awaitable, Callable
+from types import FrameType
+from typing import NoReturn
+
+
+def _exit_from_signal(signum: int, _frame: FrameType | None) -> NoReturn:
+    os._exit(128 + signum)
+
+
+def install_exit_without_finalizers_on_signals() -> None:
+    signal.signal(signal.SIGINT, _exit_from_signal)
+    signal.signal(signal.SIGTERM, _exit_from_signal)
+
+
+def run_async_main_without_finalizers(main: Callable[[], Awaitable[None]]) -> NoReturn:
+    install_exit_without_finalizers_on_signals()
+    asyncio.run(main())
+    os._exit(0)

--- a/awa-python/tests/chaos_worker.py
+++ b/awa-python/tests/chaos_worker.py
@@ -3,6 +3,7 @@ import os
 from dataclasses import dataclass
 
 import awa
+from _subprocess_exit import run_async_main_without_finalizers
 
 
 @dataclass
@@ -73,4 +74,7 @@ async def main() -> None:
 
 
 if __name__ == "__main__":
-    asyncio.run(main())
+    # PyO3/tokio teardown can segfault while Python unloads modules. These
+    # helpers run in single-purpose subprocesses, so skip finalizers after a
+    # clean run or an external stop signal.
+    run_async_main_without_finalizers(main)

--- a/awa-python/tests/mixed_fleet_helper.py
+++ b/awa-python/tests/mixed_fleet_helper.py
@@ -3,6 +3,7 @@ import os
 from dataclasses import dataclass
 
 import awa
+from _subprocess_exit import run_async_main_without_finalizers
 
 
 @dataclass
@@ -108,4 +109,7 @@ async def main() -> None:
 
 
 if __name__ == "__main__":
-    asyncio.run(main())
+    # PyO3/tokio teardown can segfault while Python unloads modules. These
+    # helpers run in single-purpose subprocesses, so skip finalizers after a
+    # clean run or an external stop signal.
+    run_async_main_without_finalizers(main)

--- a/awa-python/tests/test_subprocess_exit.py
+++ b/awa-python/tests/test_subprocess_exit.py
@@ -1,0 +1,83 @@
+import os
+import signal
+import subprocess
+import sys
+import textwrap
+
+import pytest
+
+
+def _run_helper_script(script: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, "-c", textwrap.dedent(script)],
+        check=False,
+        cwd=os.path.dirname(__file__),
+        text=True,
+        capture_output=True,
+    )
+
+
+def test_run_async_main_without_finalizers_skips_atexit_hooks():
+    result = _run_helper_script(
+        """
+        import atexit
+        import asyncio
+
+        from _subprocess_exit import run_async_main_without_finalizers
+
+        atexit.register(lambda: print("atexit-ran", flush=True))
+
+        async def main():
+            print("main-ran", flush=True)
+
+        run_async_main_without_finalizers(main)
+        print("after-runner", flush=True)
+        """
+    )
+
+    assert result.returncode == 0
+    assert result.stdout == "main-ran\n"
+    assert result.stderr == ""
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX signal status assertion")
+def test_run_async_main_without_finalizers_exits_directly_on_sigterm():
+    process = subprocess.Popen(
+        [
+            sys.executable,
+            "-c",
+            textwrap.dedent(
+                """
+                import atexit
+                import asyncio
+
+                from _subprocess_exit import run_async_main_without_finalizers
+
+                atexit.register(lambda: print("atexit-ran", flush=True))
+
+                async def main():
+                    print("ready", flush=True)
+                    await asyncio.Event().wait()
+
+                run_async_main_without_finalizers(main)
+                """
+            ),
+        ],
+        cwd=os.path.dirname(__file__),
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+    try:
+        assert process.stdout is not None
+        assert process.stdout.readline() == "ready\n"
+        process.terminate()
+        stdout, stderr = process.communicate(timeout=5)
+    finally:
+        if process.poll() is None:
+            process.kill()
+
+    assert process.returncode == 128 + signal.SIGTERM
+    assert stdout == ""
+    assert stderr == ""


### PR DESCRIPTION
## Summary

- add a shared test-helper runner that exits with `os._exit` after successful async helper completion
- install SIGINT/SIGTERM handlers so externally stopped helper subprocesses also bypass Python finalizers
- use the runner from both Python helper scripts involved in the chaos subprocess tests
- add subprocess-level tests proving normal completion and SIGTERM skip `atexit`/interpreter finalizers

This is a focused replacement for the workaround proposed by @vesperai-890 in #230. Credit to that PR for identifying the `os._exit` approach; this version rebases the idea onto current `main` without carrying the stale dispatcher/test changes from the old branch.

Fixes #228.

## Validation

- `python3 -m py_compile awa-python/tests/chaos_worker.py awa-python/tests/mixed_fleet_helper.py awa-python/tests/_subprocess_exit.py awa-python/tests/test_subprocess_exit.py`
- `uv run --with pytest python -m pytest awa-python/tests/test_subprocess_exit.py -q`

Note: local system Python does not have pytest installed, so the pytest run used `uv run --with pytest`.
