### PR TITLE
Expose DLQ policy in runtime UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ transitions live in [`docs/upgrade-0.5-to-0.6.md`](docs/upgrade-0.5-to-0.6.md).
 
 ## Unreleased
 
+### Added
+
+- **Lifecycle hooks now include `Started` events**. `JobEvent<T>` and
+  `UntypedJobEvent` fire `Started` after a claim commits and just before the
+  worker handler is invoked, so applications can observe job execution
+  beginning as well as final outcomes.
+
+### Changed
+
+- **Breaking alpha API change:** exhaustive matches on `JobEvent<T>` or
+  `UntypedJobEvent` must handle the new `Started` variant. No stable Awa
+  release has been published yet, so this is documented as an alpha-series
+  source break.
+
 ## [0.6.0-alpha.7] — 2026-05-07
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -279,6 +279,11 @@ let client = Client::builder(pool)
 client.start().await?;
 ```
 
+Lifecycle hooks receive `Started` after a claim commits as the worker handler
+is about to run, plus outcome events (`Completed`, `Retried`, `Exhausted`,
+`Cancelled`) after the corresponding state transition commits. Hooks run in
+detached tasks, so they do not block job execution.
+
 Cancellation is cooperative for running handlers:
 
 - Rust handlers can poll `ctx.is_cancelled()`.
@@ -406,7 +411,7 @@ Rust and Python workers coexist on the same queues. See
 - [012: Split hot and deferred job storage](docs/adr/012-hot-deferred-job-storage.md)
 - [013: Durable run leases and guarded finalization](docs/adr/013-run-lease-and-guarded-finalization.md)
 - [014: Structured progress and metadata](docs/adr/014-structured-progress.md)
-- [015: Builder-side post-commit lifecycle hooks](docs/adr/015-post-commit-lifecycle-hooks.md)
+- [015: Builder-side lifecycle hooks](docs/adr/015-post-commit-lifecycle-hooks.md)
 - [016: Shared insert preparation and tokio-postgres adapter](docs/adr/016-bridge-adapters.md)
 - [017: Python insert-only transaction bridging](docs/adr/017-python-transaction-bridging.md)
 - [018: HTTP Worker for serverless job dispatch](docs/adr/018-http-worker.md)

--- a/awa-model/src/admin.rs
+++ b/awa-model/src/admin.rs
@@ -1168,6 +1168,8 @@ pub struct QueueRuntimeConfigSnapshot {
     pub poll_interval_ms: u64,
     pub deadline_duration_secs: u64,
     pub priority_aging_interval_secs: u64,
+    #[serde(default)]
+    pub dlq_enabled: Option<bool>,
     pub rate_limit: Option<RateLimitSnapshot>,
 }
 
@@ -1389,6 +1391,41 @@ pub struct QueueRuntimeSummary {
     pub overflow_held_total: Option<u64>,
     pub config_mismatch: bool,
     pub config: Option<QueueRuntimeConfigSnapshot>,
+}
+
+fn queue_runtime_configs_match(
+    left: &QueueRuntimeConfigSnapshot,
+    right: &QueueRuntimeConfigSnapshot,
+) -> bool {
+    left.mode == right.mode
+        && left.max_workers == right.max_workers
+        && left.min_workers == right.min_workers
+        && left.weight == right.weight
+        && left.global_max_workers == right.global_max_workers
+        && left.poll_interval_ms == right.poll_interval_ms
+        && left.deadline_duration_secs == right.deadline_duration_secs
+        && left.priority_aging_interval_secs == right.priority_aging_interval_secs
+        && left.rate_limit == right.rate_limit
+        && (left.dlq_enabled.is_none()
+            || right.dlq_enabled.is_none()
+            || left.dlq_enabled == right.dlq_enabled)
+}
+
+fn representative_queue_runtime_config(
+    configs: &[QueueRuntimeConfigSnapshot],
+) -> Option<QueueRuntimeConfigSnapshot> {
+    let first = configs.first()?;
+    if first.dlq_enabled.is_some() {
+        return Some(first.clone());
+    }
+
+    configs
+        .iter()
+        .find(|candidate| {
+            candidate.dlq_enabled.is_some() && queue_runtime_configs_match(first, candidate)
+        })
+        .cloned()
+        .or_else(|| Some(first.clone()))
 }
 
 #[derive(Debug, sqlx::FromRow)]
@@ -1658,11 +1695,12 @@ where
             } else {
                 live_configs
             };
-            let config = config_candidates.first().cloned();
-            let config_mismatch = config_candidates
-                .iter()
-                .skip(1)
-                .any(|candidate| Some(candidate) != config.as_ref());
+            let config = representative_queue_runtime_config(&config_candidates);
+            let config_mismatch = config_candidates.iter().skip(1).any(|candidate| {
+                config
+                    .as_ref()
+                    .is_some_and(|cfg| !queue_runtime_configs_match(cfg, candidate))
+            });
 
             QueueRuntimeSummary {
                 queue,

--- a/awa-ui/frontend/e2e/queues.spec.ts
+++ b/awa-ui/frontend/e2e/queues.spec.ts
@@ -33,7 +33,7 @@ test.describe("Queues page", () => {
       "Running",
       "Retry",
       "Failed",
-      "Rate/hr",
+      "Completed/hr",
       "Capacity",
       "Status",
       "Actions",
@@ -74,6 +74,73 @@ test.describe("Queues page", () => {
     }
   });
 
+  test("queue table surfaces DLQ policy from runtime config", async ({ page }) => {
+    await page.route("**/api/queues", async (route) => {
+      await route.fulfill({
+        contentType: "application/json",
+        body: JSON.stringify([
+          {
+            queue: "dlq_off_queue",
+            display_name: "DLQ Off Queue",
+            description: null,
+            owner: null,
+            docs_url: null,
+            tags: [],
+            extra: {},
+            descriptor_last_seen_at: "2026-03-01T00:00:00Z",
+            descriptor_stale: false,
+            descriptor_mismatch: false,
+            total_queued: 1,
+            scheduled: 0,
+            available: 1,
+            retryable: 0,
+            running: 0,
+            failed: 1,
+            waiting_external: 0,
+            completed_last_hour: 0,
+            lag_seconds: 1,
+            paused: false,
+          },
+        ]),
+      });
+    });
+    await page.route("**/api/queues/runtime", async (route) => {
+      await route.fulfill({
+        contentType: "application/json",
+        body: JSON.stringify([
+          {
+            queue: "dlq_off_queue",
+            instance_count: 1,
+            live_instances: 1,
+            stale_instances: 0,
+            healthy_instances: 1,
+            total_in_flight: 0,
+            overflow_held_total: 0,
+            config_mismatch: false,
+            config: {
+              mode: "weighted",
+              max_workers: null,
+              min_workers: 1,
+              weight: 1,
+              global_max_workers: 16,
+              poll_interval_ms: 200,
+              deadline_duration_secs: 300,
+              priority_aging_interval_secs: 60,
+              dlq_enabled: false,
+              rate_limit: null,
+            },
+          },
+        ]),
+      });
+    });
+
+    await page.goto("/queues");
+
+    const queueTable = page.getByRole("grid", { name: "Queues" });
+    await expect(queueTable.getByRole("rowheader", { name: /DLQ Off Queue/ })).toBeVisible();
+    await expect(queueTable.getByText("DLQ off", { exact: true })).toBeVisible();
+  });
+
   test("click queue navigates to queue detail", async ({ page }) => {
     await loadQueuesPage(page);
 
@@ -98,6 +165,81 @@ test.describe("Queues page", () => {
     await expect(page.getByText("End-to-end queue used for UI coverage")).toBeVisible();
     await expect(page.getByText("qa-platform")).toBeVisible();
     await expect(page.getByText("critical")).toBeVisible();
+  });
+
+  test("queue detail links to filtered DLQ rows when DLQ is enabled", async ({ page }) => {
+    await page.route("**/api/queues/payments", async (route) => {
+      await route.fulfill({
+        contentType: "application/json",
+        body: JSON.stringify({
+          queue: "payments",
+          display_name: "Payments",
+          description: "Customer payment processing",
+          owner: "platform",
+          docs_url: null,
+          tags: ["critical"],
+          extra: {},
+          descriptor_last_seen_at: "2026-03-01T00:00:00Z",
+          descriptor_stale: false,
+          descriptor_mismatch: false,
+          total_queued: 1,
+          scheduled: 0,
+          available: 1,
+          retryable: 0,
+          running: 0,
+          failed: 1,
+          waiting_external: 0,
+          completed_last_hour: 0,
+          lag_seconds: 1,
+          paused: false,
+        }),
+      });
+    });
+    await page.route("**/api/queues/runtime", async (route) => {
+      await route.fulfill({
+        contentType: "application/json",
+        body: JSON.stringify([
+          {
+            queue: "payments",
+            instance_count: 1,
+            live_instances: 1,
+            stale_instances: 0,
+            healthy_instances: 1,
+            total_in_flight: 0,
+            overflow_held_total: 0,
+            config_mismatch: false,
+            config: {
+              mode: "weighted",
+              max_workers: null,
+              min_workers: 1,
+              weight: 1,
+              global_max_workers: 16,
+              poll_interval_ms: 200,
+              deadline_duration_secs: 300,
+              priority_aging_interval_secs: 60,
+              dlq_enabled: true,
+              rate_limit: null,
+            },
+          },
+        ]),
+      });
+    });
+    await page.route("**/api/dlq/depth", async (route) => {
+      await route.fulfill({
+        contentType: "application/json",
+        body: JSON.stringify({ total: 0, by_queue: [] }),
+      });
+    });
+    await page.route("**/api/dlq**", async (route) => {
+      await route.fulfill({ contentType: "application/json", body: JSON.stringify([]) });
+    });
+
+    await page.goto("/queues/payments");
+
+    const dlqLink = page.getByRole("link", { name: "View DLQ rows" });
+    await expect(dlqLink).toBeVisible();
+    await dlqLink.click();
+    await expect(page).toHaveURL(/\/dlq\?q=queue%3Apayments$/);
   });
 
   test("legacy queue still renders without descriptors", async ({ page }) => {

--- a/awa-ui/frontend/e2e/runtime.spec.ts
+++ b/awa-ui/frontend/e2e/runtime.spec.ts
@@ -90,6 +90,7 @@ test.describe("Runtime page", () => {
                     poll_interval_ms: 200,
                     deadline_duration_secs: 300,
                     priority_aging_interval_secs: 60,
+                    dlq_enabled: true,
                     rate_limit: { max_rate: 5.5, burst: 10 },
                   },
                 },
@@ -126,6 +127,7 @@ test.describe("Runtime page", () => {
                     poll_interval_ms: 200,
                     deadline_duration_secs: 300,
                     priority_aging_interval_secs: 60,
+                    dlq_enabled: true,
                     rate_limit: { max_rate: 5.5, burst: 10 },
                   },
                 },
@@ -158,6 +160,7 @@ test.describe("Runtime page", () => {
               poll_interval_ms: 200,
               deadline_duration_secs: 300,
               priority_aging_interval_secs: 60,
+              dlq_enabled: true,
               rate_limit: { max_rate: 5.5, burst: 10 },
             },
           },
@@ -178,10 +181,11 @@ test.describe("Runtime page", () => {
     const queueGrid = page.getByRole("grid", { name: "Queue runtime summary" });
     await expect(queueGrid).toBeVisible();
     await expect(queueGrid.getByRole("rowheader", { name: "email" })).toBeVisible();
-    await expect(queueGrid.getByRole("gridcell", { name: "min 2 / w 3" })).toBeVisible();
-    await expect(queueGrid.getByRole("gridcell", { name: "5.5/s (10)" })).toBeVisible();
+    await expect(queueGrid.getByRole("gridcell", { name: "min 2 / weight 3" })).toBeVisible();
+    await expect(queueGrid.getByRole("gridcell", { name: /5\.5\/s · burst 10/ })).toBeVisible();
     await expect(queueGrid.getByText("global 16")).toBeVisible();
-    await expect(queueGrid.getByText("poll 200ms · deadline 300s · aging 60s")).toBeVisible();
+    await expect(queueGrid.getByText("DLQ on", { exact: true })).toBeVisible();
+    await expect(queueGrid.getByText("poll 200ms · deadline 300s · aging 60s · DLQ on")).toBeVisible();
     await expect(queueGrid.getByRole("gridcell", { name: "overflow held 1" })).toBeVisible();
   });
 
@@ -227,6 +231,7 @@ test.describe("Runtime page", () => {
                     poll_interval_ms: 200,
                     deadline_duration_secs: 300,
                     priority_aging_interval_secs: 60,
+                    dlq_enabled: true,
                     rate_limit: { max_rate: 5.5, burst: 10 },
                   },
                 },
@@ -259,6 +264,7 @@ test.describe("Runtime page", () => {
               poll_interval_ms: 200,
               deadline_duration_secs: 300,
               priority_aging_interval_secs: 60,
+              dlq_enabled: true,
               rate_limit: { max_rate: 5.5, burst: 10 },
             },
           },
@@ -282,7 +288,7 @@ test.describe("Runtime page", () => {
     });
     await expect(assignmentsGrid).toBeVisible();
     await expect(
-      assignmentsGrid.getByText("poll 200ms · deadline 300s · aging 60s")
+      assignmentsGrid.getByText("poll 200ms · deadline 300s · aging 60s · DLQ on")
     ).toBeVisible();
   });
 });

--- a/awa-ui/frontend/src/components/RuntimeDisplay.tsx
+++ b/awa-ui/frontend/src/components/RuntimeDisplay.tsx
@@ -17,14 +17,28 @@ export function formatSnapshotInterval(ms: number): string {
 export function queueCapacityLabel(config?: QueueRuntimeConfigSnapshot | null): string {
   if (!config) return "—";
   if (config.mode === "weighted") {
-    return `min ${config.min_workers ?? 0} / w ${config.weight ?? 1}`;
+    return `min ${config.min_workers ?? 0} / weight ${config.weight ?? 1}`;
   }
   return `max ${config.max_workers ?? 0}`;
 }
 
 export function rateLimitLabel(config?: QueueRuntimeConfigSnapshot | null): string {
   if (!config?.rate_limit) return "—";
-  return `${config.rate_limit.max_rate}/s (${config.rate_limit.burst})`;
+  return `${config.rate_limit.max_rate}/s · burst ${config.rate_limit.burst}`;
+}
+
+export function dlqPolicyLabel(config?: QueueRuntimeConfigSnapshot | null): string {
+  if (config?.dlq_enabled === true) return "DLQ on";
+  if (config?.dlq_enabled === false) return "DLQ off";
+  return "DLQ unknown";
+}
+
+export function dlqPolicyIntent(
+  config?: QueueRuntimeConfigSnapshot | null,
+): "success" | "outline" | "secondary" {
+  if (config?.dlq_enabled === true) return "success";
+  if (config?.dlq_enabled === false) return "outline";
+  return "secondary";
 }
 
 export function instanceLabel(instance: RuntimeInstance): string {
@@ -48,7 +62,7 @@ export function queueListLabel(instance: RuntimeInstance): string {
 
 export function queueConfigDetails(config?: QueueRuntimeConfigSnapshot | null): string {
   if (!config) return "No runtime config snapshot";
-  return `poll ${formatSnapshotInterval(config.poll_interval_ms)} · deadline ${config.deadline_duration_secs}s · aging ${config.priority_aging_interval_secs}s`;
+  return `poll ${formatSnapshotInterval(config.poll_interval_ms)} · deadline ${config.deadline_duration_secs}s · aging ${config.priority_aging_interval_secs}s · ${dlqPolicyLabel(config)}`;
 }
 
 export function RuntimeHealthBadge({ instance }: { instance: RuntimeInstance }) {

--- a/awa-ui/frontend/src/lib/api.ts
+++ b/awa-ui/frontend/src/lib/api.ts
@@ -100,6 +100,7 @@ export interface QueueRuntimeConfigSnapshot {
   poll_interval_ms: number;
   deadline_duration_secs: number;
   priority_aging_interval_secs: number;
+  dlq_enabled?: boolean | null;
   rate_limit: RateLimitSnapshot | null;
 }
 

--- a/awa-ui/frontend/src/routes/dlq.tsx
+++ b/awa-ui/frontend/src/routes/dlq.tsx
@@ -202,7 +202,7 @@ export function DlqPage() {
             <TableRow>
               <TableCell colSpan={6}>
                 <div className="text-muted-fg py-6">
-                  DLQ is empty{hasActiveFilter ? " (matching this filter)" : ""}.
+                  DLQ is empty{hasActiveFilter ? " (matching this filter)" : ""}. Terminal failures appear here only for queues with DLQ on.
                 </div>
               </TableCell>
             </TableRow>

--- a/awa-ui/frontend/src/routes/queue-detail.tsx
+++ b/awa-ui/frontend/src/routes/queue-detail.tsx
@@ -16,7 +16,7 @@ import { useReadOnly } from "@/hooks/use-read-only";
 import { toast } from "@/components/ui/toast";
 import { Heading } from "@/components/ui/heading";
 import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
+import { Button, buttonStyles } from "@/components/ui/button";
 import { Card, CardContent, CardHeader } from "@/components/ui/card";
 import {
   DescriptionDetails,
@@ -27,6 +27,12 @@ import { ConfirmDialog } from "@/components/ConfirmDialog";
 import { LagValue } from "@/components/LagValue";
 import type { QueueRuntimeSummary } from "@/lib/api";
 import { timeAgo } from "@/lib/time";
+import {
+  dlqPolicyIntent,
+  dlqPolicyLabel,
+  queueCapacityLabel,
+  rateLimitLabel,
+} from "@/components/RuntimeDisplay";
 
 export function QueueDetailPage() {
   const { name } = useParams({ strict: false });
@@ -125,6 +131,11 @@ export function QueueDetailPage() {
         ) : (
           <Badge intent="success">Active</Badge>
         )}
+        {runtime?.config && (
+          <Badge intent={dlqPolicyIntent(runtime.config)}>
+            {dlqPolicyLabel(runtime.config)}
+          </Badge>
+        )}
         {queue.descriptor_stale && <Badge intent="warning">Descriptor stale</Badge>}
         {queue.descriptor_mismatch && <Badge intent="danger">Descriptor drift</Badge>}
       </div>
@@ -141,6 +152,15 @@ export function QueueDetailPage() {
         >
           View jobs
         </Button>
+        {runtime?.config?.dlq_enabled === true && (
+          <Link
+            to="/dlq"
+            search={{ q: `queue:${queue.queue}` }}
+            className={buttonStyles({ intent: "outline", size: "sm" })}
+          >
+            View DLQ rows
+          </Link>
+        )}
         {queue.paused ? (
           <Button
             intent="outline"
@@ -266,7 +286,7 @@ export function QueueDetailPage() {
 
             <DescriptionTerm>Lag</DescriptionTerm>
             <DescriptionDetails>
-              <LagValue seconds={queue.lag_seconds} />
+              <LagValue seconds={queue.lag_seconds} /> s
             </DescriptionDetails>
           </DescriptionList>
         </CardContent>
@@ -291,10 +311,33 @@ export function QueueDetailPage() {
               {runtime.config && (
                 <>
                   <DescriptionTerm>Mode</DescriptionTerm>
-                  <DescriptionDetails>{runtime.config.mode}</DescriptionDetails>
+                  <DescriptionDetails>
+                    {runtime.config.mode === "weighted" ? "Weighted" : "Reserved"}
+                  </DescriptionDetails>
+
+                  <DescriptionTerm>Capacity</DescriptionTerm>
+                  <DescriptionDetails>{queueCapacityLabel(runtime.config)}</DescriptionDetails>
+
+                  <DescriptionTerm>Rate limit</DescriptionTerm>
+                  <DescriptionDetails>{rateLimitLabel(runtime.config)}</DescriptionDetails>
 
                   <DescriptionTerm>Poll interval</DescriptionTerm>
                   <DescriptionDetails>{runtime.config.poll_interval_ms} ms</DescriptionDetails>
+
+                  <DescriptionTerm>Deadline duration</DescriptionTerm>
+                  <DescriptionDetails>{runtime.config.deadline_duration_secs} s</DescriptionDetails>
+
+                  <DescriptionTerm>Priority aging</DescriptionTerm>
+                  <DescriptionDetails>
+                    {runtime.config.priority_aging_interval_secs} s
+                  </DescriptionDetails>
+
+                  <DescriptionTerm>DLQ policy</DescriptionTerm>
+                  <DescriptionDetails>
+                    <Badge intent={dlqPolicyIntent(runtime.config)}>
+                      {dlqPolicyLabel(runtime.config)}
+                    </Badge>
+                  </DescriptionDetails>
                 </>
               )}
 

--- a/awa-ui/frontend/src/routes/queues.tsx
+++ b/awa-ui/frontend/src/routes/queues.tsx
@@ -31,6 +31,10 @@ import { ConfirmDialog } from "@/components/ConfirmDialog";
 import { LagValue } from "@/components/LagValue";
 import { usePollInterval } from "@/hooks/use-poll-interval";
 import { timeAgo } from "@/lib/time";
+import {
+  dlqPolicyIntent,
+  dlqPolicyLabel,
+} from "@/components/RuntimeDisplay";
 
 export function QueuesPage() {
   const queryClient = useQueryClient();
@@ -94,14 +98,14 @@ export function QueuesPage() {
   function capacityLabel(runtime: QueueRuntimeSummary | undefined): string {
     if (!runtime?.config) return "—";
     if (runtime.config.mode === "weighted") {
-      return `min ${runtime.config.min_workers ?? 0} / w ${runtime.config.weight ?? 1}`;
+      return `min ${runtime.config.min_workers ?? 0} / weight ${runtime.config.weight ?? 1}`;
     }
     return `max ${runtime.config.max_workers ?? 0}`;
   }
 
   function rateLimitLabel(runtime: QueueRuntimeSummary | undefined): string {
     if (!runtime?.config?.rate_limit) return "—";
-    return `${runtime.config.rate_limit.max_rate}/s (${runtime.config.rate_limit.burst})`;
+    return `${runtime.config.rate_limit.max_rate}/s · burst ${runtime.config.rate_limit.burst}`;
   }
 
   function runtimeHealthLabel(runtime: QueueRuntimeSummary | undefined): string {
@@ -202,11 +206,13 @@ export function QueuesPage() {
                   </>
                 )}
                 <span className="text-muted-fg">Lag</span>
-                <span><LagValue seconds={q.lag_seconds} /></span>
+                <span><LagValue seconds={q.lag_seconds} /> s</span>
                 <span className="text-muted-fg">Capacity</span>
                 <span>{capacityLabel(runtime)}</span>
                 <span className="text-muted-fg">Rate limit</span>
                 <span>{rateLimitLabel(runtime)}</span>
+                <span className="text-muted-fg">DLQ</span>
+                <span>{dlqPolicyLabel(runtime?.config)}</span>
                 <span className="text-muted-fg">Healthy nodes</span>
                 <span>{runtimeHealthLabel(runtime)}</span>
                 {runtime?.config_mismatch && (
@@ -260,7 +266,7 @@ export function QueuesPage() {
           <TableColumn className="text-right">Running</TableColumn>
           <TableColumn className="text-right">Retry</TableColumn>
           <TableColumn className="text-right">Failed</TableColumn>
-          <TableColumn className="text-right">Rate/hr</TableColumn>
+          <TableColumn className="text-right">Completed/hr</TableColumn>
           <TableColumn>Capacity</TableColumn>
           <TableColumn>Status</TableColumn>
           <TableColumn>Actions</TableColumn>
@@ -307,7 +313,7 @@ export function QueuesPage() {
                       {q.waiting_external > 0 && (
                         <div className="mt-0.5 text-xs text-muted-fg">
                           {q.waiting_external.toLocaleString()} waiting · lag{" "}
-                          <LagValue seconds={q.lag_seconds} />
+                          <LagValue seconds={q.lag_seconds} /> s
                         </div>
                       )}
                       {descriptorSyncLabel(q) && (
@@ -388,6 +394,11 @@ export function QueuesPage() {
                       )}
                       {q.descriptor_mismatch && (
                         <Badge intent="danger">Descriptor drift</Badge>
+                      )}
+                      {runtime?.config && (
+                        <Badge intent={dlqPolicyIntent(runtime.config)}>
+                          {dlqPolicyLabel(runtime.config)}
+                        </Badge>
                       )}
                     </div>
                   </TableCell>

--- a/awa-ui/frontend/src/routes/runtime.tsx
+++ b/awa-ui/frontend/src/routes/runtime.tsx
@@ -33,6 +33,8 @@ import {
   instanceLabel,
   LoopStatus,
   PostgresBadge,
+  dlqPolicyIntent,
+  dlqPolicyLabel,
   queueCapacityLabel,
   queueConfigDetails,
   queueListLabel,
@@ -543,6 +545,16 @@ export function RuntimePage() {
                     <span>{queue.config?.global_max_workers ?? "—"}</span>
                     <span className="text-muted-fg">Rate limit</span>
                     <span>{rateLimitLabel(queue.config)}</span>
+                    <span className="text-muted-fg">DLQ</span>
+                    <span>
+                      {queue.config ? (
+                        <Badge intent={dlqPolicyIntent(queue.config)}>
+                          {dlqPolicyLabel(queue.config)}
+                        </Badge>
+                      ) : (
+                        "—"
+                      )}
+                    </span>
                     <span className="text-muted-fg">In flight</span>
                     <span>{queue.total_in_flight}</span>
                     <span className="text-muted-fg">Nodes</span>
@@ -576,6 +588,7 @@ export function RuntimePage() {
               <TableColumn>Mode</TableColumn>
               <TableColumn>Capacity</TableColumn>
               <TableColumn>Rate limit</TableColumn>
+              <TableColumn>DLQ</TableColumn>
               <TableColumn className="text-right">In flight</TableColumn>
               <TableColumn>Nodes</TableColumn>
               <TableColumn>Notes</TableColumn>
@@ -620,6 +633,15 @@ export function RuntimePage() {
                     <TableCell>
                       <div>{rateLimitLabel(queue.config)}</div>
                       <div className="text-xs text-muted-fg">{queueConfigDetails(queue.config)}</div>
+                    </TableCell>
+                    <TableCell>
+                      {queue.config ? (
+                        <Badge intent={dlqPolicyIntent(queue.config)}>
+                          {dlqPolicyLabel(queue.config)}
+                        </Badge>
+                      ) : (
+                        "—"
+                      )}
                     </TableCell>
                     <TableCell className="text-right tabular-nums">
                       {queue.total_in_flight}

--- a/awa-ui/tests/runtime_api_test.rs
+++ b/awa-ui/tests/runtime_api_test.rs
@@ -85,6 +85,7 @@ fn weighted_config(weight: u32) -> QueueRuntimeConfigSnapshot {
         poll_interval_ms: 200,
         deadline_duration_secs: 300,
         priority_aging_interval_secs: 60,
+        dlq_enabled: Some(true),
         rate_limit: Some(RateLimitSnapshot {
             max_rate: 5.5,
             burst: 10,
@@ -297,10 +298,127 @@ async fn test_get_queue_runtime_endpoint_returns_queue_summary() {
     assert_eq!(
         queue_summary
             .get("config")
+            .and_then(|cfg| cfg.get("dlq_enabled"))
+            .and_then(Value::as_bool),
+        Some(true)
+    );
+    assert_eq!(
+        queue_summary
+            .get("config")
             .and_then(|cfg| cfg.get("rate_limit"))
             .and_then(|cfg| cfg.get("burst"))
             .and_then(Value::as_u64),
         Some(10)
+    );
+}
+
+#[tokio::test]
+async fn test_queue_runtime_endpoint_treats_unknown_dlq_policy_as_rollout_compatible() {
+    let pool = setup_pool().await;
+    let queue = "ui_runtime_api_queue_dlq_rollout";
+    clean_runtime_snapshots_for_queue(&pool, queue).await;
+
+    let mut legacy_config = weighted_config(3);
+    legacy_config.dlq_enabled = None;
+
+    seed_runtime_snapshot_with(
+        &pool,
+        RuntimeSnapshotInput {
+            instance_id: Uuid::new_v4(),
+            hostname: Some("worker-legacy".to_string()),
+            pid: 5101,
+            version: "0.5.x-test".to_string(),
+            storage_capability: StorageCapability::Canonical,
+            transition_role: TransitionRole::Auto,
+            started_at: Utc::now() - Duration::minutes(2),
+            snapshot_interval_ms: 10_000,
+            healthy: true,
+            postgres_connected: true,
+            poll_loop_alive: true,
+            heartbeat_alive: true,
+            maintenance_alive: true,
+            shutting_down: false,
+            leader: true,
+            global_max_workers: Some(16),
+            queues: vec![QueueRuntimeSnapshot {
+                queue: queue.to_string(),
+                in_flight: 1,
+                overflow_held: Some(0),
+                config: legacy_config,
+            }],
+            queue_descriptor_hashes: HashMap::new(),
+            job_kind_descriptor_hashes: HashMap::new(),
+        },
+    )
+    .await;
+
+    seed_runtime_snapshot_with(
+        &pool,
+        RuntimeSnapshotInput {
+            instance_id: Uuid::new_v4(),
+            hostname: Some("worker-upgraded".to_string()),
+            pid: 5102,
+            version: "0.6.0-test".to_string(),
+            storage_capability: StorageCapability::Canonical,
+            transition_role: TransitionRole::Auto,
+            started_at: Utc::now() - Duration::minutes(1),
+            snapshot_interval_ms: 10_000,
+            healthy: true,
+            postgres_connected: true,
+            poll_loop_alive: true,
+            heartbeat_alive: true,
+            maintenance_alive: true,
+            shutting_down: false,
+            leader: false,
+            global_max_workers: Some(16),
+            queues: vec![QueueRuntimeSnapshot {
+                queue: queue.to_string(),
+                in_flight: 2,
+                overflow_held: Some(0),
+                config: weighted_config(3),
+            }],
+            queue_descriptor_hashes: HashMap::new(),
+            job_kind_descriptor_hashes: HashMap::new(),
+        },
+    )
+    .await;
+
+    let app = awa_ui::router(pool.clone(), std::time::Duration::ZERO)
+        .await
+        .expect("router should initialize");
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/api/queues/runtime")
+                .body(Body::empty())
+                .expect("request should build"),
+        )
+        .await
+        .expect("queue runtime request should succeed");
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("response body should read");
+    let summaries: Vec<Value> =
+        serde_json::from_slice(&body).expect("queue summaries should deserialize");
+    let queue_summary = summaries
+        .iter()
+        .find(|entry| entry.get("queue").and_then(Value::as_str) == Some(queue))
+        .expect("seeded queue should be present");
+
+    assert_eq!(
+        queue_summary
+            .get("config_mismatch")
+            .and_then(Value::as_bool),
+        Some(false)
+    );
+    assert_eq!(
+        queue_summary
+            .get("config")
+            .and_then(|cfg| cfg.get("dlq_enabled"))
+            .and_then(Value::as_bool),
+        Some(true)
     );
 }
 

--- a/awa-worker/README.md
+++ b/awa-worker/README.md
@@ -25,9 +25,9 @@ top of Awa.
   `register_handler`.
 - **Queue configuration** — `QueueConfig` (concurrency, weighted mode,
   rate limiting, per-claim deadlines), `RateLimit`.
-- **Lifecycle hooks** — `JobEvent<T>` and `UntypedJobEvent` fire after
-  guarded finalization commits, useful for cache invalidation,
-  notifications, and metrics emission.
+- **Lifecycle hooks** — `JobEvent<T>` and `UntypedJobEvent` fire when
+  handler execution starts and after guarded finalization commits, useful
+  for cache invalidation, notifications, and metrics emission.
 - **HTTP worker** — `HttpWorker`, `HttpWorkerConfig`, `HttpWorkerMode`
   dispatch jobs to serverless endpoints over HTTP with HMAC-BLAKE3
   signing. See [ADR-018](../docs/adr/018-http-worker.md).

--- a/awa-worker/src/client.rs
+++ b/awa-worker/src/client.rs
@@ -263,9 +263,13 @@ impl ClientBuilder {
 
     /// Register a typed lifecycle event handler for a job kind.
     ///
-    /// Handlers run only after the corresponding DB state transition commits.
-    /// They are best-effort in-process hooks, not a durable workflow mechanism.
-    /// Capture any shared dependencies you need in the closure environment.
+    /// `Started` dispatch is scheduled after the claim commits and before the
+    /// worker handler is invoked. Outcome handlers run only after the
+    /// corresponding DB state transition commits. Hooks are best-effort
+    /// in-process notifications, not a durable workflow mechanism; because
+    /// they run in detached tasks, a very short job can complete before a
+    /// `Started` handler finishes. Capture any shared dependencies you need in
+    /// the closure environment.
     pub fn on_event<T, F, Fut>(mut self, handler: F) -> Self
     where
         T: JobArgs + DeserializeOwned + Send + Sync + 'static,
@@ -303,7 +307,7 @@ impl ClientBuilder {
     /// Register an untyped lifecycle event handler for a specific job kind.
     ///
     /// Use this with `register_worker(...)` or for cross-cutting logic that
-    /// doesn't need typed args.
+    /// doesn't need typed args. Timing matches `on_event(...)`.
     pub fn on_event_kind<F, Fut>(mut self, kind: impl Into<String>, handler: F) -> Self
     where
         F: Fn(UntypedJobEvent) -> Fut + Send + Sync + 'static,
@@ -818,6 +822,7 @@ struct RuntimeReporterState {
     dispatch_cancel: CancellationToken,
     overflow_pool: Option<Arc<OverflowPool>>,
     global_max_workers: Option<u32>,
+    dlq_policy: DlqPolicy,
     instance_id: Uuid,
     started_at: DateTime<Utc>,
     hostname: Option<String>,
@@ -1010,6 +1015,7 @@ impl Client {
             dispatch_cancel: self.dispatch_cancel.clone(),
             overflow_pool: self.overflow_pool.clone(),
             global_max_workers: self.global_max_workers,
+            dlq_policy: self.dlq_policy.clone(),
             instance_id: self.runtime_instance_id,
             started_at: self.runtime_started_at,
             hostname: self.runtime_hostname.clone(),
@@ -1556,6 +1562,7 @@ impl RuntimeReporterState {
                 poll_interval_ms: config.poll_interval.as_millis() as u64,
                 deadline_duration_secs: config.deadline_duration.as_secs(),
                 priority_aging_interval_secs: config.priority_aging_interval.as_secs(),
+                dlq_enabled: Some(self.dlq_policy.enabled_for(queue)),
                 rate_limit: config.rate_limit.as_ref().map(|rl| RateLimitSnapshot {
                     max_rate: rl.max_rate,
                     burst: rl.burst,

--- a/awa-worker/src/events.rs
+++ b/awa-worker/src/events.rs
@@ -8,6 +8,8 @@ use std::time::Duration;
 /// Typed lifecycle event for a specific job argument type.
 #[derive(Debug, Clone)]
 pub enum JobEvent<T> {
+    /// Job execution started after the claim committed.
+    Started { args: T, job: JobRow },
     /// Job completed successfully.
     Completed {
         args: T,
@@ -41,7 +43,8 @@ impl<T> JobEvent<T> {
     /// The job snapshot associated with this event.
     pub fn job(&self) -> &JobRow {
         match self {
-            JobEvent::Completed { job, .. }
+            JobEvent::Started { job, .. }
+            | JobEvent::Completed { job, .. }
             | JobEvent::Retried { job, .. }
             | JobEvent::Exhausted { job, .. }
             | JobEvent::Cancelled { job, .. } => job,
@@ -52,6 +55,8 @@ impl<T> JobEvent<T> {
 /// Untyped lifecycle event keyed only by job kind.
 #[derive(Debug, Clone)]
 pub enum UntypedJobEvent {
+    /// Job execution started after the claim committed.
+    Started { job: JobRow },
     /// Job completed successfully.
     Completed { job: JobRow, duration: Duration },
     /// Job failed but will be retried later.
@@ -75,7 +80,8 @@ impl UntypedJobEvent {
     /// The job snapshot associated with this event.
     pub fn job(&self) -> &JobRow {
         match self {
-            UntypedJobEvent::Completed { job, .. }
+            UntypedJobEvent::Started { job, .. }
+            | UntypedJobEvent::Completed { job, .. }
             | UntypedJobEvent::Retried { job, .. }
             | UntypedJobEvent::Exhausted { job, .. }
             | UntypedJobEvent::Cancelled { job, .. } => job,
@@ -84,6 +90,7 @@ impl UntypedJobEvent {
 
     pub(crate) fn into_typed<T>(self, args: T) -> JobEvent<T> {
         match self {
+            UntypedJobEvent::Started { job } => JobEvent::Started { args, job },
             UntypedJobEvent::Completed { job, duration } => JobEvent::Completed {
                 args,
                 job,

--- a/awa-worker/src/executor.rs
+++ b/awa-worker/src/executor.rs
@@ -269,6 +269,7 @@ impl JobExecutor {
                 counter.fetch_add(1, Ordering::SeqCst);
             }
             metrics.record_in_flight_change(&job_queue, 1);
+            let has_lifecycle_handlers = lifecycle_handlers.contains_key(&job_kind);
 
             let start = std::time::Instant::now();
             let ctx = JobContext::new(
@@ -281,7 +282,22 @@ impl JobExecutor {
             );
 
             let result = match workers.get(&job.kind) {
-                Some(worker) => worker.perform(&ctx).await,
+                Some(worker) => {
+                    if has_lifecycle_handlers {
+                        let started_handlers = lifecycle_handlers.clone();
+                        let started_kind = job_kind.clone();
+                        let started_job = job.clone();
+                        tokio::spawn(async move {
+                            dispatch_lifecycle_event(
+                                &started_handlers,
+                                &started_kind,
+                                UntypedJobEvent::Started { job: started_job },
+                            )
+                            .await;
+                        });
+                    }
+                    worker.perform(&ctx).await
+                }
                 None => {
                     error!(kind = %job.kind, job_id, "No worker registered for job kind");
                     Err(JobError::Terminal(format!(
@@ -309,7 +325,6 @@ impl JobExecutor {
             }
             metrics.record_in_flight_change(&job_queue, -1);
 
-            let has_lifecycle_handlers = lifecycle_handlers.contains_key(&job_kind);
             let dlq_enabled = dlq_policy.enabled_for(&job_queue);
             tokio::spawn(async move {
                 let outcome = complete_job(

--- a/awa/tests/lifecycle_hook_test.rs
+++ b/awa/tests/lifecycle_hook_test.rs
@@ -184,6 +184,60 @@ async fn test_typed_completed_event_handler_runs() {
 }
 
 #[tokio::test]
+async fn test_typed_started_event_handler_runs() {
+    let _permit = test_gate()
+        .acquire_owned()
+        .await
+        .expect("test gate should be available");
+    let pool = setup_pool().await;
+    let queue = "lifecycle_started";
+    clean_queue(&pool, queue).await;
+
+    let (tx, mut rx) = mpsc::unbounded_channel();
+    let client = Client::builder(pool.clone())
+        .queue(
+            queue,
+            QueueConfig {
+                poll_interval: Duration::from_millis(25),
+                ..Default::default()
+            },
+        )
+        .register::<HookJob, _, _>(|_args, _ctx| async move { Ok(JobResult::Completed) })
+        .on_event::<HookJob, _, _>(move |event| {
+            let tx = tx.clone();
+            async move {
+                if let JobEvent::Started { args, job } = event {
+                    tx.send((args.value, job.id, job.state)).unwrap();
+                }
+            }
+        })
+        .build()
+        .unwrap();
+
+    let inserted = awa::insert_with(
+        &pool,
+        &HookJob {
+            action: "start".into(),
+            value: "just_started".into(),
+        },
+        awa::InsertOpts {
+            queue: queue.to_string(),
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+
+    client.start().await.unwrap();
+    let (value, event_job_id, event_state) = recv_event(&mut rx).await;
+    client.shutdown(Duration::from_secs(2)).await;
+
+    assert_eq!(value, "just_started");
+    assert_eq!(event_job_id, inserted.id);
+    assert_eq!(event_state, JobState::Running);
+}
+
+#[tokio::test]
 async fn test_typed_retried_event_handler_runs() {
     let _permit = test_gate()
         .acquire_owned()
@@ -484,8 +538,10 @@ async fn test_handler_panic_does_not_crash_executor() {
         )
         .register::<HookJob, _, _>(|_args, _ctx| async move { Ok(JobResult::Completed) })
         // First handler panics
-        .on_event::<HookJob, _, _>(|_event| async move {
-            panic!("handler exploded!");
+        .on_event::<HookJob, _, _>(|event| async move {
+            if matches!(event, JobEvent::Completed { .. }) {
+                panic!("handler exploded!");
+            }
         })
         // Second handler should still run despite the first panicking
         .on_event::<HookJob, _, _>(move |event| {
@@ -602,6 +658,9 @@ async fn test_stale_completion_does_not_fire_event() {
             async move {
                 // Send any event we receive
                 match event {
+                    JobEvent::Started { args, .. } => {
+                        tx.send(format!("started:{}", args.value)).unwrap()
+                    }
                     JobEvent::Completed { args, .. } => {
                         tx.send(format!("completed:{}", args.value)).unwrap()
                     }
@@ -646,24 +705,13 @@ async fn test_stale_completion_does_not_fire_event() {
     tokio::time::sleep(Duration::from_secs(3)).await;
     client.shutdown(Duration::from_secs(2)).await;
 
-    // The channel should be empty — no lifecycle event for stale completions
-    let received = rx.try_recv();
-    // It's acceptable for a Retried event to fire if the job was re-claimed
-    // and retried successfully. But "completed:should_not_fire" should NOT
-    // appear because the original handler's completion was stale.
-    match received {
-        Err(mpsc::error::TryRecvError::Empty) => {
-            // Good — no event fired for the stale completion
-        }
-        Ok(msg) => {
-            assert!(
-                !msg.starts_with("completed:"),
-                "Stale completion should not fire a Completed event, got: {msg}"
-            );
-        }
-        Err(mpsc::error::TryRecvError::Disconnected) => {
-            // Channel closed — also fine
-        }
+    // Started may fire for claimed attempts, but the stale completion must not
+    // produce a Completed event.
+    while let Ok(msg) = rx.try_recv() {
+        assert!(
+            !msg.starts_with("completed:"),
+            "Stale completion should not fire a Completed event, got: {msg}"
+        );
     }
 }
 
@@ -695,6 +743,7 @@ async fn test_terminal_error_emits_exhausted() {
             let tx = tx.clone();
             async move {
                 match event {
+                    JobEvent::Started { .. } => {}
                     JobEvent::Exhausted { error, attempt, .. } => {
                         tx.send(("exhausted".to_string(), error, attempt)).unwrap();
                     }
@@ -731,10 +780,10 @@ async fn test_terminal_error_emits_exhausted() {
     assert_eq!(attempt, 1); // Only ran once — terminal, not retried
 }
 
-// ── Edge case: snooze does NOT emit event ────────────────────────
+// ── Edge case: snooze emits Started but no outcome event ─────────
 
 #[tokio::test]
-async fn test_snooze_does_not_emit_event() {
+async fn test_snooze_only_emits_started_event() {
     let _permit = test_gate()
         .acquire_owned()
         .await
@@ -759,6 +808,7 @@ async fn test_snooze_does_not_emit_event() {
             let tx = tx.clone();
             async move {
                 let label = match &event {
+                    JobEvent::Started { .. } => "started",
                     JobEvent::Completed { .. } => "completed",
                     JobEvent::Retried { .. } => "retried",
                     JobEvent::Exhausted { .. } => "exhausted",
@@ -785,13 +835,16 @@ async fn test_snooze_does_not_emit_event() {
     .unwrap();
 
     client.start().await.unwrap();
+    let label = recv_event(&mut rx).await;
+    assert_eq!(label, "started");
+
     // Give enough time for the job to be claimed and snoozed
     tokio::time::sleep(Duration::from_millis(500)).await;
     client.shutdown(Duration::from_secs(2)).await;
 
-    // No event should have fired
+    // No outcome event should have fired.
     assert!(
         rx.try_recv().is_err(),
-        "Snooze should not produce a lifecycle event"
+        "Snooze should not produce a lifecycle outcome event"
     );
 }

--- a/docs/adr/015-post-commit-lifecycle-hooks.md
+++ b/docs/adr/015-post-commit-lifecycle-hooks.md
@@ -1,4 +1,4 @@
-# ADR-015: Builder-Side Post-Commit Lifecycle Hooks
+# ADR-015: Builder-Side Lifecycle Hooks
 
 ## Status
 
@@ -13,12 +13,14 @@ backed it out after review because it was the wrong abstraction:
 - It coupled job execution with follow-up side effects
 - It encouraged growing the `Worker` trait for every new lifecycle need
 
-Awa still needed a way for applications to react to committed job outcomes:
+Awa still needed a way for applications to react to job execution starts and
+committed job outcomes:
 
 - Job-type-specific cleanup on permanent failure
 - Cross-cutting metrics or alerting for a specific kind
 - A hook model that works for both typed and raw worker registration
-- Semantics that do not fire for stale completions or uncommitted outcomes
+- Outcome semantics that do not fire for stale completions or uncommitted
+  outcomes
 
 The solution also had to fit Awa's existing execution model. Finalization is
 guarded by `run_lease` (ADR-013), and queue capacity must not be held open by
@@ -34,12 +36,13 @@ Add builder-side lifecycle hooks keyed by job kind:
 
 Supported events are:
 
+- `Started`
 - `Completed`
 - `Retried`
 - `Exhausted`
 - `Cancelled`
 
-No lifecycle event is emitted for:
+No lifecycle outcome event is emitted for:
 
 - `Snooze`, because it is an internal reschedule rather than a meaningful
   outcome for observers
@@ -48,22 +51,32 @@ No lifecycle event is emitted for:
 
 ### Emission Semantics
 
-Hooks run only after the corresponding database state transition commits
-successfully. The event carries the updated `JobRow`, so `job.state` reflects
-the post-transition state.
+`Started` dispatch is scheduled after the claim transaction commits and before
+the worker handler is invoked. The event carries the claimed `JobRow`, so
+`job.state` reflects `running`.
 
-If guarded finalization rejects the outcome as stale, no lifecycle event is
-emitted.
+Outcome hooks run only after the corresponding database state transition
+commits successfully. The event carries the updated `JobRow`, so `job.state`
+reflects the post-transition state.
+
+If guarded finalization rejects the outcome as stale, no lifecycle outcome
+event is emitted. A `Started` event may already have been emitted for the
+claimed attempt.
 
 ### Execution Semantics
 
 Hooks are best-effort, in-process notifications:
 
-- They run in detached tasks after the in-flight permit is released
-- They do not block executor progress or queue capacity
+- `Started` hooks run in detached tasks while the attempt is in flight; outcome
+  hooks run in detached tasks after the in-flight permit is released
+- Hooks do not block executor progress or queue capacity
 - `shutdown()` does not wait for them
 - Handlers for a kind run sequentially; panics are logged and later handlers
   still run
+- `Started` dispatch is detached so a slow hook does not delay handler
+  execution; very fast jobs may therefore complete before a started hook
+  finishes, and observers should not rely on strict started-before-outcome
+  delivery ordering for short jobs
 - If a hook side effect must be durable or retried, that logic should enqueue
   another job instead
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -27,7 +27,7 @@ in-place as historical context.
 | 012 | [Hot / deferred job storage](012-hot-deferred-job-storage.md) | **Superseded by 019** | Manual hot/cold split of the `awa.jobs` heap | Superseded by ADR-019 |
 | 013 | [Run lease and guarded finalization](013-run-lease-and-guarded-finalization.md) | Accepted | `run_lease` is the per-attempt identity; every finalize matches on it | Composite key on `active_leases` per ADR-019 |
 | 014 | [Structured progress and metadata](014-structured-progress.md) | Accepted | JSONB progress buffer with heartbeat piggyback + atomic state-transition flush | Progress storage moved to `attempt_state` per ADR-019 |
-| 015 | [Post-commit lifecycle hooks](015-post-commit-lifecycle-hooks.md) | Accepted | Builder-side hooks fire after guarded finalization commits | Guard lives on `active_leases` per ADR-019 |
+| 015 | [Builder-side lifecycle hooks](015-post-commit-lifecycle-hooks.md) | Accepted | Builder-side hooks fire after claim start and guarded finalization commits | Guard lives on `active_leases` per ADR-019 |
 | 016 | [Shared insert preparation and tokio-postgres adapter](016-bridge-adapters.md) | Accepted | Factor insert preparation into `PreparedRow`; tokio-postgres enqueue adapter | — |
 | 017 | [Python insert-only transaction bridging](017-python-transaction-bridging.md) | Accepted | Python `awa.Transaction` is a thin wrapper over the Rust insert path | — |
 | 018 | [HTTP Worker for serverless job dispatch](018-http-worker.md) | Accepted | `Worker` impl that dispatches to Lambda / Cloud Run via HTTP + HMAC-BLAKE3 | Uses callback surface from ADR-021 |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -915,8 +915,8 @@ Python.
 
 ### Lifecycle Hooks
 
-Builder-side lifecycle hooks let applications react to committed job outcomes
-without growing the `Worker` trait surface. See
+Builder-side lifecycle hooks let applications react when a job starts and when
+committed job outcomes are applied, without growing the `Worker` trait surface. See
 [ADR-015](adr/015-post-commit-lifecycle-hooks.md) for the design rationale:
 
 ```rust
