### PR TITLE
Fix queue-storage prepare_schema startup race

### DIFF
--- a/awa-model/src/queue_storage.rs
+++ b/awa-model/src/queue_storage.rs
@@ -2008,17 +2008,23 @@ impl QueueStorage {
     pub async fn prepare_schema(&self, pool: &PgPool) -> Result<(), AwaError> {
         let schema = self.schema();
         let install_lock_name = format!("awa.queue_storage.install:{schema}");
-        let mut install_lock_conn = pool.acquire().await.map_err(map_sqlx_error)?;
+        let mut install_tx = pool.begin().await.map_err(map_sqlx_error)?;
 
-        sqlx::query("SELECT pg_advisory_lock(hashtextextended($1, 0))")
+        sqlx::query("SELECT pg_advisory_xact_lock(hashtextextended($1, 0))")
             .bind(&install_lock_name)
-            .execute(install_lock_conn.as_mut())
+            .execute(install_tx.as_mut())
             .await
             .map_err(map_sqlx_error)?;
 
+        macro_rules! install_db {
+            () => {
+                install_tx.as_mut()
+            };
+        }
+
         let install_result = async {
             sqlx::query(&format!("CREATE SCHEMA IF NOT EXISTS {schema}"))
-                .execute(pool)
+                .execute(install_db!())
                 .await
                 .map_err(map_sqlx_error)?;
 
@@ -2041,14 +2047,14 @@ impl QueueStorage {
                 "#,
             )
             .bind(schema)
-            .fetch_one(pool)
+            .fetch_one(install_db!())
             .await
             .map_err(map_sqlx_error)?;
             if open_receipt_claims_exists {
                 let row_count: i64 = sqlx::query_scalar(&format!(
                     "SELECT count(*)::bigint FROM {schema}.open_receipt_claims"
                 ))
-                .fetch_one(pool)
+                .fetch_one(install_db!())
                 .await
                 .map_err(map_sqlx_error)?;
                 if row_count > 0 {
@@ -2062,7 +2068,7 @@ impl QueueStorage {
                 sqlx::query(&format!(
                     "DROP TABLE IF EXISTS {schema}.open_receipt_claims CASCADE"
                 ))
-                .execute(pool)
+                .execute(install_db!())
                 .await
                 .map_err(map_sqlx_error)?;
             }
@@ -2198,7 +2204,7 @@ impl QueueStorage {
                 CREATE SEQUENCE IF NOT EXISTS {schema}.job_id_seq
                 "#
             ))
-            .execute(pool)
+            .execute(install_db!())
             .await
             .map_err(map_sqlx_error)?;
 
@@ -2212,7 +2218,7 @@ impl QueueStorage {
             )
             "#
             ))
-            .execute(pool)
+            .execute(install_db!())
             .await
             .map_err(map_sqlx_error)?;
 
@@ -2232,7 +2238,7 @@ impl QueueStorage {
             )
             "#
             ))
-            .execute(pool)
+            .execute(install_db!())
             .await
             .map_err(map_sqlx_error)?;
 
@@ -2244,7 +2250,7 @@ impl QueueStorage {
             "#
             ))
             .bind(self.queue_slot_count() as i32)
-            .execute(pool)
+            .execute(install_db!())
             .await
             .map_err(map_sqlx_error)?;
 
@@ -2256,7 +2262,7 @@ impl QueueStorage {
             )
             "#
             ))
-            .execute(pool)
+            .execute(install_db!())
             .await
             .map_err(map_sqlx_error)?;
 
@@ -2271,7 +2277,7 @@ impl QueueStorage {
             )
             "#
             ))
-            .execute(pool)
+            .execute(install_db!())
             .await
             .map_err(map_sqlx_error)?;
 
@@ -2285,7 +2291,7 @@ impl QueueStorage {
             )
             "#
             ))
-            .execute(pool)
+            .execute(install_db!())
             .await
             .map_err(map_sqlx_error)?;
 
@@ -2300,7 +2306,7 @@ impl QueueStorage {
             )
             "#
             ))
-            .execute(pool)
+            .execute(install_db!())
             .await
             .map_err(map_sqlx_error)?;
 
@@ -2312,7 +2318,7 @@ impl QueueStorage {
             "#
             ))
             .bind(self.lease_slot_count() as i32)
-            .execute(pool)
+            .execute(install_db!())
             .await
             .map_err(map_sqlx_error)?;
 
