### PR TITLE
Bump remaining 0.6.0-alpha.9 dev-dep pins to 0.6.0-beta.1

### DIFF
--- a/awa-cli/Cargo.toml
+++ b/awa-cli/Cargo.toml
@@ -14,7 +14,7 @@ path = "src/main.rs"
 [dependencies]
 awa-model.workspace = true
 awa-worker.workspace = true
-awa-ui = { path = "../awa-ui", version = "0.6.0-alpha.9" }
+awa-ui = { path = "../awa-ui", version = "0.6.0-beta.1" }
 axum.workspace = true
 sqlx.workspace = true
 tokio.workspace = true
@@ -26,7 +26,7 @@ chrono.workspace = true
 hex.workspace = true
 
 [dev-dependencies]
-awa-testing = { path = "../awa-testing", version = "0.6.0-alpha.9" }
+awa-testing = { path = "../awa-testing", version = "0.6.0-beta.1" }
 assert_cmd = "2"
 serde.workspace = true
 uuid.workspace = true

--- a/awa-cli/pyproject.toml
+++ b/awa-cli/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "awa-cli"
-version = "0.6.0-alpha.9"
+version = "0.6.0-beta.1"
 description = "CLI for the Awa Postgres-native job queue (migrations, admin, serve)"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/awa/Cargo.toml
+++ b/awa/Cargo.toml
@@ -20,7 +20,7 @@ awa-macros.workspace = true
 awa-worker.workspace = true
 
 [dev-dependencies]
-awa-testing = { path = "../awa-testing", version = "0.6.0-alpha.9" }
+awa-testing = { path = "../awa-testing", version = "0.6.0-beta.1" }
 sqlx.workspace = true
 serde.workspace = true
 serde_json.workspace = true


### PR DESCRIPTION
## Summary

Catch-up to #267. The `release.yml` version-consistency job checks **five** sources for tag agreement; #267 bumped four of them.

This commit covers the last one:

- `awa-cli/pyproject.toml` `version`

Plus three Cargo dep pins that are **not** routed through `[workspace.dependencies]` and therefore did not move automatically when the workspace version bumped:

- `awa/Cargo.toml` — `awa-testing` dev-dep
- `awa-cli/Cargo.toml` — `awa-ui` dep + `awa-testing` dev-dep

The four already in `workspace.dependencies` (`awa-model`, `awa-macros`, `awa-metrics`, `awa-worker`) moved in #267.

## Validation

Mirrored the `release.yml` version-check inline:

| Source | Value |
|---|---|
| `Cargo.toml` workspace.package.version | `0.6.0-beta.1` |
| `awa-cli/pyproject.toml` project.version | `0.6.0-beta.1` |
| `awa-python/Cargo.toml` package.version | `0.6.0-beta.1` |
| `awa-python/pyproject.toml` project.version | `0.6.0-beta.1` |
| `awa-python/pyproject.toml` `[ui]` extra `awa-cli==...` pin | `0.6.0-beta.1` |

All agree. `cargo check --workspace` + `cargo fmt --check` clean.

## Why this didn't break CI on #267

CI checks compile and lints, not the version-consistency rule. The version-check job only runs on tag push. Tagging `v0.6.0-beta.1` without this commit would have failed `version-check` and skipped all downstream publish jobs — recoverable (delete the tag, fix, retag) but worth catching first.

## Blocks

Tagging `v0.6.0-beta.1`.