### PR TITLE
v016: drop queue_lanes.available_count; derive from heads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ transitions live in [`docs/upgrade-0.5-to-0.6.md`](docs/upgrade-0.5-to-0.6.md).
 
 ## Unreleased
 
+### Performance
+- Drop the `queue_lanes.available_count` cache (migration `v016`).
+  The dispatcher derives availability from
+  `queue_enqueue_heads.next_seq - queue_claim_heads.claim_seq` and
+  the admin API (`queue_counts`) scans `ready_entries` for an exact
+  count. Removes the queue-storage schema's largest dead-tuple
+  source under pinned-xmin workloads (long-running reader
+  transactions) without changing public API behaviour. See ADR-019
+  § `lane_state` and segment cursor tables.
+
 ## [0.6.0-alpha.9] — 2026-05-08
 
 ### Fixed

--- a/awa-model/migrations/v016_drop_queue_lanes_available_count.sql
+++ b/awa-model/migrations/v016_drop_queue_lanes_available_count.sql
@@ -1,0 +1,514 @@
+-- v016: Drop the redundant available_count cache from queue_lanes.
+--
+-- Background: queue_lanes is the hottest counter table on the
+-- runtime path. The 2026-05-10 investigation traced a 31 %
+-- throughput drop under pinned xmin (idle_in_tx scenario) to
+-- queue_lanes accumulating ~40k dead tuples in a 4 minute window
+-- while every other warm counter table stayed under a thousand.
+-- Live row count is ≈ 16 (one per (queue, priority)); the heap
+-- bloat ratio peaks near 2,500×.
+--
+-- queue_lanes.available_count was a denormalised cache of the
+-- difference `queue_enqueue_heads.next_seq -
+-- queue_claim_heads.claim_seq` for the same (queue, priority).
+-- The two head tables already track every enqueue and every claim;
+-- storing a third counter that must also be UPDATEd on every
+-- claim, enqueue, and completion batch triples the UPDATE rate on
+-- queue_lanes versus its siblings and made it the dominant bloat
+-- source.
+--
+-- This migration drops the column entirely. Readers compute the
+-- available count on-demand from the head-table difference. The
+-- compat functions (`insert_job_compat`, `delete_job_compat`) are
+-- replaced to remove their `available_count` mutations; their
+-- signatures stay byte-identical to v013's so CREATE OR REPLACE
+-- substitutes the body rather than installing a parallel overload.
+--
+-- For workloads with non-trivial admin DELETE traffic, the
+-- difference `next_seq - claim_seq` over-counts by the number of
+-- admin-deleted unclaimed rows. The hot-path dispatch signal
+-- tolerates this drift — the claim attempt finds no rows and the
+-- gap-recovery branch in `claim_ready_runtime` advances claim_seq
+-- to catch up.
+
+DO $$
+DECLARE
+    v_schema TEXT;
+BEGIN
+    SELECT schema_name INTO v_schema
+    FROM awa.runtime_storage_backends
+    WHERE backend = 'queue_storage'
+    LIMIT 1;
+
+    IF v_schema IS NOT NULL
+       AND to_regclass(format('%I.%I', v_schema, 'queue_lanes')) IS NOT NULL THEN
+        EXECUTE format(
+            'ALTER TABLE %I.queue_lanes DROP COLUMN IF EXISTS available_count',
+            v_schema
+        );
+    END IF;
+END
+$$ LANGUAGE plpgsql;
+
+-- Replace insert_job_compat — signature byte-identical to v013, body
+-- minus the `UPDATE queue_lanes SET available_count = available_count + 1`
+-- statement. The enqueue's contribution is already captured by the
+-- `next_seq` advance.
+CREATE OR REPLACE FUNCTION awa.insert_job_compat(
+    p_kind TEXT,
+    p_queue TEXT DEFAULT 'default',
+    p_args JSONB DEFAULT '{}'::jsonb,
+    p_state awa.job_state DEFAULT 'available',
+    p_priority SMALLINT DEFAULT 2,
+    p_max_attempts SMALLINT DEFAULT 25,
+    p_run_at TIMESTAMPTZ DEFAULT NULL,
+    p_metadata JSONB DEFAULT '{}'::jsonb,
+    p_tags TEXT[] DEFAULT ARRAY[]::TEXT[],
+    p_unique_key BYTEA DEFAULT NULL,
+    p_unique_states BIT(8) DEFAULT NULL
+)
+RETURNS awa.jobs
+AS $$
+DECLARE
+    v_schema TEXT;
+    v_queue TEXT := COALESCE(p_queue, 'default');
+    v_args JSONB := COALESCE(p_args, '{}'::jsonb);
+    v_state awa.job_state := COALESCE(p_state, 'available'::awa.job_state);
+    v_priority SMALLINT := COALESCE(p_priority, 2);
+    v_max_attempts SMALLINT := COALESCE(p_max_attempts, 25);
+    v_run_at TIMESTAMPTZ := COALESCE(p_run_at, clock_timestamp());
+    v_metadata JSONB := COALESCE(p_metadata, '{}'::jsonb);
+    v_tags TEXT[] := COALESCE(p_tags, '{}'::text[]);
+    v_created_at TIMESTAMPTZ := clock_timestamp();
+    v_job_id BIGINT;
+    v_ready_slot INT;
+    v_ready_generation BIGINT;
+    v_lane_seq BIGINT;
+    v_payload JSONB;
+    v_unique_states_text TEXT := CASE
+        WHEN p_unique_states IS NULL THEN NULL
+        ELSE p_unique_states::TEXT
+    END;
+    v_old_search_path TEXT;
+    inserted awa.jobs%ROWTYPE;
+BEGIN
+    IF length(p_kind) > 200 THEN
+        RAISE EXCEPTION 'job kind length must be <= 200 characters'
+            USING ERRCODE = '23514';
+    END IF;
+
+    IF length(v_queue) > 200 THEN
+        RAISE EXCEPTION 'queue name length must be <= 200 characters'
+            USING ERRCODE = '23514';
+    END IF;
+
+    IF v_priority < 1 OR v_priority > 4 THEN
+        RAISE EXCEPTION 'priority must be between 1 and 4'
+            USING ERRCODE = '23514';
+    END IF;
+
+    IF v_max_attempts < 1 OR v_max_attempts > 1000 THEN
+        RAISE EXCEPTION 'max_attempts must be between 1 and 1000'
+            USING ERRCODE = '23514';
+    END IF;
+
+    IF cardinality(v_tags) > 20 THEN
+        RAISE EXCEPTION 'job tags must contain at most 20 values'
+            USING ERRCODE = '23514';
+    END IF;
+
+    v_schema := awa.active_queue_storage_schema();
+
+    IF v_schema IS NULL THEN
+        IF v_state IN ('scheduled'::awa.job_state, 'retryable'::awa.job_state) THEN
+            INSERT INTO awa.scheduled_jobs AS jobs (
+                kind,
+                queue,
+                args,
+                state,
+                priority,
+                max_attempts,
+                run_at,
+                metadata,
+                tags,
+                unique_key,
+                unique_states
+            )
+            VALUES (
+                p_kind,
+                v_queue,
+                v_args,
+                v_state,
+                v_priority,
+                v_max_attempts,
+                v_run_at,
+                v_metadata,
+                v_tags,
+                p_unique_key,
+                p_unique_states
+            )
+            RETURNING * INTO inserted;
+            RETURN inserted;
+        END IF;
+
+        INSERT INTO awa.jobs_hot AS jobs (
+            kind,
+            queue,
+            args,
+            state,
+            priority,
+            max_attempts,
+            run_at,
+            metadata,
+            tags,
+            unique_key,
+            unique_states
+        )
+        VALUES (
+            p_kind,
+            v_queue,
+            v_args,
+            v_state,
+            v_priority,
+            v_max_attempts,
+            v_run_at,
+            v_metadata,
+            v_tags,
+            p_unique_key,
+            p_unique_states
+        )
+        RETURNING * INTO inserted;
+        RETURN inserted;
+    END IF;
+
+    IF v_state NOT IN (
+        'available'::awa.job_state,
+        'scheduled'::awa.job_state,
+        'retryable'::awa.job_state
+    ) THEN
+        RAISE EXCEPTION 'queue storage does not support initial state %', v_state
+            USING ERRCODE = '22023';
+    END IF;
+
+    v_old_search_path := current_setting('search_path');
+    PERFORM set_config('search_path', format('%I,awa,public', v_schema), true);
+
+    SELECT nextval(format('%I.job_id_seq', v_schema)::regclass)::bigint
+    INTO v_job_id;
+
+    IF p_unique_key IS NOT NULL
+        AND p_unique_states IS NOT NULL
+        AND awa.job_state_in_bitmask(p_unique_states, v_state)
+    THEN
+        INSERT INTO awa.job_unique_claims (unique_key, job_id)
+        VALUES (p_unique_key, v_job_id);
+    END IF;
+
+    v_payload := jsonb_build_object(
+        'metadata',
+        v_metadata,
+        'tags',
+        to_jsonb(v_tags),
+        'errors',
+        '[]'::jsonb,
+        'progress',
+        NULL
+    );
+
+    IF v_state = 'available'::awa.job_state THEN
+        INSERT INTO queue_lanes (queue, priority)
+        VALUES (v_queue, v_priority)
+        ON CONFLICT ON CONSTRAINT queue_lanes_pkey DO NOTHING;
+
+        INSERT INTO queue_enqueue_heads (queue, priority)
+        VALUES (v_queue, v_priority)
+        ON CONFLICT (queue, priority) DO NOTHING;
+
+        INSERT INTO queue_claim_heads (queue, priority)
+        VALUES (v_queue, v_priority)
+        ON CONFLICT (queue, priority) DO NOTHING;
+
+        UPDATE queue_enqueue_heads AS heads
+        SET next_seq = heads.next_seq + 1
+        WHERE heads.queue = v_queue
+          AND heads.priority = v_priority
+        RETURNING heads.next_seq - 1
+        INTO v_lane_seq;
+
+        SELECT ring.current_slot, ring.generation
+        INTO v_ready_slot, v_ready_generation
+        FROM queue_ring_state AS ring
+        WHERE ring.singleton = TRUE;
+
+        INSERT INTO ready_entries (
+            ready_slot,
+            ready_generation,
+            job_id,
+            kind,
+            queue,
+            args,
+            priority,
+            attempt,
+            run_lease,
+            max_attempts,
+            lane_seq,
+            run_at,
+            attempted_at,
+            created_at,
+            unique_key,
+            unique_states,
+            payload
+        ) VALUES (
+            v_ready_slot,
+            v_ready_generation,
+            v_job_id,
+            p_kind,
+            v_queue,
+            v_args,
+            v_priority,
+            0,
+            0,
+            v_max_attempts,
+            v_lane_seq,
+            v_run_at,
+            NULL,
+            v_created_at,
+            p_unique_key,
+            v_unique_states_text,
+            v_payload
+        );
+
+        -- v016: queue_lanes.available_count has been dropped. The
+        -- next_seq bump above is the only state change the read-side
+        -- derivation needs.
+
+        PERFORM pg_notify('awa:' || v_queue, '');
+        PERFORM set_config('search_path', v_old_search_path, true);
+
+        SELECT * INTO inserted
+        FROM awa.jobs AS jobs
+        WHERE jobs.id = v_job_id;
+
+        RETURN inserted;
+    END IF;
+
+    INSERT INTO deferred_jobs (
+        job_id,
+        kind,
+        queue,
+        args,
+        state,
+        priority,
+        attempt,
+        run_lease,
+        max_attempts,
+        run_at,
+        attempted_at,
+        finalized_at,
+        created_at,
+        unique_key,
+        unique_states,
+        payload
+    ) VALUES (
+        v_job_id,
+        p_kind,
+        v_queue,
+        v_args,
+        v_state,
+        v_priority,
+        0,
+        0,
+        v_max_attempts,
+        v_run_at,
+        NULL,
+        NULL,
+        v_created_at,
+        p_unique_key,
+        v_unique_states_text,
+        v_payload
+    );
+
+    PERFORM set_config('search_path', v_old_search_path, true);
+
+    SELECT * INTO inserted
+    FROM awa.jobs AS jobs
+    WHERE jobs.id = v_job_id;
+
+    RETURN inserted;
+END;
+$$ LANGUAGE plpgsql VOLATILE
+SET search_path = pg_catalog, awa, public;
+
+-- Replace delete_job_compat — signature unchanged from v013, body
+-- minus the `UPDATE %I.queue_lanes SET available_count = ...`
+-- block. The unclaimed delete leaves a transient over-count of 1
+-- on the derived (next_seq - claim_seq) for that lane, which the
+-- dispatcher's gap-recovery branch absorbs on the next claim
+-- attempt.
+CREATE OR REPLACE FUNCTION awa.delete_job_compat(p_id BIGINT)
+RETURNS BOOLEAN AS $$
+DECLARE
+    v_schema TEXT;
+    v_queue TEXT;
+    v_priority SMALLINT;
+    v_lane_seq BIGINT;
+    v_state awa.job_state;
+    v_unique_key BYTEA;
+    v_unique_states TEXT;
+    v_rows INT;
+BEGIN
+    v_schema := awa.active_queue_storage_schema();
+
+    IF v_schema IS NULL THEN
+        RAISE EXCEPTION 'queue storage is not active'
+            USING ERRCODE = '55000';
+    END IF;
+
+    EXECUTE format(
+        'DELETE FROM %I.ready_entries
+         WHERE job_id = $1
+         RETURNING queue, priority, lane_seq, ''available''::awa.job_state, unique_key, unique_states',
+        v_schema
+    )
+    INTO v_queue, v_priority, v_lane_seq, v_state, v_unique_key, v_unique_states
+    USING p_id;
+    GET DIAGNOSTICS v_rows = ROW_COUNT;
+
+    IF v_rows > 0 THEN
+        -- v016: no available_count column to decrement. If the deleted
+        -- lane was *exactly* at the claim head, advance the head past
+        -- it so the derived `next_seq - claim_seq` count drops by 1
+        -- immediately. Otherwise leave the cursor alone — gap-recovery
+        -- in `claim_ready_runtime` absorbs the over-count when
+        -- claim_seq eventually catches up.
+        EXECUTE format(
+            'UPDATE %I.queue_claim_heads
+             SET claim_seq = claim_seq + 1
+             WHERE queue = $1
+               AND priority = $2
+               AND claim_seq = $3',
+            v_schema
+        )
+        USING v_queue, v_priority, v_lane_seq;
+        PERFORM awa.release_queue_storage_unique_claim(
+            p_id,
+            v_unique_key,
+            v_unique_states,
+            v_state
+        );
+        RETURN TRUE;
+    END IF;
+
+    EXECUTE format(
+        'DELETE FROM %I.deferred_jobs
+         WHERE job_id = $1
+         RETURNING queue, priority, state, unique_key, unique_states',
+        v_schema
+    )
+    INTO v_queue, v_priority, v_state, v_unique_key, v_unique_states
+    USING p_id;
+    GET DIAGNOSTICS v_rows = ROW_COUNT;
+
+    IF v_rows > 0 THEN
+        PERFORM awa.release_queue_storage_unique_claim(
+            p_id,
+            v_unique_key,
+            v_unique_states,
+            v_state
+        );
+        RETURN TRUE;
+    END IF;
+
+    EXECUTE format(
+        'WITH deleted AS (
+             DELETE FROM %1$I.leases AS leases
+             WHERE job_id = $1
+             RETURNING
+                 leases.ready_slot,
+                 leases.ready_generation,
+                 leases.job_id,
+                 leases.queue,
+                 leases.priority,
+                 leases.lane_seq,
+                 leases.run_lease,
+                 leases.state
+         ),
+         deleted_attempt AS (
+             DELETE FROM %1$I.attempt_state AS attempt
+             USING deleted
+             WHERE attempt.job_id = deleted.job_id
+               AND attempt.run_lease = deleted.run_lease
+         )
+         SELECT
+             deleted.queue,
+             deleted.priority,
+             deleted.state,
+             ready.unique_key,
+             ready.unique_states
+         FROM deleted
+         JOIN %1$I.ready_entries AS ready
+           ON ready.ready_slot = deleted.ready_slot
+          AND ready.ready_generation = deleted.ready_generation
+          AND ready.queue = deleted.queue
+          AND ready.priority = deleted.priority
+          AND ready.lane_seq = deleted.lane_seq',
+        v_schema
+    )
+    INTO v_queue, v_priority, v_state, v_unique_key, v_unique_states
+    USING p_id;
+    GET DIAGNOSTICS v_rows = ROW_COUNT;
+
+    IF v_rows > 0 THEN
+        PERFORM awa.release_queue_storage_unique_claim(
+            p_id,
+            v_unique_key,
+            v_unique_states,
+            v_state
+        );
+        RETURN TRUE;
+    END IF;
+
+    EXECUTE format(
+        'DELETE FROM %I.done_entries
+         WHERE job_id = $1
+         RETURNING queue, priority, state, unique_key, unique_states',
+        v_schema
+    )
+    INTO v_queue, v_priority, v_state, v_unique_key, v_unique_states
+    USING p_id;
+    GET DIAGNOSTICS v_rows = ROW_COUNT;
+
+    IF v_rows > 0 THEN
+        PERFORM awa.release_queue_storage_unique_claim(
+            p_id,
+            v_unique_key,
+            v_unique_states,
+            v_state
+        );
+        RETURN TRUE;
+    END IF;
+
+    EXECUTE format(
+        'DELETE FROM %I.dlq_entries
+         WHERE job_id = $1
+         RETURNING queue, priority, state, unique_key, unique_states',
+        v_schema
+    )
+    INTO v_queue, v_priority, v_state, v_unique_key, v_unique_states
+    USING p_id;
+    GET DIAGNOSTICS v_rows = ROW_COUNT;
+
+    IF v_rows > 0 THEN
+        PERFORM awa.release_queue_storage_unique_claim(
+            p_id,
+            v_unique_key,
+            v_unique_states,
+            v_state
+        );
+        RETURN TRUE;
+    END IF;
+
+    RETURN FALSE;
+END;
+$$ LANGUAGE plpgsql
+SET search_path = pg_catalog, awa, public;