@@ -2324,7 +2330,7 @@ impl QueueStorage {
             )
             "#
             ))
-            .execute(pool)
+            .execute(install_db!())
             .await
             .map_err(map_sqlx_error)?;
 
@@ -2339,7 +2345,7 @@ impl QueueStorage {
             )
             "#
             ))
-            .execute(pool)
+            .execute(install_db!())
             .await
             .map_err(map_sqlx_error)?;
 
@@ -2359,7 +2365,7 @@ impl QueueStorage {
             )
             "#
             ))
-            .execute(pool)
+            .execute(install_db!())
             .await
             .map_err(map_sqlx_error)?;
 
@@ -2374,7 +2380,7 @@ impl QueueStorage {
             )
             "#
             ))
-            .execute(pool)
+            .execute(install_db!())
             .await
             .map_err(map_sqlx_error)?;
 
@@ -2386,7 +2392,7 @@ impl QueueStorage {
             "#
             ))
             .bind(self.claim_slot_count() as i32)
-            .execute(pool)
+            .execute(install_db!())
             .await
             .map_err(map_sqlx_error)?;
 
@@ -2398,7 +2404,7 @@ impl QueueStorage {
             )
             "#
             ))
-            .execute(pool)
+            .execute(install_db!())
             .await
             .map_err(map_sqlx_error)?;
 
@@ -2413,7 +2419,7 @@ impl QueueStorage {
             )
             "#
             ))
-            .execute(pool)
+            .execute(install_db!())
             .await
             .map_err(map_sqlx_error)?;
 
@@ -2429,7 +2435,7 @@ impl QueueStorage {
             )
             "#
             ))
-            .execute(pool)
+            .execute(install_db!())
             .await
             .map_err(map_sqlx_error)?;
 
@@ -2444,7 +2450,7 @@ impl QueueStorage {
             )
             "#
             ))
-            .execute(pool)
+            .execute(install_db!())
             .await
             .map_err(map_sqlx_error)?;
 
@@ -2466,7 +2472,7 @@ impl QueueStorage {
             )
             "#
             ))
-            .execute(pool)
+            .execute(install_db!())
             .await
             .map_err(map_sqlx_error)?;
 
@@ -2481,7 +2487,7 @@ impl QueueStorage {
             )
             "#
             ))
-            .execute(pool)
+            .execute(install_db!())
             .await
             .map_err(map_sqlx_error)?;
 
@@ -2496,7 +2502,7 @@ impl QueueStorage {
             )
             "#
             ))
-            .execute(pool)
+            .execute(install_db!())
             .await
             .map_err(map_sqlx_error)?;
 
@@ -2510,7 +2516,7 @@ impl QueueStorage {
             )
             "#
             ))
-            .execute(pool)
+            .execute(install_db!())
             .await
             .map_err(map_sqlx_error)?;
 
@@ -2524,7 +2530,7 @@ impl QueueStorage {
             sqlx::query(&format!(
                 "DROP TABLE IF EXISTS {schema}.queue_count_snapshots"
             ))
-            .execute(pool)
+            .execute(install_db!())
             .await
             .map_err(map_sqlx_error)?;
 
@@ -2542,7 +2548,7 @@ impl QueueStorage {
             )
             "#
             ))
-            .execute(pool)
+            .execute(install_db!())
             .await
             .map_err(map_sqlx_error)?;
 
@@ -2564,7 +2570,7 @@ impl QueueStorage {
             )
             "#
             ))
-            .execute(pool)
+            .execute(install_db!())
             .await
             .map_err(map_sqlx_error)?;
 
@@ -2577,7 +2583,7 @@ impl QueueStorage {
             )
             "#
             ))
-            .execute(pool)
+            .execute(install_db!())
             .await
             .map_err(map_sqlx_error)?;
 
@@ -2601,7 +2607,7 @@ impl QueueStorage {
             DROP INDEX IF EXISTS {schema}.idx_{schema}_queue_claimer_leases_owner
             "#
             ))
-            .execute(pool)
+            .execute(install_db!())
             .await
             .map_err(map_sqlx_error)?;
 
@@ -2611,11 +2617,10 @@ impl QueueStorage {
                 ON {schema}.queue_claimer_leases (queue, owner_instance_id)
             "#
             ))
-            .execute(pool)
+            .execute(install_db!())
             .await
             .map_err(map_sqlx_error)?;
 
