### PR TITLE
Add direct COPY producer path and deep backlog benchmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,9 +81,12 @@ pickup**, **417 exact final dead tuples**. Enqueue reference: ~30k/s
 single-producer, ~100k/s multi-producer.
 
 For high-volume queue-storage producers, use the direct queue-storage COPY
-path: Python `enqueue_many_copy()` or Rust `awa::enqueue_many_copy()`. The
-older `insert_many_copy()` API is the compatibility insert surface; it remains
-useful for canonical-storage compatibility and adapters, but it is not the
+path: Python `enqueue_many_copy()` or Rust
+`QueueStorage::enqueue_params_copy()`. Configure direct-copy producers with the
+same queue-storage routing knobs as the worker fleet, especially
+`queue_stripe_count` / `queue_storage_queue_stripe_count`. The older
+`insert_many_copy()` API is the compatibility insert surface; it remains useful
+for canonical-storage compatibility and adapters, but it is not the
 queue-storage producer fast path.
 
 A phase-driven portable benchmark harness comparing Awa against pgque,

--- a/README.md
+++ b/README.md
@@ -80,6 +80,12 @@ Queue-storage soak reference, 5k-job runtime run: **9.5k jobs/s**, **22 ms p95
 pickup**, **417 exact final dead tuples**. Enqueue reference: ~30k/s
 single-producer, ~100k/s multi-producer.
 
+For high-volume queue-storage producers, use the direct queue-storage COPY
+path: Python `enqueue_many_copy()` or Rust `awa::enqueue_many_copy()`. The
+older `insert_many_copy()` API is the compatibility insert surface; it remains
+useful for canonical-storage compatibility and adapters, but it is not the
+queue-storage producer fast path.
+
 A phase-driven portable benchmark harness comparing Awa against pgque,
 procrastinate, pg-boss, river, oban, and pgmq on a shared Postgres
 instance lives in its own repository:

--- a/awa-metrics/src/lib.rs
+++ b/awa-metrics/src/lib.rs
@@ -72,6 +72,10 @@ pub mod names {
     pub const RING_GENERATION: &str = "awa.ring.generation";
 }
 