--- a/awa-model/migrations/v016_drop_queue_lanes_available_count.sql
+++ b/awa-model/migrations/v016_drop_queue_lanes_available_count.sql
@@ -512,3 +512,7 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql
 SET search_path = pg_catalog, awa, public;
+
+INSERT INTO awa.schema_version (version, description)
+VALUES (16, 'Drop redundant queue_lanes.available_count cache; reader derives from heads')
+ON CONFLICT (version) DO NOTHING;

--- a/awa-model/migrations/v016_drop_queue_lanes_available_count.sql
+++ b/awa-model/migrations/v016_drop_queue_lanes_available_count.sql
@@ -1,35 +1,31 @@
 -- v016: Drop the redundant available_count cache from queue_lanes.
 --
--- Background: queue_lanes is the hottest counter table on the
--- runtime path. The 2026-05-10 investigation traced a 31 %
--- throughput drop under pinned xmin (idle_in_tx scenario) to
--- queue_lanes accumulating ~40k dead tuples in a 4 minute window
--- while every other warm counter table stayed under a thousand.
--- Live row count is ≈ 16 (one per (queue, priority)); the heap
--- bloat ratio peaks near 2,500×.
+-- queue_lanes.available_count was a denormalised cache of
+-- `queue_enqueue_heads.next_seq - queue_claim_heads.claim_seq` for
+-- the same (queue, priority). The two head tables already track
+-- every enqueue and claim independently, so the cache was a third
+-- counter that had to be UPDATEd on every enqueue, claim, and
+-- completion batch — at a multiple of its siblings' write rate.
+-- Under a pinned xmin (long-running reader transaction) this made
+-- queue_lanes the dominant source of heap bloat in the schema:
+-- live rows ≈ 16, dead tuples in the tens of thousands within
+-- minutes, with a measured throughput drop while the column
+-- existed.
 --
--- queue_lanes.available_count was a denormalised cache of the
--- difference `queue_enqueue_heads.next_seq -
--- queue_claim_heads.claim_seq` for the same (queue, priority).
--- The two head tables already track every enqueue and every claim;
--- storing a third counter that must also be UPDATEd on every
--- claim, enqueue, and completion batch triples the UPDATE rate on
--- queue_lanes versus its siblings and made it the dominant bloat
--- source.
+-- This migration removes the column. Readers derive the count
+-- on demand from the head-table difference. The compat functions
+-- (`insert_job_compat`, `delete_job_compat`) are replaced to drop
+-- their `available_count` mutations; their signatures stay
+-- byte-identical to v013's so CREATE OR REPLACE substitutes the
+-- body rather than installing a parallel overload.
 --
--- This migration drops the column entirely. Readers compute the
--- available count on-demand from the head-table difference. The
--- compat functions (`insert_job_compat`, `delete_job_compat`) are
--- replaced to remove their `available_count` mutations; their
--- signatures stay byte-identical to v013's so CREATE OR REPLACE
--- substitutes the body rather than installing a parallel overload.
---
--- For workloads with non-trivial admin DELETE traffic, the
--- difference `next_seq - claim_seq` over-counts by the number of
--- admin-deleted unclaimed rows. The hot-path dispatch signal
--- tolerates this drift — the claim attempt finds no rows and the
--- gap-recovery branch in `claim_ready_runtime` advances claim_seq
--- to catch up.
+-- Admin-side DELETE of an unclaimed row leaves the derived count
+-- transiently high (by 1 per deleted row): `next_seq` reflects the
+-- enqueue and `claim_seq` has not advanced. delete_job_compat
+-- advances claim_seq when the deleted lane is exactly at the head;
+-- non-head deletes leave a gap that the dispatcher's gap-recovery
+-- branch in `claim_ready_runtime` absorbs on the next claim
+-- attempt that finds no rows at the head.
 
 DO $$
 DECLARE
@@ -50,10 +46,10 @@ BEGIN
 END
 $$ LANGUAGE plpgsql;
 
--- Replace insert_job_compat — signature byte-identical to v013, body
--- minus the `UPDATE queue_lanes SET available_count = available_count + 1`
--- statement. The enqueue's contribution is already captured by the
--- `next_seq` advance.
+-- insert_job_compat: signature byte-identical to v013, body minus
+-- the queue_lanes.available_count mutation. The enqueue's
+-- contribution to the available count is now captured solely by
+-- the queue_enqueue_heads.next_seq advance below.
 CREATE OR REPLACE FUNCTION awa.insert_job_compat(
     p_kind TEXT,
     p_queue TEXT DEFAULT 'default',
@@ -278,10 +274,6 @@ BEGIN
             v_payload
         );
 
-        -- v016: queue_lanes.available_count has been dropped. The
-        -- next_seq bump above is the only state change the read-side
-        -- derivation needs.
-
         PERFORM pg_notify('awa:' || v_queue, '');
         PERFORM set_config('search_path', v_old_search_path, true);
 
@@ -339,12 +331,13 @@ END;
 $$ LANGUAGE plpgsql VOLATILE
 SET search_path = pg_catalog, awa, public;
 
--- Replace delete_job_compat — signature unchanged from v013, body
--- minus the `UPDATE %I.queue_lanes SET available_count = ...`
--- block. The unclaimed delete leaves a transient over-count of 1
--- on the derived (next_seq - claim_seq) for that lane, which the
--- dispatcher's gap-recovery branch absorbs on the next claim
--- attempt.
+-- delete_job_compat: signature unchanged from v013, body adjusted
+-- so that admin-side deletion of an unclaimed row keeps the
+-- derived `next_seq - claim_seq` count honest:
+--   * head-lane delete → advance claim_seq past the deleted row;
+--   * non-head delete  → leave a gap; the dispatcher's gap-recovery
+--     branch in claim_ready_runtime closes it on the next attempt
+--     that finds no rows at the head.
 CREATE OR REPLACE FUNCTION awa.delete_job_compat(p_id BIGINT)
 RETURNS BOOLEAN AS $$
 DECLARE
@@ -375,12 +368,10 @@ BEGIN
     GET DIAGNOSTICS v_rows = ROW_COUNT;
 
     IF v_rows > 0 THEN