-            let mut backfill_tx = pool.begin().await.map_err(map_sqlx_error)?;
             sqlx::query(&format!(
                 r#"
             INSERT INTO {schema}.queue_enqueue_heads AS heads (
@@ -2634,7 +2639,7 @@ impl QueueStorage {
             SET next_seq = GREATEST(heads.next_seq, EXCLUDED.next_seq)
             "#
             ))
-            .execute(backfill_tx.as_mut())
+            .execute(install_db!())
             .await
             .map_err(map_sqlx_error)?;
 
@@ -2656,7 +2661,7 @@ impl QueueStorage {
             SET claim_seq = GREATEST(heads.claim_seq, EXCLUDED.claim_seq)
             "#
             ))
-            .execute(backfill_tx.as_mut())
+            .execute(install_db!())
             .await
             .map_err(map_sqlx_error)?;
 
@@ -2680,7 +2685,7 @@ impl QueueStorage {
             )
             "#
             ))
-            .execute(backfill_tx.as_mut())
+            .execute(install_db!())
             .await
             .map_err(map_sqlx_error)?;
 
@@ -2691,11 +2696,9 @@ impl QueueStorage {
             WHERE pruned_completed_count > 0
             "#
             ))
-            .execute(backfill_tx.as_mut())
+            .execute(install_db!())
             .await
             .map_err(map_sqlx_error)?;
-
-            backfill_tx.commit().await.map_err(map_sqlx_error)?;
 
             sqlx::query(
                 r#"
@@ -2706,7 +2709,7 @@ impl QueueStorage {
             )
             "#,
             )
-            .execute(pool)
+            .execute(install_db!())
             .await
             .map_err(map_sqlx_error)?;
 
@@ -2735,7 +2738,7 @@ impl QueueStorage {
             ) PARTITION BY LIST (lease_slot)
             "#
             ))
-            .execute(pool)
+            .execute(install_db!())
             .await
             .map_err(map_sqlx_error)?;
 
@@ -2757,7 +2760,7 @@ impl QueueStorage {
                 "#,
             )
             .bind(schema)
-            .fetch_optional(pool)
+            .fetch_optional(install_db!())
             .await
             .map_err(map_sqlx_error)?;
 
@@ -2770,7 +2773,7 @@ impl QueueStorage {
                 "#,
             )
             .bind(schema)
-            .fetch_optional(pool)
+            .fetch_optional(install_db!())
             .await
             .map_err(map_sqlx_error)?;
 
@@ -2780,7 +2783,7 @@ impl QueueStorage {
                 sqlx::query(&format!(
                     "ALTER TABLE {schema}.lease_claims RENAME TO lease_claims_legacy"
                 ))
-                .execute(pool)
+                .execute(install_db!())
                 .await
                 .map_err(map_sqlx_error)?;
             }
@@ -2788,7 +2791,7 @@ impl QueueStorage {
                 sqlx::query(&format!(
                     "ALTER TABLE {schema}.lease_claim_closures RENAME TO lease_claim_closures_legacy"
                 ))
-                .execute(pool)
+                .execute(install_db!())
                 .await
                 .map_err(map_sqlx_error)?;
             }
@@ -2814,7 +2817,7 @@ impl QueueStorage {
             ) PARTITION BY LIST (claim_slot)
             "#
             ))
-            .execute(pool)
+            .execute(install_db!())
             .await
             .map_err(map_sqlx_error)?;
 
@@ -2827,7 +2830,7 @@ impl QueueStorage {
                 ADD COLUMN IF NOT EXISTS deadline_at TIMESTAMPTZ
             "#
             ))
-            .execute(pool)
+            .execute(install_db!())
             .await
             .map_err(map_sqlx_error)?;
 
@@ -2839,7 +2842,7 @@ impl QueueStorage {
                 "#,
                     claim_child_name(schema, slot)
                 ))
-                .execute(pool)
+                .execute(install_db!())
                 .await
                 .map_err(map_sqlx_error)?;
             }
@@ -2850,7 +2853,7 @@ impl QueueStorage {
                 ON {schema}.lease_claims (materialized_at, claimed_at, job_id)
             "#
             ))
-            .execute(pool)
+            .execute(install_db!())
             .await
             .map_err(map_sqlx_error)?;
 
@@ -2865,7 +2868,7 @@ impl QueueStorage {
                 WITH (pages_per_range = 16)
             "#
             ))
-            .execute(pool)
+            .execute(install_db!())
             .await
             .map_err(map_sqlx_error)?;
 