+const WAIT_DURATION_BUCKETS_SECONDS: [f64; 14] = [
+    0.001, 0.005, 0.010, 0.025, 0.050, 0.100, 0.250, 0.500, 1.0, 2.5, 5.0, 10.0, 30.0, 60.0,
+];
+
 /// Awa worker metrics backed by OpenTelemetry.
 #[derive(Clone)]
 pub struct AwaMetrics {
@@ -342,6 +346,7 @@ impl AwaMetrics {
                 .f64_histogram(names::JOB_WAIT_DURATION)
                 .with_description("Time from job creation to claim")
                 .with_unit("s")
+                .with_boundaries(WAIT_DURATION_BUCKETS_SECONDS.to_vec())
                 .build(),
             dlq_moved: meter
                 .u64_counter(names::JOB_DLQ_MOVED)

--- a/awa-model/README.md
+++ b/awa-model/README.md
@@ -16,7 +16,8 @@ against the admin API.
 - **Job model** — `JobRow`, `JobState`, `InsertOpts`, `UniqueOpts`,
   `InsertParams`.
 - **Insertion** — `insert`, `insert_with`, `insert_many`,
-  `insert_many_copy` (COPY-batched for large fan-outs).
+  `insert_many_copy` for the compatibility insert surface, and
+  `enqueue_many_copy` for direct queue-storage COPY ingestion.
 - **Migrations** — `migrations::run` applies the schema; `migrations`,
   `migrations_range`, and `current_migration_version` expose the
   catalog for tooling.
@@ -31,9 +32,7 @@ against the admin API.
 - **Cron** (`cron`) — `PeriodicJob`, `PeriodicJobBuilder`, `CronJobRow`.
 - **Queue storage** (`queue_storage`) — `QueueStorage`,
   `QueueStorageConfig`, `ClaimedRuntimeJob`, `RotateOutcome`,
-  `PruneOutcome`. The vacuum-aware engine introduced in 0.6, including
-  `QueueStorage::enqueue_params_copy` for direct COPY ingestion into
-  `ready_entries` / `deferred_jobs`.
+  `PruneOutcome`. The vacuum-aware engine introduced in 0.6.
 - **Storage status** (`storage`) — `StorageStatus` and the
   transition-state primitives the `awa storage` CLI surfaces.
 - **Adapter API** (`adapter`) — stable Postgres insert preparation and SQL

--- a/awa-model/README.md
+++ b/awa-model/README.md
@@ -17,7 +17,8 @@ against the admin API.
   `InsertParams`.
 - **Insertion** — `insert`, `insert_with`, `insert_many`,
   `insert_many_copy` for the compatibility insert surface, and
-  `enqueue_many_copy` for direct queue-storage COPY ingestion.
+  `QueueStorage::enqueue_params_copy` for direct queue-storage COPY ingestion
+  with an explicitly configured queue-storage engine.
 - **Migrations** — `migrations::run` applies the schema; `migrations`,
   `migrations_range`, and `current_migration_version` expose the
   catalog for tooling.

--- a/awa-model/migrations/v021_shard_aware_lane_indexes.sql
+++ b/awa-model/migrations/v021_shard_aware_lane_indexes.sql
@@ -1,0 +1,115 @@
+-- v021: Shard-aware lane indexes on ready_entries / done_entries / leases.
+--
+-- Background:
+--   v017 added `enqueue_shard` to ready_entries (and the claim/enqueue head
+--   rows) and threaded it into `claim_ready_runtime`'s WHERE clause. The
+--   narrow lane indexes on each child partition —
+--   `idx_{schema}_{ready|done|leases}_<slot>_lane` on
+--   `(queue, priority, lane_seq)` — predate that change and do NOT include
+--   `enqueue_shard`. Under `enqueue_shards > 1` and deep backlog the planner
+--   scans the lane index forward and post-filters shard, discarding roughly
+--   `(shards-1)/shards` of rows per partition per claim probe.
+--
+--   Staging measurement (Cloud SQL PG18 4 vCPU, 16 partitions,
+--   `enqueue_shards = 16`, ~4.1M-row backlog):
+--     * Single claim probe (EXPLAIN ANALYZE):
+--         - before: 11.4 ms, scanning all 16 partitions, `Rows Removed by
+--           Filter: 2,800 – 7,300` per partition, ~30k buffer hits.
+--         - after:   0.81 ms, every partition uses an Index Only Scan with
+--           2 – 5 buffer hits.
+--     * End-to-end drain rate against a 3.5M-row backlog:
+--         - before: ~1,300 jobs/s (vs. ~10,000 jobs/s equilibrium ceiling).
+--         - after:  ~8,800 – 10,600 jobs/s — back to the equilibrium rate.
+--
+-- Fix:
+--   Create `idx_{schema}_{kind}_<slot>_lane_shard` on
+--   `(queue, priority, enqueue_shard, lane_seq)` on every partition of
+--   `ready_entries`, `done_entries`, and `leases` in every queue-storage
+--   schema, and drop the old narrow `_lane` indexes. The old indexes are
+--   a strict prefix of the new ones and so become redundant. We drop them
+--   in the same migration because, even after `ANALYZE`, the planner
+--   sometimes prefers the old narrower index on smaller-startup-cost
+--   grounds — keeping both in place leaves the regression latent.
+--
+-- Safety:
+--   Index DDL only — no data rewrite. `CREATE INDEX IF NOT EXISTS` is
+--   idempotent; `DROP INDEX IF EXISTS` is a no-op when the old index is
+--   already gone. The migration discovers partitions dynamically via
+--   `pg_inherits`, so it copes with any `queue_slot_count` /
+--   `lease_slot_count` the runtime has provisioned.
+
+DO $$
+DECLARE
+    v_schema      TEXT;
+    v_kind        TEXT;
+    v_parent_oid  OID;
+    v_child_oid   OID;
+    v_child_name  TEXT;
+    v_slot        TEXT;
+    v_new_index   TEXT;
+    v_old_index   TEXT;
+BEGIN
+    FOR v_schema IN
+        SELECT schema_name
+        FROM awa.runtime_storage_backends
+        WHERE schema_name IS NOT NULL
+    LOOP
+        FOREACH v_kind IN ARRAY ARRAY['ready_entries', 'done_entries', 'leases']
+        LOOP
+            v_parent_oid := to_regclass(format('%I.%I', v_schema, v_kind));
+            IF v_parent_oid IS NULL THEN
+                CONTINUE;
+            END IF;
+
+            FOR v_child_oid, v_child_name IN
+                SELECT c.oid, c.relname
+                FROM pg_inherits AS i
+                JOIN pg_class    AS c ON c.oid = i.inhrelid
+                WHERE i.inhparent = v_parent_oid
+            LOOP
+                -- child relname is `<kind>_<slot>`; pull the trailing
+                -- slot off so the index names line up with what
+                -- `prepare_schema` produces for fresh deployments.
+                v_slot := substring(v_child_name FROM length(v_kind) + 2);
+
+                -- Index-name short kind: leases -> "leases", others drop
+                -- the `_entries` suffix to match prepare_schema naming.
+                v_new_index := format(
+                    'idx_%I_%s_%s_lane_shard',
+                    v_schema,
+                    CASE v_kind
+                        WHEN 'ready_entries' THEN 'ready'
+                        WHEN 'done_entries'  THEN 'done'
+                        ELSE 'leases'
+                    END,
+                    v_slot
+                );
+                v_old_index := format(
+                    'idx_%I_%s_%s_lane',
+                    v_schema,
+                    CASE v_kind
+                        WHEN 'ready_entries' THEN 'ready'
+                        WHEN 'done_entries'  THEN 'done'
+                        ELSE 'leases'
+                    END,
+                    v_slot
+                );
+
+                EXECUTE format(
+                    'CREATE INDEX IF NOT EXISTS %I ON %I.%I (queue, priority, enqueue_shard, lane_seq)',
+                    v_new_index, v_schema, v_child_name
+                );
+
+                EXECUTE format(
+                    'DROP INDEX IF EXISTS %I.%I',
+                    v_schema, v_old_index
+                );
+            END LOOP;
+        END LOOP;
+    END LOOP;
+END
+$$ LANGUAGE plpgsql;
+
+INSERT INTO awa.schema_version (version, description)
+VALUES (21, 'Shard-aware lane indexes on ready_entries/done_entries/leases')
+ON CONFLICT (version) DO NOTHING;

--- a/awa-model/migrations/v021_shard_aware_lane_indexes.sql
+++ b/awa-model/migrations/v021_shard_aware_lane_indexes.sql
@@ -25,11 +25,14 @@
 --   Create `idx_{schema}_{kind}_<slot>_lane_shard` on
 --   `(queue, priority, enqueue_shard, lane_seq)` on every partition of
 --   `ready_entries`, `done_entries`, and `leases` in every queue-storage
---   schema, and drop the old narrow `_lane` indexes. The old indexes are
---   a strict prefix of the new ones and so become redundant. We drop them
---   in the same migration because, even after `ANALYZE`, the planner
---   sometimes prefers the old narrower index on smaller-startup-cost
---   grounds — keeping both in place leaves the regression latent.
+--   schema, and drop the old narrow `_lane` indexes. The old index is not
+--   a prefix of the new one: `enqueue_shard` is inserted before
+--   `lane_seq`. It is redundant for the current queue-storage query set
+--   because all lane lookups that need this access path are
+--   shard-qualified. We drop it in the same migration because, even after
+--   `ANALYZE`, the planner sometimes prefers the old narrower index on
+--   smaller-startup-cost grounds — keeping both in place leaves the
+--   regression latent.
 --
 -- Safety:
 --   Index DDL only — no data rewrite. `CREATE INDEX IF NOT EXISTS` is

--- a/awa-model/src/insert.rs
+++ b/awa-model/src/insert.rs
@@ -428,12 +428,13 @@ where
     Ok(results)
 }
 
-/// Insert many jobs using COPY for high throughput.
+/// Insert many jobs through the compatibility COPY surface.
 ///
 /// Uses a temp staging table with no constraints for fast COPY ingestion,
-/// then INSERT...SELECT into `awa.jobs` with ON CONFLICT DO NOTHING for
-/// unique jobs. Accepts `&mut PgConnection` so callers can use pool
-/// connections or transactions (Transaction derefs to PgConnection).
+/// then routes staged rows through `awa.insert_job_compat`. Accepts
+/// `&mut PgConnection` so callers can use pool connections or transactions
+/// (Transaction derefs to PgConnection). For high-volume queue-storage
+/// producers, prefer [`crate::enqueue_many_copy`].
 #[tracing::instrument(skip(conn, jobs), fields(job.count = jobs.len()))]
 pub async fn insert_many_copy(
     conn: &mut PgConnection,

--- a/awa-model/src/insert.rs
+++ b/awa-model/src/insert.rs
@@ -434,7 +434,8 @@ where
 /// then routes staged rows through `awa.insert_job_compat`. Accepts
 /// `&mut PgConnection` so callers can use pool connections or transactions
 /// (Transaction derefs to PgConnection). For high-volume queue-storage
-/// producers, prefer [`crate::enqueue_many_copy`].
+/// producers, prefer [`QueueStorage::enqueue_params_copy`](crate::QueueStorage::enqueue_params_copy)
+/// on a `QueueStorage` built with the same config as the worker fleet.
 #[tracing::instrument(skip(conn, jobs), fields(job.count = jobs.len()))]
 pub async fn insert_many_copy(
     conn: &mut PgConnection,

--- a/awa-model/src/lib.rs
+++ b/awa-model/src/lib.rs
@@ -33,8 +33,8 @@ pub use error::AwaError;
 pub use insert::{insert, insert_many, insert_many_copy, insert_many_copy_from_pool, insert_with};
 pub use job::{InsertOpts, InsertParams, JobRow, JobState, UniqueOpts};
 pub use queue_storage::{
-    enqueue_many_copy, ClaimedEntry, ClaimedRuntimeJob, PruneOutcome, QueueCounts, QueueStorage,
-    QueueStorageConfig, RotateOutcome, SkipReason,
+    ClaimedEntry, ClaimedRuntimeJob, PruneOutcome, QueueCounts, QueueStorage, QueueStorageConfig,
+    RotateOutcome, SkipReason,
 };
 pub use storage::StorageStatus;
 

--- a/awa-model/src/lib.rs
+++ b/awa-model/src/lib.rs
@@ -33,8 +33,8 @@ pub use error::AwaError;
 pub use insert::{insert, insert_many, insert_many_copy, insert_many_copy_from_pool, insert_with};
 pub use job::{InsertOpts, InsertParams, JobRow, JobState, UniqueOpts};
 pub use queue_storage::{
-    ClaimedEntry, ClaimedRuntimeJob, PruneOutcome, QueueCounts, QueueStorage, QueueStorageConfig,
-    RotateOutcome, SkipReason,
+    enqueue_many_copy, ClaimedEntry, ClaimedRuntimeJob, PruneOutcome, QueueCounts, QueueStorage,
+    QueueStorageConfig, RotateOutcome, SkipReason,
 };
 pub use storage::StorageStatus;
 

--- a/awa-model/src/migrations.rs
+++ b/awa-model/src/migrations.rs
@@ -4,7 +4,7 @@ use sqlx::PgPool;
 use tracing::info;
 
 /// Current schema version.
-pub const CURRENT_VERSION: i32 = 20;
+pub const CURRENT_VERSION: i32 = 21;
 
 /// All migrations in order. SQL lives in `awa-model/migrations/*.sql`
 /// for easy inspection by users who run their own migration tooling.
@@ -88,6 +88,11 @@ const MIGRATIONS: &[(i32, &str, &[&str])] = &[
         "Derive active queue-storage schema from transition state",
         &[V20_UP],
     ),
+    (
+        21,
+        "Shard-aware lane indexes on ready_entries/done_entries/leases",
+        &[V21_UP],
+    ),
 ];
 
 const V1_UP: &str = include_str!("../migrations/v001_canonical_schema.sql");
@@ -109,6 +114,7 @@ const V17_UP: &str = include_str!("../migrations/v017_shard_queue_enqueue_heads.
 const V18_UP: &str = include_str!("../migrations/v018_insert_job_compat_ordering_key.sql");
 const V19_UP: &str = include_str!("../migrations/v019_queue_storage_jobs_compat_shard_joins.sql");
 const V20_UP: &str = include_str!("../migrations/v020_active_queue_storage_schema_fallback.sql");
+const V21_UP: &str = include_str!("../migrations/v021_shard_aware_lane_indexes.sql");
 
 /// Old version numbers from pre-0.4 releases that used V3/V4/V5 numbering.
 /// Also tolerates the unreleased inline-V6 branch numbering used during review.

--- a/awa-model/src/queue_storage.rs
+++ b/awa-model/src/queue_storage.rs
@@ -116,6 +116,22 @@ pub struct QueueClaimerLease {
     pub lease_epoch: i64,
 }
 
+/// Enqueue many jobs into the active queue-storage backend using direct COPY.
+///
+/// This is the Rust producer fast path for high-volume queue-storage
+/// deployments. It resolves the active queue-storage schema from the
+/// transition state, then streams rows directly into `ready_entries` /
+/// `deferred_jobs` via [`QueueStorage::enqueue_params_copy`]. Use
+/// [`crate::insert_many_copy`] only when you specifically need the
+/// compatibility insert surface.
+pub async fn enqueue_many_copy(pool: &PgPool, jobs: &[InsertParams]) -> Result<usize, AwaError> {
+    let schema = QueueStorage::active_schema(pool).await?.ok_or_else(|| {
+        AwaError::Validation("enqueue_many_copy requires an active queue_storage backend".into())
+    })?;
+    let store = QueueStorage::from_existing_schema(schema)?;
+    store.enqueue_params_copy(pool, jobs).await
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, sqlx::FromRow)]
 struct QueueClaimerLeaseRow {
     claimer_slot: i16,

--- a/awa-model/src/queue_storage.rs
+++ b/awa-model/src/queue_storage.rs
@@ -116,22 +116,6 @@ pub struct QueueClaimerLease {
     pub lease_epoch: i64,
 }
 
-/// Enqueue many jobs into the active queue-storage backend using direct COPY.
-///
-/// This is the Rust producer fast path for high-volume queue-storage
-/// deployments. It resolves the active queue-storage schema from the
-/// transition state, then streams rows directly into `ready_entries` /
-/// `deferred_jobs` via [`QueueStorage::enqueue_params_copy`]. Use
-/// [`crate::insert_many_copy`] only when you specifically need the
-/// compatibility insert surface.
-pub async fn enqueue_many_copy(pool: &PgPool, jobs: &[InsertParams]) -> Result<usize, AwaError> {
-    let schema = QueueStorage::active_schema(pool).await?.ok_or_else(|| {
-        AwaError::Validation("enqueue_many_copy requires an active queue_storage backend".into())
-    })?;
-    let store = QueueStorage::from_existing_schema(schema)?;
-    store.enqueue_params_copy(pool, jobs).await
-}
-
 #[derive(Debug, Clone, Copy, PartialEq, Eq, sqlx::FromRow)]
 struct QueueClaimerLeaseRow {
     claimer_slot: i16,

--- a/awa-model/src/queue_storage.rs
+++ b/awa-model/src/queue_storage.rs
@@ -3295,10 +3295,17 @@ impl QueueStorage {
                 .await
                 .map_err(map_sqlx_error)?;
 
+                // Includes enqueue_shard so `claim_ready_runtime`'s WHERE
+                // (queue, priority, enqueue_shard, lane_seq >= claim_seq)
+                // hits the index directly under enqueue_shards > 1. The
+                // narrow (queue, priority, lane_seq) shape that predated
+                // v017 caused the planner to post-filter shard and discard
+                // (shards-1)/shards of rows per partition per claim probe
+                // (see v021 migration for measurements).
                 sqlx::query(&format!(
                     r#"
-                CREATE INDEX IF NOT EXISTS idx_{schema}_ready_{slot}_lane
-                    ON {} (queue, priority, lane_seq)
+                CREATE INDEX IF NOT EXISTS idx_{schema}_ready_{slot}_lane_shard
+                    ON {} (queue, priority, enqueue_shard, lane_seq)
                 "#,
                     ready_child_name(schema, slot)
                 ))
@@ -3328,10 +3335,12 @@ impl QueueStorage {
                 .await
                 .map_err(map_sqlx_error)?;
 
+                // Mirror of the ready_entries shard-aware lane index;
+                // see the comment there for the rationale.
                 sqlx::query(&format!(
                     r#"
-                CREATE INDEX IF NOT EXISTS idx_{schema}_done_{slot}_lane
-                    ON {} (queue, priority, lane_seq)
+                CREATE INDEX IF NOT EXISTS idx_{schema}_done_{slot}_lane_shard
+                    ON {} (queue, priority, enqueue_shard, lane_seq)
                 "#,
                     done_child_name(schema, slot)
                 ))
@@ -3363,10 +3372,12 @@ impl QueueStorage {
                 .await
                 .map_err(map_sqlx_error)?;
 
+                // Mirror of the ready_entries shard-aware lane index;
+                // see the comment there for the rationale.
                 sqlx::query(&format!(
                     r#"
-                CREATE INDEX IF NOT EXISTS idx_{schema}_leases_{slot}_lane
-                    ON {} (queue, priority, lane_seq)
+                CREATE INDEX IF NOT EXISTS idx_{schema}_leases_{slot}_lane_shard
+                    ON {} (queue, priority, enqueue_shard, lane_seq)
                 "#,
                     lease_child_name(schema, slot)
                 ))

--- a/awa-python/README.md
+++ b/awa-python/README.md
@@ -48,6 +48,8 @@ codebases that aren't async-first.
 - **COPY ingestion** — `enqueue_many_copy` streams directly into queue
   storage for high-volume Python producers. `insert_many_copy` remains the
   compatibility insert surface for canonical-storage and adapter-style callers.
+  If workers use `queue_storage_queue_stripe_count > 1`, pass the same value
+  to `enqueue_many_copy`.
 - **Crash-safe execution** — heartbeat-based lease tracking; jobs whose
   workers vanish are rescued automatically.
 - **Per-queue policy** — priorities, priority aging, weighted concurrency,

--- a/awa-python/README.md
+++ b/awa-python/README.md
@@ -45,9 +45,9 @@ codebases that aren't async-first.
   receipt ring keep dead-tuple pressure bounded under sustained load.
   See [ADR-019](https://github.com/hardbyte/awa/blob/main/docs/adr/019-queue-storage-redesign.md)
   and [ADR-023](https://github.com/hardbyte/awa/blob/main/docs/adr/023-receipt-plane-ring-partitioning.md).
-- **COPY ingestion** — `insert_many_copy` keeps the compatibility insert
-  surface fast, and `enqueue_many_copy` streams directly into queue storage
-  for high-volume Python producers.
+- **COPY ingestion** — `enqueue_many_copy` streams directly into queue
+  storage for high-volume Python producers. `insert_many_copy` remains the
+  compatibility insert surface for canonical-storage and adapter-style callers.
 - **Crash-safe execution** — heartbeat-based lease tracking; jobs whose
   workers vanish are rescued automatically.
 - **Per-queue policy** — priorities, priority aging, weighted concurrency,

--- a/awa-python/python/awa/client.py
+++ b/awa-python/python/awa/client.py
@@ -143,6 +143,7 @@ class AsyncClient:
         run_at: Any | None = None,
         unique_opts: dict[str, Any] | None = None,
         ordering_key: bytes | str | None = None,
+        queue_storage_queue_stripe_count: int = DEFAULT_QUEUE_STORAGE_QUEUE_STRIPE_COUNT,
     ) -> int:
         """Enqueue jobs into active queue storage using direct COPY."""
         return await self._raw.enqueue_many_copy(
@@ -156,6 +157,7 @@ class AsyncClient:
             run_at=run_at,
             unique_opts=unique_opts,
             ordering_key=ordering_key,
+            queue_storage_queue_stripe_count=queue_storage_queue_stripe_count,
         )
 
     async def migrate(self) -> None:
@@ -827,6 +829,7 @@ class Client:
         run_at: Any | None = None,
         unique_opts: dict[str, Any] | None = None,
         ordering_key: bytes | str | None = None,
+        queue_storage_queue_stripe_count: int = DEFAULT_QUEUE_STORAGE_QUEUE_STRIPE_COUNT,
     ) -> int:
         """Enqueue jobs into active queue storage using direct COPY."""
         return self._raw.enqueue_many_copy_sync(
@@ -840,6 +843,7 @@ class Client:
             run_at=run_at,
             unique_opts=unique_opts,
             ordering_key=ordering_key,
+            queue_storage_queue_stripe_count=queue_storage_queue_stripe_count,
         )
 
     def migrate(self) -> None:

--- a/awa-python/python/awa/client.py
+++ b/awa-python/python/awa/client.py
@@ -116,7 +116,7 @@ class AsyncClient:
         unique_opts: dict[str, Any] | None = None,
         ordering_key: bytes | str | None = None,
     ) -> list[Job]:
-        """Bulk insert jobs using COPY for high throughput."""
+        """Bulk insert jobs through the compatibility COPY surface."""
         return await self._raw.insert_many_copy(
             jobs,
             kind=kind,
@@ -800,7 +800,7 @@ class Client:
         unique_opts: dict[str, Any] | None = None,
         ordering_key: bytes | str | None = None,
     ) -> list[Job]:
-        """Bulk insert jobs using COPY for high throughput."""
+        """Bulk insert jobs through the compatibility COPY surface."""
         return self._raw.insert_many_copy_sync(
             jobs,
             kind=kind,

--- a/awa-python/scripts/benchmark_runtime.py
+++ b/awa-python/scripts/benchmark_runtime.py
@@ -136,7 +136,7 @@ def pctl_ms(samples: list[float], pct: int) -> float:
 
 
 # ═══════════════════════════════════════════════════════════════════════
-# Existing scenarios: copy, hot, scheduled
+# Existing scenarios: queue-storage copy, hot, scheduled
 # ═══════════════════════════════════════════════════════════════════════
 
 
@@ -175,7 +175,10 @@ async def run_copy_benchmark(
             drain_time_s=elapsed,
         ),
         outcomes={"inserted": inserted},
-        metadata={"chunk_size": chunk_size},
+        metadata={
+            "chunk_size": chunk_size,
+            "producer_path": "AsyncClient.enqueue_many_copy",
+        },
     ).emit()
 
 

--- a/awa-python/src/client.rs
+++ b/awa-python/src/client.rs
@@ -2111,7 +2111,7 @@ impl PyClient {
         })
     }
 
-    #[pyo3(signature = (jobs, *, kind=None, queue="default".to_string(), priority=2, max_attempts=25, tags=vec![], metadata=None, run_at=None, unique_opts=None, ordering_key=None))]
+    #[pyo3(signature = (jobs, *, kind=None, queue="default".to_string(), priority=2, max_attempts=25, tags=vec![], metadata=None, run_at=None, unique_opts=None, ordering_key=None, queue_storage_queue_stripe_count=1))]
     #[allow(clippy::too_many_arguments)]
     fn enqueue_many_copy<'py>(
         &self,
@@ -2126,7 +2126,14 @@ impl PyClient {
         run_at: Option<Py<PyAny>>,
         unique_opts: Option<Py<PyAny>>,
         ordering_key: Option<Py<PyAny>>,
+        queue_storage_queue_stripe_count: u32,
     ) -> PyResult<Bound<'py, PyAny>> {
+        if queue_storage_queue_stripe_count == 0 {
+            return Err(pyo3::exceptions::PyValueError::new_err(
+                "queue_storage_queue_stripe_count must be > 0",
+            ));
+        }
+
         let pool = self.pool.clone();
         let insert_params = prepare_insert_many_params(
             py,
@@ -2151,7 +2158,12 @@ impl PyClient {
                         "enqueue_many_copy requires an active queue_storage backend".into(),
                     ))
                 })?;
-            let store = QueueStorage::from_existing_schema(schema).map_err(map_awa_error)?;
+            let store = QueueStorage::new(QueueStorageConfig {
+                schema,
+                queue_stripe_count: queue_storage_queue_stripe_count as usize,
+                ..Default::default()
+            })
+            .map_err(map_awa_error)?;
             let count = store
                 .enqueue_params_copy(&pool, &insert_params)
                 .await
@@ -2160,7 +2172,7 @@ impl PyClient {
         })
     }
 
