### PR TITLE
Cut 0.6.0-beta.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,148 @@ transitions live in [`docs/upgrade-0.5-to-0.6.md`](docs/upgrade-0.5-to-0.6.md).
 
 ## Unreleased
 
+## [0.6.0-beta.1] — 2026-05-19
+
+First beta of the 0.6 line. Frames the user-facing diff between
+`0.5.x` and `0.6.0-beta.1` as one release; the `0.6.0-alpha.N`
+entries below remain as the granular development log.
+
+### What's new since 0.5.x
+
+**Storage and durability**
+
+- **Queue-storage engine, default-on**
+  ([ADR-019](docs/adr/019-queue-storage-redesign.md)). Append-only
+  `ready_entries`, `deferred_jobs`, `done_entries`, and `dlq_entries`
+  paired with a partitioned receipt ring keep dead-tuple footprint
+  bounded under sustained load. Replaces the row-mutating canonical
+  engine for fresh installs.
+- **Receipt-plane ring partitioning**
+  ([ADR-023](docs/adr/023-receipt-plane-ring-partitioning.md)).
+  `lease_claims` and `lease_claim_closures` partitioned by claim slot,
+  rotated by the maintenance leader.
+- **Per-claim deadlines** in receipts mode. Set
+  `QueueConfig.deadline_duration` to bound a single attempt; rescue
+  force-closes expired claims with `'deadline_expired'`.
+- **Staged 0.5 → 0.6 transition tooling**: `awa storage prepare`,
+  `prepare-queue-storage-schema`, `enter-mixed-transition`, `finalize`,
+  `abort`. Fresh installs auto-finalize on first `awa migrate`. Full
+  procedure in [`docs/upgrade-0.5-to-0.6.md`](docs/upgrade-0.5-to-0.6.md).
+
+**Operator surfaces**
+
+- **Dead Letter Queue**
+  ([ADR-020](docs/adr/020-dead-letter-queue.md)). Per-queue
+  `dlq_enabled` policy plus a full admin surface:
+  `awa dlq depth | list | retry | retry-bulk | move | purge` (CLI),
+  matching admin UI tab, Rust/Python client APIs.
+- **Descriptor catalog**
+  ([ADR-022](docs/adr/022-descriptor-catalog.md)). Code-declared queue
+  and job-kind metadata (`display_name`, `description`, `owner`,
+  `tags`, `docs_url`) drives admin UI labels and drift detection.
+- **Cron missed-fire policy**. Periodic schedules persist an explicit
+  `missed_fire_policy`: `coalesce` (default) or `catch_up`. Exposed in
+  Rust/Python APIs and CLI schedule output.
+- **`awa-pg[ui]` Python extra** + `python -m awa serve`. The bare
+  `awa-pg` install stays small (workers/producers don't pay for the
+  ~10 MB axum + dashboard bundle); `pip install 'awa-pg[ui]'` pulls in
+  the `awa-cli` wheel and lets `python -m awa serve` launch the
+  embedded React dashboard.
+- **Managed-Postgres deployment guide**
+  ([`docs/deploying-on-managed-postgres.md`](docs/deploying-on-managed-postgres.md)).
+  Per-vCPU sizing data, Cloud SQL IAM grants, AlloyDB notes,
+  auth-proxy sidecar pattern.
+
+**Producer APIs and tuning**
+
+- **Direct queue-storage COPY producer path** as the documented
+  high-volume entry point. Rust:
+  `QueueStorage::enqueue_params_copy(pool, &jobs)`. Python:
+  `Client.enqueue_many_copy(jobs)`. The compat-friendly
+  `insert_many_copy_from_pool` / `client.insert_many_copy` routes
+  through `awa.insert_job_compat()` once per row — fine for ad-hoc
+  inserts but ~100–150 ms per row through a real DB proxy, not what
+  you want for bursts.
+- **`InsertOpts::ordering_key: Option<Vec<u8>>`** pins related jobs to
+  the same shard at `enqueue_shards > 1`. Kafka-partition-key
+  analogue: jobs sharing a key inherit that shard's strict FIFO. `None`
+  rotates batches across shards.
+- **`awa.queue_meta.enqueue_shards` per-queue semantic switch**
+  ([ADR-025](docs/adr/025-sharded-enqueue-heads.md)). Default `1`
+  preserves strict `(queue, priority)` FIFO. Setting `≥ 2` switches
+  that queue to partitioned FIFO (strict within `(queue, priority,
+  enqueue_shard)`, no order across shards) — comparable to choosing
+  SQS Standard over FIFO.
+- **Completion-batcher defaults raised** to `(batch=256, flush=5ms)`.
+  Tunable via `AWA_COMPLETION_BATCH_SIZE` and `AWA_COMPLETION_FLUSH_MS`.
+
+**Telemetry**
+
+- **`awa-metrics` crate**. `AwaMetrics` and its `record_*` methods
+  live in their own crate so non-runtime callers (`awa-ui`, `awa-cli`)
+  can emit the same OTel counters as the worker. `awa-worker::AwaMetrics`
+  re-exports for source compatibility.
+- **Sub-second buckets on `awa.job.wait_duration`**. Previous boundaries
+  didn't resolve pickup latency below 5 s.
+- **`awa.enqueue.batch_size` and `awa.enqueue.duration`** histograms on
+  the direct COPY enqueue path.
+- **`awa.enqueue.shard` attribute on `awa.job.claimed`** so dashboards
+  can see per-shard claim throughput.
+
+### Upgrading from 0.5.x
+
+- Fresh installs: nothing to do. `awa migrate` auto-finalizes to the
+  queue-storage engine on first run.
+- Existing 0.5.x clusters: walk the staged transition documented in
+  [`docs/upgrade-0.5-to-0.6.md`](docs/upgrade-0.5-to-0.6.md). Roll out
+  0.6 workers first (they understand both engines and the transition
+  states), then walk `prepare → enter-mixed-transition → finalize`.
+  **Rollback boundary:** one-way after `enter-mixed-transition`
+  followed by any queue-storage write. Plan to restore from backup if
+  rollback is needed past that point.
+- Update the dependency: `awa = "0.6.0-beta.1"` (Rust) /
+  `awa-pg==0.6.0-beta.1` (Python).
+
+### Operating notes
+
+- **Set `enqueue_shards` explicitly per queue.** The default `1` is the
+  conservative FIFO-preserving choice but serialises producers on a
+  single head row. We recommend `4` for contended hot queues. The
+  trade-off is semantic, not a free perf win — see
+  [`docs/configuration.md`](docs/configuration.md#sharding-the-enqueue-head-per-queue).
+- **MVCC discipline.** If your application runs long-lived
+  `REPEATABLE READ` / `SERIALIZABLE` transactions on the same database
+  awa lives in, give awa its own database. Long-pinned `xmin` blocks
+  dead-tuple cleanup and degrades queue-storage throughput over long
+  horizons. Tracked in
+  [#169](https://github.com/hardbyte/awa/issues/169).
+- **Cloud SQL with IAM auth:** the runtime SA needs `cloudsqlsuperuser`
+  for `prepare_schema` to install. Run `GRANT cloudsqlsuperuser TO
+  "your-sa@project.iam"` once per instance. AlloyDB grants this
+  automatically. Full guide:
+  [`docs/deploying-on-managed-postgres.md`](docs/deploying-on-managed-postgres.md).
+
+### Changes since 0.6.0-alpha.9
+
+For users already running an alpha:
+
+- v021 shard-aware lane indexes on `ready_entries` / `done_entries` /
+  `leases` partitions (#263). The narrow `(queue, priority, lane_seq)`
+  indexes from before v017 didn't include `enqueue_shard`; on heavy
+  backlog the planner discarded `(shards-1)/shards` of rows per
+  partition per claim. Drain throughput at depth restored to
+  equilibrium rate.
+- `prepare_schema` startup race fixed (#264, #266). Concurrent worker
+  startup on a fresh DB previously hung on PG18; install now runs in
+  a single transaction with `pg_advisory_xact_lock`.
+- `queue_storage_schema_ready` tightened to require every object the
+  runtime depends on, so a partial install can't report ready (#266).
+- Managed-Postgres deploy guide added (#265).
+- `awa.enqueue.batch_size` / `awa.enqueue.duration` histograms added
+  (#265).
+- Direct queue-storage COPY producer path is the documented
+  high-volume entry point (#263); compat path semantics unchanged.
+
 ### Performance
 - Drop the `queue_lanes.available_count` cache (migration `v016`).
   The dispatcher derives availability from
@@ -42,6 +184,20 @@ transitions live in [`docs/upgrade-0.5-to-0.6.md`](docs/upgrade-0.5-to-0.6.md).
   workers, receipts on, `LEASE_DEADLINE_MS` A/B) is a separate
   effect on the claim / rescue side and remains open for follow-up
   measurement. See ADR-025 for the full design.
+- **Shard-aware lane indexes on `ready_entries`, `done_entries`, and
+  `leases` child partitions** (migration `v021`,
+  [#263](https://github.com/hardbyte/awa/pull/263)). The narrow
+  `(queue, priority, lane_seq)` lane indexes that predated v017 did
+  not include `enqueue_shard`, while `claim_ready_runtime` (since
+  v017) filters on it. Under `enqueue_shards > 1` and deep backlog
+  the planner scanned the lane index forward and post-filtered
+  shard, discarding roughly `(shards-1)/shards` of rows per
+  partition per claim. v021 replaces those with
+  `(queue, priority, enqueue_shard, lane_seq)` indexes and drops
+  the originals; `prepare_schema` is updated to match for fresh
+  installs. On a Cloud SQL PG18 16 vCPU staging instance with a 3.5M
+  row backlog, end-to-end drain went from ~1,300 jobs/s to
+  ~8,800–10,600 jobs/s (single-claim probe: 11.4 ms → 0.81 ms).
 
 ### Added
 - `InsertOpts::ordering_key: Option<Vec<u8>>` pins related jobs to
@@ -63,6 +219,64 @@ transitions live in [`docs/upgrade-0.5-to-0.6.md`](docs/upgrade-0.5-to-0.6.md).
   completion SQL over more rows at the cost of a small latency
   bump. Tunable via `AWA_COMPLETION_BATCH_SIZE` and
   `AWA_COMPLETION_FLUSH_MS`.
+- **Direct queue-storage COPY producer path is the documented
+  high-volume entry point** ([#263](https://github.com/hardbyte/awa/pull/263)).
+  Rust: `QueueStorage::enqueue_params_copy(pool, &jobs)`. Python:
+  `Client.enqueue_many_copy(jobs)`. `insert_many_copy_from_pool` /
+  `client.insert_many_copy` remain available as the compatibility
+  COPY surface and route through `awa.insert_job_compat()`. See
+  [`docs/configuration.md`](docs/configuration.md#producer-path-choice).
+- **Explicit sub-second buckets on `awa.job.wait_duration`**
+  ([#263](https://github.com/hardbyte/awa/pull/263)). Histogram now
+  resolves pickup latency below 5 s, which the previous bucket
+  boundaries did not.
+- **`awa.enqueue.batch_size` and `awa.enqueue.duration` histograms**
+  ([#265](https://github.com/hardbyte/awa/pull/265)). Per-batch
+  observability on the direct COPY enqueue path. Lets producers tell
+  "batches are tiny" from "batches are slow" when an enqueue rate
+  target is missed — neither was distinguishable from existing
+  metrics. Recorded by Python `Client.enqueue_many_copy` (sync and
+  async). Rust callers using `QueueStorage::enqueue_params_copy`
+  directly can record via
+  `AwaMetrics::from_global().record_enqueue_batch(queue, count, duration)`.
+- **Managed-Postgres deployment guide**
+  ([#265](https://github.com/hardbyte/awa/pull/265)). New
+  [`docs/deploying-on-managed-postgres.md`](docs/deploying-on-managed-postgres.md)
+  covering Cloud SQL and AlloyDB specifics: per-vCPU sizing
+  measurements from staging, Postgres-version recommendations, IAM
+  `cloudsqlsuperuser` grant for Cloud SQL IAM users, the auth-proxy
+  native-sidecar pattern, and `enqueue_shards` operator guidance.
+
+### Fixed
+- **`prepare_schema` no longer deadlocks on fresh-DB / small-pool /
+  concurrent worker startup** ([#264](https://github.com/hardbyte/awa/issues/264),
+  [#266](https://github.com/hardbyte/awa/pull/266)). Previously the
+  install acquired `pg_advisory_lock(…)` on one dedicated pool
+  connection but issued every DDL through `.execute(pool)`, which
+  acquired *different* connections per statement. With a one-
+  connection pool that self-deadlocked; with a small pool and
+  concurrent worker startup it exhausted the pool with every worker
+  holding one connection for the lock and competing for the rest for
+  DDL. The PG18-on-fresh-DB hang reported in #264 is the most
+  visible symptom. Install now runs in a single transaction on a
+  single connection with `pg_advisory_xact_lock(…)`; the lock
+  auto-releases on COMMIT/ROLLBACK and the install is atomic.
+- **`queue_storage_schema_ready` checks the full required surface**
+  ([#266](https://github.com/hardbyte/awa/pull/266)). Previously it
+  only checked for `queue_ring_state`, `ready_entries`, and `leases`;
+  if `prepare_schema` had failed partway through (a real failure
+  mode under the old non-atomic install) the schema could report
+  ready while `awa.job_id_seq`, `done_entries`, `deferred_jobs`, or
+  the `claim_ready_runtime` function were missing — at which point
+  producers got `relation "awa.job_id_seq" does not exist`. The
+  check now requires every queue-storage substrate object the
+  runtime depends on.
+- **`AwaMetrics::from_global()` no longer rebuilt per call on hot
+  paths** ([#265](https://github.com/hardbyte/awa/pull/265)).
+  `from_global()` registers the entire instrument set on every
+  invocation. The Python `Client`, `awa-ui` `AppState`, and
+  `awa-cli` DLQ command now cache a single `AwaMetrics` handle and
+  reuse it instead of rebuilding ~30 instruments per operation.
 
 ## [0.6.0-alpha.9] — 2026-05-08
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,7 +171,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "awa"
-version = "0.6.0-alpha.9"
+version = "0.6.0-beta.1"
 dependencies = [
  "async-trait",
  "awa-macros",
@@ -196,7 +196,7 @@ dependencies = [
 
 [[package]]
 name = "awa-cli"
-version = "0.6.0-alpha.9"
+version = "0.6.0-beta.1"
 dependencies = [
  "assert_cmd",
  "awa-model",
@@ -218,7 +218,7 @@ dependencies = [
 
 [[package]]
 name = "awa-macros"
-version = "0.6.0-alpha.9"
+version = "0.6.0-beta.1"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -228,7 +228,7 @@ dependencies = [
 
 [[package]]
 name = "awa-metrics"
-version = "0.6.0-alpha.9"
+version = "0.6.0-beta.1"
 dependencies = [
  "awa-model",
  "opentelemetry",
@@ -236,7 +236,7 @@ dependencies = [
 
 [[package]]
 name = "awa-model"
-version = "0.6.0-alpha.9"
+version = "0.6.0-beta.1"
 dependencies = [
  "awa-macros",
  "blake3",
@@ -257,7 +257,7 @@ dependencies = [
 
 [[package]]
 name = "awa-testing"
-version = "0.6.0-alpha.9"
+version = "0.6.0-beta.1"
 dependencies = [
  "async-trait",
  "awa-model",
@@ -272,7 +272,7 @@ dependencies = [
 
 [[package]]
 name = "awa-ui"
-version = "0.6.0-alpha.9"
+version = "0.6.0-beta.1"
 dependencies = [
  "awa-metrics",
  "awa-model",
@@ -295,7 +295,7 @@ dependencies = [
 
 [[package]]
 name = "awa-worker"
-version = "0.6.0-alpha.9"
+version = "0.6.0-beta.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = [
 exclude = ["awa-python", "spike"]
 
 [workspace.package]
-version = "0.6.0-alpha.9"
+version = "0.6.0-beta.1"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "Postgres-native background job queue — transactional enqueue, heartbeat crash recovery, SKIP LOCKED dispatch"
@@ -24,10 +24,10 @@ categories = ["database", "asynchronous", "web-programming"]
 
 [workspace.dependencies]
 # Internal crates
-awa-model = { path = "awa-model", version = "0.6.0-alpha.9" }
-awa-macros = { path = "awa-macros", version = "0.6.0-alpha.9" }
-awa-metrics = { path = "awa-metrics", version = "0.6.0-alpha.9" }
-awa-worker = { path = "awa-worker", version = "0.6.0-alpha.9" }
+awa-model = { path = "awa-model", version = "0.6.0-beta.1" }
+awa-macros = { path = "awa-macros", version = "0.6.0-beta.1" }
+awa-metrics = { path = "awa-metrics", version = "0.6.0-beta.1" }
+awa-worker = { path = "awa-worker", version = "0.6.0-beta.1" }
 
 # Database
 sqlx = { version = "0.8", features = ["runtime-tokio-rustls", "postgres", "chrono", "json", "migrate", "uuid"] }

--- a/awa-python/Cargo.lock
+++ b/awa-python/Cargo.lock
@@ -95,7 +95,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "awa-macros"
-version = "0.6.0-alpha.9"
+version = "0.6.0-beta.1"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -105,7 +105,7 @@ dependencies = [
 
 [[package]]
 name = "awa-metrics"
-version = "0.6.0-alpha.9"
+version = "0.6.0-beta.1"
 dependencies = [
  "awa-model",
  "opentelemetry",
@@ -113,7 +113,7 @@ dependencies = [
 
 [[package]]
 name = "awa-model"
-version = "0.6.0-alpha.9"
+version = "0.6.0-beta.1"
 dependencies = [
  "awa-macros",
  "blake3",
@@ -133,7 +133,7 @@ dependencies = [
 
 [[package]]
 name = "awa-python"
-version = "0.6.0-alpha.9"
+version = "0.6.0-beta.1"
 dependencies = [
  "async-trait",
  "awa-model",
@@ -156,7 +156,7 @@ dependencies = [
 
 [[package]]
 name = "awa-worker"
-version = "0.6.0-alpha.9"
+version = "0.6.0-beta.1"
 dependencies = [
  "async-trait",
  "awa-macros",

--- a/awa-python/Cargo.toml
+++ b/awa-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "awa-python"
-version = "0.6.0-alpha.9"
+version = "0.6.0-beta.1"
 edition = "2021"
 
 [lib]
@@ -12,8 +12,8 @@ default = ["cel"]
 cel = ["awa-model/cel"]
 
 [dependencies]
-awa-model = { path = "../awa-model", version = "0.6.0-alpha.9" }
-awa-worker = { path = "../awa-worker", version = "0.6.0-alpha.9", features = ["__python-bridge"] }
+awa-model = { path = "../awa-model", version = "0.6.0-beta.1" }
+awa-worker = { path = "../awa-worker", version = "0.6.0-beta.1", features = ["__python-bridge"] }
 pyo3 = { version = "0.28", features = ["macros", "abi3-py310", "chrono"] }
 pyo3-async-runtimes = { version = "0.28", features = ["tokio-runtime"] }
 sqlx = { version = "0.8", features = ["runtime-tokio-rustls", "postgres", "chrono", "json"] }

--- a/awa-python/pyproject.toml
+++ b/awa-python/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "maturin"
 [project]
 name = "awa-pg"
 requires-python = ">=3.10"
-version = "0.6.0-alpha.9"
+version = "0.6.0-beta.1"
 description = "Postgres-native background job queue — Python SDK with async/sync workers, transactional enqueue, and progress tracking. Install awa-pg[ui] to add the bundled web dashboard."
 readme = {file = "../README.md", content-type = "text/markdown"}
 license = {text = "MIT OR Apache-2.0"}
@@ -32,7 +32,7 @@ classifiers = [
 #
 # Kept opt-in so the default `awa-pg` install stays small — workers and
 # producers don't need the ~10 MB UI bundle.
-ui = ["awa-cli==0.6.0-alpha.9"]
+ui = ["awa-cli==0.6.0-beta.1"]
 
 [project.urls]
 Homepage = "https://github.com/hardbyte/awa"


### PR DESCRIPTION
## Summary

Cut the 0.6 line as a beta now rather than holding the stable tag while the umbrella decisions in [#197](https://github.com/hardbyte/awa/issues/197) close out (MVCC operational-limit framing, #180 finalize/rollback decisions, #167/#242 acceptance, nightly triage of #262/#252). Beta exposure gives us real-world feedback on the 0.5→0.6 transition before we promise API stability.

### CHANGELOG entry

Reframed as a 0.5.x → 0.6 user-facing diff rather than an alpha-series chronology — a user upgrading sees the whole alpha journey as one release, so the `[0.6.0-beta.1]` entry groups the changes by what an operator actually decides on:

- Storage and durability (queue-storage default, receipt-plane partitioning, per-claim deadlines, staged transition tooling)
- Operator surfaces (DLQ, descriptor catalog, cron missed-fire policy, `awa-pg[ui]`, managed-Postgres deploy guide)
- Producer APIs and tuning (direct COPY entry point, `ordering_key`, `enqueue_shards`, completion-batcher defaults)
- Telemetry (`awa-metrics` crate, sub-second buckets, `awa.enqueue.*`, shard attribute)

Plus an "Upgrading from 0.5.x" section, "Operating notes" (two items: set `enqueue_shards` explicitly, MVCC discipline as a one-line actionable), and a "Changes since 0.6.0-alpha.9" subsection for anyone already running an alpha.

The `0.6.0-alpha.N` entries below the new beta section remain as the granular development log.

### Version bumps

- `Cargo.toml` workspace and `awa-{model,macros,metrics,worker}` dep pins: `0.6.0-alpha.9` → `0.6.0-beta.1`
- `awa-python/Cargo.toml`: same
- `awa-python/pyproject.toml`: `awa-pg` version and the `ui` extra's `awa-cli` pin
- `Cargo.lock` regenerated

### What this PR is not

This is the version bump + changelog draft. The publish step (cargo crates.io, PyPI wheel, GitHub release) lives in the existing release-mechanics workflow and isn't in this PR.

## Test plan

- [ ] `cargo test --workspace`
- [ ] Skim the new beta-entry framing for tone — too operator-focused? Missing anything?
- [ ] Confirm `pyproject.toml` version format (`0.6.0-beta.1`) survives maturin's normalisation to `0.6.0b1` on the wheel
- [ ] Cargo.lock diff is just the version bumps; no unexpected dependency moves

## Related

- [#197](https://github.com/hardbyte/awa/issues/197) — release-readiness umbrella
- Companion PR **#268** — drops the `install_db!()` macro from #266 (small refactor split out for independent review)