@@ -2878,7 +2881,7 @@ impl QueueStorage {
                 ON {schema}.lease_claims (job_id, run_lease)
             "#
             ))
-            .execute(pool)
+            .execute(install_db!())
             .await
             .map_err(map_sqlx_error)?;
 
@@ -2898,12 +2901,12 @@ impl QueueStorage {
                 "#,
             )
             .bind(schema)
-            .fetch_one(pool)
+            .fetch_one(install_db!())
             .await
             .map_err(map_sqlx_error)?;
 
             if lease_claims_legacy_exists {
-                // Wrap the copy + drop in a single transaction so a
+                // The outer prepare_schema transaction keeps the copy + drop atomic so a
                 // crash between the two leaves the schema in one of
                 // exactly two states: pre-migration (legacy still
                 // there, partitioned parent empty) or post-migration
@@ -2912,7 +2915,6 @@ impl QueueStorage {
                 // and the next prepare_schema's
                 // `ON CONFLICT DO NOTHING` masks the inconsistency
                 // without surfacing it.
-                let mut migrate_tx = pool.begin().await.map_err(map_sqlx_error)?;
                 sqlx::query(&format!(
                     r#"
                 INSERT INTO {schema}.lease_claims (
@@ -2929,18 +2931,17 @@ impl QueueStorage {
                 ON CONFLICT (claim_slot, job_id, run_lease) DO NOTHING
                 "#
                 ))
-                .execute(migrate_tx.as_mut())
+                .execute(install_db!())
                 .await
                 .map_err(map_sqlx_error)?;
 
                 sqlx::query(&format!(
                     "DROP TABLE {schema}.lease_claims_legacy"
                 ))
-                .execute(migrate_tx.as_mut())
+                .execute(install_db!())
                 .await
                 .map_err(map_sqlx_error)?;
 
-                migrate_tx.commit().await.map_err(map_sqlx_error)?;
             }
 
             sqlx::query(&format!(
@@ -2955,7 +2956,7 @@ impl QueueStorage {
             ) PARTITION BY LIST (claim_slot)
             "#
             ))
-            .execute(pool)
+            .execute(install_db!())
             .await
             .map_err(map_sqlx_error)?;
 
@@ -2967,7 +2968,7 @@ impl QueueStorage {
                 "#,
                     closure_child_name(schema, slot)
                 ))
-                .execute(pool)
+                .execute(install_db!())
                 .await
                 .map_err(map_sqlx_error)?;
             }
@@ -2981,7 +2982,7 @@ impl QueueStorage {
                 ON {schema}.lease_claim_closures (job_id, run_lease)
             "#
             ))
-            .execute(pool)
+            .execute(install_db!())
             .await
             .map_err(map_sqlx_error)?;
 
@@ -2995,7 +2996,7 @@ impl QueueStorage {
                 "#,
             )
             .bind(schema)
-            .fetch_one(pool)
+            .fetch_one(install_db!())
             .await
             .map_err(map_sqlx_error)?;
 
@@ -3004,7 +3005,6 @@ impl QueueStorage {
                 // above for the rationale: copy + drop must be atomic
                 // so a crash leaves the schema either fully migrated
                 // or fully not.
-                let mut migrate_tx = pool.begin().await.map_err(map_sqlx_error)?;
                 sqlx::query(&format!(
                     r#"
                 INSERT INTO {schema}.lease_claim_closures (
@@ -3017,18 +3017,17 @@ impl QueueStorage {
                 ON CONFLICT (claim_slot, job_id, run_lease) DO NOTHING
                 "#
                 ))
-                .execute(migrate_tx.as_mut())
+                .execute(install_db!())
                 .await
                 .map_err(map_sqlx_error)?;
 
                 sqlx::query(&format!(
                     "DROP TABLE {schema}.lease_claim_closures_legacy"
                 ))
-                .execute(migrate_tx.as_mut())
+                .execute(install_db!())
                 .await
                 .map_err(map_sqlx_error)?;
 
-                migrate_tx.commit().await.map_err(map_sqlx_error)?;
             }
 
             sqlx::query(&format!(
@@ -3048,7 +3047,7 @@ impl QueueStorage {
             )
             "#
             ))
-            .execute(pool)
+            .execute(install_db!())
             .await
             .map_err(map_sqlx_error)?;
 
@@ -3058,7 +3057,7 @@ impl QueueStorage {
                 ADD COLUMN IF NOT EXISTS heartbeat_at TIMESTAMPTZ
             "#
             ))
-            .execute(pool)
+            .execute(install_db!())
             .await
             .map_err(map_sqlx_error)?;
 
@@ -3077,7 +3076,7 @@ impl QueueStorage {
             )
             "#
             ))