-    #[pyo3(signature = (jobs, *, kind=None, queue="default".to_string(), priority=2, max_attempts=25, tags=vec![], metadata=None, run_at=None, unique_opts=None, ordering_key=None))]
+    #[pyo3(signature = (jobs, *, kind=None, queue="default".to_string(), priority=2, max_attempts=25, tags=vec![], metadata=None, run_at=None, unique_opts=None, ordering_key=None, queue_storage_queue_stripe_count=1))]
     #[allow(clippy::too_many_arguments)]
     fn enqueue_many_copy_sync(
         &self,
@@ -2175,7 +2187,14 @@ impl PyClient {
         run_at: Option<Py<PyAny>>,
         unique_opts: Option<Py<PyAny>>,
         ordering_key: Option<Py<PyAny>>,
+        queue_storage_queue_stripe_count: u32,
     ) -> PyResult<usize> {
+        if queue_storage_queue_stripe_count == 0 {
+            return Err(pyo3::exceptions::PyValueError::new_err(
+                "queue_storage_queue_stripe_count must be > 0",
+            ));
+        }
+
         let pool = self.pool.clone();
         let insert_params = prepare_insert_many_params(
             py,
@@ -2201,7 +2220,12 @@ impl PyClient {
                             "enqueue_many_copy requires an active queue_storage backend".into(),
                         ))
                     })?;