-        -- v016: no available_count column to decrement. If the deleted
-        -- lane was *exactly* at the claim head, advance the head past
-        -- it so the derived `next_seq - claim_seq` count drops by 1
-        -- immediately. Otherwise leave the cursor alone — gap-recovery
-        -- in `claim_ready_runtime` absorbs the over-count when
-        -- claim_seq eventually catches up.
+        -- Keep the derived `next_seq - claim_seq` count honest when
+        -- the deleted lane was *exactly* at the claim head: advance
+        -- claim_seq past it. Non-head deletes leave a gap that the
+        -- gap-recovery branch in claim_ready_runtime closes.
         EXECUTE format(
             'UPDATE %I.queue_claim_heads
              SET claim_seq = claim_seq + 1

--- a/awa-model/src/migrations.rs
+++ b/awa-model/src/migrations.rs
@@ -4,7 +4,7 @@ use sqlx::PgPool;
 use tracing::info;
 
 /// Current schema version.
-pub const CURRENT_VERSION: i32 = 15;
+pub const CURRENT_VERSION: i32 = 16;
 
 /// All migrations in order. SQL lives in `awa-model/migrations/*.sql`
 /// for easy inspection by users who run their own migration tooling.
@@ -63,6 +63,11 @@ const MIGRATIONS: &[(i32, &str, &[&str])] = &[
         &[V14_UP],
     ),
     (15, "Cron missed-fire policy", &[V15_UP]),
+    (
+        16,
+        "Drop redundant queue_lanes.available_count cache; reader derives from heads",
+        &[V16_UP],
+    ),
 ];
 
 const V1_UP: &str = include_str!("../migrations/v001_canonical_schema.sql");
@@ -79,6 +84,7 @@ const V12_UP: &str = include_str!("../migrations/v012_queue_storage_compat.sql")
 const V13_UP: &str = include_str!("../migrations/v013_storage_auto_finalize.sql");
 const V14_UP: &str = include_str!("../migrations/v014_storage_transition_role.sql");
 const V15_UP: &str = include_str!("../migrations/v015_cron_missed_fire_policy.sql");
+const V16_UP: &str = include_str!("../migrations/v016_drop_queue_lanes_available_count.sql");
 
 /// Old version numbers from pre-0.4 releases that used V3/V4/V5 numbering.
 /// Also tolerates the unreleased inline-V6 branch numbering used during review.

--- a/awa-model/src/queue_storage.rs
+++ b/awa-model/src/queue_storage.rs
@@ -166,8 +166,10 @@ pub struct QueueCounts {
 }
 
 /// Cheap available-only signal used by the dispatcher's claimer-sizing
-/// control loop. Reads `sum(queue_lanes.available_count)` for the
-/// queue's physical stripes — O(few rows) regardless of backlog size.
+/// control loop. Derives the count from
+/// `queue_enqueue_heads.next_seq − queue_claim_heads.claim_seq`
+/// summed over the queue's physical stripes (ADR / v016) — two PK
+/// reads per lane, O(few rows) regardless of backlog size.
 ///
 /// This is intentionally a separate type from [`QueueCounts`]: the
 /// dispatcher claim hot path only consumes the available count, and
@@ -2261,7 +2263,6 @@ impl QueueStorage {
                 priority        SMALLINT NOT NULL,
                 next_seq        BIGINT NOT NULL DEFAULT 1,
                 claim_seq       BIGINT NOT NULL DEFAULT 1,
-                available_count BIGINT NOT NULL DEFAULT 0,
                 pruned_completed_count BIGINT NOT NULL DEFAULT 0,
                 PRIMARY KEY (queue, priority)
             )
@@ -2353,10 +2354,11 @@ impl QueueStorage {
             // queue_count_snapshots was the staleness-cached counterpart
             // of queue_counts_exact when the dispatcher's claim hot path
             // still polled exact counts. After the queue_counts perf
-            // fix the dispatcher reads queue_lanes.available_count
-            // directly (O(few rows)), and nothing else needs the
-            // snapshot. Drop the table on every prepare_schema so an
-            // upgrade from a pre-fix install reclaims the storage.
+            // fix the dispatcher derives the available count from the
+            // head tables (v016: `next_seq - claim_seq`) directly
+            // (O(few rows)), and nothing else needs the snapshot. Drop
+            // the table on every prepare_schema so an upgrade from a
+            // pre-fix install reclaims the storage.
             sqlx::query(&format!(
                 "DROP TABLE IF EXISTS {schema}.queue_count_snapshots"
             ))
@@ -2527,55 +2529,10 @@ impl QueueStorage {
             .await
             .map_err(map_sqlx_error)?;
 
-            // The available_count backfill needs `ready_entries` to exist.
-            // On a fresh install, ready_entries is created later in this same
-            // prepare_schema run (see the DDL block ~400 lines below). Guard
-            // both backfills with a to_regclass check so this transaction
-            // works for both upgrades (table already there) and fresh installs
-            // (skip — there's nothing to backfill, queue_lanes is empty).
-            sqlx::query(&format!(
-                r#"
-            DO $$
-            BEGIN
-                IF to_regclass('{schema}.ready_entries') IS NOT NULL THEN
-                    WITH live_ready AS (
-                        SELECT
-                            ready.queue,
-                            ready.priority,
-                            count(*)::bigint AS available_count
-                        FROM {schema}.ready_entries AS ready
-                        JOIN {schema}.queue_claim_heads AS claims
-                          ON claims.queue = ready.queue
-                         AND claims.priority = ready.priority
-                        WHERE ready.lane_seq >= claims.claim_seq
-                        GROUP BY ready.queue, ready.priority
-                    )
-                    UPDATE {schema}.queue_lanes AS lanes
-                    SET available_count = COALESCE(live_ready.available_count, 0)
-                    FROM live_ready
-                    WHERE lanes.queue = live_ready.queue
-                      AND lanes.priority = live_ready.priority;
-
-                    UPDATE {schema}.queue_lanes AS lanes
-                    SET available_count = 0
-                    WHERE available_count <> 0
-                      AND NOT EXISTS (
-                          SELECT 1
-                          FROM {schema}.ready_entries AS ready
-                          JOIN {schema}.queue_claim_heads AS claims
-                            ON claims.queue = ready.queue
-                           AND claims.priority = ready.priority
-                          WHERE ready.queue = lanes.queue
-                            AND ready.priority = lanes.priority
-                            AND ready.lane_seq >= claims.claim_seq
-                      );
-                END IF;
-            END $$
-            "#
-            ))
-            .execute(backfill_tx.as_mut())
-            .await
-            .map_err(map_sqlx_error)?;
+            // v016: queue_lanes.available_count was dropped; the reader
+            // derives the available count from queue_enqueue_heads.next_seq
+            // minus queue_claim_heads.claim_seq. No backfill is required —
+            // both head tables already maintain the source of truth.
 
             backfill_tx.commit().await.map_err(map_sqlx_error)?;
 
@@ -3481,12 +3438,17 @@ impl QueueStorage {
 
                 GET DIAGNOSTICS v_claimed_count = ROW_COUNT;
 
-                IF v_claimed_count > 0 THEN
-                    UPDATE {schema}.queue_lanes AS lanes
-                    SET available_count = GREATEST(0, lanes.available_count - v_claimed_count)
-                    WHERE lanes.queue = p_queue
-                      AND lanes.priority = v_lane_priority;
-                ELSE
+                -- v016: queue_lanes.available_count was dropped; the
+                -- derived count (next_seq - claim_seq) decreases naturally
+                -- as the `advanced` CTE above bumps claim_seq past the
+                -- claimed lane_seq. The only remaining branch is the
+                -- gap-recovery case below: if no rows were claimed but
+                -- the head says the queue is non-empty (next_seq >
+                -- claim_seq), there are deleted/missing lanes between
+                -- claim_seq and next_seq. Advance claim_seq to catch
+                -- up so subsequent reads of (next_seq - claim_seq)
+                -- don't over-count.
+                IF v_claimed_count = 0 THEN
                     UPDATE {schema}.queue_claim_heads AS claims
                     SET claim_seq = GREATEST(claims.claim_seq, v_lane_next_seq)
                     WHERE claims.queue = p_queue
@@ -4096,19 +4058,10 @@ impl QueueStorage {
         self.sync_ready_enqueue_unique_claims(tx, &ready_rows)
             .await?;
         self.execute_ready_inserts_tx(tx, &ready_rows).await?;
-        let mut count_deltas: BTreeMap<(String, i16), i64> = BTreeMap::new();
-        for row in &ready_rows {
-            *count_deltas
-                .entry((row.queue.clone(), row.priority))
-                .or_insert(0) += 1;
-        }
-        self.adjust_lane_counts_batch(
-            tx,
-            count_deltas
-                .into_iter()
-                .map(|((queue, priority), count)| (queue, priority, count, 0)),
-        )
-        .await?;
+        // v016: enqueue's contribution to the available count is
+        // captured by the next_seq advance that
+        // `execute_ready_inserts_tx` already drove. No separate
+        // counter to maintain.
         Ok(total_rows)
     }
 
@@ -4187,19 +4140,8 @@ impl QueueStorage {
         self.sync_ready_enqueue_unique_claims(tx, &ready_rows)
             .await?;
         self.execute_ready_copy_tx(tx, &ready_rows).await?;
-        let mut count_deltas: BTreeMap<(String, i16), i64> = BTreeMap::new();
-        for row in &ready_rows {
-            *count_deltas
-                .entry((row.queue.clone(), row.priority))
-                .or_insert(0) += 1;
-        }
-        self.adjust_lane_counts_batch(
-            tx,
-            count_deltas
-                .into_iter()
-                .map(|((queue, priority), count)| (queue, priority, count, 0)),
-        )
-        .await?;
+        // v016: see equivalent comment above — enqueue's contribution
+        // to the available count flows through next_seq.
         Ok(total_rows)
     }
 
@@ -4275,19 +4217,8 @@ impl QueueStorage {
         }
 
         self.execute_ready_inserts_tx(tx, &ready_rows).await?;
-        let mut count_deltas: BTreeMap<(String, i16), i64> = BTreeMap::new();
-        for row in &ready_rows {
-            *count_deltas
-                .entry((row.queue.clone(), row.priority))
-                .or_insert(0) += 1;
-        }
-        self.adjust_lane_counts_batch(
-            tx,
-            count_deltas
-                .into_iter()
-                .map(|((queue, priority), count)| (queue, priority, count, 0)),
-        )
-        .await?;
+        // v016: see equivalent comment above — enqueue's contribution
+        // to the available count flows through next_seq.
         Ok(total_rows)
     }
 
@@ -4605,95 +4536,14 @@ impl QueueStorage {
         Ok(rows.len())
     }
 
-    async fn adjust_lane_counts<'a>(
-        &self,
-        tx: &mut sqlx::Transaction<'a, sqlx::Postgres>,
-        queue: &str,
-        priority: i16,
-        available_delta: i64,
-        pruned_completed_delta: i64,
-    ) -> Result<(), AwaError> {
-        self.adjust_lane_counts_batch(
-            tx,
-            [(
-                queue.to_string(),
-                priority,
-                available_delta,
-                pruned_completed_delta,
-            )],
-        )
-        .await
-    }
-
-    async fn adjust_lane_counts_batch<'a, I>(
-        &self,
-        tx: &mut sqlx::Transaction<'a, sqlx::Postgres>,
-        deltas: I,
-    ) -> Result<(), AwaError>
-    where
-        I: IntoIterator<Item = (String, i16, i64, i64)>,
-    {
-        let mut grouped: BTreeMap<(String, i16), (i64, i64)> = BTreeMap::new();
-        for (queue, priority, available_delta, pruned_completed_delta) in deltas {
-            if available_delta == 0 && pruned_completed_delta == 0 {
-                continue;
-            }
-            let entry = grouped.entry((queue, priority)).or_insert((0_i64, 0_i64));
-            entry.0 += available_delta;
-            entry.1 += pruned_completed_delta;
-        }
-
-        if grouped.is_empty() {
-            return Ok(());
-        }
-
-        let schema = self.schema();
-        let mut queues = Vec::with_capacity(grouped.len());
-        let mut priorities = Vec::with_capacity(grouped.len());
-        let mut available_deltas = Vec::with_capacity(grouped.len());
-        let mut pruned_completed_deltas = Vec::with_capacity(grouped.len());
-
-        for ((queue, priority), (available_delta, pruned_completed_delta)) in grouped {
-            queues.push(queue);
-            priorities.push(priority);
-            available_deltas.push(available_delta);
-            pruned_completed_deltas.push(pruned_completed_delta);
-        }
-
-        sqlx::query(&format!(
-            r#"
-            WITH deltas(queue, priority, available_delta, pruned_completed_delta) AS (
-                SELECT *
-                FROM unnest(
-                    $1::text[],
-                    $2::smallint[],
-                    $3::bigint[],
-                    $4::bigint[]
-                )
-            )
-            UPDATE {schema}.queue_lanes
-            SET available_count = GREATEST(
-                    0,
-                    queue_lanes.available_count + deltas.available_delta
-                ),
-                pruned_completed_count = GREATEST(
-                    0,
-                    queue_lanes.pruned_completed_count + deltas.pruned_completed_delta
-                )
-            FROM deltas
-            WHERE queue_lanes.queue = deltas.queue
-              AND queue_lanes.priority = deltas.priority
-            "#
-        ))
-        .bind(&queues)
-        .bind(&priorities)
-        .bind(&available_deltas)
-        .bind(&pruned_completed_deltas)
-        .execute(tx.as_mut())
-        .await
-        .map_err(map_sqlx_error)?;
-        Ok(())
-    }
+    // v016: `adjust_lane_counts` and `adjust_lane_counts_batch` were
+    // removed when `queue_lanes.available_count` was dropped. Every
+    // historical caller passed `pruned_completed_delta = 0`, so the
+    // entire helper collapsed to a no-op once `available_count` was
+    // gone. `queue_lanes.pruned_completed_count` is still mutated, but
+    // that happens via `adjust_terminal_rollups_batch` and the prune
+    // path's direct INSERT into `queue_terminal_rollups`. Available-
+    // count reads compute `next_seq - claim_seq` from the head tables.
 
     async fn adjust_terminal_rollups_batch<'a, I>(
         &self,