-            .execute(pool)
+            .execute(install_db!())
             .await
             .map_err(map_sqlx_error)?;
 
@@ -3106,7 +3105,7 @@ impl QueueStorage {
             ) PARTITION BY LIST (ready_slot)
             "#
             ))
-            .execute(pool)
+            .execute(install_db!())
             .await
             .map_err(map_sqlx_error)?;
 
@@ -3137,7 +3136,7 @@ impl QueueStorage {
             ) PARTITION BY LIST (ready_slot)
             "#
             ))
-            .execute(pool)
+            .execute(install_db!())
             .await
             .map_err(map_sqlx_error)?;
 
@@ -3161,7 +3160,7 @@ impl QueueStorage {
                 ALTER COLUMN created_at DROP DEFAULT
             "#
             ))
-            .execute(pool)
+            .execute(install_db!())
             .await
             .map_err(map_sqlx_error)?;
 
@@ -3176,7 +3175,7 @@ impl QueueStorage {
             {ready_join}
             "#
             ))
-            .execute(pool)
+            .execute(install_db!())
             .await
             .map_err(map_sqlx_error)?;
 
@@ -3204,7 +3203,7 @@ impl QueueStorage {
             )
             "#
             ))
-            .execute(pool)
+            .execute(install_db!())
             .await
             .map_err(map_sqlx_error)?;
 
@@ -3214,7 +3213,7 @@ impl QueueStorage {
                 ON {schema}.deferred_jobs (state, run_at, queue, priority, job_id)
             "#
             ))
-            .execute(pool)
+            .execute(install_db!())
             .await
             .map_err(map_sqlx_error)?;
 
@@ -3224,7 +3223,7 @@ impl QueueStorage {
                 ON {schema}.deferred_jobs (unique_key)
             "#
             ))
-            .execute(pool)
+            .execute(install_db!())
             .await
             .map_err(map_sqlx_error)?;
 
@@ -3253,7 +3252,7 @@ impl QueueStorage {
             )
             "#
             ))
-            .execute(pool)
+            .execute(install_db!())
             .await
             .map_err(map_sqlx_error)?;
 
@@ -3263,7 +3262,7 @@ impl QueueStorage {
                 ON {schema}.dlq_entries (queue, dlq_at DESC)
             "#
             ))
-            .execute(pool)
+            .execute(install_db!())
             .await
             .map_err(map_sqlx_error)?;
 
@@ -3275,7 +3274,7 @@ impl QueueStorage {
                 "#,
                     ready_child_name(schema, slot)
                 ))
-                .execute(pool)
+                .execute(install_db!())
                 .await
                 .map_err(map_sqlx_error)?;
 
@@ -3293,7 +3292,7 @@ impl QueueStorage {
                 "#,
                     ready_child_name(schema, slot)
                 ))
-                .execute(pool)
+                .execute(install_db!())
                 .await
                 .map_err(map_sqlx_error)?;
 
@@ -3304,7 +3303,7 @@ impl QueueStorage {
                 "#,
                     ready_child_name(schema, slot)
                 ))
-                .execute(pool)
+                .execute(install_db!())
                 .await
                 .map_err(map_sqlx_error)?;
 
@@ -3315,7 +3314,7 @@ impl QueueStorage {
                 "#,
                     done_child_name(schema, slot)
                 ))
-                .execute(pool)
+                .execute(install_db!())
                 .await
                 .map_err(map_sqlx_error)?;
 
@@ -3328,7 +3327,7 @@ impl QueueStorage {
                 "#,
                     done_child_name(schema, slot)
                 ))
-                .execute(pool)
+                .execute(install_db!())
                 .await
                 .map_err(map_sqlx_error)?;
 
@@ -3339,7 +3338,7 @@ impl QueueStorage {
                 "#,
                     done_child_name(schema, slot)
                 ))
-                .execute(pool)
+                .execute(install_db!())
                 .await
                 .map_err(map_sqlx_error)?;
             }
@@ -3352,7 +3351,7 @@ impl QueueStorage {
                 "#,
                     lease_child_name(schema, slot)
                 ))
-                .execute(pool)
+                .execute(install_db!())
                 .await
                 .map_err(map_sqlx_error)?;
 