-                let store = QueueStorage::from_existing_schema(schema).map_err(map_awa_error)?;
+                let store = QueueStorage::new(QueueStorageConfig {
+                    schema,
+                    queue_stripe_count: queue_storage_queue_stripe_count as usize,
+                    ..Default::default()
+                })
+                .map_err(map_awa_error)?;
                 store
                     .enqueue_params_copy(&pool, &insert_params)
                     .await

--- a/awa/src/lib.rs
+++ b/awa/src/lib.rs
@@ -11,12 +11,12 @@ pub use awa_model;
 
 // Re-export core model types (includes JobArgs derive macro via awa-model)
 pub use awa_model::{
-    self as model, adapter, admin, bridge, insert, insert_many, insert_many_copy,
-    insert_many_copy_from_pool, insert_with, migrations, prepare_job_insert,
+    self as model, adapter, admin, bridge, enqueue_many_copy, insert, insert_many,
+    insert_many_copy, insert_many_copy_from_pool, insert_with, migrations, prepare_job_insert,
     prepare_raw_job_insert, storage, AwaError, CallbackConfig, DefaultAction, DlqMetadata, DlqRow,
     InsertOpts, InsertParams, JobArgs, JobKindDescriptor, JobRow, JobState, ListDlqFilter,
-    PreparedJobInsert, QueueDescriptor, ResolveOutcome, RetryFromDlqOpts, StorageCapability,
-    StorageStatus, UniqueOpts,
+    PreparedJobInsert, QueueDescriptor, QueueStorage, QueueStorageConfig, ResolveOutcome,
+    RetryFromDlqOpts, StorageCapability, StorageStatus, UniqueOpts,
 };
 
 // Re-export worker runtime

