### PR TITLE
Managed-Postgres docs + producer-side enqueue histograms

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ Configuring real workloads:
 - [Job priority and aging](docs/configuration.md#job-priority-and-aging) — priority scale, escalation, the per-queue `priority_aging_interval`
 - [Reliability timings](docs/configuration.md#reliability-timings-heartbeat-deadline-rescue) — heartbeat / deadline / callback rescue, retention, the 3× heartbeat-staleness rule
 - [Dead Letter Queue](docs/configuration.md#dead-letter-queue) — when to enable, per-queue overrides, operator workflow
+- [Deploying on managed Postgres](docs/deploying-on-managed-postgres.md) — Cloud SQL / AlloyDB sizing data, IAM grants, auth-proxy sidecar, gotchas
 
 Already running 0.5? Read the [0.5 → 0.6 upgrade guide](docs/upgrade-0.5-to-0.6.md)
 before you bump — 0.6 introduces a staged storage transition (canonical →

--- a/awa-cli/src/main.rs
+++ b/awa-cli/src/main.rs
@@ -513,146 +513,152 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     }
                 },
 
-                Commands::Dlq { command } => match command {
-                    DlqCommands::List {
-                        kind,
-                        queue,
-                        tag,
-                        before_id,
-                        before_dlq_at,
-                        limit,
-                    } => {
-                        let filter = awa_model::dlq::ListDlqFilter {
+                Commands::Dlq { command } => {
+                    // Construct AwaMetrics once per `awa dlq` invocation —
+                    // `AwaMetrics::from_global()` rebuilds the entire instrument
+                    // set on each call. Cheap here since the CLI fires at most
+                    // one DLQ branch per invocation, but the pattern matches
+                    // the long-lived call sites.
+                    let metrics = awa_worker::AwaMetrics::from_global();
+                    match command {
+                        DlqCommands::List {
                             kind,
                             queue,
                             tag,
                             before_id,
                             before_dlq_at,
-                            limit: Some(limit),
-                        };
-                        let rows = awa_model::dlq::list_dlq(&pool, &filter).await?;
-                        if rows.is_empty() {
-                            println!("DLQ is empty (no matching rows).");
-                        } else {
-                            println!(
-                                "{:<8} {:<25} {:<10} {:<30} {:<25}",
-                                "ID", "KIND", "QUEUE", "REASON", "DLQ_AT"
-                            );
-                            for row in &rows {
-                                // Truncate by characters, not bytes: byte
-                                // slicing mid-codepoint panics on Unicode
-                                // reasons (e.g. an operator typing a
-                                // non-ASCII note).
-                                let char_count = row.reason.chars().count();
-                                let reason = if char_count > 30 {
-                                    let prefix: String = row.reason.chars().take(27).collect();
-                                    format!("{prefix}...")
-                                } else {
-                                    row.reason.clone()
-                                };
+                            limit,
+                        } => {
+                            let filter = awa_model::dlq::ListDlqFilter {
+                                kind,
+                                queue,
+                                tag,
+                                before_id,
+                                before_dlq_at,
+                                limit: Some(limit),
+                            };
+                            let rows = awa_model::dlq::list_dlq(&pool, &filter).await?;
+                            if rows.is_empty() {
+                                println!("DLQ is empty (no matching rows).");
+                            } else {
                                 println!(
                                     "{:<8} {:<25} {:<10} {:<30} {:<25}",
-                                    row.job.id, row.job.kind, row.job.queue, reason, row.dlq_at
+                                    "ID", "KIND", "QUEUE", "REASON", "DLQ_AT"
                                 );
-                            }
-                            println!("\n{} rows.", rows.len());
-                            if let Some(last) = rows.last() {
-                                println!(
-                                    "Next page: --before-id {} --before-dlq-at {}",
-                                    last.job.id, last.dlq_at
-                                );
+                                for row in &rows {
+                                    // Truncate by characters, not bytes: byte
+                                    // slicing mid-codepoint panics on Unicode
+                                    // reasons (e.g. an operator typing a
+                                    // non-ASCII note).
+                                    let char_count = row.reason.chars().count();
+                                    let reason = if char_count > 30 {
+                                        let prefix: String = row.reason.chars().take(27).collect();
+                                        format!("{prefix}...")
+                                    } else {
+                                        row.reason.clone()
+                                    };
+                                    println!(
+                                        "{:<8} {:<25} {:<10} {:<30} {:<25}",
+                                        row.job.id, row.job.kind, row.job.queue, reason, row.dlq_at
+                                    );
+                                }
+                                println!("\n{} rows.", rows.len());
+                                if let Some(last) = rows.last() {
+                                    println!(
+                                        "Next page: --before-id {} --before-dlq-at {}",
+                                        last.job.id, last.dlq_at
+                                    );
+                                }
                             }
                         }
-                    }
-                    DlqCommands::Depth { queue } => {
-                        if let Some(queue_name) = queue {
-                            let depth = awa_model::dlq::dlq_depth(&pool, Some(&queue_name)).await?;
-                            println!("{queue_name}: {depth}");
-                        } else {
-                            let total = awa_model::dlq::dlq_depth(&pool, None).await?;
-                            let by_queue = awa_model::dlq::dlq_depth_by_queue(&pool).await?;
-                            println!("Total: {total}");
-                            for (q, count) in &by_queue {
-                                println!("  {q}: {count}");
+                        DlqCommands::Depth { queue } => {
+                            if let Some(queue_name) = queue {
+                                let depth =
+                                    awa_model::dlq::dlq_depth(&pool, Some(&queue_name)).await?;
+                                println!("{queue_name}: {depth}");
+                            } else {
+                                let total = awa_model::dlq::dlq_depth(&pool, None).await?;
+                                let by_queue = awa_model::dlq::dlq_depth_by_queue(&pool).await?;
+                                println!("Total: {total}");
+                                for (q, count) in &by_queue {
+                                    println!("  {q}: {count}");
+                                }
                             }
                         }
-                    }
-                    DlqCommands::Retry { id } => {
-                        let opts = awa_model::dlq::RetryFromDlqOpts::default();
-                        match awa_model::dlq::retry_from_dlq(&pool, id, &opts).await? {
-                            Some(job) => {
-                                awa_worker::AwaMetrics::from_global()
-                                    .record_dlq_retried(Some(&job.queue), 1);
-                                println!("Retried DLQ job {id} → job state {}", job.state);
+                        DlqCommands::Retry { id } => {
+                            let opts = awa_model::dlq::RetryFromDlqOpts::default();
+                            match awa_model::dlq::retry_from_dlq(&pool, id, &opts).await? {
+                                Some(job) => {
+                                    metrics.record_dlq_retried(Some(&job.queue), 1);
+                                    println!("Retried DLQ job {id} → job state {}", job.state);
+                                }
+                                None => println!("No DLQ row with id {id}"),
                             }
-                            None => println!("No DLQ row with id {id}"),
                         }
-                    }
-                    DlqCommands::RetryBulk {
-                        kind,
-                        queue,
-                        tag,
-                        all,
-                    } => {
-                        let filter = awa_model::dlq::ListDlqFilter {
+                        DlqCommands::RetryBulk {
                             kind,
-                            queue: queue.clone(),
+                            queue,
                             tag,
-                            ..Default::default()
-                        };
-                        let count =
-                            awa_model::dlq::bulk_retry_from_dlq(&pool, &filter, all).await?;
-                        if count > 0 {
-                            awa_worker::AwaMetrics::from_global()
-                                .record_dlq_retried(queue.as_deref(), count);
-                        }
-                        println!("Retried {count} DLQ rows.");
-                    }
-                    DlqCommands::Move {
-                        kind,
-                        queue,
-                        reason,
-                        all,
-                    } => {
-                        let count = awa_model::dlq::bulk_move_failed_to_dlq(
-                            &pool,
-                            kind.as_deref(),
-                            queue.as_deref(),
-                            &reason,
                             all,
-                        )
-                        .await?;
-                        // Emit the same `awa.job.dlq_moved` counter the
-                        // executor uses for automatic routing, so dashboards
-                        // and alerting see admin bulk moves too.
-                        awa_worker::AwaMetrics::from_global().record_dlq_moved_bulk(
-                            kind.as_deref(),
-                            queue.as_deref(),
-                            &reason,
-                            count,
-                        );
-                        println!("Moved {count} failed jobs into the DLQ.");
-                    }
-                    DlqCommands::Purge {
-                        kind,
-                        queue,
-                        tag,
-                        all,
-                    } => {
-                        let filter = awa_model::dlq::ListDlqFilter {
-                            kind,
-                            queue: queue.clone(),
-                            tag,
-                            ..Default::default()
-                        };
-                        let count = awa_model::dlq::purge_dlq(&pool, &filter, all).await?;
-                        if count > 0 {
-                            awa_worker::AwaMetrics::from_global()
-                                .record_dlq_purged(queue.as_deref(), count);
+                        } => {
+                            let filter = awa_model::dlq::ListDlqFilter {
+                                kind,
+                                queue: queue.clone(),
+                                tag,
+                                ..Default::default()
+                            };
+                            let count =
+                                awa_model::dlq::bulk_retry_from_dlq(&pool, &filter, all).await?;
+                            if count > 0 {
+                                metrics.record_dlq_retried(queue.as_deref(), count);
+                            }
+                            println!("Retried {count} DLQ rows.");
                         }
-                        println!("Purged {count} DLQ rows.");
+                        DlqCommands::Move {
+                            kind,
+                            queue,
+                            reason,
+                            all,
+                        } => {
+                            let count = awa_model::dlq::bulk_move_failed_to_dlq(
+                                &pool,
+                                kind.as_deref(),
+                                queue.as_deref(),
+                                &reason,
+                                all,
+                            )
+                            .await?;
+                            // Emit the same `awa.job.dlq_moved` counter the
+                            // executor uses for automatic routing, so dashboards
+                            // and alerting see admin bulk moves too.
+                            metrics.record_dlq_moved_bulk(
+                                kind.as_deref(),
+                                queue.as_deref(),
+                                &reason,
+                                count,
+                            );
+                            println!("Moved {count} failed jobs into the DLQ.");
+                        }
+                        DlqCommands::Purge {
+                            kind,
+                            queue,
+                            tag,
+                            all,
+                        } => {
+                            let filter = awa_model::dlq::ListDlqFilter {
+                                kind,
+                                queue: queue.clone(),
+                                tag,
+                                ..Default::default()
+                            };
+                            let count = awa_model::dlq::purge_dlq(&pool, &filter, all).await?;
+                            if count > 0 {
+                                metrics.record_dlq_purged(queue.as_deref(), count);
+                            }
+                            println!("Purged {count} DLQ rows.");
+                        }
                     }
-                },
+                }
 
                 Commands::Cron { command } => match command {
                     CronCommands::List => {

--- a/awa-metrics/src/lib.rs
+++ b/awa-metrics/src/lib.rs
@@ -26,6 +26,8 @@ use std::time::Duration;
 /// exporter without copy-pasting string literals.
 pub mod names {
     pub const JOB_INSERTED: &str = "awa.job.inserted";
+    pub const ENQUEUE_BATCH_SIZE: &str = "awa.enqueue.batch_size";
+    pub const ENQUEUE_DURATION: &str = "awa.enqueue.duration";
     pub const JOB_COMPLETED: &str = "awa.job.completed";
     pub const JOB_FAILED: &str = "awa.job.failed";
     pub const JOB_RETRIED: &str = "awa.job.retried";
@@ -81,6 +83,17 @@ const WAIT_DURATION_BUCKETS_SECONDS: [f64; 14] = [
 pub struct AwaMetrics {
     /// Total jobs inserted.
     pub jobs_inserted: Counter<u64>,
+    /// Per-batch size distribution for the direct queue-storage COPY enqueue
+    /// path (`QueueStorage::enqueue_params_copy` / Python
+    /// `Client.enqueue_many_copy`). Lets producers see how chunky their
+    /// batches actually land — useful when a target enqueue rate isn't being
+    /// hit and you need to disambiguate "batches are tiny" from "batches are
+    /// slow."
+    pub enqueue_batch_size: Histogram<u64>,
+    /// Per-batch wall-clock duration for the direct queue-storage COPY
+    /// enqueue path. Pair with [`enqueue_batch_size`](Self::enqueue_batch_size)
+    /// to read jobs-per-second and per-batch latency in one Grafana row.
+    pub enqueue_duration_seconds: Histogram<f64>,
     /// Total jobs completed successfully.
     pub jobs_completed: Counter<u64>,
     /// Total jobs that failed (terminal).
@@ -206,6 +219,21 @@ impl AwaMetrics {
                 .u64_counter(names::JOB_INSERTED)
                 .with_description("Number of jobs inserted")
                 .with_unit("{job}")
+                .build(),
+            enqueue_batch_size: meter
+                .u64_histogram(names::ENQUEUE_BATCH_SIZE)
+                .with_description(
+                    "Direct queue-storage COPY enqueue: per-batch job count",
+                )
+                .with_unit("{job}")
+                .build(),
+            enqueue_duration_seconds: meter
+                .f64_histogram(names::ENQUEUE_DURATION)
+                .with_description(
+                    "Direct queue-storage COPY enqueue: per-batch wall-clock duration",
+                )
+                .with_unit("s")
+                .with_boundaries(WAIT_DURATION_BUCKETS_SECONDS.to_vec())
                 .build(),
             jobs_completed: meter
                 .u64_counter(names::JOB_COMPLETED)
@@ -475,6 +503,29 @@ impl AwaMetrics {
             opentelemetry::KeyValue::new("awa.job.queue", queue.to_string()),
         ];
         self.jobs_retried.add(1, &attrs);
+    }
+
+    /// Record a producer batch through the direct queue-storage COPY
+    /// enqueue path (`QueueStorage::enqueue_params_copy` / Python
+    /// `Client.enqueue_many_copy`).
+    ///
+    /// `batch_size` is the row count that COPY actually wrote; `duration`
+    /// is the wall-clock time the producer spent in the COPY call (start
+    /// to commit), not including pre-batch row preparation.
+    ///
+    /// At `batch_size = 0` this is a no-op — empty batches are valid
+    /// callers and don't need a metric sample.
+    pub fn record_enqueue_batch(&self, queue: &str, batch_size: u64, duration: Duration) {
+        if batch_size == 0 {
+            return;
+        }
+        let attrs = [opentelemetry::KeyValue::new(
+            "awa.job.queue",
+            queue.to_string(),
+        )];
+        self.enqueue_batch_size.record(batch_size, &attrs);
+        self.enqueue_duration_seconds
+            .record(duration.as_secs_f64(), &attrs);
     }
 
     /// Record a job claimed from queue.

--- a/awa-python/src/client.rs
+++ b/awa-python/src/client.rs
@@ -1316,13 +1316,14 @@ impl PyClient {
         queue: Option<String>,
     ) -> PyResult<Bound<'py, PyAny>> {
         let pool = self.pool.clone();
+        let metrics = self.metrics.clone();
         let opts = crate::dlq::build_retry_opts(run_at, priority, queue);
         pyo3_async_runtimes::tokio::future_into_py(py, async move {
             let job = awa_model::dlq::retry_from_dlq(&pool, job_id, &opts)
                 .await
                 .map_err(map_awa_error)?;
             if let Some(job) = job.as_ref() {
-                awa_worker::AwaMetrics::from_global().record_dlq_retried(Some(&job.queue), 1);
+                metrics.record_dlq_retried(Some(&job.queue), 1);
             }
             Python::attach(|py| {
                 Ok(match job {
@@ -1347,6 +1348,7 @@ impl PyClient {
         allow_all: bool,
     ) -> PyResult<Bound<'py, PyAny>> {
         let pool = self.pool.clone();
+        let metrics = self.metrics.clone();
         pyo3_async_runtimes::tokio::future_into_py(py, async move {
             let queue_attr = queue.clone();
             let filter = crate::dlq::build_filter(kind, queue, tag, None, None, None);
@@ -1354,8 +1356,7 @@ impl PyClient {
                 .await
                 .map_err(map_awa_error)?;
             if count > 0 {
-                awa_worker::AwaMetrics::from_global()
-                    .record_dlq_retried(queue_attr.as_deref(), count);
+                metrics.record_dlq_retried(queue_attr.as_deref(), count);
             }
             Ok(count)
         })
@@ -1370,16 +1371,13 @@ impl PyClient {
         reason: String,
     ) -> PyResult<Bound<'py, PyAny>> {
         let pool = self.pool.clone();
+        let metrics = self.metrics.clone();
         pyo3_async_runtimes::tokio::future_into_py(py, async move {
             let row = awa_model::dlq::move_failed_to_dlq(&pool, job_id, &reason)
                 .await
                 .map_err(map_awa_error)?;
             if let Some(row) = row.as_ref() {
-                awa_worker::AwaMetrics::from_global().record_dlq_moved(
-                    &row.job.kind,
-                    &row.job.queue,
-                    &reason,
-                );
+                metrics.record_dlq_moved(&row.job.kind, &row.job.queue, &reason);
             }
             Python::attach(|py| {
                 Ok(match row {
@@ -1406,6 +1404,7 @@ impl PyClient {
         allow_all: bool,
     ) -> PyResult<Bound<'py, PyAny>> {
         let pool = self.pool.clone();
+        let metrics = self.metrics.clone();
         pyo3_async_runtimes::tokio::future_into_py(py, async move {
             let kind_attr = kind.clone();
             let queue_attr = queue.clone();
@@ -1419,7 +1418,7 @@ impl PyClient {
             .await
             .map_err(map_awa_error)?;
             if count > 0 {
-                awa_worker::AwaMetrics::from_global().record_dlq_moved_bulk(
+                metrics.record_dlq_moved_bulk(
                     kind_attr.as_deref(),
                     queue_attr.as_deref(),
                     &reason,
@@ -1433,6 +1432,7 @@ impl PyClient {
     /// Purge a single DLQ row. Returns `True` if the row was deleted.
     fn purge_dlq_job<'py>(&self, py: Python<'py>, job_id: i64) -> PyResult<Bound<'py, PyAny>> {
         let pool = self.pool.clone();
+        let metrics = self.metrics.clone();
         pyo3_async_runtimes::tokio::future_into_py(py, async move {
             let queue = awa_model::dlq::get_dlq_job(&pool, job_id)
                 .await
@@ -1442,7 +1442,7 @@ impl PyClient {
                 .await
                 .map_err(map_awa_error)?;
             if deleted {
-                awa_worker::AwaMetrics::from_global().record_dlq_purged(queue.as_deref(), 1);
+                metrics.record_dlq_purged(queue.as_deref(), 1);
             }
             Ok(deleted)
         })
@@ -1465,6 +1465,7 @@ impl PyClient {
         allow_all: bool,
     ) -> PyResult<Bound<'py, PyAny>> {
         let pool = self.pool.clone();
+        let metrics = self.metrics.clone();
         pyo3_async_runtimes::tokio::future_into_py(py, async move {
             let queue_attr = queue.clone();
             let filter = crate::dlq::build_filter(kind, queue, tag, before_id, before_dlq_at, None);
@@ -1472,8 +1473,7 @@ impl PyClient {
                 .await
                 .map_err(map_awa_error)?;
             if count > 0 {
-                awa_worker::AwaMetrics::from_global()
-                    .record_dlq_purged(queue_attr.as_deref(), count);
+                metrics.record_dlq_purged(queue_attr.as_deref(), count);
             }
             Ok(count)
         })
@@ -2695,6 +2695,7 @@ impl PyClient {
         queue: Option<String>,
     ) -> PyResult<Option<PyJob>> {
         let pool = self.pool.clone();
+        let metrics = self.metrics.clone();
         let opts = crate::dlq::build_retry_opts(run_at, priority, queue);
         py.detach(|| {
             pyo3_async_runtimes::tokio::get_runtime().block_on(async {
@@ -2702,7 +2703,7 @@ impl PyClient {
                     .await
                     .map_err(map_awa_error)?;
                 if let Some(job) = job.as_ref() {
-                    awa_worker::AwaMetrics::from_global().record_dlq_retried(Some(&job.queue), 1);
+                    metrics.record_dlq_retried(Some(&job.queue), 1);
                 }
                 Ok(job.map(PyJob::from))
             })
@@ -2719,6 +2720,7 @@ impl PyClient {
         allow_all: bool,
     ) -> PyResult<u64> {
         let pool = self.pool.clone();
+        let metrics = self.metrics.clone();
         let queue_attr = queue.clone();
         let filter = crate::dlq::build_filter(kind, queue, tag, None, None, None);
         py.detach(|| {
@@ -2727,8 +2729,7 @@ impl PyClient {
                     .await
                     .map_err(map_awa_error)?;
                 if count > 0 {
-                    awa_worker::AwaMetrics::from_global()
-                        .record_dlq_retried(queue_attr.as_deref(), count);
+                    metrics.record_dlq_retried(queue_attr.as_deref(), count);
                 }
                 Ok(count)
             })
@@ -2742,17 +2743,14 @@ impl PyClient {
         reason: String,
     ) -> PyResult<Option<crate::dlq::PyDlqEntry>> {
         let pool = self.pool.clone();
+        let metrics = self.metrics.clone();
         py.detach(|| {
             pyo3_async_runtimes::tokio::get_runtime().block_on(async {
                 let row = awa_model::dlq::move_failed_to_dlq(&pool, job_id, &reason)
                     .await
                     .map_err(map_awa_error)?;
                 if let Some(row) = row.as_ref() {
-                    awa_worker::AwaMetrics::from_global().record_dlq_moved(
-                        &row.job.kind,
-                        &row.job.queue,
-                        &reason,
-                    );
+                    metrics.record_dlq_moved(&row.job.kind, &row.job.queue, &reason);
                 }
                 Python::attach(|py| row.map(|r| crate::dlq::dlq_row_to_entry(py, r)).transpose())
             })
@@ -2769,6 +2767,7 @@ impl PyClient {
         allow_all: bool,
     ) -> PyResult<u64> {
         let pool = self.pool.clone();
+        let metrics = self.metrics.clone();
         let kind_attr = kind.clone();
         let queue_attr = queue.clone();
         py.detach(|| {
@@ -2783,7 +2782,7 @@ impl PyClient {
                 .await
                 .map_err(map_awa_error)?;
                 if count > 0 {
-                    awa_worker::AwaMetrics::from_global().record_dlq_moved_bulk(
+                    metrics.record_dlq_moved_bulk(
                         kind_attr.as_deref(),
                         queue_attr.as_deref(),
                         &reason,
@@ -2797,6 +2796,7 @@ impl PyClient {
 
     fn purge_dlq_job_sync(&self, py: Python<'_>, job_id: i64) -> PyResult<bool> {
         let pool = self.pool.clone();
+        let metrics = self.metrics.clone();
         py.detach(|| {
             pyo3_async_runtimes::tokio::get_runtime().block_on(async {
                 let queue = awa_model::dlq::get_dlq_job(&pool, job_id)
@@ -2807,7 +2807,7 @@ impl PyClient {
                     .await
                     .map_err(map_awa_error)?;
                 if deleted {
-                    awa_worker::AwaMetrics::from_global().record_dlq_purged(queue.as_deref(), 1);
+                    metrics.record_dlq_purged(queue.as_deref(), 1);
                 }
                 Ok(deleted)
             })
@@ -2827,6 +2827,7 @@ impl PyClient {
         allow_all: bool,
     ) -> PyResult<u64> {
         let pool = self.pool.clone();
+        let metrics = self.metrics.clone();
         let queue_attr = queue.clone();
         let filter = crate::dlq::build_filter(kind, queue, tag, before_id, before_dlq_at, None);
         py.detach(|| {
@@ -2835,8 +2836,7 @@ impl PyClient {
                     .await
                     .map_err(map_awa_error)?;
                 if count > 0 {
-                    awa_worker::AwaMetrics::from_global()
-                        .record_dlq_purged(queue_attr.as_deref(), count);
+                    metrics.record_dlq_purged(queue_attr.as_deref(), count);
                 }
                 Ok(count)
             })

--- a/awa-python/src/client.rs
+++ b/awa-python/src/client.rs
@@ -2164,10 +2164,16 @@ impl PyClient {
                 ..Default::default()
             })
             .map_err(map_awa_error)?;
+            let started = std::time::Instant::now();
             let count = store
                 .enqueue_params_copy(&pool, &insert_params)
                 .await
                 .map_err(map_awa_error)?;
+            awa_worker::AwaMetrics::from_global().record_enqueue_batch(
+                &queue,
+                count as u64,
+                started.elapsed(),
+            );
             Ok(count)
         })
     }
@@ -2226,10 +2232,17 @@ impl PyClient {
                     ..Default::default()
                 })
                 .map_err(map_awa_error)?;
-                store
+                let started = std::time::Instant::now();
+                let count = store
                     .enqueue_params_copy(&pool, &insert_params)
                     .await
-                    .map_err(map_awa_error)
+                    .map_err(map_awa_error)?;
+                awa_worker::AwaMetrics::from_global().record_enqueue_batch(
+                    &queue,
+                    count as u64,
+                    started.elapsed(),
+                );
+                Ok(count)
             })
         })
     }

--- a/awa-python/src/client.rs
+++ b/awa-python/src/client.rs
@@ -379,6 +379,11 @@ pub struct PyClient {
     job_kind_descriptors: Arc<Mutex<HashMap<String, JobKindDescriptor>>>,
     lifecycle: Arc<Mutex<RuntimeLifecycle>>,
     runtime: Arc<Mutex<Option<Arc<awa_worker::Client>>>>,
+    /// Cached `AwaMetrics` handle. `AwaMetrics::from_global()` builds the
+    /// full instrument set on every call; on hot paths (per-batch
+    /// `enqueue_many_copy` recording in particular) we keep one instance
+    /// and reuse it.
+    metrics: awa_worker::AwaMetrics,
 }
 
 #[pymethods]
@@ -413,6 +418,7 @@ impl PyClient {
             job_kind_descriptors: Arc::new(Mutex::new(HashMap::new())),
             lifecycle: Arc::new(Mutex::new(RuntimeLifecycle::Idle)),
             runtime: Arc::new(Mutex::new(None)),
+            metrics: awa_worker::AwaMetrics::from_global(),
         })
     }
 
@@ -2135,6 +2141,7 @@ impl PyClient {
         }
 
         let pool = self.pool.clone();
+        let metrics = self.metrics.clone();
         let insert_params = prepare_insert_many_params(
             py,
             &jobs,
@@ -2169,11 +2176,7 @@ impl PyClient {
                 .enqueue_params_copy(&pool, &insert_params)
                 .await
                 .map_err(map_awa_error)?;
-            awa_worker::AwaMetrics::from_global().record_enqueue_batch(
-                &queue,
-                count as u64,
-                started.elapsed(),
-            );
+            metrics.record_enqueue_batch(&queue, count as u64, started.elapsed());
             Ok(count)
         })
     }
@@ -2202,6 +2205,7 @@ impl PyClient {
         }
 
         let pool = self.pool.clone();
+        let metrics = self.metrics.clone();
         let insert_params = prepare_insert_many_params(
             py,
             &jobs,
@@ -2237,11 +2241,7 @@ impl PyClient {
                     .enqueue_params_copy(&pool, &insert_params)
                     .await
                     .map_err(map_awa_error)?;
-                awa_worker::AwaMetrics::from_global().record_enqueue_batch(
-                    &queue,
-                    count as u64,
-                    started.elapsed(),
-                );
+                metrics.record_enqueue_batch(&queue, count as u64, started.elapsed());
                 Ok(count)
             })
         })

--- a/awa-ui/src/handlers/dlq.rs
+++ b/awa-ui/src/handlers/dlq.rs
@@ -2,7 +2,6 @@ use axum::extract::{Path, Query, State};
 use axum::Json;
 use serde::{Deserialize, Serialize};
 
-use awa_metrics::AwaMetrics;
 use awa_model::dlq::{self, DlqRow, ListDlqFilter, RetryFromDlqOpts};
 
 use crate::error::ApiError;
@@ -101,7 +100,7 @@ pub async fn retry_dlq_job(
         .map(|row| row.job.queue);
     let job = dlq::retry_from_dlq(&state.pool, job_id, &opts).await?;
     if job.is_some() {
-        AwaMetrics::from_global().record_dlq_retried(source_queue.as_deref(), 1);
+        state.metrics.record_dlq_retried(source_queue.as_deref(), 1);
     }
     Ok(Json(job))
 }
@@ -139,7 +138,9 @@ pub async fn bulk_retry_dlq(
     };
     let count = dlq::bulk_retry_from_dlq(&state.pool, &filter, payload.all).await?;
     if count > 0 {
-        AwaMetrics::from_global().record_dlq_retried(queue_attr.as_deref(), count);
+        state
+            .metrics
+            .record_dlq_retried(queue_attr.as_deref(), count);
     }
     Ok(Json(CountResponse { count }))
 }
@@ -157,7 +158,7 @@ pub async fn purge_dlq_job(
     let deleted = dlq::purge_dlq_job(&state.pool, job_id).await?;
     let count = if deleted { 1 } else { 0 };
     if count > 0 {
-        AwaMetrics::from_global().record_dlq_purged(queue.as_deref(), count);
+        state.metrics.record_dlq_purged(queue.as_deref(), count);
     }
     Ok(Json(CountResponse { count }))
 }
@@ -176,7 +177,9 @@ pub async fn bulk_purge_dlq(
     };
     let count = dlq::purge_dlq(&state.pool, &filter, payload.all).await?;
     if count > 0 {
-        AwaMetrics::from_global().record_dlq_purged(queue_attr.as_deref(), count);
+        state
+            .metrics
+            .record_dlq_purged(queue_attr.as_deref(), count);
     }
     Ok(Json(CountResponse { count }))
 }
@@ -215,7 +218,7 @@ pub async fn bulk_move_failed(
     )
     .await?;
     if count > 0 {
-        AwaMetrics::from_global().record_dlq_moved_bulk(
+        state.metrics.record_dlq_moved_bulk(
             payload.kind.as_deref(),
             payload.queue.as_deref(),
             &payload.reason,

--- a/awa-ui/src/state.rs
+++ b/awa-ui/src/state.rs
@@ -1,5 +1,6 @@
 use std::time::Duration;
 
+use awa_metrics::AwaMetrics;
 use serde::Serialize;
 use sqlx::PgPool;
 
@@ -15,6 +16,10 @@ pub struct AppState {
     /// Suggested frontend poll interval — at least as long as the cache TTL
     /// so clients don't poll faster than the cache can refresh.
     pub poll_interval_ms: u64,
+    /// Cached `AwaMetrics` handle. `AwaMetrics::from_global()` rebuilds the
+    /// full instrument set on every call, so we construct it once here and
+    /// share it across request handlers.
+    pub metrics: AwaMetrics,
 }
 
 impl AppState {
@@ -31,6 +36,7 @@ impl AppState {
             cache: DashboardCache::new(cache_ttl),
             callback_hmac_secret,
             poll_interval_ms,
+            metrics: AwaMetrics::from_global(),
         }
     }
 

--- a/docs/deploying-on-managed-postgres.md
+++ b/docs/deploying-on-managed-postgres.md
@@ -1,0 +1,221 @@
+# Deploying awa on managed Postgres
+
+This page collects the operational gotchas and sizing data we learned
+running awa workers against Google Cloud SQL and AlloyDB in staging.
+Most of it applies to any managed Postgres (Amazon RDS / Aurora, Azure
+Database for PostgreSQL, etc.); GCP-specific advice is called out.
+
+The reference data here was captured on a single 4-pod consumer × 4-pod
+producer fleet against a dedicated benchmarking database on each
+engine, with `enqueue_shards = 16` and the queue-storage direct COPY
+producer path. See [`benchmarking.md`](benchmarking.md) for methodology
+and the `awa-bench-driver` reports for raw numbers and EXPLAIN traces.
+
+## Pick a Postgres version
+
+**Use Postgres 18 if it's available.** On AlloyDB specifically we
+measured a hard cap at 4 vCPU on PG17 (~2 k jobs/s sustained, with
+`AccessShareLock` waiters queueing behind ring-rotation
+`ACCESS EXCLUSIVE` operations from the maintenance loop) that
+disappeared after an in-place upgrade to PG18 — the same 4 vCPU
+instance jumped to ~5 k jobs/s sustained, matching Cloud SQL PG18 at
+the same shape exactly.
+
+Cloud SQL on PG17 is fine in our measurements; we did not see the same
+cap there. If you're on AlloyDB PG17 today and considering an upgrade
+for other reasons, awa throughput is one more reason to do it.
+
+## Pick a vCPU size
+
+The numbers below are *steady-state job completion* and *burst enqueue*
+on the queue-storage direct COPY producer path with `bench.noop`
+handlers (no per-job work). Real handlers reduce the consumer side
+proportionally; the burst-enqueue side is producer-bound and largely
+indifferent to handler cost.
+
+| Engine | vCPU | PG | Sustained completed | 1 M spike enqueue | 1 M backlog drain |
+|---|---:|---:|---:|---:|---:|
+| Cloud SQL | 1  | 17 | ~500   jobs/s | ~40,000 inserts/s | — |
+| Cloud SQL | 4  | 18 | ~5,000 jobs/s | ~70,000 inserts/s | — |
+| Cloud SQL | 16 | 18 | ~14,000 jobs/s | ~77,000 inserts/s | ~14,000 jobs/s |
+| AlloyDB  | 4  | 18 | ~5,200 jobs/s | ~52,000 inserts/s | ~9,000 jobs/s |
+
+Reading the table:
+
+- **Sustained completed** scales roughly linearly with vCPU on Cloud
+  SQL PG18: 4 → 5 k/s, 16 → 14 k/s. AlloyDB PG18 4 vCPU matches Cloud
+  SQL PG18 4 vCPU end-to-end at this scale.
+- **Burst enqueue rate** saturates near 70–80 k/s on any 4 vCPU or
+  larger instance — the bottleneck is the producer-side COPY pipeline
+  and connection fan-out, not the DB CPU. Even a 1 vCPU Cloud SQL
+  absorbed 1 M jobs at 40 k/s.
+- **Backlog drain** matches the steady-state completion rate after
+  awa-model v021 (PR #263) — heavy depth no longer collapses the
+  dispatcher to ~10× slower than equilibrium.
+
+Sizing rule of thumb: pick the vCPU count for your steady-state
+completion target, not the burst. Burst-only workloads can run on
+much smaller instances than their peak insertion rate would suggest.
+
+## IAM and Cloud SQL connectivity
+
+The runtime needs schema-owner privileges to call `prepare_schema`
+(which idempotently creates partitions, indexes, and sequences during
+worker startup) and to run migrations.
+
+### Cloud SQL with IAM authentication
+
+If your runtime SA authenticates via Cloud SQL IAM (recommended over
+password-based auth in GCP), the SA needs `cloudsqlsuperuser` to call
+`CREATE SEQUENCE`, `CREATE TABLE`, and a handful of other DDL the
+queue-storage substrate uses. Granting the role is a one-shot manual
+step — Cloud SQL doesn't expose it through the IAM grant — so it
+typically lives next to your Terraform that creates the IAM user:
+
+```sql
+-- Run once per instance as a built-in superuser (e.g. `postgres`).
+GRANT cloudsqlsuperuser TO "operator@PROJECT.iam";
+```
+
+If you skip this, the first worker startup against a fresh DB will
+fail with `permission denied to create database` or similar, and your
+migrate job will hang waiting for DDL it can't issue.
+
+### AlloyDB
+
+AlloyDB grants `alloydbsuperuser` to IAM SAs automatically — no manual
+GRANT step needed.
+
+### Cloud SQL Auth Proxy / AlloyDB Auth Proxy as a native sidecar
+
+Both Cloud SQL Auth Proxy 2.x and AlloyDB Auth Proxy 1.x work well as
+Kubernetes native sidecars (initContainer with `restartPolicy:
+Always`) — preferable to a regular container because the proxy starts
+before the main container and the lifecycle is tied to the pod.
+Example consumer-pod fragment:
+
+```yaml
+spec:
+  serviceAccountName: awa-runtime
+  initContainers:
+    - name: auth-proxy
+      image: gcr.io/cloud-sql-connectors/cloud-sql-proxy:2.13.0
+      imagePullPolicy: IfNotPresent
+      restartPolicy: Always               # makes it a native sidecar
+      args:
+        - "--auto-iam-authn"
+        - "--port=5432"
+        - "PROJECT:REGION:INSTANCE"
+      resources:
+        requests: { cpu: 100m, memory: 128Mi }
+        limits:   { cpu: 500m, memory: 256Mi }
+  containers:
+    - name: worker
+      image: ghcr.io/your-org/your-worker:tag
+      env:
+        - name: DATABASE_URL
+          value: "postgres://operator%40PROJECT.iam@127.0.0.1:5432/your_db?sslmode=disable"
+```
+
+The same shape works for AlloyDB; swap the image to
+`gcr.io/alloydb-connectors/alloydb-auth-proxy:1.13.0` and the
+connection arg to
+`projects/PROJECT/locations/REGION/clusters/CLUSTER/instances/INSTANCE`.
+
+## `enqueue_shards`: set this explicitly
+
+The default `awa.queue_meta.enqueue_shards = 1` means every producer
+contends on a single enqueue-head row per `(queue, priority)`. With
+multiple concurrent producers this serialises the entire enqueue path.
+
+**Recommendation: insert a `queue_meta` row for every queue you create,
+with `enqueue_shards` set to at least 4.** A 16-producer same-queue
+sweep in awa's own benchmark measured 1.0× / 1.60× / 2.75× / 3.69× at
+S=1/2/4/8 — that's about a 2.75× lift from S=1 to S=4 on a contended
+queue. The staging benchmark sweep at S=4/8/16/32 (a different,
+4-producer setup with the producer not the bottleneck) showed no
+material difference between those values at 10 k offered.
+
+```sql
+INSERT INTO awa.queue_meta (queue, enqueue_shards)
+VALUES ('your_queue', 4)
+ON CONFLICT (queue)
+DO UPDATE SET enqueue_shards = EXCLUDED.enqueue_shards;
+```
+
+Use an upsert — first-enqueue may create lane rows before any operator
+inserts a `queue_meta` row, so a plain `UPDATE` can quietly affect zero
+rows.
+
+Going higher than 4 only helps when producer-side head-row contention
+is your bottleneck; raise it after measuring. Lowering it later is
+safe (see [`upgrade-0.5-to-0.6.md`](upgrade-0.5-to-0.6.md#lowering-enqueue_shards))
+but the FIFO contract changes — see
+[`configuration.md`](configuration.md#sharding-the-enqueue-head-per-queue)
+and [ADR-025](adr/025-sharded-enqueue-heads.md).
+
+## Producer path: use the direct COPY entry point
+
+For any high-volume producer running against managed Postgres (rather
+than a Docker-localhost benchmark) prefer the queue-storage native
+COPY path:
+
+- **Rust:** `QueueStorage::enqueue_params_copy(pool, &jobs)`.
+- **Python:** `client.enqueue_many_copy(jobs)`.
+
+The compat-friendly `insert_many_copy_from_pool` / `client.insert_many_copy`
+path routes each row through the `awa.insert_job_compat()` SQL function
+once per row. On a real DB the per-row function-call cost (lane head
+update, NOTIFY, admin metadata) sums to ~100–150 ms per row on
+AlloyDB through the auth-proxy — fine when the goal is "one writer,
+strict compatibility", catastrophic when the goal is "burst 10⁶ jobs
+in seconds." The direct path runs at the inserts-per-second numbers in
+the sizing table above.
+
+See [`configuration.md`](configuration.md#producer-path-choice) for the
+full surface comparison.
+
+## Things that broke for us in staging — worth pre-empting
+
+These all eventually have fixes or workarounds, but each one cost
+hours the first time:
+
+- **Concurrent worker startup on a fresh DB can hang `prepare_schema`.**
+  All N consumer pods race to do `CREATE SEQUENCE IF NOT EXISTS
+  awa.job_id_seq` and (especially on PG18) block indefinitely. Until
+  this is fixed in the runtime (tracked as
+  [#264](https://github.com/hardbyte/awa/issues/264)), bring the
+  runtime up with `replicas=1` first, let it finish `prepare_schema`,
+  then scale to your target replica count. Or pre-create
+  `awa.job_id_seq` as part of your deploy pipeline.
+
+- **`pg_stat_activity` shows nothing during the hang.** No active
+  query, no error log — just consumer pods sitting on "Starting Awa
+  worker runtime" forever. Don't waste time hunting for a stuck query;
+  go straight to a manual rollout / replica reduction.
+
+- **PG18-on-AlloyDB upgrade preserves the schema and v021 indexes
+  across the cut-over.** No re-bootstrap needed; just verify the
+  upgrade completed cleanly with `gcloud alloydb clusters describe`
+  showing `databaseVersion: POSTGRES_18` and run a smoke
+  enqueue/claim.
+
+- **Cloud SQL `must be owner of database` errors when cleaning up.**
+  Test databases created by `partly_staging` (or whatever non-IAM user
+  ran your migration job) can't be dropped by the IAM SA. Use the
+  built-in `postgres` user via password from the
+  `*-postgres-password` Secret Manager secret, or grant ownership over
+  before dropping.
+
+## Next
+
+- [Configuration knobs](configuration.md) — `enqueue_shards`, claimers,
+  retention, etc.
+- [PostgreSQL roles and privileges](security.md) — the SQL grants the
+  runtime expects.
+- [Migration guide](migrations.md) — schema version table and upgrade
+  ordering, including v021's shard-aware lane indexes.
+- [Deployment guide](deployment.md) — generic deployment patterns
+  (Docker, K8s, rolling deploys) not specific to managed Postgres.
+- [Benchmarking notes](benchmarking.md) — the in-repo benchmark
+  harness and reference numbers.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -260,6 +260,7 @@ If you expose the callback receiver endpoints for `HttpWorker`, also configure
 
 ## Next
 
+- [Deploying on managed Postgres](deploying-on-managed-postgres.md) — Cloud SQL / AlloyDB specifics, sizing data, IAM grants, auth-proxy sidecar
 - [PostgreSQL roles and privileges](security.md)
 - [Migration guide](migrations.md)
 - [Configuration](configuration.md)


### PR DESCRIPTION
## Summary

Two related additions falling out of an awa-bench-driver staging run.

- **`docs/deploying-on-managed-postgres.md`** — Cloud SQL / AlloyDB specifics that aren't covered in the existing benchmarking / configuration / deployment docs. Per-vCPU sizing numbers, PG18-on-AlloyDB recommendation (with measurement), IAM `cloudsqlsuperuser` GRANT for first-connect, auth-proxy native-sidecar pattern, `enqueue_shards` recommendation (linking to existing config docs), and a "things that broke for us, worth pre-empting" section linking to #264.

- **Producer-side timing observability.** `awa.enqueue.batch_size` and `awa.enqueue.duration` histograms on `AwaMetrics`, recorded by the Python binding's `enqueue_many_copy` / `enqueue_many_copy_sync`. Producers using the direct queue-storage COPY path couldn't tell from existing metrics whether a missed enqueue rate was \"batches are tiny\" or \"batches are slow\" — these histograms split that signal directly. Rust callers using `QueueStorage::enqueue_params_copy` directly can call `AwaMetrics::from_global().record_enqueue_batch(queue, count, duration)` themselves; a thin `awa::enqueue_many_copy` Rust facade that wraps this is a natural follow-up (out of scope here).

## Headline numbers powering the docs page

| Engine | vCPU | PG | Sustained completed | 1M spike enqueue |
|---|---:|---:|---:|---:|
| AlloyDB | 4 | 18 | ~5,200 jobs/s | ~52,000 inserts/s |
| Cloud SQL | 1 | 17 | ~500 jobs/s | ~40,000 inserts/s |
| Cloud SQL | 4 | 18 | ~5,000 jobs/s | ~70,000 inserts/s |
| Cloud SQL | 16 | 18 | ~14,000 jobs/s | ~77,000 inserts/s |

The headline PG17→PG18 finding on AlloyDB: same instance, same v021 schema, same image, same vCPU — `~2k` jobs/s sustained on PG17 (with `AccessShareLock` waiters queueing behind ring-rotation `ACCESS EXCLUSIVE`) became `~5.2k` jobs/s on PG18, matching Cloud SQL PG18 at the same vCPU exactly. PG17 had a real ceiling AlloyDB-side that PG18 cleared.

## Validation

- `SQLX_OFFLINE=true cargo check -p awa-metrics`
- `SQLX_OFFLINE=true cargo check -p awa-worker`
- `cargo check` on `awa-python` (excluded from workspace, ran in its own dir)
- `cargo fmt --all -- --check`
- Existing tests not run in this branch — Brian to run the full suite locally before merge.

## Test plan

- [ ] `cargo test --workspace`
- [ ] `cargo test` inside `awa-python/` (or `maturin develop` + the Python test suite)
- [ ] Sanity-render `docs/deploying-on-managed-postgres.md` on GitHub and click every cross-link

## Out of scope (deliberately)

- A Rust `awa::enqueue_many_copy` facade that records the metric automatically — left for a follow-up so this PR doesn't touch the awa-model → awa-metrics dependency graph.
- Wiring the new histograms into the in-repo benchmark harness in `awa/tests/queue_storage_benchmark_test.rs`. Could be added in the same follow-up.
- Filing the `awa.enqueue.shard` attribute on the new histograms — would let dashboards split p99 enqueue duration per shard. Tracked mentally; happy to add if reviewers want.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added observability metrics for bulk enqueue operations to track batch job counts and enqueue durations.

* **Documentation**
  * New comprehensive guide for deploying on managed Postgres (Cloud SQL/AlloyDB) covering sizing, IAM requirements, auth-proxy setup, and operational gotchas.
  * Updated deployment documentation with navigation to managed Postgres guidance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hardbyte/awa/pull/265?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->