@@ -3365,7 +3364,7 @@ impl QueueStorage {
                 "#,
                     lease_child_name(schema, slot)
                 ))
-                .execute(pool)
+                .execute(install_db!())
                 .await
                 .map_err(map_sqlx_error)?;
 
@@ -3376,7 +3375,7 @@ impl QueueStorage {
                 "#,
                     lease_child_name(schema, slot)
                 ))
-                .execute(pool)
+                .execute(install_db!())
                 .await
                 .map_err(map_sqlx_error)?;
 
@@ -3387,7 +3386,7 @@ impl QueueStorage {
                 "#,
                     lease_child_name(schema, slot)
                 ))
-                .execute(pool)
+                .execute(install_db!())
                 .await
                 .map_err(map_sqlx_error)?;
 
@@ -3398,7 +3397,7 @@ impl QueueStorage {
                 "#,
                     lease_child_name(schema, slot)
                 ))
-                .execute(pool)
+                .execute(install_db!())
                 .await
                 .map_err(map_sqlx_error)?;
 
@@ -3409,7 +3408,7 @@ impl QueueStorage {
                 "#,
                     lease_child_name(schema, slot)
                 ))
-                .execute(pool)
+                .execute(install_db!())
                 .await
                 .map_err(map_sqlx_error)?;
 
@@ -3420,7 +3419,7 @@ impl QueueStorage {
                 "#,
                     lease_child_name(schema, slot)
                 ))
-                .execute(pool)
+                .execute(install_db!())
                 .await
                 .map_err(map_sqlx_error)?;
 
@@ -3431,7 +3430,7 @@ impl QueueStorage {
                 "#,
                     lease_child_name(schema, slot)
                 ))
-                .execute(pool)
+                .execute(install_db!())
                 .await
                 .map_err(map_sqlx_error)?;
             }
@@ -3683,7 +3682,7 @@ impl QueueStorage {
             "#,
                 claimed_cte = claimed_cte
             ))
-            .execute(pool)
+            .execute(install_db!())
             .await
             .map_err(map_sqlx_error)?;
 
@@ -3697,7 +3696,7 @@ impl QueueStorage {
                 ))
                 .bind(slot as i32)
                 .bind(if slot == 0 { 0_i64 } else { -1_i64 })
-                .execute(pool)
+                .execute(install_db!())
                 .await
                 .map_err(map_sqlx_error)?;
             }
@@ -3712,7 +3711,7 @@ impl QueueStorage {
                 ))
                 .bind(slot as i32)
                 .bind(if slot == 0 { 0_i64 } else { -1_i64 })
-                .execute(pool)
+                .execute(install_db!())
                 .await
                 .map_err(map_sqlx_error)?;
             }
@@ -3727,7 +3726,7 @@ impl QueueStorage {
                 ))
                 .bind(slot as i32)
                 .bind(if slot == 0 { 0_i64 } else { -1_i64 })
-                .execute(pool)
+                .execute(install_db!())
                 .await
                 .map_err(map_sqlx_error)?;
             }
@@ -3736,18 +3735,12 @@ impl QueueStorage {
         }
         .await;
 
-        let unlock_result = sqlx::query("SELECT pg_advisory_unlock(hashtextextended($1, 0))")
-            .bind(&install_lock_name)
-            .execute(install_lock_conn.as_mut())
-            .await
-            .map(|_| ())
-            .map_err(map_sqlx_error);
-
-        match (install_result, unlock_result) {
-            (Ok(()), Ok(())) => Ok(()),
-            (Err(err), Ok(())) => Err(err),
-            (Ok(()), Err(err)) => Err(err),
-            (Err(err), Err(_)) => Err(err),
+        match install_result {
+            Ok(()) => install_tx.commit().await.map_err(map_sqlx_error),
+            Err(err) => {
+                let _ = install_tx.rollback().await;
+                Err(err)
+            }
         }
     }
 

--- a/awa-model/src/queue_storage.rs
+++ b/awa-model/src/queue_storage.rs
@@ -2004,6 +2004,23 @@ impl QueueStorage {
         self.sync_enqueue_unique_claims(tx, claims).await
     }
 