--- a/awa/src/lib.rs
+++ b/awa/src/lib.rs
@@ -11,8 +11,8 @@ pub use awa_model;
 
 // Re-export core model types (includes JobArgs derive macro via awa-model)
 pub use awa_model::{
-    self as model, adapter, admin, bridge, enqueue_many_copy, insert, insert_many,
-    insert_many_copy, insert_many_copy_from_pool, insert_with, migrations, prepare_job_insert,
+    self as model, adapter, admin, bridge, insert, insert_many, insert_many_copy,
+    insert_many_copy_from_pool, insert_with, migrations, prepare_job_insert,
     prepare_raw_job_insert, storage, AwaError, CallbackConfig, DefaultAction, DlqMetadata, DlqRow,
     InsertOpts, InsertParams, JobArgs, JobKindDescriptor, JobRow, JobState, ListDlqFilter,
     PreparedJobInsert, QueueDescriptor, QueueStorage, QueueStorageConfig, ResolveOutcome,

--- a/awa/tests/queue_storage_benchmark_test.rs
+++ b/awa/tests/queue_storage_benchmark_test.rs
@@ -1192,7 +1192,7 @@ async fn test_queue_storage_deep_backlog_drain_benchmark() {
     let copy_chunk_size = env_u64("AWA_QS_DEEP_BACKLOG_COPY_BATCH", 1_000) as usize;
     let consumers = env_u32("AWA_QS_DEEP_BACKLOG_CONSUMERS", 8);
     let claim_batch_size = env_u64("AWA_QS_DEEP_BACKLOG_CLAIM_BATCH_SIZE", 512) as i64;
-    let enqueue_shards = env_u32("AWA_QS_DEEP_BACKLOG_SHARDS", 16).clamp(1, 64) as i16;
+    let enqueue_shards = env_u32("AWA_QS_DEEP_BACKLOG_SHARDS", 16);
     let queue_slot_count = env_u32("AWA_QS_DEEP_BACKLOG_QUEUE_SLOT_COUNT", 16);
     let lease_slot_count = env_u32("AWA_QS_DEEP_BACKLOG_LEASE_SLOT_COUNT", 8);
     let schema = env_string("AWA_QS_DEEP_BACKLOG_SCHEMA", "awa_qs_deep_backlog");
@@ -1203,6 +1203,16 @@ async fn test_queue_storage_deep_backlog_drain_benchmark() {
 
     assert!(total_jobs > 0, "AWA_QS_DEEP_BACKLOG_JOBS must be > 0");
     assert!(duration_secs > 0, "AWA_QS_DEEP_BACKLOG_SECONDS must be > 0");
+    assert!(consumers > 0, "AWA_QS_DEEP_BACKLOG_CONSUMERS must be > 0");
+    assert!(
+        claim_batch_size > 0,
+        "AWA_QS_DEEP_BACKLOG_CLAIM_BATCH_SIZE must be > 0"
+    );
+    assert!(
+        (1..=64).contains(&enqueue_shards),
+        "AWA_QS_DEEP_BACKLOG_SHARDS must be between 1 and 64"
+    );
+    let enqueue_shards = enqueue_shards as i16;
 
     let pool = pool_with(max_conns).await;
     ensure_pgstattuple(&pool).await;

--- a/awa/tests/queue_storage_benchmark_test.rs
+++ b/awa/tests/queue_storage_benchmark_test.rs
@@ -9,7 +9,8 @@
 mod bench_output;
 
 use awa::model::{
-    migrations, AwaError, PruneOutcome, QueueStorage, QueueStorageConfig, RotateOutcome,
+    migrations, AwaError, InsertOpts, InsertParams, PruneOutcome, QueueStorage, QueueStorageConfig,
+    RotateOutcome,
 };
 use bench_output::{BenchLatency, BenchMetrics, BenchThroughput, BenchmarkResult, SCHEMA_VERSION};
 use serde::Serialize;
@@ -356,6 +357,59 @@ async fn sample_snapshot(
         leases_dead_tup,
         attempt_state_dead_tup,
     }
+}
+
+async fn upsert_enqueue_shards(pool: &sqlx::PgPool, queue: &str, enqueue_shards: i16) {
+    sqlx::query(
+        r#"
+        INSERT INTO awa.queue_meta (queue, enqueue_shards)
+        VALUES ($1, $2)
+        ON CONFLICT (queue)
+        DO UPDATE SET enqueue_shards = EXCLUDED.enqueue_shards
+        "#,
+    )
+    .bind(queue)
+    .bind(enqueue_shards)
+    .execute(pool)
+    .await
+    .expect("Failed to configure queue_meta.enqueue_shards");
+}
+
+fn deep_backlog_job(queue: &str, priority: i16, seq: u64) -> InsertParams {
+    InsertParams {
+        kind: "deep_backlog_job".to_string(),
+        args: serde_json::json!({ "seq": seq }),
+        opts: InsertOpts {
+            queue: queue.to_string(),
+            priority,
+            ..Default::default()
+        },
+    }
+}
+
+async fn seed_deep_backlog_copy(
+    pool: &sqlx::PgPool,
+    store: &QueueStorage,
+    queue: &str,
+    priority: i16,
+    total_jobs: u64,
+    chunk_size: usize,
+) -> u64 {
+    let mut inserted = 0_u64;
+    let chunk_size = chunk_size.max(1);
+
+    for chunk_start in (0..total_jobs).step_by(chunk_size) {
+        let chunk_end = (chunk_start + chunk_size as u64).min(total_jobs);
+        let jobs: Vec<_> = (chunk_start..chunk_end)
+            .map(|seq| deep_backlog_job(queue, priority, seq))
+            .collect();
+        inserted += store
+            .enqueue_params_copy(pool, &jobs)
+            .await
+            .expect("Deep-backlog direct COPY seed failed") as u64;
+    }
+
+    inserted
 }
 
 fn percentile(values: &[f64], percentile: f64) -> Option<f64> {
@@ -1121,6 +1175,253 @@ async fn test_queue_storage_storage_benchmark() {
             }),
             enqueue_per_s: Some(producer_rate as f64),
             drain_time_s: Some(elapsed.as_secs_f64()),
+            latency_ms: Some(BenchLatency { p50, p95, p99 }),
+            rescue: None,
+        },
+        outcomes,
+        metadata: Some(metadata),
+    }
+    .emit();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 8)]
+#[ignore]
+async fn test_queue_storage_deep_backlog_drain_benchmark() {
+    let total_jobs = env_u64("AWA_QS_DEEP_BACKLOG_JOBS", 100_000);
+    let duration_secs = env_u64("AWA_QS_DEEP_BACKLOG_SECONDS", 60);
+    let copy_chunk_size = env_u64("AWA_QS_DEEP_BACKLOG_COPY_BATCH", 1_000) as usize;
+    let consumers = env_u32("AWA_QS_DEEP_BACKLOG_CONSUMERS", 8);
+    let claim_batch_size = env_u64("AWA_QS_DEEP_BACKLOG_CLAIM_BATCH_SIZE", 512) as i64;
+    let enqueue_shards = env_u32("AWA_QS_DEEP_BACKLOG_SHARDS", 16).clamp(1, 64) as i16;
+    let queue_slot_count = env_u32("AWA_QS_DEEP_BACKLOG_QUEUE_SLOT_COUNT", 16);
+    let lease_slot_count = env_u32("AWA_QS_DEEP_BACKLOG_LEASE_SLOT_COUNT", 8);
+    let schema = env_string("AWA_QS_DEEP_BACKLOG_SCHEMA", "awa_qs_deep_backlog");
+    let queue = env_string("AWA_QS_DEEP_BACKLOG_QUEUE", "qs_deep_backlog");
+    let priority = env_u32("AWA_QS_DEEP_BACKLOG_PRIORITY", 2) as i16;
+    let analyze_ready = env_u32("AWA_QS_DEEP_BACKLOG_ANALYZE", 1) != 0;
+    let max_conns = env_u32("AWA_QS_DEEP_BACKLOG_POOL", consumers + 8);
+
+    assert!(total_jobs > 0, "AWA_QS_DEEP_BACKLOG_JOBS must be > 0");
+    assert!(duration_secs > 0, "AWA_QS_DEEP_BACKLOG_SECONDS must be > 0");
+
+    let pool = pool_with(max_conns).await;
+    ensure_pgstattuple(&pool).await;
+    let store = Arc::new(
+        QueueStorage::new(QueueStorageConfig {
+            schema,
+            queue_slot_count: queue_slot_count as usize,
+            lease_slot_count: lease_slot_count as usize,
+            // This benchmark measures the ready-claim path under depth
+            // using `claim_batch` -> `complete_batch` directly. Keep the
+            // legacy lease-row completion path so completion bookkeeping
+            // does not short-circuit the harness.
+            lease_claim_receipts: false,
+            ..Default::default()
+        })
+        .expect("Failed to construct deep-backlog queue storage store"),
+    );
+
+    recreate_store_schema(&pool, &store).await;
+    store
+        .install(&pool)
+        .await
+        .expect("Failed to install deep-backlog queue storage store");
+    store
+        .reset(&pool)
+        .await
+        .expect("Failed to reset deep-backlog queue storage store");
+    upsert_enqueue_shards(&pool, &queue, enqueue_shards).await;
+
+    let seed_started = Instant::now();
+    let inserted =
+        seed_deep_backlog_copy(&pool, &store, &queue, priority, total_jobs, copy_chunk_size).await;
+    let seed_elapsed = seed_started.elapsed();
+    let seed_rate = inserted as f64 / seed_elapsed.as_secs_f64().max(0.001);
+
+    if analyze_ready {
+        sqlx::query(&format!("ANALYZE {}.ready_entries", store.schema()))
+            .execute(&pool)
+            .await
+            .expect("Failed to analyze ready_entries after deep-backlog seed");
+    }
+
+    println!(
+        "[queue storage deep backlog] seeded={} copy_batch={} enqueue_shards={} seed_elapsed={:.3}s seed_rate={:.0}/s analyze_ready={}",
+        inserted,
+        copy_chunk_size,
+        enqueue_shards,
+        seed_elapsed.as_secs_f64(),
+        seed_rate,
+        analyze_ready,
+    );
+
+    let initial = sample_snapshot(&pool, &store, &queue).await;
+    let db_profile_start = capture_db_profile(&pool).await;
+    let completed = Arc::new(AtomicU64::new(0));
+    let claim_latencies_ms = Arc::new(Mutex::new(Vec::new()));
+    let (consumer_tx, consumer_rx) = tokio::sync::watch::channel(false);
+    let mut consumer_handles = Vec::new();
+
+    for _ in 0..consumers {
+        consumer_handles.push(tokio::spawn(consumer_loop(
+            pool.clone(),
+            store.clone(),
+            queue.clone(),
+            claim_batch_size,
+            claim_latencies_ms.clone(),
+            completed.clone(),
+            consumer_rx.clone(),
+        )));
+    }
+
+    let drain_started = Instant::now();
+    let mut samples = Vec::with_capacity(duration_secs as usize);
+    let mut previous_completed = 0_u64;
+    for second in 1..=duration_secs {
+        tokio::time::sleep(Duration::from_secs(1)).await;
+
+        let snapshot = sample_snapshot(&pool, &store, &queue).await;
+        let completed_total = completed.load(Ordering::Relaxed);
+        let completed_delta = completed_total.saturating_sub(previous_completed);
+        previous_completed = completed_total;
+
+        let sample = QueueStorageSample {
+            second,
+            seeded_total: inserted,
+            completed_total,
+            completed_delta,
+            available: snapshot.available,
+            running: snapshot.running,
+            completed: snapshot.completed,
+            queue_lanes_dead_tup: snapshot.queue_lanes_dead_tup,
+            ready_dead_tup: snapshot.ready_dead_tup,
+            done_dead_tup: snapshot.done_dead_tup,
+            leases_dead_tup: snapshot.leases_dead_tup,
+            attempt_state_dead_tup: snapshot.attempt_state_dead_tup,
+            queue_prune_ok: 0,
+            queue_prune_blocked: 0,
+            queue_prune_skipped_active: 0,
+            lease_prune_ok: 0,
+            lease_prune_blocked: 0,
+            lease_prune_skipped_active: 0,
+        };
+
+        println!(
+            "[queue storage deep backlog] second={:>3} completed={} (+{}) available={} running={} claim_samples={}",
+            sample.second,
+            sample.completed_total,
+            sample.completed_delta,
+            sample.available,
+            sample.running,
+            claim_latencies_ms
+                .lock()
+                .expect("claim latency lock poisoned")
+                .len(),
+        );
+
+        samples.push(sample);
+        if completed_total >= inserted {
+            break;
+        }
+    }
+
+    let _ = consumer_tx.send(true);
+    for handle in consumer_handles {
+        handle.await.expect("Deep-backlog consumer task failed");
+    }
+
+    let drain_elapsed = drain_started.elapsed();
+    let final_snapshot = sample_snapshot(&pool, &store, &queue).await;
+    let final_exact_dead = sample_exact_dead_tuples(&pool, &store).await;
+    let completed_total = completed.load(Ordering::Relaxed);
+    let observed_completed_per_s = average_completed_rate(&samples);
+    let elapsed_completed_per_s = completed_total as f64 / drain_elapsed.as_secs_f64().max(0.001);
+    let claim_latencies = claim_latencies_ms
+        .lock()
+        .expect("claim latency lock poisoned")
+        .clone();
+    let p50 = percentile(&claim_latencies, 0.50);
+    let p95 = percentile(&claim_latencies, 0.95);
+    let p99 = percentile(&claim_latencies, 0.99);
+
+    println!(
+        "[queue storage deep backlog] completed={} observed_rate={:.0}/s elapsed_rate={:.0}/s final_available={} final_running={} claim_latency_ms p50={:.3} p95={:.3} p99={:.3}",
+        completed_total,
+        observed_completed_per_s,
+        elapsed_completed_per_s,
+        final_snapshot.available,
+        final_snapshot.running,
+        p50.unwrap_or(0.0),
+        p95.unwrap_or(0.0),
+        p99.unwrap_or(0.0),
+    );
+    if let Some(exact) = final_exact_dead {
+        println!(
+            "[queue storage deep backlog] exact_dead_tuples queue_lanes={} ready={} done={} leases={} attempt_state={} total={}",
+            exact.queue_lanes,
+            exact.ready,
+            exact.done,
+            exact.leases,
+            exact.attempt_state,
+            exact.queue_lanes + exact.ready + exact.done + exact.leases + exact.attempt_state,
+        );
+    }
+
+    let mut outcomes = HashMap::new();
+    outcomes.insert("completed".to_string(), completed_total);
+    outcomes.insert("available".to_string(), final_snapshot.available as u64);
+    outcomes.insert("running".to_string(), final_snapshot.running as u64);
+
+    let mut metadata = serde_json::json!({
+        "profile": "queue_storage_deep_backlog_drain",
+        "queue": queue,
+        "priority": priority,
+        "queue_slot_count": store.queue_slot_count(),
+        "lease_slot_count": store.lease_slot_count(),
+        "claim_slot_count": store.claim_slot_count(),
+        "lease_claim_receipts": false,
+        "copy_chunk_size": copy_chunk_size,
+        "seed_elapsed_s": seed_elapsed.as_secs_f64(),
+        "seed_enqueue_per_s": seed_rate,
+        "consumers": consumers,
+        "claim_batch_size": claim_batch_size,
+        "enqueue_shards": enqueue_shards,
+        "duration_secs": duration_secs,
+        "observed_completed_per_s": observed_completed_per_s,
+        "elapsed_completed_per_s": elapsed_completed_per_s,
+        "initial_available": initial.available,
+        "initial_running": initial.running,
+        "initial_completed": initial.completed,
+        "final_available": final_snapshot.available,
+        "final_running": final_snapshot.running,
+        "final_completed": final_snapshot.completed,
+        "final_ready_dead_tup": final_snapshot.ready_dead_tup,
+        "final_done_dead_tup": final_snapshot.done_dead_tup,
+        "final_leases_dead_tup": final_snapshot.leases_dead_tup,
+        "exact_final_dead_tuples": final_exact_dead,
+        "samples": samples,
+    });
+    if let Some(start) = db_profile_start.as_ref() {
+        if let Some(db_profile) = capture_db_profile_delta(&pool, start).await {
+            metadata
+                .as_object_mut()
+                .expect("benchmark metadata should be an object")
+                .insert("db_profile".to_string(), db_profile);
+        }
+    }
+
+    BenchmarkResult {
+        schema_version: SCHEMA_VERSION,
+        scenario: "queue_storage_deep_backlog_drain".to_string(),
+        language: "rust".to_string(),
+        seeded: inserted,
+        metrics: BenchMetrics {
+            throughput: Some(BenchThroughput {
+                handler_per_s: observed_completed_per_s,
+                db_finalized_per_s: observed_completed_per_s,
+            }),
+            enqueue_per_s: Some(seed_rate),
+            drain_time_s: Some(drain_elapsed.as_secs_f64()),
             latency_ms: Some(BenchLatency { p50, p95, p99 }),
             rescue: None,
         },

--- a/docs/adr/025-sharded-enqueue-heads.md
+++ b/docs/adr/025-sharded-enqueue-heads.md
@@ -296,7 +296,15 @@ the new value.
 
 Operational procedure:
 
-1. `UPDATE awa.queue_meta SET enqueue_shards = <newS> WHERE queue = '<q>';`
+1. Upsert `awa.queue_meta.enqueue_shards` for the queue:
+
+   ```sql
+   INSERT INTO awa.queue_meta (queue, enqueue_shards)
+   VALUES ('<q>', <newS>)
+   ON CONFLICT (queue)
+   DO UPDATE SET enqueue_shards = EXCLUDED.enqueue_shards;
+   ```
+
 2. Restart runtime processes (or rely on natural restart cadence)
    so the in-process cache observes the new value.
 3. Optionally watch the per-shard SQL above until `lag` reaches 0

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -149,7 +149,7 @@ sequenceDiagram
     participant R as Ring state
     participant E as Executor
 
-    P->>Q: insert / enqueue_many_copy inside app transaction
+    P->>Q: single insert or direct COPY enqueue inside app transaction
     Q->>Q: append ready_entries or deferred_jobs
     Q-->>D: NOTIFY awa:<queue>
     D->>D: pre-acquire local permits

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -78,7 +78,7 @@ physical transition surfaces:
 
 | Surface | Role | Consumer contract |
 |---|---|---|
-| `awa.jobs` / `awa.insert_job_compat()` | Canonical compatibility surface used during the storage transition and by SQL adapters that need the public job shape. | Public compatibility surface. Prefer the Rust/Python/adapter APIs for writes; do not depend on physical queue-storage tables for enqueue. |
+| `awa.jobs` / `awa.insert_job_compat()` | Canonical compatibility surface used during the storage transition and by SQL adapters that need the public job shape. When queue storage is active, the runtime does not claim or complete from `awa.jobs`; compatibility inserts route into the active backend. | Public compatibility surface. Prefer Rust/Python/adapter APIs for ordinary writes. For high-volume queue-storage producers, prefer configured direct COPY through `QueueStorage::enqueue_params_copy()` or Python `enqueue_many_copy()` rather than the compat COPY path. |
 | `{schema}.terminal_jobs` | Read-only hydrated view over queue-storage terminal history. It joins narrow `done_entries_*` rows back to retained `ready_entries_*` bodies. | Public read surface for SQL inspection and reporting of terminal queue-storage rows. It is not a write or transition surface. |
 | `ready_entries_*` | Physical runnable queue ring. | Internal storage. Read only for low-level debugging; writes must go through Awa enqueue, claim, retry, cancel, or maintenance paths. |
 | `done_entries_*` | Physical terminal fact ring. Ready-backed terminal rows can intentionally omit duplicated body columns. | Internal storage. Direct readers must tolerate nullable duplicated body fields; use `{schema}.terminal_jobs` for hydrated terminal rows. |
@@ -86,7 +86,7 @@ physical transition surfaces:
 | `dlq_entries` | Durable operator hold table for DLQ-enabled terminal failures. | Operator surface through CLI/UI/API; direct SQL inspection is reasonable, direct mutation is not. |
 | `lease_claims_*` / `lease_claim_closures_*` | Receipt-plane execution history for short attempts. | Internal storage. Live receipt attempts are claims without matching closures. |
 | `leases_*` / `attempt_state` | Materialized execution state for heartbeat, callbacks, progress, and other mutable attempt data. | Internal storage. Runtime and rescue paths own mutations. |
-| `queue_lanes`, queue heads, ring-state tables, `queue_meta` | Claim cursors, enqueue heads, rotation/prune state, and queue storage configuration. | Internal control surface except documented configuration fields such as `queue_meta.enqueue_shards`. |
+| `queue_lanes`, queue heads, ring-state tables, `queue_meta` | Claim cursors, enqueue heads, rotation/prune state, and queue storage configuration. | Internal control surface except documented configuration fields such as `queue_meta.enqueue_shards`. If no `queue_meta` row exists for a queue, enqueue defaults to one shard; operators should configure shard counts with an UPSERT before load tests or production traffic. |
 | descriptors, runtime snapshots, cron tables | Operator metadata and scheduler declarations. | Public through Awa APIs and UI; SQL reads are acceptable for reporting. Writes should go through the corresponding Awa APIs. |
 
 ADR-019 is the storage-engine source of truth; ADR-023 supersedes it for the
@@ -163,14 +163,30 @@ sequenceDiagram
 
 Enqueue is transactional: if the producer's outer transaction rolls back, the
 job never becomes visible. Immediate jobs append to `ready_entries_*`; future
-scheduled or retryable jobs append to `deferred_jobs`; COPY ingestion uses the
-same storage actions with larger batches.
+scheduled or retryable jobs append to `deferred_jobs`.
+
+There are two COPY-shaped producer paths:
+
+- Direct queue-storage COPY is the high-throughput path: Rust producers use a
+  configured `QueueStorage::enqueue_params_copy()`, and Python producers use
+  `enqueue_many_copy()`. Direct-copy producers must use the same queue-storage
+  configuration as the worker fleet, especially `queue_stripe_count` /
+  `queue_storage_queue_stripe_count`.
+- `insert_many_copy()` is the compatibility path. It stages rows with COPY but
+  then routes each row through `awa.insert_job_compat()`, so it preserves the
+  public compatibility surface rather than bypassing to the direct producer
+  path.
 
 Claim is cursor-based rather than heap-scan based:
 
-- `queue_enqueue_heads` allocates lane sequence ranges at enqueue time.
+- `queue_meta.enqueue_shards` controls how many independent enqueue/claim head
+  rows a queue has. The default is one shard. Raising it changes the ordering
+  contract to FIFO within `(queue, priority, enqueue_shard)`, with no global
+  ordering promise across shards.
+- `queue_enqueue_heads` allocates lane sequence ranges at enqueue time per
+  `(physical queue, priority, enqueue_shard)`.
 - `queue_claim_heads` advances monotonically during claim and is the authority
-  for the next claimable lane position.
+  for the next claimable lane position on the same shard-qualified lane.
 - The dispatcher pre-acquires execution permits before claiming, so every
   claimed `running` job has reserved local capacity.
 - Queue striping and bounded claimers reduce contention on very hot logical
@@ -179,9 +195,13 @@ Claim is cursor-based rather than heap-scan based:
   they do not own jobs. Recovery still follows the receipt/lease state in
   Postgres.
 
-Priority ordering is by `(queue, priority, lane_seq)`. With queue storage,
-priority aging is applied at claim time rather than by physically rewriting
-ready rows.
+Priority ordering is by effective priority first. Within one enqueue shard the
+lane sequence is FIFO; across enqueue shards, strict global lane order is not
+promised. With queue storage, priority aging is applied at claim time rather
+than by physically rewriting ready rows. The ready/done/lease partitions carry
+shard-aware lane indexes on `(queue, priority, enqueue_shard, lane_seq)` so
+deep backlog claim probes do not scan a non-shard-selective lane index and
+post-filter most rows.
 
 ## Completion And Callbacks
 

--- a/docs/benchmarking.md
+++ b/docs/benchmarking.md
@@ -310,7 +310,7 @@ reusing the same database-facing benchmark shapes as the Rust runtime:
 
 **Baseline scenarios** (`--scenario baseline`):
 
-- `copy`: Python client `insert_many_copy` throughput
+- `copy`: Python client `enqueue_many_copy` direct queue-storage COPY throughput
 - `hot`: sustained worker throughput over pre-seeded `awa.jobs_hot`
 - `scheduled`: sustained deferred promotion over pre-seeded `awa.scheduled_jobs`
 
@@ -376,13 +376,41 @@ more than offset the metrics instrumentation cost.
 Measured with `awa-python/scripts/benchmark_runtime.py` on the developer
 laptop reference database:
 
-- `insert_many_copy`: about `16.2k jobs/s` (`50,000` jobs in `3.09s`)
+- `enqueue_many_copy`: about `16.2k jobs/s` (`50,000` jobs in `3.09s`)
 - sustained hot path:
   - handler returns: about `3.2k jobs/s`
   - DB `completed` transitions: about `3.1k jobs/s`
 
-These runs isolate the Python worker path. Seed data is inserted with SQL so
-the runtime number is not dominated by Python-side enqueue serialization.
+The `copy` scenario measures producer serialization and direct queue-storage
+COPY. The worker-focused scenarios seed with SQL so the runtime number is not
+dominated by Python-side enqueue serialization.
+
+### Deep Backlog Drain
+
+`test_queue_storage_deep_backlog_drain_benchmark` is an ignored regression
+benchmark for the spike shape where a large ready backlog drains more slowly
+than the same fleet processes steady offered load. It seeds with direct
+queue-storage COPY, optionally analyzes `ready_entries`, then measures
+claim/complete throughput and claim latency while draining a fixed backlog.
+
+```bash
+DATABASE_URL_QUEUE_STORAGE=postgres://postgres:test@localhost:15432/awa_test_queue_storage \
+AWA_QS_DEEP_BACKLOG_JOBS=1000000 \
+AWA_QS_DEEP_BACKLOG_SECONDS=120 \
+AWA_QS_DEEP_BACKLOG_CONSUMERS=16 \
+AWA_QS_DEEP_BACKLOG_SHARDS=16 \
+cargo test --package awa --test queue_storage_benchmark_test \
+  test_queue_storage_deep_backlog_drain_benchmark -- --exact --ignored --nocapture
+```
+
+Useful knobs:
+
+- `AWA_QS_DEEP_BACKLOG_JOBS` — ready rows to seed (default `100000`)
+- `AWA_QS_DEEP_BACKLOG_COPY_BATCH` — direct COPY chunk size (default `1000`)
+- `AWA_QS_DEEP_BACKLOG_CONSUMERS` — concurrent claim/complete loops (default `8`)
+- `AWA_QS_DEEP_BACKLOG_CLAIM_BATCH_SIZE` — claim batch size (default `512`)
+- `AWA_QS_DEEP_BACKLOG_SHARDS` — `awa.queue_meta.enqueue_shards` upserted before seeding (default `16`)
+- `AWA_QS_DEEP_BACKLOG_ANALYZE` — run `ANALYZE` after seeding (default `1`)
 
 ### Large Deferred Frontier
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -442,6 +442,18 @@ the defaults. Queue-storage tables live in the canonical `awa` schema; the
 main knobs are there for large fleets, very bursty queues, or operators who
 want to trade off the partition-reclaim window against rotation churn.
 
+### Producer path choice
+
+For bulk producers on queue storage, prefer direct queue-storage COPY:
+Python `enqueue_many_copy()` or Rust `awa::enqueue_many_copy()`. Those paths
+stream rows straight into `ready_entries` / `deferred_jobs` and use the
+queue-storage enqueue heads directly.
+
+`insert_many_copy()` is the compatibility insert API. It is still useful when a
+caller needs the canonical insert surface, but in queue-storage mode it routes
+through the compatibility function rather than being the primary producer fast
+path.
+
 ### Rust
 
 ```rust
@@ -515,8 +527,15 @@ Raising `enqueue_shards` is a **semantic mode switch**, not a hidden performance
 
 ```sql
 -- Opt a contended queue into 4 shards.
-UPDATE awa.queue_meta SET enqueue_shards = 4 WHERE queue = 'my_hot_queue';
+INSERT INTO awa.queue_meta (queue, enqueue_shards)
+VALUES ('my_hot_queue', 4)
+ON CONFLICT (queue)
+DO UPDATE SET enqueue_shards = EXCLUDED.enqueue_shards;
 ```
+
+Use an upsert rather than a plain `UPDATE`: the first enqueue can create
+queue-storage lane rows before an operator-owned `queue_meta` row exists, so a
+plain `UPDATE` may quietly affect zero rows.
 
 A 16-producer same-queue reference sweep measured 1.0× / 1.60× / 2.75× /
 3.69× at S=1/2/4/8. Application authors who need per-key FIFO at S>1

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -445,9 +445,18 @@ want to trade off the partition-reclaim window against rotation churn.
 ### Producer path choice
 
 For bulk producers on queue storage, prefer direct queue-storage COPY:
-Python `enqueue_many_copy()` or Rust `awa::enqueue_many_copy()`. Those paths
-stream rows straight into `ready_entries` / `deferred_jobs` and use the
-queue-storage enqueue heads directly.
+Python `enqueue_many_copy()` or Rust `QueueStorage::enqueue_params_copy()`.
+Those paths stream rows straight into `ready_entries` / `deferred_jobs` and use
+the queue-storage enqueue heads directly.
+
+Direct-copy producers must use the same queue-storage routing config as the
+worker fleet. This matters most for `queue_stripe_count` /
+`queue_storage_queue_stripe_count`: a producer using the default unstriped
+config can write to `queue` while striped workers claim from `queue#0`,
+`queue#1`, etc. Rust producers should construct `QueueStorage` with the same
+`QueueStorageConfig` used by workers. Python producers should pass the same
+`queue_storage_queue_stripe_count` to `enqueue_many_copy()` when the fleet uses
+non-default striping.
 
 `insert_many_copy()` is the compatibility insert API. It is still useful when a
 caller needs the canonical insert surface, but in queue-storage mode it routes

--- a/docs/grafana/README.md
+++ b/docs/grafana/README.md
@@ -125,6 +125,7 @@ All metrics use the `awa` OTel meter name and are exported via OTLP to your conf
 | `awa.job.claimed` | Counter | queue | Jobs claimed from DB |
 | `awa.job.in_flight` | UpDownCounter | queue | Currently executing |
 | `awa.job.duration` | Histogram (s) | kind, queue | Execution time |
+| `awa.job.wait_duration` | Histogram (s) | kind, queue | Time from creation to claim; explicit buckets include 1ms, 5ms, 10ms, 25ms, 50ms, 100ms, 250ms, 500ms, and 1s |
 | `awa.job.waiting_external` | Counter | kind, queue | Parked for callback |
 
 ### Dispatcher

--- a/docs/security.md
+++ b/docs/security.md
@@ -112,7 +112,7 @@ GRANT TEMP ON DATABASE mydb TO awa_runtime;
 ```
 
 This allows creating temporary staging tables for the `COPY` bulk insert path.
-Queue-storage direct COPY (`awa::enqueue_many_copy` in Rust,
+Queue-storage direct COPY (`QueueStorage::enqueue_params_copy` in Rust,
 `enqueue_many_copy` in Python) writes to the queue-storage tables directly and
 does not need this temporary-table grant.
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -104,13 +104,17 @@ ALTER DEFAULT PRIVILEGES FOR ROLE awa_owner IN SCHEMA awa
   GRANT EXECUTE ON FUNCTIONS TO awa_runtime;
 ```
 
-If you use the high-throughput `insert_many_copy` path (Rust `InsertOpts::copy()`), also grant:
+If you use the compatibility `insert_many_copy` path (Rust
+`InsertOpts::copy()`), also grant:
 
 ```sql
 GRANT TEMP ON DATABASE mydb TO awa_runtime;
 ```
 
 This allows creating temporary staging tables for the `COPY` bulk insert path.
+Queue-storage direct COPY (`awa::enqueue_many_copy` in Rust,
+`enqueue_many_copy` in Python) writes to the queue-storage tables directly and
+does not need this temporary-table grant.
 
 ### Custom queue-storage schema
 

--- a/docs/upgrade-0.5-to-0.6.md
+++ b/docs/upgrade-0.5-to-0.6.md
@@ -190,10 +190,13 @@ When the migration runs:
 
 ### Raising `enqueue_shards`
 
-Opt a contended queue into multiple shards with a single UPDATE on `awa.queue_meta`:
+Opt a contended queue into multiple shards by upserting `awa.queue_meta`:
 
 ```sql
-UPDATE awa.queue_meta SET enqueue_shards = 4 WHERE queue = 'my_hot_queue';
+INSERT INTO awa.queue_meta (queue, enqueue_shards)
+VALUES ('my_hot_queue', 4)
+ON CONFLICT (queue)
+DO UPDATE SET enqueue_shards = EXCLUDED.enqueue_shards;
 ```
 
 The producer-side rotor picks up the new shard count on the next enqueue. Existing in-flight rows on shard 0 continue to be claimed and drained; new no-key batches spread across shards 0..S-1 over time.
@@ -229,7 +232,10 @@ The only operator-visible caveat is the per-runtime `enqueue_shards_cache`: a ru
 1. Lower the value:
 
    ```sql
-   UPDATE awa.queue_meta SET enqueue_shards = 2 WHERE queue = 'my_hot_queue';
+   INSERT INTO awa.queue_meta (queue, enqueue_shards)
+   VALUES ('my_hot_queue', 2)
+   ON CONFLICT (queue)
+   DO UPDATE SET enqueue_shards = EXCLUDED.enqueue_shards;
    ```
 
 2. Restart worker processes (or rely on the next deploy) so the in-process cache observes the new value.


### PR DESCRIPTION
## Summary
- make direct queue-storage COPY the documented high-volume producer path: Rust producers use a configured `QueueStorage::enqueue_params_copy()`, while Python exposes `enqueue_many_copy()` with explicit stripe configuration
- clarify that `insert_many_copy()` is the compatibility COPY surface and routes staged rows through `awa.insert_job_compat()`
- add explicit subsecond buckets for `awa.job.wait_duration`
- add an ignored deep-backlog drain benchmark seeded through direct queue-storage COPY
- add v021 shard-aware lane indexes for ready/done/lease partitions and align fresh `prepare_schema` index creation with upgraded deployments
- update queue_meta `enqueue_shards` examples and architecture guidance to use upserts so missing meta rows do not become silent no-ops

## Validation
- `cargo fmt`
- `cargo check -p awa-model`
- `cargo check -p awa-metrics`
- `cargo test -p awa --test queue_storage_benchmark_test --no-run`
- `PYO3_PYTHON=/Users/brian/.local/bin/python3.12 cargo check --manifest-path awa-python/Cargo.toml`
- `python3 -m py_compile awa-python/python/awa/client.py awa-python/scripts/benchmark_runtime.py`
- `git diff --check`
