### PR TITLE
awa-seaorm: focused SeaORM adapter for transactional enqueue

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "aliasable"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "250f629c0161ad8107cf89319e990051fae62832fd343083bea452d93e2205fd"
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -138,6 +144,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-stream"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -253,6 +281,18 @@ dependencies = [
  "tokio-postgres",
  "tracing",
  "uuid",
+]
+
+[[package]]
+name = "awa-seaorm"
+version = "0.6.0-alpha.9"
+dependencies = [
+ "awa",
+ "awa-testing",
+ "sea-orm",
+ "serde",
+ "sqlx",
+ "tokio",
 ]
 
 [[package]]
@@ -571,7 +611,7 @@ version = "4.5.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn",
@@ -752,6 +792,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "der"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -760,6 +834,28 @@ dependencies = [
  "const-oid 0.9.6",
  "pem-rfc7468",
  "zeroize",
+]
+
+[[package]]
+name = "derive_more"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -1139,6 +1235,12 @@ dependencies = [
 
 [[package]]
 name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+
+[[package]]
+name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
@@ -1444,6 +1546,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1474,6 +1582,17 @@ dependencies = [
  "hashbrown 0.16.1",
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "inherent"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c727f80bfa4a6c6e2508d2f05b6f4bfce242030bd88ed15ae5331c5b5d30fba7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1924,6 +2043,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
+name = "ordered-float"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bb71e1b3fa6ca1c61f383464aaf2bb0e2f8e772a1f01d486832464de363b951"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "ouroboros"
+version = "0.18.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0f050db9c44b97a94723127e6be766ac5c340c48f2c4bb3ffa11713744be59"
+dependencies = [
+ "aliasable",
+ "ouroboros_macro",
+ "static_assertions",
+]
+
+[[package]]
+name = "ouroboros_macro"
+version = "0.18.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c7028bdd3d43083f6d8d4d5187680d0d3560d54df4cc9d752005268b41e64d0"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro2",
+ "proc-macro2-diagnostics",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "parking"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2076,6 +2228,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
+name = "pluralizer"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b3eba432a00a1f6c16f39147847a870e94e2e9b992759b503e330efec778cbe"
+dependencies = [
+ "once_cell",
+ "regex",
+]
+
+[[package]]
 name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2185,6 +2347,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "proc-macro2-diagnostics"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "version_check",
+ "yansi",
 ]
 
 [[package]]
@@ -2477,6 +2652,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2558,6 +2742,106 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sea-orm"
+version = "2.0.0-rc.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b5428ce6a0c8f6b9858df21ad1aa00c2fb94e1c9f344a0436bc855391e5a225"
+dependencies = [
+ "async-stream",
+ "async-trait",
+ "derive_more",
+ "futures-util",
+ "itertools",
+ "log",
+ "ouroboros",
+ "sea-orm-macros",
+ "sea-query",
+ "sea-query-sqlx",
+ "sea-schema",
+ "serde",
+ "sqlx",
+ "strum",
+ "thiserror 2.0.18",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "sea-orm-macros"
+version = "2.0.0-rc.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae1374d83dd5b43f14dcc90fc726486c556f4db774b680b12b8c680af76e8233"
+dependencies = [
+ "heck 0.5.0",
+ "itertools",
+ "pluralizer",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "unicode-ident",
+]
+
+[[package]]
+name = "sea-query"
+version = "1.0.0-rc.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b04cdb0135c16e829504e93fbe7880513578d56f07aaea152283526590111828"
+dependencies = [
+ "inherent",
+ "ordered-float",
+ "sea-query-derive",
+]
+
+[[package]]
+name = "sea-query-derive"
+version = "1.0.0-rc.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d88ad44b6ad9788c8b9476b6b91f94c7461d1e19d39cd8ea37838b1e6ff5aa8"
+dependencies = [
+ "darling",
+ "heck 0.4.1",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "sea-query-sqlx"
+version = "0.8.0-rc.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a04aeecfe00614fece56336fd35dc385bb9ffed0c75660695ba925e42a3991ef"
+dependencies = [
+ "sea-query",
+ "sqlx",
+]
+
+[[package]]
+name = "sea-schema"
+version = "0.17.0-rc.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b363dd21c20fe4d1488819cb2bc7f8d4696c62dd9f39554f97639f54d57dd0ab"
+dependencies = [
+ "async-trait",
+ "sea-query",
+ "sea-query-sqlx",
+ "sea-schema-derive",
+ "sqlx",
+]
+
+[[package]]
+name = "sea-schema-derive"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "debdc8729c37fdbf88472f97fd470393089f997a909e535ff67c544d18cfccf0"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "security-framework"
@@ -2853,7 +3137,7 @@ checksum = "19a9c1841124ac5a61741f96e1d9e2ec77424bf323962dd894bdb93f37d5219b"
 dependencies = [
  "dotenvy",
  "either",
- "heck",
+ "heck 0.5.0",
  "hex",
  "once_cell",
  "proc-macro2",
@@ -2986,6 +3270,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "stringprep"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3001,6 +3291,12 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
 
 [[package]]
 name = "subtle"
@@ -4044,7 +4340,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
 dependencies = [
  "anyhow",
- "heck",
+ "heck 0.5.0",
  "wit-parser",
 ]
 
@@ -4055,7 +4351,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
- "heck",
+ "heck 0.5.0",
  "indexmap",
  "prettyplease",
  "syn",
@@ -4121,6 +4417,12 @@ name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "yansi"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yoke"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,31 @@
 version = 4
 
 [[package]]
+name = "ahash"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
+dependencies = [
+ "getrandom 0.2.17",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "const-random",
+ "getrandom 0.3.4",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -118,6 +143,165 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
+name = "arrow"
+version = "57.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3bd47f2a6ddc39244bd722a27ee5da66c03369d087b9e024eafdb03e98b98ea7"
+dependencies = [
+ "arrow-arith",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-cast",
+ "arrow-data",
+ "arrow-ord",
+ "arrow-row",
+ "arrow-schema",
+ "arrow-select",
+ "arrow-string",
+]
+
+[[package]]
+name = "arrow-arith"
+version = "57.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c7bbd679c5418b8639b92be01f361d60013c4906574b578b77b63c78356594c"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "chrono",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-array"
+version = "57.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8a4ab47b3f3eac60f7fd31b81e9028fda018607bcc63451aca4f2b755269862"
+dependencies = [
+ "ahash 0.8.12",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "chrono",
+ "half",
+ "hashbrown 0.16.1",
+ "num-complex",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-buffer"
+version = "57.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d18b89b4c4f4811d0858175e79541fe98e33e18db3b011708bc287b1240593f"
+dependencies = [
+ "bytes",
+ "half",
+ "num-bigint",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-cast"
+version = "57.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "722b5c41dd1d14d0a879a1bce92c6fe33f546101bb2acce57a209825edd075b3"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-ord",
+ "arrow-schema",
+ "arrow-select",
+ "atoi",
+ "base64",
+ "chrono",
+ "half",
+ "lexical-core",
+ "num-traits",
+ "ryu",
+]
+
+[[package]]
+name = "arrow-data"
+version = "57.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1683705c63dcf0d18972759eda48489028cbbff67af7d6bef2c6b7b74ab778a"
+dependencies = [
+ "arrow-buffer",
+ "arrow-schema",
+ "half",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-ord"
+version = "57.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "082342947d4e5a2bcccf029a0a0397e21cb3bb8421edd9571d34fb5dd2670256"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "arrow-select",
+]
+
+[[package]]
+name = "arrow-row"
+version = "57.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a931b520a2a5e22033e01a6f2486b4cdc26f9106b759abeebc320f125e94d7"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "half",
+]
+
+[[package]]
+name = "arrow-schema"
+version = "57.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4cf0d4a6609679e03002167a61074a21d7b1ad9ea65e462b2c0a97f8a3b2bc6"
+
+[[package]]
+name = "arrow-select"
+version = "57.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b320d86a9806923663bb0fd9baa65ecaba81cb0cd77ff8c1768b9716b4ef891"
+dependencies = [
+ "ahash 0.8.12",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-string"
+version = "57.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b493e99162e5764077e7823e50ba284858d365922631c7aaefe9487b1abd02c2"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "arrow-select",
+ "memchr",
+ "num-traits",
+ "regex",
+ "regex-syntax",
+]
+
+[[package]]
 name = "assert_cmd"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -162,7 +346,7 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -173,7 +357,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -251,7 +435,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -285,12 +469,13 @@ dependencies = [
 
 [[package]]
 name = "awa-seaorm"
-version = "0.6.0-alpha.9"
+version = "0.6.0-beta.1"
 dependencies = [
  "awa",
  "awa-testing",
  "sea-orm",
  "serde",
+ "serde_json",
  "sqlx",
  "tokio",
 ]
@@ -430,6 +615,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4372b9543397a4b86050cc5e7ee36953edf4bac9518e8a774c2da694977fb6e4"
 
 [[package]]
+name = "bigdecimal"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d6867f1565b3aad85681f1015055b087fcfd840d6aeee6eee7f2da317603695"
+dependencies = [
+ "autocfg",
+ "libm",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+ "serde",
+]
+
+[[package]]
 name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -451,6 +650,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "bitvec"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
 ]
 
 [[package]]
@@ -486,6 +697,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "borsh"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfd1e3f8955a5d7de9fab72fc8373fade9fb8a703968cb200ae3dc6cf08e185a"
+dependencies = [
+ "borsh-derive",
+ "bytes",
+ "cfg_aliases",
+]
+
+[[package]]
+name = "borsh-derive"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfcfdc083699101d5a7965e49925975f2f55060f94f9a05e7187be95d530ca59"
+dependencies = [
+ "once_cell",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "bstr"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -501,6 +736,28 @@ name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "bytecheck"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23cdc57ce23ac53c931e88a43d06d070a6fd142f2617be5855eb75efc9beb1c2"
+dependencies = [
+ "bytecheck_derive",
+ "ptr_meta",
+ "simdutf8",
+]
+
+[[package]]
+name = "bytecheck_derive"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3db406d29fbcd95542e92559bed4d8ad92636d1ca8b3b72ede10b4bcc010e659"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
 
 [[package]]
 name = "byteorder"
@@ -547,6 +804,12 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chacha20"
@@ -614,7 +877,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -655,6 +918,26 @@ name = "const-oid"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
+name = "const-random"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87e00182fe74b066627d63b85fd550ac2998d4b0bd86bfed477a0ae4c7c71359"
+dependencies = [
+ "const-random-macro",
+]
+
+[[package]]
+name = "const-random-macro"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
+dependencies = [
+ "getrandom 0.2.17",
+ "once_cell",
+ "tiny-keccak",
+]
 
 [[package]]
 name = "constant_time_eq"
@@ -764,6 +1047,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -811,7 +1100,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -822,7 +1111,7 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -834,6 +1123,16 @@ dependencies = [
  "const-oid 0.9.6",
  "pem-rfc7468",
  "zeroize",
+]
+
+[[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "powerfmt",
+ "serde_core",
 ]
 
 [[package]]
@@ -854,7 +1153,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn",
+ "syn 2.0.117",
  "unicode-xid",
 ]
 
@@ -917,7 +1216,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1058,6 +1357,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
+
+[[package]]
 name = "futures-channel"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1109,7 +1414,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1205,6 +1510,27 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+]
+
+[[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "num-traits",
+ "zerocopy",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+dependencies = [
+ "ahash 0.7.8",
 ]
 
 [[package]]
@@ -1592,7 +1918,7 @@ checksum = "c727f80bfa4a6c6e2508d2f05b6f4bfce242030bd88ed15ae5331c5b5d30fba7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1660,6 +1986,63 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
+name = "lexical-core"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d8d125a277f807e55a77304455eb7b1cb52f2b18c143b60e766c120bd64a594"
+dependencies = [
+ "lexical-parse-float",
+ "lexical-parse-integer",
+ "lexical-util",
+ "lexical-write-float",
+ "lexical-write-integer",
+]
+
+[[package]]
+name = "lexical-parse-float"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52a9f232fbd6f550bc0137dcb5f99ab674071ac2d690ac69704593cb4abbea56"
+dependencies = [
+ "lexical-parse-integer",
+ "lexical-util",
+]
+
+[[package]]
+name = "lexical-parse-integer"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a7a039f8fb9c19c996cd7b2fcce303c1b2874fe1aca544edc85c4a5f8489b34"
+dependencies = [
+ "lexical-util",
+]
+
+[[package]]
+name = "lexical-util"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2604dd126bb14f13fb5d1bd6a66155079cb9fa655b37f875b3a742c705dbed17"
+
+[[package]]
+name = "lexical-write-float"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50c438c87c013188d415fbabbb1dceb44249ab81664efbd31b14ae55dabb6361"
+dependencies = [
+ "lexical-util",
+ "lexical-write-integer",
+]
+
+[[package]]
+name = "lexical-write-integer"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "409851a618475d2d5796377cad353802345cba92c867d9fbcde9cf4eac4e14df"
+dependencies = [
+ "lexical-util",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.184"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1721,6 +2104,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "mac_address"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0aeb26bf5e836cc1c341c8106051b573f1766dfa05aa87f0b98be5e51b02303"
+dependencies = [
+ "nix",
+ "serde",
+ "winapi",
+]
+
+[[package]]
 name = "matchers"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1760,6 +2154,15 @@ name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "mime"
@@ -1841,6 +2244,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+ "memoffset",
+]
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1860,6 +2276,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-bigint-dig"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1874,6 +2300,21 @@ dependencies = [
  "smallvec",
  "zeroize",
 ]
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-conv"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
 
 [[package]]
 name = "num-integer"
@@ -1939,7 +2380,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2072,7 +2513,7 @@ dependencies = [
  "proc-macro2",
  "proc-macro2-diagnostics",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2124,6 +2565,15 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "pgvector"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3673cba5b9a124916096a423b806a9f29620972c6c97b08db5f2053e9428b481"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "phf"
@@ -2179,7 +2629,7 @@ checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2286,6 +2736,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2328,7 +2784,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2357,7 +2813,7 @@ checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "version_check",
  "yansi",
 ]
@@ -2382,7 +2838,27 @@ dependencies = [
  "itertools",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "ptr_meta"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0738ccf7ea06b608c10564b31debd4f5bc5e197fc8bfe088f68ae5ce81e7a4f1"
+dependencies = [
+ "ptr_meta_derive",
+]
+
+[[package]]
+name = "ptr_meta_derive"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16b845dbfca988fa33db069c0e230574d15a3088f147a87b64c7589eb662c9ac"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2405,6 +2881,12 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
@@ -2541,6 +3023,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "rend"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71fe3824f5629716b1589be05dacd749f6aa084c87e00e016714a8cdfccc997c"
+dependencies = [
+ "bytecheck",
+]
+
+[[package]]
 name = "reqwest"
 version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2597,6 +3088,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "rkyv"
+version = "0.7.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2297bf9c81a3f0dc96bc9521370b88f054168c29826a75e89c55ff196e7ed6a1"
+dependencies = [
+ "bitvec",
+ "bytecheck",
+ "bytes",
+ "hashbrown 0.12.3",
+ "ptr_meta",
+ "rend",
+ "rkyv_derive",
+ "seahash",
+ "tinyvec",
+ "uuid",
+]
+
+[[package]]
+name = "rkyv_derive"
+version = "0.7.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84d7b42d4b8d06048d3ac8db0eb31bcb942cbeb709f0b5f2b2ebde398d3038f5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "rsa"
 version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2637,7 +3157,7 @@ dependencies = [
  "quote",
  "rust-embed-utils",
  "shellexpand",
- "syn",
+ "syn 2.0.117",
  "walkdir",
 ]
 
@@ -2649,6 +3169,23 @@ checksum = "5bcdef0be6fe7f6fa333b1073c949729274b05f123a0ad7efcb8efd878e5c3b1"
 dependencies = [
  "sha2 0.10.9",
  "walkdir",
+]
+
+[[package]]
+name = "rust_decimal"
+version = "1.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c5108e3d4d903e21aac27f12ba5377b6b34f9f44b325e4894c7924169d06995"
+dependencies = [
+ "arrayvec",
+ "borsh",
+ "bytes",
+ "num-traits",
+ "rand 0.8.5",
+ "rkyv",
+ "serde",
+ "serde_json",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2751,21 +3288,41 @@ checksum = "9b5428ce6a0c8f6b9858df21ad1aa00c2fb94e1c9f344a0436bc855391e5a225"
 dependencies = [
  "async-stream",
  "async-trait",
+ "bigdecimal",
+ "chrono",
  "derive_more",
  "futures-util",
  "itertools",
  "log",
+ "mac_address",
  "ouroboros",
+ "pgvector",
+ "rust_decimal",
+ "sea-orm-arrow",
  "sea-orm-macros",
  "sea-query",
  "sea-query-sqlx",
  "sea-schema",
  "serde",
+ "serde_json",
  "sqlx",
  "strum",
  "thiserror 2.0.18",
+ "time",
  "tracing",
  "url",
+ "uuid",
+]
+
+[[package]]
+name = "sea-orm-arrow"
+version = "2.0.0-rc.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c2eee8405f16c1f337fe3a83389361caea83c928d14dbd666a480407072c365"
+dependencies = [
+ "arrow",
+ "sea-query",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -2779,7 +3336,7 @@ dependencies = [
  "pluralizer",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "unicode-ident",
 ]
 
@@ -2789,9 +3346,11 @@ version = "1.0.0-rc.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b04cdb0135c16e829504e93fbe7880513578d56f07aaea152283526590111828"
 dependencies = [
+ "chrono",
  "inherent",
  "ordered-float",
  "sea-query-derive",
+ "serde_json",
 ]
 
 [[package]]
@@ -2804,7 +3363,7 @@ dependencies = [
  "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "thiserror 2.0.18",
 ]
 
@@ -2840,8 +3399,14 @@ dependencies = [
  "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
+
+[[package]]
+name = "seahash"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
 
 [[package]]
 name = "security-framework"
@@ -2899,7 +3464,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3016,6 +3581,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
 name = "siphasher"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3126,7 +3697,7 @@ dependencies = [
  "quote",
  "sqlx-core",
  "sqlx-macros-core",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3149,7 +3720,7 @@ dependencies = [
  "sqlx-mysql",
  "sqlx-postgres",
  "sqlx-sqlite",
- "syn",
+ "syn 2.0.117",
  "tokio",
  "url",
 ]
@@ -3306,6 +3877,17 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
@@ -3332,7 +3914,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3361,6 +3943,12 @@ name = "tagptr"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
+
+[[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempfile"
@@ -3407,7 +3995,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3418,7 +4006,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3428,6 +4016,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "time"
+version = "0.3.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+dependencies = [
+ "deranged",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
+name = "time-macros"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
+
+[[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
 ]
 
 [[package]]
@@ -3480,7 +4107,7 @@ checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3689,7 +4316,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3949,6 +4576,7 @@ dependencies = [
  "cfg-if",
  "once_cell",
  "rustversion",
+ "serde",
  "wasm-bindgen-macro",
  "wasm-bindgen-shared",
 ]
@@ -3982,7 +4610,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
@@ -4089,6 +4717,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4096,6 +4740,12 @@ checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"
@@ -4118,7 +4768,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4129,7 +4779,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4354,7 +5004,7 @@ dependencies = [
  "heck 0.5.0",
  "indexmap",
  "prettyplease",
- "syn",
+ "syn 2.0.117",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -4370,7 +5020,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -4419,6 +5069,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
+name = "wyz"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+dependencies = [
+ "tap",
+]
+
+[[package]]
 name = "yansi"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4443,7 +5102,7 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -4464,7 +5123,7 @@ checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4484,7 +5143,7 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -4524,7 +5183,7 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ awa-worker = { path = "awa-worker", version = "0.6.0-beta.1" }
 awa = { path = "awa", version = "0.6.0-beta.1" }
 
 # Database
-sea-orm = { version = "=2.0.0-rc.38", default-features = false, features = ["sqlx-postgres", "runtime-tokio-rustls"] }
+sea-orm = { version = "=2.0.0-rc.38", default-features = false, features = ["sqlx-postgres", "runtime-tokio-rustls", "with-chrono", "with-json"] }
 sqlx = { version = "0.8", features = ["runtime-tokio-rustls", "postgres", "chrono", "json", "migrate", "uuid"] }
 
 # UUID

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
     "awa",
     "awa-testing",
     "awa-cli",
+    "awa-seaorm",
     "awa-ui",
 ]
 exclude = ["awa-python", "spike"]
@@ -28,8 +29,10 @@ awa-model = { path = "awa-model", version = "0.6.0-beta.1" }
 awa-macros = { path = "awa-macros", version = "0.6.0-beta.1" }
 awa-metrics = { path = "awa-metrics", version = "0.6.0-beta.1" }
 awa-worker = { path = "awa-worker", version = "0.6.0-beta.1" }
+awa = { path = "awa", version = "0.6.0-beta.1" }
 
 # Database
+sea-orm = { version = "=2.0.0-rc.38", default-features = false, features = ["sqlx-postgres", "runtime-tokio-rustls"] }
 sqlx = { version = "0.8", features = ["runtime-tokio-rustls", "postgres", "chrono", "json", "migrate", "uuid"] }
 
 # UUID

--- a/awa-model/src/error.rs
+++ b/awa-model/src/error.rs
@@ -36,3 +36,23 @@ impl From<sqlx::Error> for AwaError {
         AwaError::Database(err)
     }
 }
+
+/// The single Rust-side mapping from a raw `sqlx::Error` to an [`AwaError`],
+/// translating a Postgres unique violation (SQLSTATE 23505) into
+/// [`AwaError::UniqueConflict`] with the offending constraint name.
+///
+/// Insert paths call this explicitly rather than relying on the blanket
+/// `From<sqlx::Error>` (which preserves the raw error for general `?` use).
+/// Database adapters running Awa's insert SQL through another driver should
+/// route the underlying sqlx error through here so their errors match the
+/// native path.
+pub fn map_sqlx_error(err: sqlx::Error) -> AwaError {
+    if let sqlx::Error::Database(ref db_err) = err {
+        if db_err.code().as_deref() == Some("23505") {
+            return AwaError::UniqueConflict {
+                constraint: db_err.constraint().map(|c| c.to_string()),
+            };
+        }
+    }
+    AwaError::Database(err)
+}

--- a/awa-model/src/insert.rs
+++ b/awa-model/src/insert.rs
@@ -1,4 +1,4 @@
-use crate::error::AwaError;
+use crate::error::{map_sqlx_error, AwaError};
 use crate::job::{InsertOpts, InsertParams, JobRow, JobState};
 use crate::unique::compute_unique_key;
 use crate::JobArgs;
@@ -178,17 +178,6 @@ impl PreparedJobInsert {
     pub fn ordering_key(&self) -> Option<&[u8]> {
         self.ordering_key.as_deref()
     }
-}
-
-fn map_sqlx_error(err: sqlx::Error) -> AwaError {
-    if let sqlx::Error::Database(ref db_err) = err {
-        if db_err.code().as_deref() == Some("23505") {
-            return AwaError::UniqueConflict {
-                constraint: db_err.constraint().map(|c| c.to_string()),
-            };
-        }
-    }
-    AwaError::Database(err)
 }
 
 fn build_multi_insert_query(count: usize) -> String {

--- a/awa-model/src/lib.rs
+++ b/awa-model/src/lib.rs
@@ -29,7 +29,7 @@ pub use admin::{
 pub type QueueStats = QueueOverview;
 pub use cron::{CronJobRow, CronMissedFirePolicy, PeriodicJob, PeriodicJobBuilder};
 pub use dlq::{DlqMetadata, DlqRow, ListDlqFilter, RetryFromDlqOpts};
-pub use error::AwaError;
+pub use error::{map_sqlx_error, AwaError};
 pub use insert::{insert, insert_many, insert_many_copy, insert_many_copy_from_pool, insert_with};
 pub use job::{InsertOpts, InsertParams, JobRow, JobState, UniqueOpts};
 pub use queue_storage::{

--- a/awa-seaorm/Cargo.toml
+++ b/awa-seaorm/Cargo.toml
@@ -10,6 +10,7 @@ readme = "README.md"
 [dependencies]
 awa.workspace = true
 sea-orm.workspace = true
+serde_json.workspace = true
 sqlx.workspace = true
 
 [dev-dependencies]

--- a/awa-seaorm/Cargo.toml
+++ b/awa-seaorm/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "awa-seaorm"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+description = "SeaORM integration helpers for the Awa job queue"
+repository.workspace = true
+readme = "README.md"
+
+[dependencies]
+awa.workspace = true
+sea-orm.workspace = true
+sqlx.workspace = true
+
+[dev-dependencies]
+awa-testing = { path = "../awa-testing", version = "0.6.0-beta.1" }
+serde = { workspace = true, features = ["derive"] }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+

--- a/awa-seaorm/README.md
+++ b/awa-seaorm/README.md
@@ -1,0 +1,65 @@
+# awa-seaorm
+
+SeaORM integration helpers for the [Awa](https://github.com/hardbyte/awa)
+job queue.
+
+This crate is intentionally small:
+
+- it surfaces the underlying `sqlx::PgPool` from `sea_orm::DatabaseConnection`
+- it reuses Awa's existing migration and insertion helpers
+- it gives SeaORM-first applications a convenient Awa client builder
+
+It does **not** replace Awa's core `sqlx` API or introduce a new storage
+engine. It is just a thin adapter for SeaORM applications that already
+own a PostgreSQL connection.
+
+## Usage
+
+```toml
+[dependencies]
+awa = "0.6.0-alpha.9"
+awa-seaorm = "0.6.0-alpha.9"
+sea-orm = { version = "=2.0.0-rc.38", default-features = false, features = [
+    "sqlx-postgres",
+    "runtime-tokio-rustls",
+] }
+serde = { version = "1", features = ["derive"] }
+tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+```
+
+```rust
+use awa::{JobArgs, QueueConfig};
+use awa_seaorm::{client_builder, insert, migrate, SeaOrmAwaExt};
+use sea_orm::Database;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize, JobArgs)]
+struct SendEmail {
+    to: String,
+    subject: String,
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let db = Database::connect(&std::env::var("DATABASE_URL")?).await?;
+
+    migrate(&db).await?;
+
+    let _client = client_builder(&db)
+        .queue("email", QueueConfig::default())
+        .build()?;
+
+    let job = insert(
+        &db,
+        &SendEmail {
+            to: "ada@example.com".into(),
+            subject: "hello".into(),
+        },
+    )
+    .await?;
+
+    println!("enqueued job {}", job.id);
+    let _pool = db.awa_pool();
+    Ok(())
+}
+```

--- a/awa-seaorm/README.md
+++ b/awa-seaorm/README.md
@@ -3,22 +3,30 @@
 SeaORM integration helpers for the [Awa](https://github.com/hardbyte/awa)
 job queue.
 
-This crate is intentionally small:
+This crate is intentionally small. Awa's core is SQLx/Postgres-native, and a
+SeaORM `DatabaseConnection` already wraps a `sqlx::PgPool`, so most integration
+needs no glue at all:
 
-- it surfaces the underlying `sqlx::PgPool` from `sea_orm::DatabaseConnection`
-- it reuses Awa's existing migration and insertion helpers
-- it gives SeaORM-first applications a convenient Awa client builder
+- building a client, running migrations, or reading job state — reach the pool
+  with `awa_pool()` / `pool()` and use Awa's existing APIs unchanged.
 
-It does **not** replace Awa's core `sqlx` API or introduce a new storage
-engine. It is just a thin adapter for SeaORM applications that already
-own a PostgreSQL connection.
+The one thing the pool **can't** do is enqueue a job on the same connection as
+an in-flight SeaORM transaction — `get_postgres_connection_pool()` hands back a
+separate pooled connection, so a job inserted through it commits independently
+of your ORM writes. The `insert` / `insert_with` / `insert_raw` functions run
+Awa's canonical insert SQL through SeaORM's `ConnectionTrait`, so they bind to a
+`DatabaseConnection` *or* a `DatabaseTransaction` and let you enqueue a job
+atomically with the rest of a transaction.
+
+It does **not** replace Awa's core `sqlx` API, reimplement Awa's admin/lifecycle
+operations, or introduce a new storage engine.
 
 ## Usage
 
 ```toml
 [dependencies]
-awa = "0.6.0-alpha.9"
-awa-seaorm = "0.6.0-alpha.9"
+awa = "0.6.0-beta.1"
+awa-seaorm = "0.6.0-beta.1"
 sea-orm = { version = "=2.0.0-rc.38", default-features = false, features = [
     "sqlx-postgres",
     "runtime-tokio-rustls",
@@ -27,9 +35,39 @@ serde = { version = "1", features = ["derive"] }
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 ```
 
+### Enqueue atomically inside a SeaORM transaction
+
+```rust
+use awa::JobArgs;
+use awa_seaorm::{insert, migrate};
+use sea_orm::{Database, TransactionTrait};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize, JobArgs)]
+struct SendWelcomeEmail {
+    user_id: i64,
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let db = Database::connect(&std::env::var("DATABASE_URL")?).await?;
+    migrate(&db).await?;
+
+    // The user row and its welcome-email job commit together, or not at all.
+    let txn = db.begin().await?;
+    // ... insert your application rows via SeaORM on `txn` ...
+    insert(&txn, &SendWelcomeEmail { user_id: 42 }).await?;
+    txn.commit().await?;
+
+    Ok(())
+}
+```
+
+### Build a client / enqueue without a transaction
+
 ```rust
 use awa::{JobArgs, QueueConfig};
-use awa_seaorm::{client_builder, insert, migrate, SeaOrmAwaExt};
+use awa_seaorm::{client_builder, insert, migrate};
 use sea_orm::Database;
 use serde::{Deserialize, Serialize};
 
@@ -42,13 +80,13 @@ struct SendEmail {
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let db = Database::connect(&std::env::var("DATABASE_URL")?).await?;
-
     migrate(&db).await?;
 
     let _client = client_builder(&db)
         .queue("email", QueueConfig::default())
         .build()?;
 
+    // Passing the connection (not a transaction) enqueues immediately.
     let job = insert(
         &db,
         &SendEmail {
@@ -59,7 +97,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     .await?;
 
     println!("enqueued job {}", job.id);
-    let _pool = db.awa_pool();
     Ok(())
 }
 ```

--- a/awa-seaorm/src/lib.rs
+++ b/awa-seaorm/src/lib.rs
@@ -1,0 +1,63 @@
+//! SeaORM integration helpers for Awa.
+//!
+//! This crate stays deliberately thin: it exposes the underlying
+//! `sqlx::PgPool` from a SeaORM `DatabaseConnection`, then reuses Awa's
+//! existing migration and insertion helpers on that pool.
+//!
+//! It does not add a new storage engine, and it does not replace the
+//! existing `awa` sqlx API.
+
+use awa::{AwaError, Client, ClientBuilder, InsertOpts, JobArgs, JobRow};
+use sea_orm::DatabaseConnection;
+use sqlx::PgPool;
+
+/// Convenience methods for using a SeaORM connection with Awa.
+pub trait SeaOrmAwaExt {
+    /// Access the underlying PostgreSQL pool.
+    fn awa_pool(&self) -> &PgPool;
+
+    /// Build an Awa client from the SeaORM connection's pool.
+    fn awa_client_builder(&self) -> ClientBuilder;
+}
+
+impl SeaOrmAwaExt for DatabaseConnection {
+    fn awa_pool(&self) -> &PgPool {
+        self.get_postgres_connection_pool()
+    }
+
+    fn awa_client_builder(&self) -> ClientBuilder {
+        Client::builder(self.awa_pool().clone())
+    }
+}
+
+/// Return the underlying PostgreSQL pool from a SeaORM connection.
+pub fn pool(connection: &DatabaseConnection) -> &PgPool {
+    connection.awa_pool()
+}
+
+/// Build an Awa client builder from a SeaORM connection.
+pub fn client_builder(connection: &DatabaseConnection) -> ClientBuilder {
+    connection.awa_client_builder()
+}
+
+/// Run Awa migrations on a SeaORM connection.
+pub async fn migrate(connection: &DatabaseConnection) -> Result<(), AwaError> {
+    awa::migrations::run(connection.awa_pool()).await
+}
+
+/// Insert a job using Awa's existing sqlx path via the SeaORM connection pool.
+pub async fn insert(
+    connection: &DatabaseConnection,
+    args: &impl JobArgs,
+) -> Result<JobRow, AwaError> {
+    awa::insert(connection.awa_pool(), args).await
+}
+
+/// Insert a job with custom options using the SeaORM connection pool.
+pub async fn insert_with(
+    connection: &DatabaseConnection,
+    args: &impl JobArgs,
+    opts: InsertOpts,
+) -> Result<JobRow, AwaError> {
+    awa::insert_with(connection.awa_pool(), args, opts).await
+}

--- a/awa-seaorm/src/lib.rs
+++ b/awa-seaorm/src/lib.rs
@@ -19,10 +19,11 @@
 //! API on the pool from [`pool`].
 
 use awa::adapter::postgres::{prepare_job_insert, prepare_raw_job_insert, PreparedJobInsert};
-use awa::{AwaError, Client, ClientBuilder, InsertOpts, JobArgs, JobRow};
-use sea_orm::{ConnectionTrait, DatabaseConnection, DbErr, SqlErr, Statement};
+use awa::{map_sqlx_error, AwaError, Client, ClientBuilder, InsertOpts, JobArgs, JobRow};
+use sea_orm::{ConnectionTrait, DatabaseConnection, DbErr, Statement};
 use sqlx::FromRow;
 use sqlx::PgPool;
+use std::sync::Arc;
 
 /// Convenience methods for using a SeaORM connection with Awa.
 pub trait SeaOrmAwaExt {
@@ -153,37 +154,21 @@ where
     JobRow::from_row(row).map_err(AwaError::from)
 }
 
-/// Translate a SeaORM error into Awa's error type, preserving unique-conflict
-/// detection (so callers see [`AwaError::UniqueConflict`]) and the underlying
-/// sqlx error where SeaORM exposes it.
+/// Translate a SeaORM error into Awa's error type.
+///
+/// Where SeaORM carries the underlying sqlx error, route it through Awa's
+/// canonical [`map_sqlx_error`] so the result — including unique-conflict
+/// detection — is identical to the native `awa::insert` path. SeaORM mints a
+/// fresh `Arc` per error, so the unwrap normally succeeds; the rare shared
+/// case falls back to a database error.
 fn map_db_err(err: DbErr) -> AwaError {
-    if matches!(err.sql_err(), Some(SqlErr::UniqueConstraintViolation(_))) {
-        return AwaError::UniqueConflict {
-            constraint: unique_constraint_name(&err),
-        };
-    }
-
     match err {
         DbErr::Exec(sea_orm::RuntimeErr::SqlxError(err))
         | DbErr::Query(sea_orm::RuntimeErr::SqlxError(err))
-        | DbErr::Conn(sea_orm::RuntimeErr::SqlxError(err)) => {
-            match std::sync::Arc::try_unwrap(err) {
-                Ok(err) => AwaError::from(err),
-                Err(err) => AwaError::Database(sqlx::Error::Protocol(err.to_string())),
-            }
-        }
+        | DbErr::Conn(sea_orm::RuntimeErr::SqlxError(err)) => match Arc::try_unwrap(err) {
+            Ok(err) => map_sqlx_error(err),
+            Err(err) => AwaError::Database(sqlx::Error::Protocol(err.to_string())),
+        },
         other => AwaError::Database(sqlx::Error::Protocol(other.to_string())),
-    }
-}
-
-fn unique_constraint_name(err: &DbErr) -> Option<String> {
-    let (DbErr::Exec(sea_orm::RuntimeErr::SqlxError(sqlx_err))
-    | DbErr::Query(sea_orm::RuntimeErr::SqlxError(sqlx_err))) = err
-    else {
-        return None;
-    };
-    match std::ops::Deref::deref(sqlx_err) {
-        sqlx::Error::Database(db_err) => db_err.constraint().map(|c| c.to_string()),
-        _ => None,
     }
 }

--- a/awa-seaorm/src/lib.rs
+++ b/awa-seaorm/src/lib.rs
@@ -1,14 +1,27 @@
 //! SeaORM integration helpers for Awa.
 //!
-//! This crate stays deliberately thin: it exposes the underlying
-//! `sqlx::PgPool` from a SeaORM `DatabaseConnection`, then reuses Awa's
-//! existing migration and insertion helpers on that pool.
+//! This crate stays deliberately thin. Awa's core is SQLx/Postgres-native,
+//! and a SeaORM `DatabaseConnection` already wraps a `sqlx::PgPool` — so for
+//! building a client, running migrations, or reading job state you can reach
+//! the pool directly (see [`pool`]) and use Awa's existing APIs unchanged.
 //!
-//! It does not add a new storage engine, and it does not replace the
-//! existing `awa` sqlx API.
+//! The one thing the pool *can't* give you is enqueueing a job on the same
+//! connection as an in-flight SeaORM transaction: `get_postgres_connection_pool()`
+//! hands back a separate pooled connection, so a job inserted through it would
+//! commit independently of your ORM writes. The [`insert`], [`insert_with`],
+//! and [`insert_raw`] functions here run Awa's canonical insert SQL through
+//! SeaORM's [`ConnectionTrait`], so they bind to whatever you pass —
+//! a `DatabaseConnection` *or* a `DatabaseTransaction` — letting you enqueue a
+//! job atomically with the rest of a transaction. The returned row is decoded
+//! with Awa's own `FromRow`, so it is identical to a job from `awa::insert`.
+//!
+//! Job administration and reads are not duplicated here: use the `awa::admin`
+//! API on the pool from [`pool`].
 
+use awa::adapter::postgres::{prepare_job_insert, prepare_raw_job_insert, PreparedJobInsert};
 use awa::{AwaError, Client, ClientBuilder, InsertOpts, JobArgs, JobRow};
-use sea_orm::DatabaseConnection;
+use sea_orm::{ConnectionTrait, DatabaseConnection, DbErr, SqlErr, Statement};
+use sqlx::FromRow;
 use sqlx::PgPool;
 
 /// Convenience methods for using a SeaORM connection with Awa.
@@ -45,19 +58,132 @@ pub async fn migrate(connection: &DatabaseConnection) -> Result<(), AwaError> {
     awa::migrations::run(connection.awa_pool()).await
 }
 
-/// Insert a job using Awa's existing sqlx path via the SeaORM connection pool.
-pub async fn insert(
-    connection: &DatabaseConnection,
-    args: &impl JobArgs,
-) -> Result<JobRow, AwaError> {
-    awa::insert(connection.awa_pool(), args).await
+/// Enqueue a job using the type-provided job kind and serialized arguments.
+///
+/// Runs on the supplied SeaORM connection or transaction, so passing a
+/// `&DatabaseTransaction` commits the job atomically with the rest of that
+/// transaction.
+pub async fn insert<C>(connection: &C, args: &impl JobArgs) -> Result<JobRow, AwaError>
+where
+    C: ConnectionTrait,
+{
+    insert_with(connection, args, InsertOpts::default()).await
 }
 
-/// Insert a job with custom options using the SeaORM connection pool.
-pub async fn insert_with(
-    connection: &DatabaseConnection,
+/// Enqueue a job with explicit enqueue options.
+///
+/// Like [`insert`], this binds to the supplied connection or transaction.
+pub async fn insert_with<C>(
+    connection: &C,
     args: &impl JobArgs,
     opts: InsertOpts,
-) -> Result<JobRow, AwaError> {
-    awa::insert_with(connection.awa_pool(), args, opts).await
+) -> Result<JobRow, AwaError>
+where
+    C: ConnectionTrait,
+{
+    let prepared = prepare_job_insert(args, opts)?;
+    insert_prepared(connection, &prepared).await
+}
+
+/// Enqueue a job from a raw kind name and JSON-compatible arguments.
+///
+/// Like [`insert`], this binds to the supplied connection or transaction.
+pub async fn insert_raw<C>(
+    connection: &C,
+    kind: impl Into<String>,
+    args: impl Into<serde_json::Value>,
+    opts: InsertOpts,
+) -> Result<JobRow, AwaError>
+where
+    C: ConnectionTrait,
+{
+    let prepared = prepare_raw_job_insert(kind, args, opts)?;
+    insert_prepared(connection, &prepared).await
+}
+
+async fn insert_prepared<C>(
+    connection: &C,
+    prepared: &PreparedJobInsert,
+) -> Result<JobRow, AwaError>
+where
+    C: ConnectionTrait,
+{
+    let unique_key = prepared.unique_key().map(<[u8]>::to_vec);
+    let unique_states = prepared.unique_states_bit_string().map(ToOwned::to_owned);
+    let ordering_key = prepared.ordering_key().map(<[u8]>::to_vec);
+
+    let statement = Statement::from_sql_and_values(
+        connection.get_database_backend(),
+        awa::adapter::postgres::INSERT_JOB_SQL,
+        vec![
+            prepared.kind().into(),
+            prepared.queue().into(),
+            prepared.args().clone().into(),
+            prepared.state_db_str().into(),
+            prepared.priority().into(),
+            prepared.max_attempts().into(),
+            prepared.run_at().into(),
+            prepared.metadata().clone().into(),
+            prepared.tags().to_vec().into(),
+            unique_key.into(),
+            unique_states.into(),
+            ordering_key.into(),
+        ],
+    );
+
+    let result = connection
+        .query_one_raw(statement)
+        .await
+        .map_err(map_db_err)?
+        .ok_or_else(|| {
+            AwaError::Database(sqlx::Error::Protocol(
+                "insert_job_compat returned no row".to_string(),
+            ))
+        })?;
+
+    // SeaORM ran the query but `JobRow` already knows how to decode an
+    // `awa.jobs` row, so reach the underlying sqlx row and reuse it rather
+    // than maintaining a parallel column-by-column decoder.
+    let row = result.try_as_pg_row().ok_or_else(|| {
+        AwaError::Database(sqlx::Error::Protocol(
+            "expected a PostgreSQL row from the insert".to_string(),
+        ))
+    })?;
+
+    JobRow::from_row(row).map_err(AwaError::from)
+}
+
+/// Translate a SeaORM error into Awa's error type, preserving unique-conflict
+/// detection (so callers see [`AwaError::UniqueConflict`]) and the underlying
+/// sqlx error where SeaORM exposes it.
+fn map_db_err(err: DbErr) -> AwaError {
+    if matches!(err.sql_err(), Some(SqlErr::UniqueConstraintViolation(_))) {
+        return AwaError::UniqueConflict {
+            constraint: unique_constraint_name(&err),
+        };
+    }
+
+    match err {
+        DbErr::Exec(sea_orm::RuntimeErr::SqlxError(err))
+        | DbErr::Query(sea_orm::RuntimeErr::SqlxError(err))
+        | DbErr::Conn(sea_orm::RuntimeErr::SqlxError(err)) => {
+            match std::sync::Arc::try_unwrap(err) {
+                Ok(err) => AwaError::from(err),
+                Err(err) => AwaError::Database(sqlx::Error::Protocol(err.to_string())),
+            }
+        }
+        other => AwaError::Database(sqlx::Error::Protocol(other.to_string())),
+    }
+}
+
+fn unique_constraint_name(err: &DbErr) -> Option<String> {
+    let (DbErr::Exec(sea_orm::RuntimeErr::SqlxError(sqlx_err))
+    | DbErr::Query(sea_orm::RuntimeErr::SqlxError(sqlx_err))) = err
+    else {
+        return None;
+    };
+    match std::ops::Deref::deref(sqlx_err) {
+        sqlx::Error::Database(db_err) => db_err.constraint().map(|c| c.to_string()),
+        _ => None,
+    }
 }

--- a/awa-seaorm/tests/seaorm.rs
+++ b/awa-seaorm/tests/seaorm.rs
@@ -1,6 +1,6 @@
 use awa::{JobArgs, JobResult, QueueConfig};
-use awa_seaorm::{client_builder, insert, migrate, SeaOrmAwaExt};
-use sea_orm::DatabaseConnection;
+use awa_seaorm::{client_builder, insert, insert_raw, migrate, SeaOrmAwaExt};
+use sea_orm::{ConnectionTrait, DatabaseConnection, TransactionTrait};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Serialize, Deserialize, JobArgs)]
@@ -14,12 +14,38 @@ fn test_database_url() -> String {
         .unwrap_or_else(|_| "postgres://postgres:test@localhost:15432/awa_test".to_string())
 }
 
-#[tokio::test]
-async fn seaorm_adapter_can_migrate_build_client_and_insert() {
+async fn setup_database() -> (sqlx::PgPool, DatabaseConnection) {
     let pool = awa_testing::setup::setup(2).await;
     let db = DatabaseConnection::from(pool.clone());
-
     migrate(&db).await.expect("awa migration should succeed");
+    (pool, db)
+}
+
+async fn create_app_table(pool: &sqlx::PgPool, table_name: &str) {
+    let table_name = quoted_identifier(table_name);
+    sqlx::query(&format!(
+        "CREATE TABLE IF NOT EXISTS {table_name} (id TEXT PRIMARY KEY, note TEXT NOT NULL)"
+    ))
+    .execute(pool)
+    .await
+    .expect("create app table");
+}
+
+async fn drop_app_table(pool: &sqlx::PgPool, table_name: &str) {
+    let table_name = quoted_identifier(table_name);
+    sqlx::query(&format!("DROP TABLE IF EXISTS {table_name}"))
+        .execute(pool)
+        .await
+        .expect("drop app table");
+}
+
+fn quoted_identifier(identifier: &str) -> String {
+    format!("\"{}\"", identifier.replace('"', "\"\""))
+}
+
+#[tokio::test]
+async fn seaorm_adapter_can_migrate_build_client_and_insert() {
+    let (_pool, db) = setup_database().await;
 
     let client = client_builder(&db)
         .queue("email", QueueConfig::default())
@@ -54,10 +80,98 @@ async fn seaorm_pool_helper_matches_database_connection() {
         .expect("database connection should succeed");
 
     let pool = db.awa_pool();
-    let row: (i64,) = sqlx::query_as("SELECT 1")
+    let row: (i64,) = sqlx::query_as("SELECT 1::bigint")
         .fetch_one(pool)
         .await
         .expect("underlying postgres pool should execute sqlx queries");
 
     assert_eq!(row.0, 1);
+}
+
+#[tokio::test]
+async fn enqueue_commits_atomically_with_app_writes() {
+    let (pool, db) = setup_database().await;
+    let table_name = "seaorm_commit_rows";
+    create_app_table(&pool, table_name).await;
+
+    let txn = db.begin().await.expect("begin transaction");
+    txn.execute_unprepared(&format!(
+        "INSERT INTO {table_name} (id, note) VALUES ('commit-app-row', 'persisted')"
+    ))
+    .await
+    .expect("insert app row inside transaction");
+
+    let job = insert(
+        &txn,
+        &SendEmail {
+            to: "commit@example.com".into(),
+            subject: "atomic commit".into(),
+        },
+    )
+    .await
+    .expect("insert job inside transaction");
+
+    txn.commit().await.expect("commit transaction");
+
+    let app_count: i64 = sqlx::query_scalar(&format!(
+        "SELECT count(*) FROM {table_name} WHERE id = 'commit-app-row'"
+    ))
+    .fetch_one(&pool)
+    .await
+    .expect("count committed app row");
+    assert_eq!(app_count, 1);
+
+    let job_count: i64 = sqlx::query_scalar("SELECT count(*) FROM awa.jobs WHERE id = $1")
+        .bind(job.id)
+        .fetch_one(&pool)
+        .await
+        .expect("count committed job");
+    assert_eq!(job_count, 1);
+
+    drop_app_table(&pool, table_name).await;
+}
+
+#[tokio::test]
+async fn enqueue_rolls_back_with_app_writes() {
+    let (pool, db) = setup_database().await;
+    let table_name = "seaorm_rollback_rows";
+    create_app_table(&pool, table_name).await;
+
+    let txn = db.begin().await.expect("begin transaction");
+    txn.execute_unprepared(&format!(
+        "INSERT INTO {table_name} (id, note) VALUES ('rollback-app-row', 'discarded')"
+    ))
+    .await
+    .expect("insert app row inside transaction");
+
+    let job = insert_raw(
+        &txn,
+        "rollback_seaorm_job",
+        serde_json::json!({"rolled_back": true}),
+        awa::InsertOpts {
+            queue: "seaorm_rollback_queue".into(),
+            ..Default::default()
+        },
+    )
+    .await
+    .expect("insert raw job inside transaction");
+
+    txn.rollback().await.expect("rollback transaction");
+
+    let app_count: i64 = sqlx::query_scalar(&format!(
+        "SELECT count(*) FROM {table_name} WHERE id = 'rollback-app-row'"
+    ))
+    .fetch_one(&pool)
+    .await
+    .expect("count rolled-back app row");
+    assert_eq!(app_count, 0);
+
+    let job_count: i64 = sqlx::query_scalar("SELECT count(*) FROM awa.jobs WHERE id = $1")
+        .bind(job.id)
+        .fetch_one(&pool)
+        .await
+        .expect("count rolled-back job");
+    assert_eq!(job_count, 0);
+
+    drop_app_table(&pool, table_name).await;
 }

--- a/awa-seaorm/tests/seaorm.rs
+++ b/awa-seaorm/tests/seaorm.rs
@@ -1,0 +1,63 @@
+use awa::{JobArgs, JobResult, QueueConfig};
+use awa_seaorm::{client_builder, insert, migrate, SeaOrmAwaExt};
+use sea_orm::DatabaseConnection;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize, JobArgs)]
+struct SendEmail {
+    to: String,
+    subject: String,
+}
+
+fn test_database_url() -> String {
+    std::env::var("DATABASE_URL")
+        .unwrap_or_else(|_| "postgres://postgres:test@localhost:15432/awa_test".to_string())
+}
+
+#[tokio::test]
+async fn seaorm_adapter_can_migrate_build_client_and_insert() {
+    let pool = awa_testing::setup::setup(2).await;
+    let db = DatabaseConnection::from(pool.clone());
+
+    migrate(&db).await.expect("awa migration should succeed");
+
+    let client = client_builder(&db)
+        .queue("email", QueueConfig::default())
+        .register::<SendEmail, _, _>(|_args, _ctx| async move { Ok(JobResult::Completed) })
+        .build()
+        .expect("awa client should build from seaorm connection");
+    drop(client);
+
+    let job = insert(
+        &db,
+        &SendEmail {
+            to: "ada@example.com".into(),
+            subject: "hello".into(),
+        },
+    )
+    .await
+    .expect("awa insert should succeed through seaorm connection");
+
+    let stored_kind: String = sqlx::query_scalar("SELECT kind FROM awa.jobs WHERE id = $1")
+        .bind(job.id)
+        .fetch_one(db.awa_pool())
+        .await
+        .expect("inserted job should be visible in awa.jobs");
+
+    assert_eq!(stored_kind, "send_email");
+}
+
+#[tokio::test]
+async fn seaorm_pool_helper_matches_database_connection() {
+    let db = sea_orm::Database::connect(&test_database_url())
+        .await
+        .expect("database connection should succeed");
+
+    let pool = db.awa_pool();
+    let row: (i64,) = sqlx::query_as("SELECT 1")
+        .fetch_one(pool)
+        .await
+        .expect("underlying postgres pool should execute sqlx queries");
+
+    assert_eq!(row.0, 1);
+}

--- a/awa-seaorm/tests/seaorm.rs
+++ b/awa-seaorm/tests/seaorm.rs
@@ -1,7 +1,8 @@
-use awa::{JobArgs, JobResult, QueueConfig};
-use awa_seaorm::{client_builder, insert, insert_raw, migrate, SeaOrmAwaExt};
+use awa::{AwaError, InsertOpts, JobArgs, JobResult, QueueConfig, UniqueOpts};
+use awa_seaorm::{client_builder, insert, insert_raw, insert_with, migrate, SeaOrmAwaExt};
 use sea_orm::{ConnectionTrait, DatabaseConnection, TransactionTrait};
 use serde::{Deserialize, Serialize};
+use std::sync::atomic::{AtomicU64, Ordering};
 
 #[derive(Debug, Serialize, Deserialize, JobArgs)]
 struct SendEmail {
@@ -12,6 +13,17 @@ struct SendEmail {
 fn test_database_url() -> String {
     std::env::var("DATABASE_URL")
         .unwrap_or_else(|_| "postgres://postgres:test@localhost:15432/awa_test".to_string())
+}
+
+/// Unique identifier for per-test tables and queues so a failed run that
+/// skips cleanup can't collide with the next one.
+fn unique_suffix(prefix: &str) -> String {
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    format!(
+        "{prefix}_{}_{}",
+        std::process::id(),
+        COUNTER.fetch_add(1, Ordering::Relaxed)
+    )
 }
 
 async fn setup_database() -> (sqlx::PgPool, DatabaseConnection) {
@@ -91,8 +103,8 @@ async fn seaorm_pool_helper_matches_database_connection() {
 #[tokio::test]
 async fn enqueue_commits_atomically_with_app_writes() {
     let (pool, db) = setup_database().await;
-    let table_name = "seaorm_commit_rows";
-    create_app_table(&pool, table_name).await;
+    let table_name = unique_suffix("seaorm_commit_rows");
+    create_app_table(&pool, &table_name).await;
 
     let txn = db.begin().await.expect("begin transaction");
     txn.execute_unprepared(&format!(
@@ -128,14 +140,14 @@ async fn enqueue_commits_atomically_with_app_writes() {
         .expect("count committed job");
     assert_eq!(job_count, 1);
 
-    drop_app_table(&pool, table_name).await;
+    drop_app_table(&pool, &table_name).await;
 }
 
 #[tokio::test]
 async fn enqueue_rolls_back_with_app_writes() {
     let (pool, db) = setup_database().await;
-    let table_name = "seaorm_rollback_rows";
-    create_app_table(&pool, table_name).await;
+    let table_name = unique_suffix("seaorm_rollback_rows");
+    create_app_table(&pool, &table_name).await;
 
     let txn = db.begin().await.expect("begin transaction");
     txn.execute_unprepared(&format!(
@@ -173,5 +185,47 @@ async fn enqueue_rolls_back_with_app_writes() {
         .expect("count rolled-back job");
     assert_eq!(job_count, 0);
 
-    drop_app_table(&pool, table_name).await;
+    drop_app_table(&pool, &table_name).await;
+}
+
+#[tokio::test]
+async fn duplicate_unique_job_maps_to_unique_conflict() {
+    let (_pool, db) = setup_database().await;
+    let queue = unique_suffix("seaorm_unique_q");
+    let opts = || InsertOpts {
+        queue: queue.clone(),
+        unique: Some(UniqueOpts {
+            by_queue: true,
+            ..UniqueOpts::default()
+        }),
+        ..Default::default()
+    };
+
+    let first = insert_with(
+        &db,
+        &SendEmail {
+            to: "unique@example.com".into(),
+            subject: "first".into(),
+        },
+        opts(),
+    )
+    .await
+    .expect("first insert should succeed");
+    assert!(first.unique_key.is_some());
+
+    // A second insert with the same uniqueness key must surface as a typed
+    // UniqueConflict, identical to the native awa::insert path.
+    let result = insert_with(
+        &db,
+        &SendEmail {
+            to: "unique@example.com".into(),
+            subject: "first".into(),
+        },
+        opts(),
+    )
+    .await;
+    assert!(
+        matches!(result, Err(AwaError::UniqueConflict { .. })),
+        "expected UniqueConflict, got {result:?}"
+    );
 }

--- a/awa/src/lib.rs
+++ b/awa/src/lib.rs
@@ -12,7 +12,7 @@ pub use awa_model;
 // Re-export core model types (includes JobArgs derive macro via awa-model)
 pub use awa_model::{
     self as model, adapter, admin, bridge, insert, insert_many, insert_many_copy,
-    insert_many_copy_from_pool, insert_with, migrations, prepare_job_insert,
+    insert_many_copy_from_pool, insert_with, map_sqlx_error, migrations, prepare_job_insert,
     prepare_raw_job_insert, storage, AwaError, CallbackConfig, DefaultAction, DlqMetadata, DlqRow,
     InsertOpts, InsertParams, JobArgs, JobKindDescriptor, JobRow, JobState, ListDlqFilter,
     PreparedJobInsert, QueueDescriptor, QueueStorage, QueueStorageConfig, ResolveOutcome,

--- a/docs/bridge-adapters.md
+++ b/docs/bridge-adapters.md
@@ -165,17 +165,26 @@ All functions return `awa::JobRow` with the full row from `RETURNING *` — same
 
 ## Rust: SeaORM
 
-SeaORM already sits on top of SQLx, so this adapter keeps the integration
-thin: it surfaces the underlying `sqlx::PgPool` from
-`sea_orm::DatabaseConnection`, then reuses Awa's existing insert and
-migration helpers on that pool.
+SeaORM already sits on top of SQLx, so the integration is deliberately thin.
+A `sea_orm::DatabaseConnection` wraps a `sqlx::PgPool`, so for building a
+client, running migrations, or reading job state you can reach the pool
+directly (`awa_seaorm::pool(&db)` / `db.awa_pool()`) and use Awa's existing
+APIs unchanged.
+
+The part that needs a real adapter is **transactional enqueue**.
+`get_postgres_connection_pool()` hands back a *separate* pooled connection, so
+a job inserted through it commits independently of your ORM writes. The
+`insert` / `insert_with` / `insert_raw` helpers instead run Awa's canonical
+insert SQL through SeaORM's `ConnectionTrait`, so they bind to whatever you
+pass — a `DatabaseConnection` *or* a `DatabaseTransaction` — letting a job
+commit atomically with the rest of a transaction.
 
 The adapter lives in the optional `awa-seaorm` crate:
 
 ```toml
 [dependencies]
-awa = "0.6.0-alpha.9"
-awa-seaorm = "0.6.0-alpha.9"
+awa = "0.6.0-beta.1"
+awa-seaorm = "0.6.0-beta.1"
 sea-orm = { version = "=2.0.0-rc.38", default-features = false, features = [
     "sqlx-postgres",
     "runtime-tokio-rustls",
@@ -183,15 +192,14 @@ sea-orm = { version = "=2.0.0-rc.38", default-features = false, features = [
 ```
 
 ```rust
-use awa::{JobArgs, QueueConfig};
-use awa_seaorm::{client_builder, insert, migrate};
-use sea_orm::Database;
+use awa::JobArgs;
+use awa_seaorm::{insert, migrate};
+use sea_orm::{Database, TransactionTrait};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Serialize, Deserialize, JobArgs)]
-struct SendEmail {
-    to: String,
-    subject: String,
+struct SendWelcomeEmail {
+    user_id: i64,
 }
 
 #[tokio::main]
@@ -199,22 +207,38 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let db = Database::connect(&std::env::var("DATABASE_URL")?).await?;
     migrate(&db).await?;
 
-    let _client = client_builder(&db)
-        .queue("email", QueueConfig::default())
-        .build()?;
-
-    insert(
-        &db,
-        &SendEmail {
-            to: "ada@example.com".into(),
-            subject: "hello".into(),
-        },
-    )
-    .await?;
+    // The user row and its welcome-email job commit together, or not at all.
+    let txn = db.begin().await?;
+    // ... insert your application rows via SeaORM on `txn` ...
+    insert(&txn, &SendWelcomeEmail { user_id: 42 }).await?;
+    txn.commit().await?;
 
     Ok(())
 }
 ```
+
+Without a transaction, pass the connection directly (`insert(&db, &job)`) to
+enqueue immediately, or use `client_builder(&db)` to build a worker client.
+
+### Why the adapter runs SQL rather than reusing `awa::insert_with`
+
+Awa's native `insert_with` is a *pull* API: hand it a `&mut sqlx::PgConnection`
+and it runs on it. A SeaORM `DatabaseTransaction` can't satisfy that. It owns
+the connection inside an `Arc<Mutex<…>>` and must keep it so a later
+`commit()`/`rollback()` runs on that same connection — so it never lends out a
+`&mut PgConnection`, and exposes no `Into`/`AsMut`/accessor for one. The only
+way it lets you use that connection is its `ConnectionTrait`, a *push* API:
+you give it a `Statement` and it runs it for you.
+
+So the adapter inverts the direction — it pushes Awa's canonical insert SQL
+(`awa::adapter::postgres::INSERT_JOB_SQL`, the same statement and bind order
+the native path and the tokio-postgres bridge use) through `ConnectionTrait`.
+The result row, however, *is* surrendered: `QueryResult::try_as_pg_row` yields
+the underlying `sqlx::PgRow`, which Awa's own `JobRow: FromRow` decodes — so
+the returned job is identical to one from `awa::insert`, with no parallel
+decoder to drift. This is also why the workspace enables SeaORM's `with-chrono`
+and `with-json` features: only so the timestamp and JSONB bind values can
+become `sea_orm::Value`.
 
 ## Python: psycopg3, asyncpg, SQLAlchemy, Django
 

--- a/docs/bridge-adapters.md
+++ b/docs/bridge-adapters.md
@@ -163,6 +163,59 @@ let job = tokio_pg::insert_job_raw(
 
 All functions return `awa::JobRow` with the full row from `RETURNING *` — same type as `awa::insert_with`. The only field not populated is `unique_states` (BIT(8), no direct tokio-postgres mapping). All other fields, including `errors`, are decoded from the database row.
 
+## Rust: SeaORM
+
+SeaORM already sits on top of SQLx, so this adapter keeps the integration
+thin: it surfaces the underlying `sqlx::PgPool` from
+`sea_orm::DatabaseConnection`, then reuses Awa's existing insert and
+migration helpers on that pool.
+
+The adapter lives in the optional `awa-seaorm` crate:
+
+```toml
+[dependencies]
+awa = "0.6.0-alpha.9"
+awa-seaorm = "0.6.0-alpha.9"
+sea-orm = { version = "=2.0.0-rc.38", default-features = false, features = [
+    "sqlx-postgres",
+    "runtime-tokio-rustls",
+] }
+```
+
+```rust
+use awa::{JobArgs, QueueConfig};
+use awa_seaorm::{client_builder, insert, migrate};
+use sea_orm::Database;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize, JobArgs)]
+struct SendEmail {
+    to: String,
+    subject: String,
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let db = Database::connect(&std::env::var("DATABASE_URL")?).await?;
+    migrate(&db).await?;
+
+    let _client = client_builder(&db)
+        .queue("email", QueueConfig::default())
+        .build()?;
+
+    insert(
+        &db,
+        &SendEmail {
+            to: "ada@example.com".into(),
+            subject: "hello".into(),
+        },
+    )
+    .await?;
+
+    Ok(())
+}
+```
+
 ## Python: psycopg3, asyncpg, SQLAlchemy, Django
 
 See [Python getting started — ORM Transaction Bridging](getting-started-python.md#orm-transaction-bridging).


### PR DESCRIPTION
Reworks the SeaORM integration proposed in #257 down to the capability that genuinely needs an adapter, with no changes to `awa`'s public API.

Builds on @chencaizhi's original crate (cherry-picked, attribution preserved) and a follow-up that refocuses it.

## What needs an adapter — and what doesn't

A `sea_orm::DatabaseConnection` already wraps a `sqlx::PgPool`, so building a client, running migrations, and reading job state need no glue: reach the pool with `awa_seaorm::pool(&db)` / `db.awa_pool()` and use Awa's existing APIs. Job administration likewise stays on the pool-based `awa::admin` API.

The one thing the pool **can't** do is enqueue on the same connection as an in-flight SeaORM transaction — `get_postgres_connection_pool()` returns a *separate* pooled connection, so a job inserted through it commits independently of the app's ORM writes. `insert` / `insert_with` / `insert_raw` run Awa's canonical insert SQL through SeaORM's `ConnectionTrait`, binding to a `DatabaseConnection` *or* a `DatabaseTransaction`, so a job commits atomically with surrounding ORM writes.

## Design rationale (pull vs push)

Awa's native `insert_with` is a *pull* API: hand it a `&mut sqlx::PgConnection` and it runs on it. A SeaORM `DatabaseTransaction` cannot satisfy that — it owns the connection inside an `Arc<Mutex<…>>` and must keep it so a later `commit()`/`rollback()` runs on that same connection. It exposes no `Into`/`AsMut`/accessor for the connection; the only way to use it is `ConnectionTrait`, a *push* API (give it a `Statement`, it runs it).

So the adapter inverts the direction: it pushes Awa's canonical `awa::adapter::postgres::INSERT_JOB_SQL` (same statement + bind order the native path and the tokio-postgres bridge use) through `ConnectionTrait`. The result row *is* surrendered — `QueryResult::try_as_pg_row()` yields the underlying `sqlx::PgRow`, which Awa's own `JobRow: FromRow` decodes — so the returned job is byte-identical to `awa::insert`, with no parallel decoder to drift. (This is documented in `docs/bridge-adapters.md`.)

## Changes vs #257

- **No changes to `awa` core** (`git diff main -- awa-model/ awa/src/` is empty). Uses only already-public extension points.
- **Dropped** the SeaORM entity model and the ~900-line lifecycle/admin repository: it reimplemented Awa's admin SQL as hand-copied strings (drift risk) and added nothing over the pool-based `awa::admin` API.
- **Dropped** the hand-written `QueryResult → JobRow` decoder in favour of reusing `JobRow: FromRow` via `try_as_pg_row()`.
- Workspace enables SeaORM `with-chrono` + `with-json` only so timestamp/JSONB bind values can become `sea_orm::Value`.

## Test plan

- [x] `cargo fmt --all --check` clean
- [x] `cargo clippy -p awa-seaorm --all-targets -- -D warnings` clean
- [x] `cargo test -p awa-seaorm` — 4 pass, including atomic commit and rollback alongside application rows
- [x] Native path unaffected (no core diff)

Supersedes #257.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced SeaORM database adapter for Awa job system, enabling atomic job enqueueing within SeaORM transactions
  * Support for both transactional and non-transactional job enqueueing workflows

* **Documentation**
  * Added SeaORM bridge adapter documentation with usage examples and integration guidelines

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hardbyte/awa/pull/275?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->