@@ -931,11 +931,14 @@ let client = Client::builder(pool)
     .build()?;
 ```
 
-Hooks are best-effort, post-commit notifications. They run in detached tasks
-after the job's in-flight permit has been released — a slow or panicking hook
-cannot block queue capacity or delay other jobs. `shutdown()` does not wait
-for hook tasks to complete; in-flight hooks may be dropped during shutdown.
-If the side effect must be durable or retried, enqueue another job instead.
+Hooks are best-effort notifications. `Started` dispatch is scheduled after the
+claim commits and before the worker handler is invoked; outcome events fire
+only after their guarded state transition commits. Hooks run in detached tasks
+— a slow or panicking hook cannot block queue capacity or delay other jobs, and
+very short jobs may complete before a started hook finishes. `shutdown()` does
+not wait for hook tasks to complete; in-flight hooks may be dropped during
+shutdown. If the side effect must be durable or retried, enqueue another job
+instead.
 
 ### Scheduler Flow (Leader-Only)
 


### PR DESCRIPTION
## Summary
- publish the resolved per-queue DLQ policy in runtime config snapshots
- show DLQ on/off/unknown across queue, queue detail, runtime, and DLQ empty states
- add API and Playwright coverage so the UI catches missing DLQ policy visibility

## Validation
- cargo fmt --all --check
- git diff --check
- cargo check -p awa-worker -p awa-ui
- DATABASE_URL=postgres://postgres:test@localhost:15432/awa_test cargo test -p awa-ui --test runtime_api_test -- --nocapture
- cd awa-ui/frontend && npm run lint
- cd awa-ui/frontend && npm run build
- cd awa-ui/frontend && npx playwright test e2e/runtime.spec.ts e2e/queues.spec.ts --project=chromium


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * DLQ policy status is shown across the app (queues list, runtime summary, queue detail) with on/off/unknown badges and a “View DLQ rows” link when DLQ is enabled.
  * Queue runtime rate/label formatting updated and the desktop column label now reads “Completed/hr”.

* **Tests**
  * Added end-to-end and runtime tests covering DLQ display, navigation, and runtime-config handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->