@@ -5373,11 +5223,13 @@ impl QueueStorage {
         signal: &AvailableSignal,
         max_claimers: i16,
     ) -> i16 {
-        // The signal source (queue_lanes.available_count) tracks
-        // unclaimed lane positions, so we don't subtract a running
-        // count — claimed rows are already excluded by the counter.
-        // Keep the original `backlog` name in the threshold table so
-        // future tweaks can compare against the pre-fix shape.
+        // The signal source (`queue_enqueue_heads.next_seq -
+        // queue_claim_heads.claim_seq`, per v016) is the count of
+        // lane positions enqueued but not yet claimed, so we don't
+        // subtract a running count — already-claimed rows are excluded
+        // by the claim_seq advance. Keep the original `backlog` name
+        // in the threshold table so future tweaks can compare against
+        // the pre-fix shape.
         let available = signal.available.max(0) as u64;
         let backlog = available;
         let current = current_target.unwrap_or(1).clamp(1, max_claimers.max(1));
@@ -5495,11 +5347,17 @@ impl QueueStorage {
     ) -> Result<AvailableSignal, AwaError> {
         let schema = self.schema();
         let queues = self.physical_queues_for_logical(queue);
+        // v016: derive available from the two head tables. Two PK
+        // reads per (queue, priority) lane via the JOIN; no longer
+        // touches the heavily-mutated queue_lanes heap.
         let available: i64 = sqlx::query_scalar(&format!(
             r#"
-            SELECT COALESCE(sum(available_count), 0)::bigint
-            FROM {schema}.queue_lanes
-            WHERE queue = ANY($1)
+            SELECT COALESCE(sum(GREATEST(qe.next_seq - qc.claim_seq, 0)), 0)::bigint
+            FROM {schema}.queue_enqueue_heads AS qe
+            JOIN {schema}.queue_claim_heads AS qc
+              ON qc.queue = qe.queue
+             AND qc.priority = qe.priority
+            WHERE qe.queue = ANY($1)
             "#
         ))
         .bind(&queues)
@@ -6095,10 +5953,20 @@ impl QueueStorage {
         let row: (i64, i64, i64) = sqlx::query_as(&format!(
             r#"
             WITH lane_counts AS (
-                SELECT
-                    COALESCE(sum(available_count), 0)::bigint AS available
-                FROM {schema}.queue_lanes
-                WHERE queue = ANY($1)
+                -- v016: queue_lanes.available_count was dropped. The
+                -- admin-grade API needs an exact count, so we scan
+                -- ready_entries with the same lane_seq >= claim_seq
+                -- predicate the legacy ground-truth CTE used. The hot
+                -- path (queue_claimer_signal) takes the cheap
+                -- `next_seq - claim_seq` approximation; this slower
+                -- scan is reserved for admin / UI calls.
+                SELECT COALESCE(count(*)::bigint, 0) AS available
+                FROM {schema}.ready_entries AS ready
+                JOIN {schema}.queue_claim_heads AS claims
+                  ON claims.queue = ready.queue
+                 AND claims.priority = ready.priority
+                WHERE ready.queue = ANY($1)
+                  AND ready.lane_seq >= claims.claim_seq
             ),
             pruned_terminal AS (
                 SELECT COALESCE(
@@ -6234,8 +6102,6 @@ impl QueueStorage {
             };
             self.insert_existing_ready_rows_tx(tx, vec![ready_row.clone()], Some(waiting.state))
                 .await?;
-            self.adjust_lane_counts(tx, &waiting.queue, waiting.priority, 0, 0)
-                .await?;
             self.notify_queues_tx(tx, std::iter::once(waiting.queue.clone()))
                 .await?;
             return Ok(Some(
@@ -6315,8 +6181,6 @@ impl QueueStorage {
                 payload: terminal.payload,
             };
             self.insert_existing_ready_rows_tx(tx, vec![ready_row.clone()], Some(terminal.state))
-                .await?;
-            self.adjust_lane_counts(tx, &terminal.queue, terminal.priority, 0, 0)
                 .await?;
             self.notify_queues_tx(tx, std::iter::once(terminal.queue.clone()))
                 .await?;
@@ -6493,8 +6357,29 @@ impl QueueStorage {
                     .into_done_row(JobState::Cancelled, Utc::now(), ready.payload.clone());
             self.insert_done_rows_tx(tx, std::slice::from_ref(&done), Some(JobState::Available))
                 .await?;
-            self.adjust_lane_counts(tx, &ready.queue, ready.priority, -1, 0)
-                .await?;
+            // v016: if the cancelled lane was *exactly* at the claim
+            // head, advance the head past it so the derived
+            // `next_seq - claim_seq` count drops by 1 without waiting
+            // for the dispatcher's gap-recovery branch. When other
+            // unclaimed lanes still sit between claim_seq and the
+            // cancelled lane_seq, leave claim_seq alone — advancing
+            // would skip past those still-claimable rows. Gap-recovery
+            // absorbs the over-count later, when claim_seq catches up.
+            sqlx::query(&format!(
+                r#"
+                UPDATE {schema}.queue_claim_heads
+                SET claim_seq = claim_seq + 1
+                WHERE queue = $1
+                  AND priority = $2
+                  AND claim_seq = $3
+                "#
+            ))
+            .bind(&ready.queue)
+            .bind(ready.priority)
+            .bind(ready.lane_seq)
+            .execute(tx.as_mut())
+            .await
+            .map_err(map_sqlx_error)?;
             return Ok(Some(done.into_job_row()?));
         }
 
@@ -6539,8 +6424,6 @@ impl QueueStorage {
                 .clone()
                 .into_done_row(JobState::Cancelled, Utc::now(), done_payload);
             self.insert_done_rows_tx(tx, std::slice::from_ref(&done), Some(lease.state))
-                .await?;
-            self.adjust_lane_counts(tx, &lease.queue, lease.priority, 0, 0)
                 .await?;
             // Receipt-plane consistency: close any matching open
             // receipt so the ADR-023 anti-join no longer considers this
@@ -6718,7 +6601,6 @@ impl QueueStorage {
                 .execute(tx.as_mut())
                 .await
                 .map_err(map_sqlx_error)?;
-                self.adjust_lane_counts(tx, &queue, priority, 0, 0).await?;
                 self.notify_cancellation_tx(tx, job_id, run_lease).await?;
                 return Ok(Some(done.into_job_row()?));
             }
@@ -6779,8 +6661,6 @@ impl QueueStorage {
                 payload: deferred.payload,
             };
             self.insert_done_rows_tx(tx, std::slice::from_ref(&done), Some(deferred.state))
-                .await?;
-            self.adjust_lane_counts(tx, &done.queue, done.priority, 0, 0)
                 .await?;
             return Ok(Some(done.into_job_row()?));
         }
@@ -6885,14 +6765,10 @@ impl QueueStorage {
         let mut ids = Vec::with_capacity(moved.len());
         let mut queues = BTreeSet::new();
         let mut ready_rows = Vec::with_capacity(moved.len());
-        let mut removed_count_deltas: BTreeMap<(String, i16), i64> = BTreeMap::new();
 
         for row in moved {
             ids.push(row.job_id);
             queues.insert(row.queue.clone());
-            *removed_count_deltas
-                .entry((row.queue.clone(), row.priority))
-                .or_insert(0) -= 1;
 
             let mut payload = RuntimePayload::from_json(row.payload)?;
             let metadata = payload.metadata.as_object_mut().ok_or_else(|| {
@@ -6922,13 +6798,14 @@ impl QueueStorage {
             });
         }
 
-        self.adjust_lane_counts_batch(
-            &mut tx,
-            removed_count_deltas
-                .into_iter()
-                .map(|((queue, priority), count)| (queue, priority, count, 0)),
-        )
-        .await?;
+        // v016: aging deletes ready rows from the source lane without
+        // moving the source's claim_seq, then re-inserts on the target
+        // lane (which bumps target's next_seq). Source's derived
+        // available (`next_seq - claim_seq`) over-counts by `moved`
+        // until the dispatcher's next claim attempt on that lane
+        // hits the gap-recovery branch in `claim_ready_runtime` and
+        // catches claim_seq up to next_seq. The drift is bounded by
+        // aging rate × poll interval and self-corrects.
         self.insert_existing_ready_rows_tx(&mut tx, ready_rows, Some(JobState::Available))
             .await?;
         self.notify_queues_tx(&mut tx, queues).await?;
@@ -8689,8 +8566,6 @@ impl QueueStorage {
                 .into_done_row(JobState::Completed, Utc::now(), payload.into_json());
         self.insert_done_rows_tx(&mut tx, std::slice::from_ref(&done_row), Some(moved.state))
             .await?;
-        self.adjust_lane_counts(&mut tx, &moved.queue, moved.priority, 0, 0)
-            .await?;
         tx.commit().await.map_err(map_sqlx_error)?;
         done_row.into_job_row()
     }
@@ -8787,8 +8662,6 @@ impl QueueStorage {
                 .into_done_row(JobState::Failed, Utc::now(), payload.into_json());
         self.insert_done_rows_tx(&mut tx, std::slice::from_ref(&done_row), Some(moved.state))
             .await?;
-        self.adjust_lane_counts(&mut tx, &moved.queue, moved.priority, 0, 0)
-            .await?;
         tx.commit().await.map_err(map_sqlx_error)?;
         done_row.into_job_row()
     }
@@ -8850,8 +8723,6 @@ impl QueueStorage {
             ..moved.clone().into_ready_row(Utc::now(), ready_payload)
         };
         self.insert_existing_ready_rows_tx(&mut tx, vec![ready_row.clone()], Some(moved.state))
-            .await?;
-        self.adjust_lane_counts(&mut tx, &moved.queue, moved.priority, 0, 0)
             .await?;
         self.notify_queues_tx(&mut tx, std::iter::once(moved.queue.clone()))
             .await?;
@@ -9082,8 +8953,6 @@ impl QueueStorage {
         );
         self.insert_deferred_rows_tx(&mut tx, vec![deferred.clone()], Some(moved.state))
             .await?;
-        self.adjust_lane_counts(&mut tx, &moved.queue, moved.priority, 0, 0)
-            .await?;
         tx.commit().await.map_err(map_sqlx_error)?;
         Ok(Some(deferred.into_job_row()?))
     }
@@ -9117,8 +8986,6 @@ impl QueueStorage {
         );
         deferred.attempt = deferred.attempt.saturating_sub(1);
         self.insert_deferred_rows_tx(&mut tx, vec![deferred.clone()], Some(moved.state))
-            .await?;
-        self.adjust_lane_counts(&mut tx, &moved.queue, moved.priority, 0, 0)
             .await?;
         tx.commit().await.map_err(map_sqlx_error)?;
         Ok(Some(deferred.into_job_row()?))
@@ -9156,8 +9023,6 @@ impl QueueStorage {
                 .into_done_row(JobState::Cancelled, Utc::now(), payload.into_json());
         self.insert_done_rows_tx(&mut tx, std::slice::from_ref(&done), Some(moved.state))
             .await?;
-        self.adjust_lane_counts(&mut tx, &moved.queue, moved.priority, 0, 0)
-            .await?;
         tx.commit().await.map_err(map_sqlx_error)?;
         Ok(Some(done.into_job_row()?))
     }
@@ -9188,8 +9053,6 @@ impl QueueStorage {
             .clone()
             .into_done_row(JobState::Failed, Utc::now(), payload.into_json());
         self.insert_done_rows_tx(&mut tx, std::slice::from_ref(&done), Some(moved.state))
-            .await?;
-        self.adjust_lane_counts(&mut tx, &moved.queue, moved.priority, 0, 0)
             .await?;
         tx.commit().await.map_err(map_sqlx_error)?;
         Ok(Some(done.into_job_row()?))
@@ -9227,8 +9090,6 @@ impl QueueStorage {
             dlq_at,
         );
         self.insert_dlq_rows_tx(&mut tx, std::slice::from_ref(&dlq_row), Some(moved.state))
-            .await?;
-        self.adjust_lane_counts(&mut tx, &moved.queue, moved.priority, 0, 0)
             .await?;
         tx.commit().await.map_err(map_sqlx_error)?;
         Ok(Some(dlq_row.into_job_row()?))
@@ -9290,8 +9151,6 @@ impl QueueStorage {
             .clone()
             .into_dlq_row(dlq_reason.to_string(), Utc::now());
         self.insert_dlq_rows_tx(&mut tx, std::slice::from_ref(&dlq_row), Some(moved.state))
-            .await?;
-        self.adjust_lane_counts(&mut tx, &moved.queue, moved.priority, 0, 0)
             .await?;
         tx.commit().await.map_err(map_sqlx_error)?;
         Ok(Some(dlq_row.into_job_row()?))
@@ -9660,8 +9519,6 @@ impl QueueStorage {
                     .into_done_row(JobState::Failed, Utc::now(), payload.into_json());
             self.insert_done_rows_tx(&mut tx, std::slice::from_ref(&done), Some(moved.state))
                 .await?;
-            self.adjust_lane_counts(&mut tx, &moved.queue, moved.priority, 0, 0)
-                .await?;
             tx.commit().await.map_err(map_sqlx_error)?;
             return Ok(Some(done.into_job_row()?));
         }
@@ -9674,8 +9531,6 @@ impl QueueStorage {
             payload.into_json(),
         );
         self.insert_deferred_rows_tx(&mut tx, vec![deferred.clone()], Some(moved.state))
-            .await?;
-        self.adjust_lane_counts(&mut tx, &moved.queue, moved.priority, 0, 0)
             .await?;
         tx.commit().await.map_err(map_sqlx_error)?;
         Ok(Some(deferred.into_job_row()?))
@@ -9763,8 +9618,6 @@ impl QueueStorage {
             );
             self.insert_deferred_rows_tx(&mut tx, vec![deferred.clone()], Some(row.state))
                 .await?;
-            self.adjust_lane_counts(&mut tx, &row.queue, row.priority, 0, 0)
-                .await?;
             rescued.push(deferred.into_job_row()?);
         }
         for row in moved_receipts {
@@ -9785,8 +9638,6 @@ impl QueueStorage {
                 payload.into_json(),
             );
             self.insert_deferred_rows_tx(&mut tx, vec![deferred.clone()], Some(row.state))
-                .await?;
-            self.adjust_lane_counts(&mut tx, &row.queue, row.priority, 0, 0)
                 .await?;
             rescued.push(deferred.into_job_row()?);
         }
@@ -9875,8 +9726,6 @@ impl QueueStorage {
             );
             self.insert_deferred_rows_tx(&mut tx, vec![deferred.clone()], Some(row.state))
                 .await?;
-            self.adjust_lane_counts(&mut tx, &row.queue, row.priority, 0, 0)
-                .await?;
             rescued.push(deferred.into_job_row()?);
         }
         tx.commit().await.map_err(map_sqlx_error)?;
@@ -9947,8 +9796,6 @@ impl QueueStorage {
                         .into_done_row(JobState::Failed, Utc::now(), payload.into_json());
                 self.insert_done_rows_tx(&mut tx, std::slice::from_ref(&done), Some(row.state))
                     .await?;
-                self.adjust_lane_counts(&mut tx, &row.queue, row.priority, 0, 0)
-                    .await?;
                 rescued.push(done.into_job_row()?);
             } else {
                 let deferred = row.clone().into_deferred_row(
@@ -9959,8 +9806,6 @@ impl QueueStorage {
                     payload.into_json(),
                 );
                 self.insert_deferred_rows_tx(&mut tx, vec![deferred.clone()], Some(row.state))
-                    .await?;
-                self.adjust_lane_counts(&mut tx, &row.queue, row.priority, 0, 0)
                     .await?;
                 rescued.push(deferred.into_job_row()?);
             }

--- a/awa-model/src/queue_storage.rs
+++ b/awa-model/src/queue_storage.rs
@@ -168,8 +168,8 @@ pub struct QueueCounts {
 /// Cheap available-only signal used by the dispatcher's claimer-sizing
 /// control loop. Derives the count from
 /// `queue_enqueue_heads.next_seq − queue_claim_heads.claim_seq`
-/// summed over the queue's physical stripes (ADR / v016) — two PK
-/// reads per lane, O(few rows) regardless of backlog size.
+/// summed over the queue's physical stripes — two PK reads per lane,
+/// O(few rows) regardless of backlog size.
 ///
 /// This is intentionally a separate type from [`QueueCounts`]: the
 /// dispatcher claim hot path only consumes the available count, and
@@ -2351,14 +2351,13 @@ impl QueueStorage {
             .await
             .map_err(map_sqlx_error)?;
 
-            // queue_count_snapshots was the staleness-cached counterpart
-            // of queue_counts_exact when the dispatcher's claim hot path
-            // still polled exact counts. After the queue_counts perf
-            // fix the dispatcher derives the available count from the
-            // head tables (v016: `next_seq - claim_seq`) directly
-            // (O(few rows)), and nothing else needs the snapshot. Drop
-            // the table on every prepare_schema so an upgrade from a
-            // pre-fix install reclaims the storage.
+            // queue_count_snapshots was a staleness-cached counterpart
+            // of queue_counts_exact, used when the dispatcher's claim
+            // hot path still polled exact counts. The dispatcher now
+            // derives the available count directly from the head tables
+            // (`next_seq - claim_seq`, O(few rows)) and nothing else
+            // needs the snapshot. Drop it on every prepare_schema so
+            // an upgrade from an older install reclaims the storage.
             sqlx::query(&format!(
                 "DROP TABLE IF EXISTS {schema}.queue_count_snapshots"
             ))
@@ -2528,11 +2527,6 @@ impl QueueStorage {
             .execute(backfill_tx.as_mut())
             .await
             .map_err(map_sqlx_error)?;
-
-            // v016: queue_lanes.available_count was dropped; the reader
-            // derives the available count from queue_enqueue_heads.next_seq
-            // minus queue_claim_heads.claim_seq. No backfill is required —
-            // both head tables already maintain the source of truth.
 
             backfill_tx.commit().await.map_err(map_sqlx_error)?;
 
@@ -3438,16 +3432,14 @@ impl QueueStorage {
 
                 GET DIAGNOSTICS v_claimed_count = ROW_COUNT;
 
-                -- v016: queue_lanes.available_count was dropped; the
-                -- derived count (next_seq - claim_seq) decreases naturally
-                -- as the `advanced` CTE above bumps claim_seq past the
-                -- claimed lane_seq. The only remaining branch is the
-                -- gap-recovery case below: if no rows were claimed but
+                -- The derived available count `next_seq - claim_seq`
+                -- decreases naturally as the `advanced` CTE above bumps
+                -- claim_seq past the claimed lane_seq. The only extra
+                -- branch is gap-recovery: if no rows were claimed but
                 -- the head says the queue is non-empty (next_seq >
-                -- claim_seq), there are deleted/missing lanes between
+                -- claim_seq), admin deletes have left a gap between
                 -- claim_seq and next_seq. Advance claim_seq to catch
-                -- up so subsequent reads of (next_seq - claim_seq)
-                -- don't over-count.
+                -- up so subsequent readers don't see a stale over-count.
                 IF v_claimed_count = 0 THEN
                     UPDATE {schema}.queue_claim_heads AS claims
                     SET claim_seq = GREATEST(claims.claim_seq, v_lane_next_seq)
@@ -4058,10 +4050,6 @@ impl QueueStorage {
         self.sync_ready_enqueue_unique_claims(tx, &ready_rows)
             .await?;
         self.execute_ready_inserts_tx(tx, &ready_rows).await?;
-        // v016: enqueue's contribution to the available count is
-        // captured by the next_seq advance that
-        // `execute_ready_inserts_tx` already drove. No separate
-        // counter to maintain.
         Ok(total_rows)
     }
 
@@ -4140,8 +4128,6 @@ impl QueueStorage {
         self.sync_ready_enqueue_unique_claims(tx, &ready_rows)
             .await?;
         self.execute_ready_copy_tx(tx, &ready_rows).await?;
-        // v016: see equivalent comment above — enqueue's contribution
-        // to the available count flows through next_seq.
         Ok(total_rows)
     }
 
@@ -4217,8 +4203,6 @@ impl QueueStorage {
         }
 
         self.execute_ready_inserts_tx(tx, &ready_rows).await?;
-        // v016: see equivalent comment above — enqueue's contribution
-        // to the available count flows through next_seq.
         Ok(total_rows)
     }
 
@@ -4535,15 +4519,6 @@ impl QueueStorage {
 
         Ok(rows.len())
     }
-
-    // v016: `adjust_lane_counts` and `adjust_lane_counts_batch` were
-    // removed when `queue_lanes.available_count` was dropped. Every
-    // historical caller passed `pruned_completed_delta = 0`, so the
-    // entire helper collapsed to a no-op once `available_count` was
-    // gone. `queue_lanes.pruned_completed_count` is still mutated, but
-    // that happens via `adjust_terminal_rollups_batch` and the prune
-    // path's direct INSERT into `queue_terminal_rollups`. Available-
-    // count reads compute `next_seq - claim_seq` from the head tables.
 
     async fn adjust_terminal_rollups_batch<'a, I>(
         &self,
@@ -5223,13 +5198,13 @@ impl QueueStorage {
         signal: &AvailableSignal,
         max_claimers: i16,
     ) -> i16 {
-        // The signal source (`queue_enqueue_heads.next_seq -
-        // queue_claim_heads.claim_seq`, per v016) is the count of
-        // lane positions enqueued but not yet claimed, so we don't
-        // subtract a running count — already-claimed rows are excluded
-        // by the claim_seq advance. Keep the original `backlog` name
-        // in the threshold table so future tweaks can compare against
-        // the pre-fix shape.
+        // The signal source `queue_enqueue_heads.next_seq -
+        // queue_claim_heads.claim_seq` counts lane positions enqueued
+        // but not yet claimed, so we don't subtract a running count —
+        // already-claimed rows are excluded by the claim_seq advance.
+        // `backlog` is retained as a separate name in the threshold
+        // table to keep room for shape tweaks that diverge from
+        // `available` later.
         let available = signal.available.max(0) as u64;
         let backlog = available;
         let current = current_target.unwrap_or(1).clamp(1, max_claimers.max(1));
@@ -5340,6 +5315,19 @@ impl QueueStorage {
             .clamp(1, max_claimers.max(1)))
     }
 
+    /// Cheap, dispatcher-grade available-count signal.
+    ///
+    /// Sums `next_seq - claim_seq` across the queue's (queue, priority)
+    /// lanes — one PK read into each of the two head tables per lane
+    /// (typically ≤ 4 lanes per logical queue). The difference is an
+    /// upper bound on the count of unclaimed ready rows: admin DELETEs
+    /// of unclaimed jobs leave a gap between `claim_seq` and `next_seq`
+    /// until the next claim attempt's gap-recovery branch closes it.
+    /// The dispatcher tolerates this drift because the worst case is
+    /// one wasted claim attempt that finds no rows.
+    ///
+    /// For an exact count, use [`Self::queue_counts_exact`], which
+    /// scans `ready_entries`.
     async fn queue_claimer_signal(
         &self,
         pool: &PgPool,
@@ -5347,9 +5335,6 @@ impl QueueStorage {
     ) -> Result<AvailableSignal, AwaError> {
         let schema = self.schema();
         let queues = self.physical_queues_for_logical(queue);
-        // v016: derive available from the two head tables. Two PK
-        // reads per (queue, priority) lane via the JOIN; no longer
-        // touches the heavily-mutated queue_lanes heap.
         let available: i64 = sqlx::query_scalar(&format!(
             r#"
             SELECT COALESCE(sum(GREATEST(qe.next_seq - qc.claim_seq, 0)), 0)::bigint
@@ -5943,6 +5928,11 @@ impl QueueStorage {
             .collect())
     }
 
+    /// Exact admin/UI-grade queue counts. Scans `ready_entries` rather
+    /// than reading the head tables — slower, but unaffected by the
+    /// transient gap between admin DELETE of an unclaimed row and the
+    /// dispatcher's next gap-recovery pass. Use [`Self::queue_claimer_signal`]
+    /// for the dispatcher hot path.
     async fn queue_counts_exact(
         &self,
         pool: &PgPool,
@@ -5953,13 +5943,13 @@ impl QueueStorage {
         let row: (i64, i64, i64) = sqlx::query_as(&format!(
             r#"
             WITH lane_counts AS (
-                -- v016: queue_lanes.available_count was dropped. The
-                -- admin-grade API needs an exact count, so we scan
-                -- ready_entries with the same lane_seq >= claim_seq
-                -- predicate the legacy ground-truth CTE used. The hot
-                -- path (queue_claimer_signal) takes the cheap
-                -- `next_seq - claim_seq` approximation; this slower
-                -- scan is reserved for admin / UI calls.
+                -- Exact count: a ready row is available iff its
+                -- lane_seq has not yet been passed by the lane's
+                -- claim_seq cursor. Equivalent to the dispatcher's
+                -- cheap `next_seq - claim_seq` signal in the absence
+                -- of admin DELETEs of unclaimed jobs, and tighter
+                -- when such deletes have occurred but gap-recovery
+                -- has not yet caught up.
                 SELECT COALESCE(count(*)::bigint, 0) AS available
                 FROM {schema}.ready_entries AS ready
                 JOIN {schema}.queue_claim_heads AS claims
@@ -6357,14 +6347,14 @@ impl QueueStorage {
                     .into_done_row(JobState::Cancelled, Utc::now(), ready.payload.clone());
             self.insert_done_rows_tx(tx, std::slice::from_ref(&done), Some(JobState::Available))
                 .await?;
-            // v016: if the cancelled lane was *exactly* at the claim
-            // head, advance the head past it so the derived
-            // `next_seq - claim_seq` count drops by 1 without waiting
-            // for the dispatcher's gap-recovery branch. When other
-            // unclaimed lanes still sit between claim_seq and the
-            // cancelled lane_seq, leave claim_seq alone — advancing
-            // would skip past those still-claimable rows. Gap-recovery
-            // absorbs the over-count later, when claim_seq catches up.
+            // If the cancelled lane was *exactly* at the claim head,
+            // advance the head past it so the derived
+            // `next_seq - claim_seq` count drops by 1 immediately.
+            // When other unclaimed lanes still sit between claim_seq
+            // and the cancelled lane_seq, leave claim_seq alone —
+            // advancing would skip past those still-claimable rows.
+            // The dispatcher's gap-recovery branch absorbs the
+            // transient over-count when claim_seq later catches up.
             sqlx::query(&format!(
                 r#"
                 UPDATE {schema}.queue_claim_heads
@@ -6798,14 +6788,14 @@ impl QueueStorage {
             });
         }
 
-        // v016: aging deletes ready rows from the source lane without
-        // moving the source's claim_seq, then re-inserts on the target
-        // lane (which bumps target's next_seq). Source's derived
-        // available (`next_seq - claim_seq`) over-counts by `moved`
-        // until the dispatcher's next claim attempt on that lane
-        // hits the gap-recovery branch in `claim_ready_runtime` and
-        // catches claim_seq up to next_seq. The drift is bounded by
-        // aging rate × poll interval and self-corrects.
+        // Aging deletes ready rows from the source lane without
+        // moving the source's claim_seq, then re-inserts on the
+        // target lane (which bumps target's next_seq). The source's
+        // derived `next_seq - claim_seq` over-counts by `moved` until
+        // the dispatcher's next claim attempt on that lane hits the
+        // gap-recovery branch in `claim_ready_runtime` and catches
+        // claim_seq up. The drift is bounded by aging rate × poll
+        // interval and self-corrects.
         self.insert_existing_ready_rows_tx(&mut tx, ready_rows, Some(JobState::Available))
             .await?;
         self.notify_queues_tx(&mut tx, queues).await?;

--- a/awa-model/tests/queue_storage_copy_test.rs
+++ b/awa-model/tests/queue_storage_copy_test.rs
@@ -206,8 +206,7 @@ async fn queue_storage_copy_enqueues_ready_and_deferred_rows() {
     .expect("count deferred rows");
     assert_eq!(deferred_count, 1);
 
-    // v016: queue_lanes.available_count was dropped. Available count
-    // is derived from queue_enqueue_heads.next_seq -
+    // Available count is derived from queue_enqueue_heads.next_seq -
     // queue_claim_heads.claim_seq.
     let available_count: i64 = sqlx::query_scalar(&format!(
         "SELECT GREATEST(qe.next_seq - qc.claim_seq, 0)

--- a/awa-model/tests/queue_storage_copy_test.rs
+++ b/awa-model/tests/queue_storage_copy_test.rs
@@ -206,9 +206,17 @@ async fn queue_storage_copy_enqueues_ready_and_deferred_rows() {
     .expect("count deferred rows");
     assert_eq!(deferred_count, 1);
 
+    // v016: queue_lanes.available_count was dropped. Available count
+    // is derived from queue_enqueue_heads.next_seq -
+    // queue_claim_heads.claim_seq.
     let available_count: i64 = sqlx::query_scalar(&format!(
-        "SELECT available_count FROM {}.queue_lanes WHERE queue = $1 AND priority = 1",
-        store.schema()
+        "SELECT GREATEST(qe.next_seq - qc.claim_seq, 0)
+         FROM {schema}.queue_enqueue_heads AS qe
+         JOIN {schema}.queue_claim_heads AS qc
+           ON qc.queue = qe.queue
+          AND qc.priority = qe.priority
+         WHERE qe.queue = $1 AND qe.priority = 1",
+        schema = store.schema()
     ))
     .bind(queue)
     .fetch_one(&pool)
@@ -261,7 +269,7 @@ async fn queue_storage_copy_rolls_back_on_unique_conflict() {
     assert_eq!(ready_count, 0);
 
     let lane_available: i64 = sqlx::query_scalar(&format!(
-        "SELECT COALESCE(sum(available_count), 0)::bigint FROM {}.queue_lanes WHERE queue = $1",
+        "SELECT COALESCE(sum(GREATEST(qe.next_seq - qc.claim_seq, 0)), 0)::bigint FROM {0}.queue_enqueue_heads qe JOIN {0}.queue_claim_heads qc ON qc.queue = qe.queue AND qc.priority = qe.priority WHERE qe.queue = $1",
         store.schema()
     ))
     .bind(queue)
@@ -315,7 +323,7 @@ async fn queue_storage_batch_rolls_back_on_batched_unique_conflict() {
     assert_eq!(ready_count, 0);
 
     let lane_available: i64 = sqlx::query_scalar(&format!(
-        "SELECT COALESCE(sum(available_count), 0)::bigint FROM {}.queue_lanes WHERE queue = $1",
+        "SELECT COALESCE(sum(GREATEST(qe.next_seq - qc.claim_seq, 0)), 0)::bigint FROM {0}.queue_enqueue_heads qe JOIN {0}.queue_claim_heads qc ON qc.queue = qe.queue AND qc.priority = qe.priority WHERE qe.queue = $1",
         store.schema()
     ))
     .bind(queue)
@@ -369,7 +377,7 @@ async fn queue_storage_copy_rolls_back_on_existing_unique_conflict() {
     assert_eq!(ready_count, 1);
 
     let lane_available: i64 = sqlx::query_scalar(&format!(
-        "SELECT COALESCE(sum(available_count), 0)::bigint FROM {}.queue_lanes WHERE queue = $1",
+        "SELECT COALESCE(sum(GREATEST(qe.next_seq - qc.claim_seq, 0)), 0)::bigint FROM {0}.queue_enqueue_heads qe JOIN {0}.queue_claim_heads qc ON qc.queue = qe.queue AND qc.priority = qe.priority WHERE qe.queue = $1",
         store.schema()
     ))
     .bind(queue)
@@ -433,7 +441,7 @@ async fn queue_storage_copy_concurrent_lane_seq_is_dense() {
     }
 
     let available_count: i64 = sqlx::query_scalar(&format!(
-        "SELECT COALESCE(sum(available_count), 0)::bigint FROM {}.queue_lanes WHERE queue = $1",
+        "SELECT COALESCE(sum(GREATEST(qe.next_seq - qc.claim_seq, 0)), 0)::bigint FROM {0}.queue_enqueue_heads qe JOIN {0}.queue_claim_heads qc ON qc.queue = qe.queue AND qc.priority = qe.priority WHERE qe.queue = $1",
         store.schema()
     ))
     .bind(queue)
@@ -478,7 +486,7 @@ async fn queue_storage_copy_distributes_across_stripes() {
     }
 
     let available_count: i64 = sqlx::query_scalar(&format!(
-        "SELECT COALESCE(sum(available_count), 0)::bigint FROM {}.queue_lanes WHERE queue = ANY($1)",
+        "SELECT COALESCE(sum(GREATEST(qe.next_seq - qc.claim_seq, 0)), 0)::bigint FROM {0}.queue_enqueue_heads qe JOIN {0}.queue_claim_heads qc ON qc.queue = qe.queue AND qc.priority = qe.priority WHERE qe.queue = ANY($1)",
         store.schema()
     ))
     .bind((0..4).map(|stripe| format!("{queue}#{stripe}")).collect::<Vec<_>>())

--- a/awa-python/tests/test_awa.py
+++ b/awa-python/tests/test_awa.py
@@ -327,9 +327,9 @@ async def test_enqueue_many_copy_queue_storage(client):
         """,
         queue,
     )
-    # v016: queue_lanes.available_count was dropped. Available count
-    # is derived from queue_enqueue_heads.next_seq -
-    # queue_claim_heads.claim_seq.
+    # Available count derives from queue_enqueue_heads.next_seq -
+    # queue_claim_heads.claim_seq; aliased to keep the historical
+    # `available_count` field name on the returned row.
     counts = await tx.fetch_one(
         f"""
         SELECT GREATEST(qe.next_seq - qc.claim_seq, 0) AS available_count

--- a/awa-python/tests/test_awa.py
+++ b/awa-python/tests/test_awa.py
@@ -327,11 +327,17 @@ async def test_enqueue_many_copy_queue_storage(client):
         """,
         queue,
     )
+    # v016: queue_lanes.available_count was dropped. Available count
+    # is derived from queue_enqueue_heads.next_seq -
+    # queue_claim_heads.claim_seq.
     counts = await tx.fetch_one(
         f"""
-        SELECT available_count
-        FROM {schema}.queue_lanes
-        WHERE queue = $1 AND priority = 1
+        SELECT GREATEST(qe.next_seq - qc.claim_seq, 0) AS available_count
+        FROM {schema}.queue_enqueue_heads AS qe
+        JOIN {schema}.queue_claim_heads AS qc
+          ON qc.queue = qe.queue
+         AND qc.priority = qe.priority
+        WHERE qe.queue = $1 AND qe.priority = 1
         """,
         queue,
     )

--- a/awa-python/tests/test_cli.py
+++ b/awa-python/tests/test_cli.py
@@ -247,17 +247,6 @@ def _move_ready_to_failed_done(client: awa.Client, job_id: int) -> None:
             )
             FROM moved
         ),
-        lane_fix AS (
-            UPDATE {SCHEMA}.queue_lanes AS lanes
-            SET available_count = GREATEST(0, lanes.available_count - delta.moved_count)
-            FROM (
-                SELECT queue, priority, count(*)::bigint AS moved_count
-                FROM moved
-                GROUP BY queue, priority
-            ) AS delta
-            WHERE lanes.queue = delta.queue
-              AND lanes.priority = delta.priority
-        )
         INSERT INTO {SCHEMA}.done_entries (
             ready_slot, ready_generation, job_id, kind, queue, args, state,
             priority, attempt, run_lease, max_attempts, lane_seq,

--- a/awa-python/tests/test_cli.py
+++ b/awa-python/tests/test_cli.py
@@ -246,7 +246,7 @@ def _move_ready_to_failed_done(client: awa.Client, job_id: int) -> None:
                 job_id, unique_key, unique_states, 'available'::awa.job_state
             )
             FROM moved
-        ),
+        )
         INSERT INTO {SCHEMA}.done_entries (
             ready_slot, ready_generation, job_id, kind, queue, args, state,
             priority, attempt, run_lease, max_attempts, lane_seq,

--- a/awa-python/tests/test_dlq.py
+++ b/awa-python/tests/test_dlq.py
@@ -57,7 +57,7 @@ def _move_ready_to_failed_done(client: awa.Client, job_id: int) -> None:
                 'available'::awa.job_state
             )
             FROM moved
-        ),
+        )
         INSERT INTO {SCHEMA}.done_entries (
             ready_slot,
             ready_generation,
@@ -141,7 +141,7 @@ async def _move_ready_to_failed_done_async(client: awa.AsyncClient, job_id: int)
                     'available'::awa.job_state
                 )
                 FROM moved
-            ),
+            )
             INSERT INTO {SCHEMA}.done_entries (
                 ready_slot,
                 ready_generation,

--- a/awa-python/tests/test_dlq.py
+++ b/awa-python/tests/test_dlq.py
@@ -58,17 +58,6 @@ def _move_ready_to_failed_done(client: awa.Client, job_id: int) -> None:
             )
             FROM moved
         ),
-        lane_fix AS (
-            UPDATE {SCHEMA}.queue_lanes AS lanes
-            SET available_count = GREATEST(0, lanes.available_count - delta.moved_count)
-            FROM (
-                SELECT queue, priority, count(*)::bigint AS moved_count
-                FROM moved
-                GROUP BY queue, priority
-            ) AS delta
-            WHERE lanes.queue = delta.queue
-              AND lanes.priority = delta.priority
-        )
         INSERT INTO {SCHEMA}.done_entries (
             ready_slot,
             ready_generation,
@@ -153,17 +142,6 @@ async def _move_ready_to_failed_done_async(client: awa.AsyncClient, job_id: int)
                 )
                 FROM moved
             ),
-            lane_fix AS (
-                UPDATE {SCHEMA}.queue_lanes AS lanes
-                SET available_count = GREATEST(0, lanes.available_count - delta.moved_count)
-                FROM (
-                    SELECT queue, priority, count(*)::bigint AS moved_count
-                    FROM moved
-                    GROUP BY queue, priority
-                ) AS delta
-                WHERE lanes.queue = delta.queue
-                  AND lanes.priority = delta.priority
-            )
             INSERT INTO {SCHEMA}.done_entries (
                 ready_slot,
                 ready_generation,

--- a/awa-python/tests/test_sync.py
+++ b/awa-python/tests/test_sync.py
@@ -292,7 +292,9 @@ def test_enqueue_many_copy_sync_queue_storage(client):
         """,
         queue,
     )
-    # v016: queue_lanes.available_count was dropped; derive from heads.
+    # Available count derives from queue_enqueue_heads.next_seq -
+    # queue_claim_heads.claim_seq; aliased to keep the historical
+    # `available_count` field name on the returned row.
     counts = tx.fetch_one(
         f"""
         SELECT GREATEST(qe.next_seq - qc.claim_seq, 0) AS available_count

--- a/awa-python/tests/test_sync.py
+++ b/awa-python/tests/test_sync.py
@@ -292,11 +292,15 @@ def test_enqueue_many_copy_sync_queue_storage(client):
         """,
         queue,
     )
+    # v016: queue_lanes.available_count was dropped; derive from heads.
     counts = tx.fetch_one(
         f"""
-        SELECT available_count
-        FROM {schema}.queue_lanes
-        WHERE queue = $1 AND priority = 1
+        SELECT GREATEST(qe.next_seq - qc.claim_seq, 0) AS available_count
+        FROM {schema}.queue_enqueue_heads AS qe
+        JOIN {schema}.queue_claim_heads AS qc
+          ON qc.queue = qe.queue
+         AND qc.priority = qe.priority
+        WHERE qe.queue = $1 AND qe.priority = 1
         """,
         queue,
     )

--- a/awa-ui/frontend/e2e/seed.ts
+++ b/awa-ui/frontend/e2e/seed.ts
@@ -116,12 +116,12 @@ export default async function globalSetup() {
       now()
     );
 
-    INSERT INTO ${queueStorageSchema}.queue_lanes (queue, priority, next_seq, claim_seq, available_count)
+    INSERT INTO ${queueStorageSchema}.queue_lanes (queue, priority, next_seq, claim_seq)
     VALUES
-      ('e2e_test', 2, 6, 2, 1),
-      ('e2e_test', 1, 2, 1, 1),
-      ('legacy_queue', 2, 2, 1, 1),
-      ('e2e_dlq', 2, 1, 1, 0);
+      ('e2e_test', 2, 6, 2),
+      ('e2e_test', 1, 2, 1),
+      ('legacy_queue', 2, 2, 1),
+      ('e2e_dlq', 2, 1, 1);
 
     -- The per-lane next_seq/claim_seq cursors live in their own
     -- tables, not in queue_lanes. The runtime's enqueue and claim

--- a/awa/tests/queue_storage_runtime_test.rs
+++ b/awa/tests/queue_storage_runtime_test.rs
@@ -3716,6 +3716,7 @@ async fn test_queue_storage_queue_counts_reads_legacy_lane_rollups_and_backfills
     let schema = "awa_qs_legacy_pruned_rollup";
     let store = create_store(&pool, schema).await;
 
+    // v016: queue_lanes.available_count was dropped.
     sqlx::query(&format!(
         r#"
         INSERT INTO {schema}.queue_lanes (
@@ -3723,10 +3724,9 @@ async fn test_queue_storage_queue_counts_reads_legacy_lane_rollups_and_backfills
             priority,
             next_seq,
             claim_seq,
-            available_count,
             pruned_completed_count
         )
-        VALUES ($1, 1, 1, 1, 0, 7)
+        VALUES ($1, 1, 1, 1, 7)
         ON CONFLICT (queue, priority) DO UPDATE
         SET pruned_completed_count = EXCLUDED.pruned_completed_count
         "#
@@ -3855,15 +3855,43 @@ async fn test_available_count_matches_ready_entries_scan() {
         .await
         .expect("Failed to run legacy ready_entries scan");
 
-        let counter: i64 = sqlx::query_scalar(&format!(
-            "SELECT COALESCE(sum(available_count), 0)::bigint
-             FROM {schema}.queue_lanes
-             WHERE queue = $1"
+        // v016 design note: there are now TWO available-count
+        // formulations, and they only agree when no admin DELETE has
+        // punched a gap in the ready ring between claim_seq and
+        // next_seq.
+        //
+        // - Hot-path signal (queue_claimer_signal): cheap derived
+        //   `sum(next_seq - claim_seq)`. Two PK reads per lane.
+        //   Tolerates transient over-counts after admin DELETEs of
+        //   non-head lanes — the dispatcher's gap-recovery branch
+        //   absorbs the drift on the next claim attempt.
+        // - Admin API (queue_counts): exact, via a scan over
+        //   ready_entries with `lane_seq >= claim_seq`. Same
+        //   predicate as the ground-truth scan below.
+        //
+        // The test only pins API == scan (the admin contract). The
+        // hot-path approximation is allowed to drift by the number
+        // of mid-ring deletes since the last claim against that
+        // lane.
+        let derived_approx: i64 = sqlx::query_scalar(&format!(
+            "SELECT COALESCE(
+                sum(GREATEST(qe.next_seq - qc.claim_seq, 0)),
+                0
+            )::bigint
+             FROM {schema}.queue_enqueue_heads AS qe
+             JOIN {schema}.queue_claim_heads AS qc
+               ON qc.queue = qe.queue
+              AND qc.priority = qe.priority
+             WHERE qe.queue = $1"
         ))
         .bind(queue)
         .fetch_one(pool)
         .await
-        .expect("Failed to read queue_lanes.available_count");
+        .expect("Failed to read derived available count");
+        assert!(
+            derived_approx >= scan,
+            "[{checkpoint}] derived hot-path count must never under-count vs scan: scan={scan} derived={derived_approx}"
+        );
 
         let api = store
             .queue_counts(pool, queue)
@@ -3871,10 +3899,6 @@ async fn test_available_count_matches_ready_entries_scan() {
             .expect("Failed to call queue_counts")
             .available;
 
-        assert_eq!(
-            scan, counter,
-            "[{checkpoint}] queue_lanes.available_count drifted from ready_entries scan: scan={scan} counter={counter}"
-        );
         assert_eq!(
             scan, api,
             "[{checkpoint}] queue_counts API diverged from the legacy scan: scan={scan} api={api}"

--- a/awa/tests/queue_storage_runtime_test.rs
+++ b/awa/tests/queue_storage_runtime_test.rs
@@ -3716,7 +3716,6 @@ async fn test_queue_storage_queue_counts_reads_legacy_lane_rollups_and_backfills
     let schema = "awa_qs_legacy_pruned_rollup";
     let store = create_store(&pool, schema).await;
 
-    // v016: queue_lanes.available_count was dropped.
     sqlx::query(&format!(
         r#"
         INSERT INTO {schema}.queue_lanes (
@@ -3773,12 +3772,11 @@ async fn test_queue_storage_queue_counts_reads_legacy_lane_rollups_and_backfills
 }
 
 /// Pin that prepare_schema removes the legacy queue_count_snapshots
-/// table. Runtimes upgraded from a pre-fix install used to carry the
-/// snapshot table alongside the queue-storage tables; with the
-/// dispatcher reading queue_lanes.available_count directly, the
-/// snapshot table is no longer populated and prepare_schema drops it
-/// to reclaim the storage and remove the misleading shape from psql
-/// inspections.
+/// table. Older runtimes carried this snapshot table to cache an exact
+/// queue_counts result; the dispatcher now derives the available count
+/// directly from the head tables, so the snapshot is no longer
+/// populated. prepare_schema drops it to reclaim the storage and to
+/// remove the misleading shape from psql inspections.
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn test_queue_storage_prepare_schema_drops_legacy_count_snapshots_table() {
     let _guard = QUEUE_STORAGE_RUNTIME_LOCK.lock().await;
@@ -3801,30 +3799,36 @@ async fn test_queue_storage_prepare_schema_drops_legacy_count_snapshots_table() 
     assert!(
         !table_exists,
         "prepare_schema should drop the legacy queue_count_snapshots table — \
-         the dispatcher reads queue_lanes.available_count directly now"
+         the dispatcher derives the available count from the head tables now"
     );
 }
 
-/// Drift-detection guard for the queue_counts perf fix.
+/// Drift-detection guard for the head-table-derived available count.
 ///
-/// `queue_counts_exact` was migrated from a `count(*) FROM ready_entries
-/// WHERE lane_seq >= claim_seq` scan to `sum(queue_lanes.available_count)`.
-/// The two are only equivalent if every code path that adds or removes a
-/// "live" ready row maintains the counter. A missed call site would
-/// silently under-count forever — autovacuum doesn't rebuild a maintained
-/// counter, so divergence is permanent until someone runs the v012 / v013
-/// backfill.
+/// `queue_counts_exact` (admin API) scans `ready_entries` with
+/// `lane_seq >= claim_seq`; the dispatcher hot path reads the cheaper
+/// `sum(next_seq - claim_seq)` from the two head tables. The two are
+/// only equivalent when every lifecycle path that adds or removes a
+/// live ready row keeps the head tables honest:
 ///
-/// This test pins the equivalence at every steady state across the
-/// lifecycle paths the production runtime exercises: enqueue, claim
-/// (with priority aging), cancel of an available row, and the canonical-
-/// side `awa.insert_job_compat` / `awa.delete_job_compat` paths. At every
-/// checkpoint, all three numbers must agree:
+///   * enqueue → bumps queue_enqueue_heads.next_seq
+///   * claim   → bumps queue_claim_heads.claim_seq past the lane_seq
+///   * cancel / delete of an unclaimed head-lane → bumps claim_seq
+///   * cancel / delete of a non-head lane → leaves a gap that the
+///     dispatcher's gap-recovery branch in claim_ready_runtime closes
 ///
-///   - `sum(queue_lanes.available_count)` — what queue_counts_exact reads
-///   - `count(*) FROM ready_entries WHERE lane_seq >= claim_seq` — the
-///     legacy ground-truth CTE
-///   - `store.queue_counts(...).available` — the public API
+/// A missed bump would persistently over-count and burn dispatcher
+/// claim attempts on phantom availability. This test pins the
+/// invariants at every steady state across the lifecycle paths the
+/// production runtime exercises: enqueue, claim (with priority aging),
+/// cancel of an available row, and the canonical-side
+/// `awa.insert_job_compat` / `awa.delete_job_compat` paths.
+///
+/// At every checkpoint:
+///   - `store.queue_counts(...).available` (public API) ==
+///     `count(*) FROM ready_entries WHERE lane_seq >= claim_seq`
+///   - `sum(next_seq - claim_seq)` (hot-path approximation)
+///     `>= scan` (never under-counts)
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn test_available_count_matches_ready_entries_scan() {
     let _guard = QUEUE_STORAGE_RUNTIME_LOCK.lock().await;
@@ -3855,10 +3859,9 @@ async fn test_available_count_matches_ready_entries_scan() {
         .await
         .expect("Failed to run legacy ready_entries scan");
 
-        // v016 design note: there are now TWO available-count
-        // formulations, and they only agree when no admin DELETE has
-        // punched a gap in the ready ring between claim_seq and
-        // next_seq.
+        // There are two available-count formulations and they only
+        // agree when no admin DELETE has punched a gap between
+        // claim_seq and next_seq:
         //
         // - Hot-path signal (queue_claimer_signal): cheap derived
         //   `sum(next_seq - claim_seq)`. Two PK reads per lane.
@@ -3869,10 +3872,10 @@ async fn test_available_count_matches_ready_entries_scan() {
         //   ready_entries with `lane_seq >= claim_seq`. Same
         //   predicate as the ground-truth scan below.
         //
-        // The test only pins API == scan (the admin contract). The
-        // hot-path approximation is allowed to drift by the number
-        // of mid-ring deletes since the last claim against that
-        // lane.
+        // The test pins API == scan (the admin contract) and only
+        // asserts a never-undercount invariant on the hot-path
+        // approximation, which is allowed to drift up by the number
+        // of mid-ring deletes since the last claim on that lane.
         let derived_approx: i64 = sqlx::query_scalar(&format!(
             "SELECT COALESCE(
                 sum(GREATEST(qe.next_seq - qc.claim_seq, 0)),

--- a/docs/adr/008-copy-batch-ingestion.md
+++ b/docs/adr/008-copy-batch-ingestion.md
@@ -133,11 +133,14 @@ and dispatchers handle duplicates gracefully.
 - **Staging overhead remains:** COPY still pays for staging and a final insert
   into the real Awa tables, so it is not automatically faster than chunked
   multi-row `INSERT` in every workload.
-- **Lane counters remain online:** queue-storage enqueue still updates
-  `queue_lanes.available_count` once per touched lane and transaction. Deferring
-  those writes would reduce hot-lane churn further, but the dispatcher scaling
-  path reads the counters as online state, so lazy reconciliation needs a
-  separate design.
+- **Lane cursors remain online:** queue-storage enqueue still bumps
+  `queue_enqueue_heads.next_seq` once per touched lane and
+  transaction. Earlier iterations also maintained a
+  `queue_lanes.available_count` cache on the same path; that cache
+  has been dropped (see [ADR-019](019-queue-storage-redesign.md) §
+  `lane_state` and segment cursor tables) and the dispatcher now
+  derives availability from the head-table difference, so the only
+  remaining hot-lane write on the enqueue path is the cursor bump.
 
 ## Relationship to ADR-019
 

--- a/docs/adr/019-queue-storage-redesign.md
+++ b/docs/adr/019-queue-storage-redesign.md
@@ -148,13 +148,19 @@ The implementation and migrations use these physical names:
 - `lane_state` itself is reduced to stable per-lane identity and legacy
   fallback fields. The mutable enqueue cursor lives in `queue_enqueue_heads`
   and the mutable claim cursor lives in `queue_claim_heads`.
-- **historical:** the original ADR-019 design derived availability from
-  `ready_entries` plus the claim head, deliberately avoiding a hot cached
-  counter on `lane_state`. Long-horizon validation showed that scan was the
-  dispatcher hot-path bottleneck under multi-million-row backlogs; the
-  current implementation reads `sum(queue_lanes.available_count)`, which the
-  queue-storage SQL functions keep in lockstep with `ready_entries` inserts
-  and claim-head advances. `lane_state` itself remains cold.
+- Availability counts have two grades, both cheap. The dispatcher
+  hot path reads `sum(queue_enqueue_heads.next_seq -
+  queue_claim_heads.claim_seq)` — two PK reads per lane, no scan over
+  `ready_entries`. Admin / UI calls (`queue_counts`) scan
+  `ready_entries WHERE lane_seq >= claim_seq` for an exact result.
+  The dispatcher tolerates the head difference's transient over-count
+  after admin DELETEs of unclaimed rows; the next claim attempt's
+  gap-recovery branch in `claim_ready_runtime` advances `claim_seq`
+  to close the gap. **historical:** earlier iterations cached this as
+  `queue_lanes.available_count` (a third counter mutated on every
+  enqueue / claim / completion); long-horizon profiling under pinned
+  xmin showed the cache was the dominant dead-tuple source, so v016
+  removed it in favour of the head-difference derivation.
 - Completed-history rollups live in a separate cold cache table so prune can
   preserve queue counts without serializing on the hot `lane_state` rows.
 - Completion must not update `lane_state` on every terminal transition; the


### PR DESCRIPTION
## Summary

Removes the redundant \`available_count\` cache from \`queue_lanes\`. The 2026-05-10 investigation traced this column as the dominant bloat source under pinned xmin — every claim, enqueue, and completion batch was UPDATEing it, tripling \`queue_lanes\`'s mutation rate vs its sibling counter tables. The value is mathematically identical to \`queue_enqueue_heads.next_seq − queue_claim_heads.claim_seq\`, which the two head tables already maintain; storing a third counter just to denormalise a difference was pure cost.

## Results — noise-controlled A/B

Three iterations of two cells (idle_in_tx; W=64 steady), interleaving prefix and v016 so any time-correlated host noise hits both alike. Local docker pg18.

### queue_lanes dead-tuple peak during idle_in_tx — deterministic

| iter | prefix | v016 |
|---:|---:|---:|
| 1 | 30,926 | **0** |
| 2 | 35,956 | **0** |
| 3 | 35,442 | **0** |

The bloat source is gone. Live row count is ~16 and stays that way.

### Throughput — v016 stable, prefix unstable

| iter | shape | prefix clean | v016 clean | prefix idle | v016 idle | v016 idle/clean |
|---|---|---:|---:|---:|---:|---:|
| 1 | idle_in_tx | 592 | **740** | 524 | **707** | 96 % |
| 2 | idle_in_tx | 0 | **1,000** | 0 | **651** | 65 % |
| 3 | idle_in_tx | 0 | **914** | 574 | **789** | 86 % |
| 1 | W=64 steady | 0 | **1,657** | — | — | — |
| 2 | W=64 steady | 0 | **1,505** | — | — | — |
| 3 | W=64 steady | 1,424 | 1,422 | — | — | — |

Prefix hits a "0 jobs/s" stall in 4 of 6 cells. v016 never does. In the one cell where prefix didn't stall (iter 3 W=64), the two are equivalent (~1,420). The bench harness sampling is the same on both sides — the stalls are real production-style stalls in the prefix code, made visible by macOS docker's higher MVCC pressure.

The v016 numbers themselves vary across iterations (740–1,000 clean, 651–789 idle, 1,505–1,657 W=64), which is normal docker-on-Mac noise. The point is v016 doesn't stall.

## Code changes

**Hot path** (\`queue_storage.rs\`):
- Drop \`available_count\` column from \`queue_lanes\` CREATE TABLE.
- Remove the column's backfill from \`prepare_schema\`.
- Remove the \`UPDATE queue_lanes SET available_count = …\` from \`claim_ready_runtime\` PL/pgSQL (the gap-recovery branch stays).
- Delete \`adjust_lane_counts\` and \`adjust_lane_counts_batch\` — every historical caller passed \`pruned_completed_delta = 0\`, so the entire helper collapsed to a no-op once \`available_count\` was dropped.
- Rewrite \`queue_claimer_signal\` to derive the count from the head-table difference (two PK reads per lane).
- Rewrite \`queue_counts_exact\` (admin-grade API) to scan \`ready_entries WHERE lane_seq >= claim_seq\` for the exact count.
- \`cancel_job_tx\` and the v016 \`delete_job_compat\` each gain a small head-advance UPDATE for the head-lane delete case, so the cheap hot-path approximation doesn't have to wait for gap-recovery.

**Migration** (\`v016_drop_queue_lanes_available_count.sql\`):
- \`ALTER TABLE queue_lanes DROP COLUMN available_count\`.
- \`CREATE OR REPLACE FUNCTION\` for \`insert_job_compat\` and \`delete_job_compat\`, byte-identical to v013's signatures, bodies minus their \`available_count\` UPDATEs.
- \`migrations.rs\` bumps \`CURRENT_VERSION 15 → 16\`.

**Tests** (no production code path uses the dropped column):
- \`test_available_count_matches_ready_entries_scan\` reframed against two contracts: hot-path approximation never under-counts vs scan; admin API exactly equals scan.
- 7 inline-SQL sites in Rust + Python tests + the awa-ui seed: rewrite to head-difference or just drop the column.
- 3 lane_fix CTE sites in Python tests: deleted (no column to update).

## Trade

The cheap hot-path approximation (\`next_seq − claim_seq\`) over-counts by 1 each time an admin operation deletes an unclaimed *non-head* lane, until the next claim attempt on that lane hits the gap-recovery branch in \`claim_ready_runtime\` and catches \`claim_seq\` up. The dispatcher's wake-up signal is tolerant of brief over-counts — an over-eager wake-up is harmless. Admin tools that need exactness route through \`queue_counts_exact\`, which scans \`ready_entries\`.

## Test plan

- [x] \`cargo build --workspace\`
- [x] \`cargo clippy --workspace --tests -- -D warnings\` clean
- [x] \`cargo fmt --all\`
- [x] \`cargo test -p awa --test queue_storage_runtime_test\` — 57/57 pass on pg18 local
- [x] Bloat A/B: \`queue_lanes\` idle dead-tuple peak 30k+ → 0, deterministic over 3 iterations
- [x] Throughput A/B: v016 stable; prefix stalls in 4 of 6 cells under macOS docker pressure
- [ ] Confirmation on the NixOS sweep box (more stable hardware) — optional given the bloat metric is deterministic and v016 was strictly stabler in every cell

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Optimized queue availability calculation by eliminating a cached counter and deriving availability from sequence cursors. Reduces database dead-tuple overhead in high-load workloads without affecting the public API.

* **Tests**
  * Updated queue availability assertions across test suites to reflect the new calculation method.

* **Documentation**
  * Updated architectural decision records documenting queue availability computation approach.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hardbyte/awa/pull/251)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->