+    /// Idempotently install the queue-storage substrate (schema, tables,
+    /// indexes, functions) for this configuration.
+    ///
+    /// Runs entirely inside one transaction on a single pooled connection,
+    /// guarded by `pg_advisory_xact_lock` so concurrent worker startups
+    /// serialize cleanly rather than fighting over pool slots. The lock
+    /// auto-releases on COMMIT/ROLLBACK.
+    ///
+    /// **Note on index builds:** the `CREATE INDEX IF NOT EXISTS` calls
+    /// below are not `CONCURRENTLY` (Postgres bans `CONCURRENTLY` inside a
+    /// transaction). On a fresh install that's a no-op cost. On a redeploy
+    /// against a database that already has rows in the queue tables, each
+    /// fresh-index build takes `ShareUpdateExclusiveLock` on its table for
+    /// the duration of the build, and concurrent writers to that table
+    /// queue up. For typical operator scenarios this is bounded by the
+    /// `IF NOT EXISTS` guard — only the *new* indexes added by a runtime
+    /// upgrade get built; the rest are no-ops.
     #[tracing::instrument(skip(self, pool), name = "queue_storage.prepare_schema")]
     pub async fn prepare_schema(&self, pool: &PgPool) -> Result<(), AwaError> {
         let schema = self.schema();
@@ -2016,6 +2033,11 @@ impl QueueStorage {
             .await
             .map_err(map_sqlx_error)?;
 
+        // Each query needs its own `&mut` reborrow of `install_tx`; a
+        // helper function returning `&mut Tx<…>` would tangle the borrow
+        // checker because the returned reference would alias the function's
+        // own parameter. A declarative macro emits a fresh reborrow at every
+        // call site, which is what we need here.
         macro_rules! install_db {
             () => {
                 install_tx.as_mut()

--- a/awa-model/src/storage.rs
+++ b/awa-model/src/storage.rs
@@ -108,9 +108,17 @@ pub async fn queue_storage_schema_ready(pool: &PgPool, schema: &str) -> Result<b
     sqlx::query_scalar::<_, bool>(
         r#"
         SELECT
-            to_regclass(format('%I.%I', $1, 'queue_ring_state')) IS NOT NULL
+            to_regclass(format('%I.%I', $1, 'job_id_seq')) IS NOT NULL
+            AND to_regclass(format('%I.%I', $1, 'queue_ring_state')) IS NOT NULL
             AND to_regclass(format('%I.%I', $1, 'ready_entries')) IS NOT NULL
+            AND to_regclass(format('%I.%I', $1, 'done_entries')) IS NOT NULL
             AND to_regclass(format('%I.%I', $1, 'leases')) IS NOT NULL
+            AND to_regclass(format('%I.%I', $1, 'deferred_jobs')) IS NOT NULL
+            AND to_regclass(format('%I.%I', $1, 'lease_claims')) IS NOT NULL
+            AND to_regclass(format('%I.%I', $1, 'lease_claim_closures')) IS NOT NULL
+            AND to_regprocedure(
+                format('%I.%I(text,bigint,double precision,double precision)', $1, 'claim_ready_runtime')
+            ) IS NOT NULL
         "#,
     )
     .bind(schema)

--- a/awa-model/src/storage.rs
+++ b/awa-model/src/storage.rs
@@ -104,6 +104,17 @@ fn queue_storage_schema_from_status(status: &StorageStatus) -> Option<String> {
     )
 }
 
+/// Returns true only when every queue-storage substrate object the
+/// runtime depends on is present. Workers and producers should treat
+/// `false` as "schema not installed yet" and either wait or trigger
+/// `QueueStorage::prepare_schema`.
+///
+/// The required objects (tables, the job-id sequence, the claim
+/// function and its exact signature) all originate from
+/// [`QueueStorage::prepare_schema`](crate::QueueStorage::prepare_schema).
+/// If you change a name or the `claim_ready_runtime` signature there,
+/// update this check at the same time — they are intentionally a
+/// single source of truth split across two files for readability.
 pub async fn queue_storage_schema_ready(pool: &PgPool, schema: &str) -> Result<bool, AwaError> {
     sqlx::query_scalar::<_, bool>(
         r#"

--- a/awa/tests/migration_test.rs
+++ b/awa/tests/migration_test.rs
@@ -791,6 +791,52 @@ async fn test_prepare_queue_storage_schema_does_not_activate_routing() {
 }
 
 #[tokio::test]
+async fn test_queue_storage_schema_ready_requires_sequence_and_claim_function() {
+    let _guard = acquire_migration_guard().await;
+    let pool = pool().await;
+    reset_schema(&pool).await;
+
+    migrations::run(&pool).await.unwrap();
+
+    let schema = "awa_queue_storage_ready_probe";
+    prepare_queue_storage_schema(&pool, schema).await;
+
+    assert!(
+        storage::queue_storage_schema_ready(&pool, schema)
+            .await
+            .expect("schema readiness should be queryable"),
+        "freshly prepared queue-storage schema should be ready"
+    );
+
+    sqlx::query(&format!("DROP SEQUENCE {schema}.job_id_seq CASCADE"))
+        .execute(&pool)
+        .await
+        .expect("test sequence drop should succeed");
+
+    assert!(
+        !storage::queue_storage_schema_ready(&pool, schema)
+            .await
+            .expect("schema readiness should be queryable after sequence drop"),
+        "schema without job_id_seq must not be reported as ready"
+    );
+
+    prepare_queue_storage_schema(&pool, schema).await;
+    sqlx::query(&format!(
+        "DROP FUNCTION {schema}.claim_ready_runtime(text, bigint, double precision, double precision)"
+    ))
+        .execute(&pool)
+        .await
+        .expect("test claim function drop should succeed");
+
+    assert!(
+        !storage::queue_storage_schema_ready(&pool, schema)
+            .await
+            .expect("schema readiness should be queryable after function drop"),
+        "schema without claim_ready_runtime must not be reported as ready"
+    );
+}
+
+#[tokio::test]
 async fn test_install_queue_storage_backend_activates_routing_and_state() {
     let _guard = acquire_migration_guard().await;
     let pool = pool().await;

--- a/awa/tests/queue_storage_runtime_test.rs
+++ b/awa/tests/queue_storage_runtime_test.rs
@@ -176,6 +176,60 @@ async fn setup_pool(max_connections: u32) -> sqlx::PgPool {
     pool
 }
 
+#[tokio::test]
+async fn test_queue_storage_prepare_schema_completes_with_single_connection_pool() {
+    let _guard = QUEUE_STORAGE_RUNTIME_LOCK.lock().await;
+    let pool = setup_pool(1).await;
+    let store =
+        QueueStorage::new(QueueStorageConfig::default()).expect("queue storage config is valid");
+
+    tokio::time::timeout(Duration::from_secs(30), store.prepare_schema(&pool))
+        .await
+        .expect("prepare_schema should not self-starve on a one-connection pool")
+        .expect("prepare_schema should succeed");
+
+    assert!(
+        storage::queue_storage_schema_ready(&pool, store.schema())
+            .await
+            .expect("schema readiness query should succeed"),
+        "prepared queue-storage schema should be reported as ready"
+    );
+}
+
+#[tokio::test]
+async fn test_queue_storage_prepare_schema_concurrent_startups_serialize() {
+    let _guard = QUEUE_STORAGE_RUNTIME_LOCK.lock().await;
+    let pool = setup_pool(4).await;
+
+    let mut handles = Vec::new();
+    for _ in 0..4 {
+        let pool = pool.clone();
+        handles.push(tokio::spawn(async move {
+            let store = QueueStorage::new(QueueStorageConfig::default())
+                .expect("queue storage config is valid");
+            store.prepare_schema(&pool).await
+        }));
+    }
+
+    tokio::time::timeout(Duration::from_secs(30), async {
+        for handle in handles {
+            handle
+                .await
+                .expect("prepare_schema task should not panic")
+                .expect("prepare_schema should succeed");
+        }
+    })
+    .await
+    .expect("concurrent prepare_schema calls should not deadlock");
+
+    assert!(
+        storage::queue_storage_schema_ready(&pool, "awa")
+            .await
+            .expect("schema readiness query should succeed"),
+        "prepared queue-storage schema should be reported as ready"
+    );
+}
+
 async fn recreate_store_schema(pool: &sqlx::PgPool, store: &QueueStorage) {
     let drop_sql = format!("DROP SCHEMA IF EXISTS {} CASCADE", store.schema());
     sqlx::query(&drop_sql)


### PR DESCRIPTION
## Summary
- run queue-storage prepare_schema under one transaction-scoped advisory lock instead of holding one pooled lock connection while the install body reacquires the pool
- tighten queue-storage schema readiness so a missing job_id_seq or claim runtime function is not treated as ready
- add regressions for one-connection prepare_schema and concurrent prepare_schema startup

Fixes #264.

## Tests
- cargo check -p awa-model
- cargo test --test queue_storage_runtime_test test_queue_storage_prepare_schema -- --nocapture
- cargo test --test migration_test test_queue_storage_schema_ready_requires_sequence_and_claim_function -- --nocapture
- cargo fmt --check
- git diff --check