### PR TITLE
Bump version to 0.6.0-alpha.7

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,6 +68,7 @@ jobs:
 
           checks = [
               ("Cargo.toml", cargo_version("Cargo.toml")),
+              ("awa-cli/pyproject.toml", pyproject_version("awa-cli/pyproject.toml")),
               ("awa-python/Cargo.toml", cargo_version("awa-python/Cargo.toml")),
               ("awa-python/pyproject.toml", pyproject_version("awa-python/pyproject.toml")),
               ("awa-python/pyproject.toml [ui] extra", ui_extra_pin("awa-python/pyproject.toml")),

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,39 @@ transitions live in [`docs/upgrade-0.5-to-0.6.md`](docs/upgrade-0.5-to-0.6.md).
 
 ## Unreleased
 
+## [0.6.0-alpha.7] — 2026-05-07
+
+### Added
+
+- **Cron missed-fire policy** ([#239](https://github.com/hardbyte/awa/issues/239),
+  [#240](https://github.com/hardbyte/awa/pull/240)). Periodic schedules now
+  persist an explicit `missed_fire_policy`: `coalesce` remains the default and
+  enqueues only the latest due fire after delayed evaluation, while `catch_up`
+  enqueues missed fires in timestamp order for idempotent reconciliation jobs.
+  The policy is exposed through the Rust and Python APIs, CLI schedule output,
+  docs, and migration v015.
+
+### Changed
+
+- **Cron evaluation runs in its own leader-scoped maintenance lane**
+  ([#240](https://github.com/hardbyte/awa/pull/240)). Slow cleanup, rotation,
+  or reconciliation work no longer starves the scheduler branch. Coalesced
+  schedules also use a bounded latest-fire lookup so a stale high-frequency
+  schedule does not scan every missed tick.
+- **Runtime grants now document required `TRUNCATE` privileges**
+  ([#239](https://github.com/hardbyte/awa/issues/239),
+  [#240](https://github.com/hardbyte/awa/pull/240)). The security guide now
+  includes `TRUNCATE` in runtime table grants and default privileges, with a
+  DB-backed regression covering the previously documented grants.
+
+### Fixed
+
+- **Queue-storage claim transactions commit before rescueable runtime payload
+  conversion** ([#222](https://github.com/hardbyte/awa/pull/222)). Runtime
+  claims now keep hot claim transactions shorter while preserving rollback
+  behavior for legacy zero-deadline claims that cannot be rescued after a
+  conversion error.
+
 ## [0.6.0-alpha.6] — 2026-05-07
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,7 +171,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "awa"
-version = "0.6.0-alpha.6"
+version = "0.6.0-alpha.7"
 dependencies = [
  "async-trait",
  "awa-macros",
@@ -196,7 +196,7 @@ dependencies = [
 
 [[package]]
 name = "awa-cli"
-version = "0.6.0-alpha.6"
+version = "0.6.0-alpha.7"
 dependencies = [
  "assert_cmd",
  "awa-model",
@@ -218,7 +218,7 @@ dependencies = [
 
 [[package]]
 name = "awa-macros"
-version = "0.6.0-alpha.6"
+version = "0.6.0-alpha.7"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -228,7 +228,7 @@ dependencies = [
 
 [[package]]
 name = "awa-metrics"
-version = "0.6.0-alpha.6"
+version = "0.6.0-alpha.7"
 dependencies = [
  "awa-model",
  "opentelemetry",
@@ -236,7 +236,7 @@ dependencies = [
 
 [[package]]
 name = "awa-model"
-version = "0.6.0-alpha.6"
+version = "0.6.0-alpha.7"
 dependencies = [
  "awa-macros",
  "blake3",
@@ -257,7 +257,7 @@ dependencies = [
 
 [[package]]
 name = "awa-testing"
-version = "0.6.0-alpha.6"
+version = "0.6.0-alpha.7"
 dependencies = [
  "async-trait",
  "awa-model",
@@ -272,7 +272,7 @@ dependencies = [
 
 [[package]]
 name = "awa-ui"
-version = "0.6.0-alpha.6"
+version = "0.6.0-alpha.7"
 dependencies = [
  "awa-metrics",
  "awa-model",
@@ -295,7 +295,7 @@ dependencies = [
 
 [[package]]
 name = "awa-worker"
-version = "0.6.0-alpha.6"
+version = "0.6.0-alpha.7"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = [
 exclude = ["awa-python", "spike"]
 
 [workspace.package]
-version = "0.6.0-alpha.6"
+version = "0.6.0-alpha.7"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "Postgres-native background job queue — transactional enqueue, heartbeat crash recovery, SKIP LOCKED dispatch"
@@ -24,10 +24,10 @@ categories = ["database", "asynchronous", "web-programming"]
 
 [workspace.dependencies]
 # Internal crates
-awa-model = { path = "awa-model", version = "0.6.0-alpha.6" }
-awa-macros = { path = "awa-macros", version = "0.6.0-alpha.6" }
-awa-metrics = { path = "awa-metrics", version = "0.6.0-alpha.6" }
-awa-worker = { path = "awa-worker", version = "0.6.0-alpha.6" }
+awa-model = { path = "awa-model", version = "0.6.0-alpha.7" }
+awa-macros = { path = "awa-macros", version = "0.6.0-alpha.7" }
+awa-metrics = { path = "awa-metrics", version = "0.6.0-alpha.7" }
+awa-worker = { path = "awa-worker", version = "0.6.0-alpha.7" }
 
 # Database
 sqlx = { version = "0.8", features = ["runtime-tokio-rustls", "postgres", "chrono", "json", "migrate", "uuid"] }

--- a/awa-cli/Cargo.toml
+++ b/awa-cli/Cargo.toml
@@ -14,7 +14,7 @@ path = "src/main.rs"
 [dependencies]
 awa-model.workspace = true
 awa-worker.workspace = true
-awa-ui = { path = "../awa-ui", version = "0.6.0-alpha.6" }
+awa-ui = { path = "../awa-ui", version = "0.6.0-alpha.7" }
 axum.workspace = true
 sqlx.workspace = true
 tokio.workspace = true
@@ -26,7 +26,7 @@ chrono.workspace = true
 hex.workspace = true
 
 [dev-dependencies]
-awa-testing = { path = "../awa-testing", version = "0.6.0-alpha.6" }
+awa-testing = { path = "../awa-testing", version = "0.6.0-alpha.7" }
 assert_cmd = "2"
 serde.workspace = true
 uuid.workspace = true

--- a/awa-cli/pyproject.toml
+++ b/awa-cli/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "awa-cli"
-version = "0.6.0-alpha.6"
+version = "0.6.0-alpha.7"
 description = "CLI for the Awa Postgres-native job queue (migrations, admin, serve)"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/awa-python/Cargo.lock
+++ b/awa-python/Cargo.lock
@@ -95,7 +95,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "awa-macros"
-version = "0.6.0-alpha.6"
+version = "0.6.0-alpha.7"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -105,7 +105,7 @@ dependencies = [
 
 [[package]]
 name = "awa-metrics"
-version = "0.6.0-alpha.6"
+version = "0.6.0-alpha.7"
 dependencies = [
  "awa-model",
  "opentelemetry",
@@ -113,7 +113,7 @@ dependencies = [
 
 [[package]]
 name = "awa-model"
-version = "0.6.0-alpha.6"
+version = "0.6.0-alpha.7"
 dependencies = [
  "awa-macros",
  "blake3",
@@ -133,7 +133,7 @@ dependencies = [
 
 [[package]]
 name = "awa-python"
-version = "0.6.0-alpha.6"
+version = "0.6.0-alpha.7"
 dependencies = [
  "async-trait",
  "awa-model",
@@ -156,7 +156,7 @@ dependencies = [
 
 [[package]]
 name = "awa-worker"
-version = "0.6.0-alpha.6"
+version = "0.6.0-alpha.7"
 dependencies = [
  "async-trait",
  "awa-macros",

--- a/awa-python/Cargo.toml
+++ b/awa-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "awa-python"
-version = "0.6.0-alpha.6"
+version = "0.6.0-alpha.7"
 edition = "2021"
 
 [lib]
@@ -12,8 +12,8 @@ default = ["cel"]
 cel = ["awa-model/cel"]
 
 [dependencies]
-awa-model = { path = "../awa-model", version = "0.6.0-alpha.6" }
-awa-worker = { path = "../awa-worker", version = "0.6.0-alpha.6", features = ["__python-bridge"] }
+awa-model = { path = "../awa-model", version = "0.6.0-alpha.7" }
+awa-worker = { path = "../awa-worker", version = "0.6.0-alpha.7", features = ["__python-bridge"] }
 pyo3 = { version = "0.28", features = ["macros", "abi3-py310", "chrono"] }
 pyo3-async-runtimes = { version = "0.28", features = ["tokio-runtime"] }
 sqlx = { version = "0.8", features = ["runtime-tokio-rustls", "postgres", "chrono", "json"] }

--- a/awa-python/pyproject.toml
+++ b/awa-python/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "maturin"
 [project]
 name = "awa-pg"
 requires-python = ">=3.10"
-version = "0.6.0-alpha.6"
+version = "0.6.0-alpha.7"
 description = "Postgres-native background job queue — Python SDK with async/sync workers, transactional enqueue, and progress tracking. Install awa-pg[ui] to add the bundled web dashboard."
 readme = {file = "../README.md", content-type = "text/markdown"}
 license = {text = "MIT OR Apache-2.0"}
@@ -32,7 +32,7 @@ classifiers = [
 #
 # Kept opt-in so the default `awa-pg` install stays small — workers and
 # producers don't need the ~10 MB UI bundle.
-ui = ["awa-cli==0.6.0-alpha.6"]
+ui = ["awa-cli==0.6.0-alpha.7"]
 
 [project.urls]
 Homepage = "https://github.com/hardbyte/awa"

--- a/awa/Cargo.toml
+++ b/awa/Cargo.toml
@@ -20,7 +20,7 @@ awa-macros.workspace = true
 awa-worker.workspace = true
 
 [dev-dependencies]
-awa-testing = { path = "../awa-testing", version = "0.6.0-alpha.5" }
+awa-testing = { path = "../awa-testing", version = "0.6.0-alpha.7" }
 sqlx.workspace = true
 serde.workspace = true
 serde_json.workspace = true


### PR DESCRIPTION
## Summary

- bump Rust workspace, Python package metadata, and lockfiles to 0.6.0-alpha.7
- add changelog notes for cron maintenance isolation, explicit missed-fire policy, TRUNCATE grant docs, and queue-storage claim transaction shortening

## Testing

- cargo check -p awa-cli -p awa-worker
- PYO3_PYTHON=/Users/brian/.local/bin/python3.12 cargo check --manifest-path awa-python/Cargo.toml
- cargo fmt --all --check
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Cron missed-fire policy for periodic schedules with configurable coalesce and catch_up behaviors
  * Implemented Cron evaluation isolation to prevent scheduler starvation

* **Bug Fixes**
  * Fixed queue-storage claim transactions to commit before payload conversion, preserving rollback semantics

* **Chores**
  * Bumped version to 0.6.0-alpha.7

<!-- end of auto-generated comment: release notes by coderabbit.ai -->