### PR TITLE
Lifecycle events for the callback path

### DIFF
--- a/README.md
+++ b/README.md
@@ -409,6 +409,7 @@ Rust and Python workers coexist on the same queues. See
 | [0.5 → 0.6 upgrade](docs/upgrade-0.5-to-0.6.md) | Step-by-step operator checklist for the staged storage transition |
 | [Configuration reference](docs/configuration.md) | `QueueConfig`, `ClientBuilder`, Python `start()`, env vars |
 | [HTTP workers and callbacks](docs/http-callbacks.md) | Serverless dispatch, callback receiver endpoints, signature verification |
+| [Lifecycle hooks](docs/lifecycle-hooks.md) | React to job start/finish/retry/callback events for metrics, alerting, cleanup |
 | [Security & Postgres roles](docs/security.md) | Minimum-privilege roles, callback auth, operational guidance |
 | [Troubleshooting](docs/troubleshooting.md) | Stuck `running` jobs, leader delays, heartbeat timeouts |
 | [Architecture overview](docs/architecture.md) | System design, data flow, state machine, crash recovery |

--- a/awa-worker/src/client.rs
+++ b/awa-worker/src/client.rs
@@ -1464,16 +1464,33 @@ impl Client {
     }
 
     /// Requeue a waiting job via its callback and dispatch a `Retried` hook.
+    ///
+    /// `admin::retry_external` resets `attempt` to 0 as part of requeuing the
+    /// job from scratch, so the returned `JobRow` no longer reflects the
+    /// attempt that was being retried. Capture the parked attempt first so
+    /// the `Retried` event reports the failed-attempt number — matching the
+    /// inline `Retried` semantics, where `attempt` is "the attempt that was
+    /// retried", not the post-transition value.
     pub async fn retry_external(
         &self,
         callback_id: Uuid,
         run_lease: Option<i64>,
     ) -> Result<awa_model::JobRow, awa_model::AwaError> {
+        let parked_attempt: Option<i16> = sqlx::query_scalar(
+            "SELECT attempt FROM awa.jobs \
+             WHERE callback_id = $1 AND state = 'waiting_external' \
+               AND ($2::bigint IS NULL OR run_lease = $2)",
+        )
+        .bind(callback_id)
+        .bind(run_lease)
+        .fetch_optional(&self.pool)
+        .await?;
+
         let job = admin::retry_external(&self.pool, callback_id, run_lease).await?;
         self.dispatch_callback_event(UntypedJobEvent::Retried {
             job: job.clone(),
             error: latest_error_message(&job),
-            attempt: job.attempt,
+            attempt: parked_attempt.unwrap_or(job.attempt),
             next_run_at: job.run_at,
         })
         .await;

--- a/awa-worker/src/client.rs
+++ b/awa-worker/src/client.rs
@@ -847,6 +847,19 @@ struct RuntimeReporterState {
     metrics: crate::metrics::AwaMetrics,
 }
 
+/// Best-effort extraction of the most recent error message from a job's
+/// `errors` history, for populating callback-driven `Exhausted`/`Retried`
+/// events. Returns an empty string when no structured error is present.
+fn latest_error_message(job: &awa_model::JobRow) -> String {
+    job.errors
+        .as_ref()
+        .and_then(|errors| errors.last())
+        .and_then(|entry| entry.get("error"))
+        .and_then(|value| value.as_str())
+        .map(str::to_string)
+        .unwrap_or_default()
+}
+
 impl Client {
     /// Create a new builder.
     pub fn builder(pool: PgPool) -> ClientBuilder {
@@ -1378,6 +1391,98 @@ impl Client {
     /// Get the pool reference.
     pub fn pool(&self) -> &PgPool {
         &self.pool
+    }
+
+    /// Resolve a pending external callback, then dispatch the matching
+    /// lifecycle event to this client's registered hooks.
+    ///
+    /// Prefer this over [`awa_model::admin::resolve_callback`] when you want
+    /// `Completed`/`Exhausted` hooks to fire for callback-driven outcomes.
+    /// Hooks fire only in this process; resolving through the bare `admin`
+    /// function transitions the job correctly but emits no event. A `resume`
+    /// or `ignore` outcome emits nothing — the job either re-enters execution
+    /// (and the executor emits the usual events) or nothing changed.
+    pub async fn resolve_callback(
+        &self,
+        callback_id: Uuid,
+        payload: Option<serde_json::Value>,
+        default_action: awa_model::DefaultAction,
+        run_lease: Option<i64>,
+    ) -> Result<awa_model::ResolveOutcome, awa_model::AwaError> {
+        let outcome =
+            admin::resolve_callback(&self.pool, callback_id, payload, default_action, run_lease)
+                .await?;
+        let event = match &outcome {
+            awa_model::ResolveOutcome::Completed { job, .. } => Some(UntypedJobEvent::Completed {
+                job: job.clone(),
+                duration: Duration::ZERO,
+            }),
+            awa_model::ResolveOutcome::Failed { job } => Some(UntypedJobEvent::Exhausted {
+                job: job.clone(),
+                error: latest_error_message(job),
+                attempt: job.attempt,
+            }),
+            awa_model::ResolveOutcome::Ignored { .. } => None,
+        };
+        if let Some(event) = event {
+            self.dispatch_callback_event(event).await;
+        }
+        Ok(outcome)
+    }
+
+    /// Complete a waiting job via its callback and dispatch a `Completed` hook.
+    pub async fn complete_external(
+        &self,
+        callback_id: Uuid,
+        payload: Option<serde_json::Value>,
+        run_lease: Option<i64>,
+    ) -> Result<awa_model::JobRow, awa_model::AwaError> {
+        let job = admin::complete_external(&self.pool, callback_id, payload, run_lease).await?;
+        self.dispatch_callback_event(UntypedJobEvent::Completed {
+            job: job.clone(),
+            duration: Duration::ZERO,
+        })
+        .await;
+        Ok(job)
+    }
+
+    /// Fail a waiting job via its callback and dispatch an `Exhausted` hook.
+    pub async fn fail_external(
+        &self,
+        callback_id: Uuid,
+        error: &str,
+        run_lease: Option<i64>,
+    ) -> Result<awa_model::JobRow, awa_model::AwaError> {
+        let job = admin::fail_external(&self.pool, callback_id, error, run_lease).await?;
+        self.dispatch_callback_event(UntypedJobEvent::Exhausted {
+            job: job.clone(),
+            error: error.to_string(),
+            attempt: job.attempt,
+        })
+        .await;
+        Ok(job)
+    }
+
+    /// Requeue a waiting job via its callback and dispatch a `Retried` hook.
+    pub async fn retry_external(
+        &self,
+        callback_id: Uuid,
+        run_lease: Option<i64>,
+    ) -> Result<awa_model::JobRow, awa_model::AwaError> {
+        let job = admin::retry_external(&self.pool, callback_id, run_lease).await?;
+        self.dispatch_callback_event(UntypedJobEvent::Retried {
+            job: job.clone(),
+            error: latest_error_message(&job),
+            attempt: job.attempt,
+            next_run_at: job.run_at,
+        })
+        .await;
+        Ok(job)
+    }
+
+    async fn dispatch_callback_event(&self, event: UntypedJobEvent) {
+        let kind = event.job().kind.clone();
+        crate::executor::dispatch_lifecycle_event(&self.lifecycle_handlers, &kind, event).await;
     }
 
     /// Health check.

--- a/awa-worker/src/events.rs
+++ b/awa-worker/src/events.rs
@@ -10,7 +10,13 @@ use std::time::Duration;
 pub enum JobEvent<T> {
     /// Job execution started after the claim committed.
     Started { args: T, job: JobRow },
+    /// Job parked waiting for an external callback. `job.callback_id` and
+    /// `job.callback_timeout_at` identify the pending callback.
+    WaitingForCallback { args: T, job: JobRow },
     /// Job completed successfully.
+    ///
+    /// For a callback-driven completion `duration` is [`Duration::ZERO`], since
+    /// no handler ran during the parked phase.
     Completed {
         args: T,
         job: JobRow,
@@ -44,6 +50,7 @@ impl<T> JobEvent<T> {
     pub fn job(&self) -> &JobRow {
         match self {
             JobEvent::Started { job, .. }
+            | JobEvent::WaitingForCallback { job, .. }
             | JobEvent::Completed { job, .. }
             | JobEvent::Retried { job, .. }
             | JobEvent::Exhausted { job, .. }
@@ -57,6 +64,8 @@ impl<T> JobEvent<T> {
 pub enum UntypedJobEvent {
     /// Job execution started after the claim committed.
     Started { job: JobRow },
+    /// Job parked waiting for an external callback.
+    WaitingForCallback { job: JobRow },
     /// Job completed successfully.
     Completed { job: JobRow, duration: Duration },
     /// Job failed but will be retried later.
@@ -81,6 +90,7 @@ impl UntypedJobEvent {
     pub fn job(&self) -> &JobRow {
         match self {
             UntypedJobEvent::Started { job, .. }
+            | UntypedJobEvent::WaitingForCallback { job, .. }
             | UntypedJobEvent::Completed { job, .. }
             | UntypedJobEvent::Retried { job, .. }
             | UntypedJobEvent::Exhausted { job, .. }
@@ -91,6 +101,9 @@ impl UntypedJobEvent {
     pub(crate) fn into_typed<T>(self, args: T) -> JobEvent<T> {
         match self {
             UntypedJobEvent::Started { job } => JobEvent::Started { args, job },
+            UntypedJobEvent::WaitingForCallback { job } => {
+                JobEvent::WaitingForCallback { args, job }
+            }
             UntypedJobEvent::Completed { job, duration } => JobEvent::Completed {
                 args,
                 job,

--- a/awa-worker/src/executor.rs
+++ b/awa-worker/src/executor.rs
@@ -782,8 +782,17 @@ async fn complete_job_canonical(
                     }
                 }
             }
+            let event = if needs_event {
+                let parked_job: JobRow = sqlx::query_as("SELECT * FROM awa.jobs WHERE id = $1")
+                    .bind(job.id)
+                    .fetch_one(pool)
+                    .await?;
+                Some(UntypedJobEvent::WaitingForCallback { job: parked_job })
+            } else {
+                None
+            };
             Ok(CompletionOutcome::Applied {
-                event: None,
+                event,
                 terminal: false,
             })
         }
@@ -1246,8 +1255,22 @@ async fn complete_job_queue_storage(
                     }
                 }
             }
+            let event = if needs_event {
+                let parked_job = runtime
+                    .store
+                    .load_job(pool, job.id)
+                    .await?
+                    .unwrap_or_else(|| {
+                        let mut parked = job.clone();
+                        parked.state = JobState::WaitingExternal;
+                        parked
+                    });
+                Some(UntypedJobEvent::WaitingForCallback { job: parked_job })
+            } else {
+                None
+            };
             Ok(CompletionOutcome::Applied {
-                event: None,
+                event,
                 terminal: false,
             })
         }
@@ -1445,7 +1468,7 @@ async fn direct_complete_job_queue_storage(
 /// Handlers are called sequentially. Panics are caught and logged — a
 /// misbehaving handler cannot crash the dispatch loop or lose events
 /// for subsequent handlers.
-async fn dispatch_lifecycle_event(
+pub(crate) async fn dispatch_lifecycle_event(
     handlers: &HashMap<String, Vec<BoxedUntypedEventHandler>>,
     kind: &str,
     event: UntypedJobEvent,

--- a/awa/tests/integration_test.rs
+++ b/awa/tests/integration_test.rs
@@ -1470,11 +1470,19 @@ async fn test_flush_dirty_admin_metadata_drains_full_backlog() {
         .await
         .unwrap();
 
-    let dirty_after: i64 = sqlx::query_scalar("SELECT count(*) FROM awa.admin_dirty_queues")
-        .fetch_one(client.pool())
-        .await
-        .unwrap();
-    assert_eq!(dirty_after, 0, "all dirty queues should be drained");
+    // Scope the post-flush check to this test's queues. Parallel test
+    // binaries share the database and can write fresh dirty markers between
+    // our flush and this assertion, so a global count(*) is racy.
+    let dirty_after: i64 = sqlx::query_scalar(
+        "SELECT count(*) FROM awa.admin_dirty_queues WHERE queue LIKE 'integ_flush_backlog_%'",
+    )
+    .fetch_one(client.pool())
+    .await
+    .unwrap();
+    assert_eq!(
+        dirty_after, 0,
+        "all dirty queues for this test should be drained"
+    );
 
     // Verify the cache is accurate for a sample queue
     let stats = admin::queue_overviews(client.pool()).await.unwrap();

--- a/awa/tests/lifecycle_hook_test.rs
+++ b/awa/tests/lifecycle_hook_test.rs
@@ -673,6 +673,9 @@ async fn test_stale_completion_does_not_fire_event() {
                     JobEvent::Cancelled { args, .. } => {
                         tx.send(format!("cancelled:{}", args.value)).unwrap()
                     }
+                    JobEvent::WaitingForCallback { args, .. } => {
+                        tx.send(format!("waiting:{}", args.value)).unwrap()
+                    }
                 }
             }
         })
@@ -809,6 +812,7 @@ async fn test_snooze_only_emits_started_event() {
             async move {
                 let label = match &event {
                     JobEvent::Started { .. } => "started",
+                    JobEvent::WaitingForCallback { .. } => "waiting",
                     JobEvent::Completed { .. } => "completed",
                     JobEvent::Retried { .. } => "retried",
                     JobEvent::Exhausted { .. } => "exhausted",
@@ -847,4 +851,186 @@ async fn test_snooze_only_emits_started_event() {
         rx.try_recv().is_err(),
         "Snooze should not produce a lifecycle outcome event"
     );
+}
+
+// ── Callback lifecycle events ───────────────────────────────────────────
+
+#[derive(Debug)]
+enum CbEvent {
+    Waiting(awa::JobRow),
+    Completed(awa::JobRow, Duration),
+    Exhausted(awa::JobRow, String),
+}
+
+/// Worker that parks on an external callback. Uses a `Worker` impl rather than
+/// a closure because awaiting `ctx.register_callback()` borrows the context,
+/// which the `'static` closure-handler bound disallows.
+struct ParkingWorker;
+
+#[async_trait::async_trait]
+impl Worker for ParkingWorker {
+    fn kind(&self) -> &'static str {
+        HookJob::kind()
+    }
+
+    async fn perform(&self, ctx: &awa::JobContext) -> Result<JobResult, JobError> {
+        let callback = ctx
+            .register_callback(Duration::from_secs(3600))
+            .await
+            .map_err(JobError::retryable)?;
+        Ok(JobResult::WaitForCallback(callback))
+    }
+}
+
+/// Build a client whose `HookJob` worker parks on an external callback and
+/// whose hook forwards Waiting/Completed/Exhausted events onto `tx`.
+fn parking_client(pool: &sqlx::PgPool, queue: &str, tx: mpsc::UnboundedSender<CbEvent>) -> Client {
+    Client::builder(pool.clone())
+        .queue(
+            queue,
+            QueueConfig {
+                poll_interval: Duration::from_millis(25),
+                ..Default::default()
+            },
+        )
+        .register_worker(ParkingWorker)
+        .on_event::<HookJob, _, _>(move |event| {
+            let tx = tx.clone();
+            async move {
+                match event {
+                    JobEvent::WaitingForCallback { job, .. } => {
+                        let _ = tx.send(CbEvent::Waiting(job));
+                    }
+                    JobEvent::Completed { job, duration, .. } => {
+                        let _ = tx.send(CbEvent::Completed(job, duration));
+                    }
+                    JobEvent::Exhausted { job, error, .. } => {
+                        let _ = tx.send(CbEvent::Exhausted(job, error));
+                    }
+                    _ => {}
+                }
+            }
+        })
+        .build()
+        .unwrap()
+}
+
+async fn insert_hook_job(pool: &sqlx::PgPool, queue: &str, value: &str) -> awa::JobRow {
+    awa::insert_with(
+        pool,
+        &HookJob {
+            action: "wait".into(),
+            value: value.into(),
+        },
+        awa::InsertOpts {
+            queue: queue.to_string(),
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap()
+}
+
+#[tokio::test]
+async fn test_waiting_for_callback_event_fires_on_park() {
+    let _permit = test_gate().acquire_owned().await.unwrap();
+    let pool = setup_pool().await;
+    let queue = "lifecycle_waiting";
+    clean_queue(&pool, queue).await;
+
+    let (tx, mut rx) = mpsc::unbounded_channel();
+    let client = parking_client(&pool, queue, tx);
+    let inserted = insert_hook_job(&pool, queue, "park").await;
+
+    client.start().await.unwrap();
+    let event = recv_event(&mut rx).await;
+    client.shutdown(Duration::from_secs(2)).await;
+
+    match event {
+        CbEvent::Waiting(job) => {
+            assert_eq!(job.id, inserted.id);
+            assert_eq!(job.state, JobState::WaitingExternal);
+            assert!(job.callback_id.is_some(), "callback_id should be set");
+        }
+        other => panic!("expected WaitingForCallback, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn test_client_complete_external_dispatches_completed_event() {
+    let _permit = test_gate().acquire_owned().await.unwrap();
+    let pool = setup_pool().await;
+    let queue = "lifecycle_cb_complete";
+    clean_queue(&pool, queue).await;
+
+    let (tx, mut rx) = mpsc::unbounded_channel();
+    let client = parking_client(&pool, queue, tx);
+    let inserted = insert_hook_job(&pool, queue, "complete").await;
+
+    client.start().await.unwrap();
+
+    // Park first.
+    let callback_id = match recv_event(&mut rx).await {
+        CbEvent::Waiting(job) => job.callback_id.expect("callback_id set"),
+        other => panic!("expected Waiting, got {other:?}"),
+    };
+
+    // Resolve through the worker Client → Completed hook should fire.
+    let completed = client
+        .complete_external(callback_id, None, None)
+        .await
+        .unwrap();
+    assert_eq!(completed.id, inserted.id);
+
+    let event = recv_event(&mut rx).await;
+    client.shutdown(Duration::from_secs(2)).await;
+
+    match event {
+        CbEvent::Completed(job, duration) => {
+            assert_eq!(job.id, inserted.id);
+            assert_eq!(job.state, JobState::Completed);
+            assert_eq!(
+                duration,
+                Duration::ZERO,
+                "callback completion has no handler duration"
+            );
+        }
+        other => panic!("expected Completed, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn test_client_fail_external_dispatches_exhausted_event() {
+    let _permit = test_gate().acquire_owned().await.unwrap();
+    let pool = setup_pool().await;
+    let queue = "lifecycle_cb_fail";
+    clean_queue(&pool, queue).await;
+
+    let (tx, mut rx) = mpsc::unbounded_channel();
+    let client = parking_client(&pool, queue, tx);
+    let inserted = insert_hook_job(&pool, queue, "fail").await;
+
+    client.start().await.unwrap();
+
+    let callback_id = match recv_event(&mut rx).await {
+        CbEvent::Waiting(job) => job.callback_id.expect("callback_id set"),
+        other => panic!("expected Waiting, got {other:?}"),
+    };
+
+    client
+        .fail_external(callback_id, "payment declined", None)
+        .await
+        .unwrap();
+
+    let event = recv_event(&mut rx).await;
+    client.shutdown(Duration::from_secs(2)).await;
+
+    match event {
+        CbEvent::Exhausted(job, error) => {
+            assert_eq!(job.id, inserted.id);
+            assert_eq!(job.state, JobState::Failed);
+            assert_eq!(error, "payment declined");
+        }
+        other => panic!("expected Exhausted, got {other:?}"),
+    }
 }

--- a/awa/tests/lifecycle_hook_test.rs
+++ b/awa/tests/lifecycle_hook_test.rs
@@ -859,7 +859,28 @@ async fn test_snooze_only_emits_started_event() {
 enum CbEvent {
     Waiting(awa::JobRow),
     Completed(awa::JobRow, Duration),
+    Retried(awa::JobRow),
     Exhausted(awa::JobRow, String),
+}
+
+/// Like [`setup_pool`] but leaves the runtime on canonical storage (queue
+/// storage is never installed), so tests can exercise the canonical executor
+/// path.
+async fn setup_pool_canonical() -> sqlx::PgPool {
+    let pool = PgPoolOptions::new()
+        .max_connections(5)
+        .acquire_timeout(Duration::from_secs(10))
+        .connect(&database_url())
+        .await
+        .expect("Failed to connect to database — is Postgres running?");
+    sqlx::query("DROP SCHEMA IF EXISTS awa CASCADE")
+        .execute(&pool)
+        .await
+        .expect("Failed to drop awa schema");
+    migrations::run(&pool)
+        .await
+        .expect("Failed to run migrations");
+    pool
 }
 
 /// Worker that parks on an external callback. Uses a `Worker` impl rather than
@@ -883,9 +904,15 @@ impl Worker for ParkingWorker {
 }
 
 /// Build a client whose `HookJob` worker parks on an external callback and
-/// whose hook forwards Waiting/Completed/Exhausted events onto `tx`.
-fn parking_client(pool: &sqlx::PgPool, queue: &str, tx: mpsc::UnboundedSender<CbEvent>) -> Client {
-    Client::builder(pool.clone())
+/// whose hook forwards callback lifecycle events onto `tx`. With `canonical`
+/// set, the runtime uses canonical storage instead of queue storage.
+fn parking_client(
+    pool: &sqlx::PgPool,
+    queue: &str,
+    canonical: bool,
+    tx: mpsc::UnboundedSender<CbEvent>,
+) -> Client {
+    let mut builder = Client::builder(pool.clone())
         .queue(
             queue,
             QueueConfig {
@@ -904,15 +931,20 @@ fn parking_client(pool: &sqlx::PgPool, queue: &str, tx: mpsc::UnboundedSender<Cb
                     JobEvent::Completed { job, duration, .. } => {
                         let _ = tx.send(CbEvent::Completed(job, duration));
                     }
+                    JobEvent::Retried { job, .. } => {
+                        let _ = tx.send(CbEvent::Retried(job));
+                    }
                     JobEvent::Exhausted { job, error, .. } => {
                         let _ = tx.send(CbEvent::Exhausted(job, error));
                     }
                     _ => {}
                 }
             }
-        })
-        .build()
-        .unwrap()
+        });
+    if canonical {
+        builder = builder.canonical_storage();
+    }
+    builder.build().unwrap()
 }
 
 async fn insert_hook_job(pool: &sqlx::PgPool, queue: &str, value: &str) -> awa::JobRow {
@@ -939,7 +971,7 @@ async fn test_waiting_for_callback_event_fires_on_park() {
     clean_queue(&pool, queue).await;
 
     let (tx, mut rx) = mpsc::unbounded_channel();
-    let client = parking_client(&pool, queue, tx);
+    let client = parking_client(&pool, queue, false, tx);
     let inserted = insert_hook_job(&pool, queue, "park").await;
 
     client.start().await.unwrap();
@@ -964,7 +996,7 @@ async fn test_client_complete_external_dispatches_completed_event() {
     clean_queue(&pool, queue).await;
 
     let (tx, mut rx) = mpsc::unbounded_channel();
-    let client = parking_client(&pool, queue, tx);
+    let client = parking_client(&pool, queue, false, tx);
     let inserted = insert_hook_job(&pool, queue, "complete").await;
 
     client.start().await.unwrap();
@@ -1007,7 +1039,7 @@ async fn test_client_fail_external_dispatches_exhausted_event() {
     clean_queue(&pool, queue).await;
 
     let (tx, mut rx) = mpsc::unbounded_channel();
-    let client = parking_client(&pool, queue, tx);
+    let client = parking_client(&pool, queue, false, tx);
     let inserted = insert_hook_job(&pool, queue, "fail").await;
 
     client.start().await.unwrap();
@@ -1033,4 +1065,135 @@ async fn test_client_fail_external_dispatches_exhausted_event() {
         }
         other => panic!("expected Exhausted, got {other:?}"),
     }
+}
+
+#[tokio::test]
+async fn test_client_resolve_callback_dispatches_completed_event() {
+    let _permit = test_gate().acquire_owned().await.unwrap();
+    let pool = setup_pool().await;
+    let queue = "lifecycle_cb_resolve";
+    clean_queue(&pool, queue).await;
+
+    let (tx, mut rx) = mpsc::unbounded_channel();
+    let client = parking_client(&pool, queue, false, tx);
+    let inserted = insert_hook_job(&pool, queue, "resolve").await;
+
+    client.start().await.unwrap();
+    let callback_id = match recv_event(&mut rx).await {
+        CbEvent::Waiting(job) => job.callback_id.expect("callback_id set"),
+        other => panic!("expected Waiting, got {other:?}"),
+    };
+
+    let outcome = client
+        .resolve_callback(callback_id, None, awa::DefaultAction::Complete, None)
+        .await
+        .unwrap();
+    assert!(outcome.is_completed());
+
+    let event = recv_event(&mut rx).await;
+    client.shutdown(Duration::from_secs(2)).await;
+
+    match event {
+        CbEvent::Completed(job, duration) => {
+            assert_eq!(job.id, inserted.id);
+            assert_eq!(job.state, JobState::Completed);
+            assert_eq!(duration, Duration::ZERO);
+        }
+        other => panic!("expected Completed, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn test_client_retry_external_dispatches_retried_event() {
+    let _permit = test_gate().acquire_owned().await.unwrap();
+    let pool = setup_pool().await;
+    let queue = "lifecycle_cb_retry";
+    clean_queue(&pool, queue).await;
+
+    let (tx, mut rx) = mpsc::unbounded_channel();
+    let client = parking_client(&pool, queue, false, tx);
+    let inserted = insert_hook_job(&pool, queue, "retry").await;
+
+    client.start().await.unwrap();
+    let callback_id = match recv_event(&mut rx).await {
+        CbEvent::Waiting(job) => job.callback_id.expect("callback_id set"),
+        other => panic!("expected Waiting, got {other:?}"),
+    };
+
+    client.retry_external(callback_id, None).await.unwrap();
+
+    // The worker will re-claim the now-retryable job and park it again, so we
+    // may observe a fresh Waiting after the Retried; assert we see Retried.
+    let mut saw_retried = false;
+    for _ in 0..3 {
+        match recv_event(&mut rx).await {
+            CbEvent::Retried(job) => {
+                assert_eq!(job.id, inserted.id);
+                saw_retried = true;
+                break;
+            }
+            CbEvent::Waiting(_) => continue,
+            other => panic!("expected Retried/Waiting, got {other:?}"),
+        }
+    }
+    client.shutdown(Duration::from_secs(2)).await;
+    assert!(saw_retried, "expected a Retried event after retry_external");
+}
+
+#[tokio::test]
+async fn test_waiting_for_callback_event_fires_on_canonical_storage() {
+    let _permit = test_gate().acquire_owned().await.unwrap();
+    let pool = setup_pool_canonical().await;
+    let queue = "lifecycle_waiting_canonical";
+    clean_queue(&pool, queue).await;
+
+    let (tx, mut rx) = mpsc::unbounded_channel();
+    let client = parking_client(&pool, queue, true, tx);
+    let inserted = insert_hook_job(&pool, queue, "park").await;
+
+    client.start().await.unwrap();
+    let event = recv_event(&mut rx).await;
+    client.shutdown(Duration::from_secs(2)).await;
+
+    match event {
+        CbEvent::Waiting(job) => {
+            assert_eq!(job.id, inserted.id);
+            assert_eq!(job.state, JobState::WaitingExternal);
+            assert!(job.callback_id.is_some());
+        }
+        other => panic!("expected WaitingForCallback on canonical storage, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn test_bare_admin_resolution_fires_no_hook() {
+    let _permit = test_gate().acquire_owned().await.unwrap();
+    let pool = setup_pool().await;
+    let queue = "lifecycle_cb_bare_admin";
+    clean_queue(&pool, queue).await;
+
+    let (tx, mut rx) = mpsc::unbounded_channel();
+    let client = parking_client(&pool, queue, false, tx);
+    let inserted = insert_hook_job(&pool, queue, "bare").await;
+
+    client.start().await.unwrap();
+    let callback_id = match recv_event(&mut rx).await {
+        CbEvent::Waiting(job) => job.callback_id.expect("callback_id set"),
+        other => panic!("expected Waiting, got {other:?}"),
+    };
+
+    // Resolve through the bare admin function (the boundary): the job
+    // transitions but no lifecycle hook should fire.
+    admin::complete_external(&pool, callback_id, None, None)
+        .await
+        .unwrap();
+    let completed = wait_for_job_state(&pool, inserted.id, JobState::Completed).await;
+    assert_eq!(completed.state, JobState::Completed);
+
+    tokio::time::sleep(Duration::from_millis(300)).await;
+    client.shutdown(Duration::from_secs(2)).await;
+    assert!(
+        rx.try_recv().is_err(),
+        "bare admin resolution must not dispatch a lifecycle hook"
+    );
 }

--- a/awa/tests/lifecycle_hook_test.rs
+++ b/awa/tests/lifecycle_hook_test.rs
@@ -859,7 +859,7 @@ async fn test_snooze_only_emits_started_event() {
 enum CbEvent {
     Waiting(awa::JobRow),
     Completed(awa::JobRow, Duration),
-    Retried(awa::JobRow),
+    Retried { job: awa::JobRow, attempt: i16 },
     Exhausted(awa::JobRow, String),
 }
 
@@ -931,8 +931,8 @@ fn parking_client(
                     JobEvent::Completed { job, duration, .. } => {
                         let _ = tx.send(CbEvent::Completed(job, duration));
                     }
-                    JobEvent::Retried { job, .. } => {
-                        let _ = tx.send(CbEvent::Retried(job));
+                    JobEvent::Retried { job, attempt, .. } => {
+                        let _ = tx.send(CbEvent::Retried { job, attempt });
                     }
                     JobEvent::Exhausted { job, error, .. } => {
                         let _ = tx.send(CbEvent::Exhausted(job, error));
@@ -1123,12 +1123,19 @@ async fn test_client_retry_external_dispatches_retried_event() {
     client.retry_external(callback_id, None).await.unwrap();
 
     // The worker will re-claim the now-retryable job and park it again, so we
-    // may observe a fresh Waiting after the Retried; assert we see Retried.
+    // may observe a fresh Waiting after the Retried; assert we see Retried,
+    // and that the event's attempt is the parked attempt (>= 1), not the
+    // post-transition value (admin::retry_external resets attempt to 0 as
+    // part of requeuing).
     let mut saw_retried = false;
     for _ in 0..3 {
         match recv_event(&mut rx).await {
-            CbEvent::Retried(job) => {
+            CbEvent::Retried { job, attempt } => {
                 assert_eq!(job.id, inserted.id);
+                assert!(
+                    attempt >= 1,
+                    "Retried event must report the parked (failed) attempt, not the post-reset 0; got {attempt}"
+                );
                 saw_retried = true;
                 break;
             }

--- a/correctness/races/AwaCbk.tla
+++ b/correctness/races/AwaCbk.tla
@@ -7,9 +7,13 @@ EXTENDS FiniteSets, Naturals
 
   Verifies the three-way race between:
     1. External system calling complete_external / fail_external /
-       resolve_callback / resume_external
+       resolve_callback / resume_external / retry_external
     2. Maintenance leader running rescue_expired_callbacks (timeout)
     3. Heartbeat rescue clearing stale callback after worker crash
+
+  retry_external is a plain UPDATE like complete/fail, but its WHERE matches
+  only state='waiting_external' (not 'running'), so if it locks the row while
+  the job is still running it matches 0 rows and simply releases.
 
   Sequential callbacks: after resume_external transitions the job from
   waiting_external back to running, the handler can register a NEW
@@ -40,7 +44,7 @@ MaxCallbackGen == 2   \* Allow up to 2 callback lifecycles per job run
 
 JobStates == {"available", "running", "waiting_external", "completed", "retryable", "failed"}
 TerminalStates == {"completed", "retryable", "failed"}
-BlockingOps == {"complete", "fail", "resolve", "resume"}
+BlockingOps == {"complete", "fail", "resolve", "resume", "retry"}
 
 \* Row lock states. NoLock means the row is unlocked.
 \* Other values identify which operation holds the lock.
@@ -280,6 +284,30 @@ ResolveIgnoreRelease ==
     /\ UNCHANGED <<jobState, callbackId, callbackTimedOut, heartbeatFresh, owner, lease,
                    taskLease, leader, resolved, callbackGen, blockedOps>>
 
+\* retry_external: plain UPDATE, WHERE state='waiting_external'. Requeues the
+\* job to available (attempt reset) and clears the callback.
+RetryExecute ==
+    /\ rowLock = "retry"
+    /\ jobState = "waiting_external"
+    /\ callbackId = CbId
+    /\ jobState' = "available"
+    /\ callbackId' = NoCb
+    /\ callbackTimedOut' = FALSE
+    /\ heartbeatFresh' = FALSE
+    /\ owner' = NoInstance
+    /\ resolved' = resolved + 1
+    /\ rowLock' = NoLock
+    /\ UNCHANGED <<lease, taskLease, leader, callbackGen, blockedOps>>
+
+\* retry_external matches only waiting_external. If it locked the row while the
+\* job was still running, the UPDATE matches 0 rows and just releases the lock.
+RetryNoOpRelease ==
+    /\ rowLock = "retry"
+    /\ jobState = "running"
+    /\ rowLock' = NoLock
+    /\ UNCHANGED <<jobState, callbackId, callbackTimedOut, heartbeatFresh, owner, lease,
+                   taskLease, leader, resolved, callbackGen, blockedOps>>
+
 \* ─── rescue_expired_callbacks: SKIP LOCKED UPDATE ─────────
 \*
 \* Uses FOR UPDATE SKIP LOCKED in the inner SELECT.
@@ -361,6 +389,8 @@ Next ==
     \/ ResolveCompleteExecute
     \/ ResolveFailExecute
     \/ ResolveIgnoreRelease
+    \/ RetryExecute
+    \/ RetryNoOpRelease
     \/ TimeoutExpires
     \/ \E i \in Instances : TimeoutTryLock(i)
     \/ TimeoutRetryExecute
@@ -385,6 +415,8 @@ StableNext ==
     \/ ResolveCompleteExecute
     \/ ResolveFailExecute
     \/ ResolveIgnoreRelease
+    \/ RetryExecute
+    \/ RetryNoOpRelease
     \/ TimeoutExpires
     \/ \E i \in Instances : TimeoutTryLock(i)
     \/ TimeoutRetryExecute
@@ -447,6 +479,8 @@ LockHolderConsistent ==
         (jobState \in {"waiting_external", "running"} /\ callbackId = CbId)
     /\ rowLock = "resume" =>
         (jobState \in {"waiting_external", "running"} /\ callbackId = CbId)
+    /\ rowLock = "retry" =>
+        (jobState \in {"waiting_external", "running"} /\ callbackId = CbId)
     /\ rowLock = "timeout_rescue" =>
         (jobState = "waiting_external" /\ callbackId = CbId /\ callbackTimedOut)
     /\ rowLock = "heartbeat_rescue" =>
@@ -480,6 +514,8 @@ FairnessAssumptions ==
     /\ WF_vars(ResolveCompleteExecute)
     /\ WF_vars(ResolveFailExecute)
     /\ WF_vars(ResolveIgnoreRelease)
+    /\ WF_vars(RetryExecute)
+    /\ WF_vars(RetryNoOpRelease)
     /\ WF_vars(HeartbeatExecute)
     /\ \A op \in BlockingOps : WF_vars(BlockingReEvaluate(op))
 

--- a/docs/adr/015-post-commit-lifecycle-hooks.md
+++ b/docs/adr/015-post-commit-lifecycle-hooks.md
@@ -42,12 +42,17 @@ Supported events are:
 - `Exhausted`
 - `Cancelled`
 
+> Later extended with `WaitingForCallback` and callback-resolution events —
+> see [Amendment: callback lifecycle events](#amendment-callback-lifecycle-events).
+
 No lifecycle outcome event is emitted for:
 
 - `Snooze`, because it is an internal reschedule rather than a meaningful
   outcome for observers
 - `WaitForCallback`, because the job has only parked; the meaningful outcome
   happens later when the callback completes, retries, fails, or is cancelled
+  (superseded by the amendment, which emits `WaitingForCallback` at park and a
+  terminal event at resolution)
 
 ### Emission Semantics
 
@@ -144,3 +149,80 @@ permit released, regardless of whether that commit targeted the canonical
 append. The guarded-finalization contract that gates hook emission lives on
 `(job_id, run_lease)` and is unchanged under queue storage. See
 [ADR-019](019-queue-storage-redesign.md).
+
+## Amendment: callback lifecycle events
+
+The original decision left `WaitForCallback` without any event, on the reasoning
+that "the meaningful outcome happens later when the callback completes, retries,
+fails, or is cancelled." In practice nothing was emitted at that later point
+either: callback resolution runs in `awa_model::admin` (the storage layer, which
+has no handler registry and is often invoked from a different process than the
+worker), so a job that parked on a callback could fire `Started` and then go
+silent through to its terminal state — invisible to lifecycle hooks. This
+amendment closes that gap.
+
+### `WaitingForCallback`
+
+A new event, emitted by the executor when a handler returns
+`JobResult::WaitForCallback` and the `waiting_external` transition commits. It
+carries the parked `JobRow` (so `job.state` is `waiting_external`, and
+`job.callback_id` / `job.callback_timeout_at` identify the pending callback).
+This makes the park observable and, paired with the resolution event below,
+lets callers measure external-wait latency. The supported event set becomes:
+
+- `Started`
+- `WaitingForCallback`
+- `Completed`
+- `Retried`
+- `Exhausted`
+- `Cancelled`
+
+`Snooze` remains event-free: it is an internal reschedule, not a job outcome.
+
+### Resolution events
+
+Callback resolution maps onto the existing terminal events rather than
+introducing callback-specific variants — an outcome is an outcome, and
+`WaitingForCallback` already marks that the job took the callback path:
+
+| Resolution | Event |
+|---|---|
+| callback completes the job | `Completed` |
+| callback fails the job (terminal) | `Exhausted` |
+| callback requeues the job for retry | `Retried` |
+| callback is cancelled | `Cancelled` |
+| callback resumes the job to `running` | none — the job re-enters execution and the executor emits `Started` plus a terminal event as usual |
+
+For a callback-driven `Completed`, the `duration` field is `Duration::ZERO`:
+no handler executed during this phase, and conflating it with the parked-wait
+time would overload the field's "handler execution time" meaning. If wait
+latency is needed later, it should be a dedicated field sourced from a recorded
+park timestamp, not this one.
+
+### Where resolution events are dispatched
+
+Resolution events are dispatched **in-process, at the resolving call site**, by
+worker-`Client` methods (`Client::resolve_callback`, `complete_external`,
+`fail_external`, `retry_external`). Each calls the corresponding
+`awa_model::admin` function and then, after the transition commits, dispatches
+the mapped event through the same guarded path as inline outcome hooks.
+
+This keeps the storage layer free of the handler registry and preserves
+at-most-once dispatch: exactly one process performs a given resolution, so
+exactly one dispatch occurs — mirroring how an inline outcome fires once from
+the single worker that claimed the job. A broadcast/NOTIFY fan-out (as used for
+`awa:cancel`) was rejected here precisely because it would re-fire the hook in
+every process that holds handlers, breaking at-most-once for metrics.
+
+The boundary is therefore: resolving a callback through the worker `Client`
+fires hooks; resolving it through the bare `awa_model::admin::*` functions, the
+CLI, or a process without the worker `Client` does not. This matches the
+existing contract that lifecycle hooks are a worker-side, best-effort,
+in-process facility.
+
+### Superseded consequences
+
+The original Negative bullet — "`Snooze` and `WaitForCallback` do not produce
+immediate notifications" — now applies only to `Snooze`. `WaitForCallback`
+produces a `WaitingForCallback` event at park and a terminal event at
+resolution (when resolved via the worker `Client`).

--- a/docs/lifecycle-hooks.md
+++ b/docs/lifecycle-hooks.md
@@ -105,8 +105,12 @@ mechanism:
   ordering for short jobs.
 - A panicking hook is logged; later hooks for the same kind still run.
 
-If a side effect must fire exactly once or survive a crash, do not rely on a
-hook — enqueue another Awa job from the resolving transaction (a real outbox),
-or have the hook enqueue follow-up work whose own delivery Awa guarantees.
+If a side effect must fire exactly once or survive a crash, do not drive it
+from a hook at all — the dispatch may never run, and enqueueing the follow-up
+work *from* the hook just inherits that same unreliability. Drive it from
+something durable instead: enqueue the follow-up as an Awa job inside a
+transaction you control — for a callback, the very transaction that resolves it
+(a transactional outbox) — or make the job handler perform the side effect
+idempotently so re-execution is safe.
 
 See [ADR-015](adr/015-post-commit-lifecycle-hooks.md) for the design rationale.

--- a/docs/lifecycle-hooks.md
+++ b/docs/lifecycle-hooks.md
@@ -1,0 +1,105 @@
+# Lifecycle hooks
+
+Lifecycle hooks let application code react to the points in a job's life —
+when it starts, finishes, retries, parks on an external callback, and so on —
+without putting that logic inside the job handler itself. Typical uses are
+metrics, alerting, and job-type-specific cleanup on permanent failure.
+
+Hooks are registered on the `ClientBuilder` and keyed by job kind. They work
+for both the typed (`register::<T, _>()`) and raw (`register_worker(...)`)
+worker paths.
+
+## Registering a hook
+
+```rust
+use awa::{Client, JobEvent, QueueConfig};
+
+let client = Client::builder(pool)
+    .queue("email", QueueConfig::default())
+    .register::<SendEmail, _, _>(|args, _ctx| async move { /* ... */ Ok(awa::JobResult::Completed) })
+    // Typed hook: args are deserialized from the committed job snapshot.
+    .on_event::<SendEmail, _, _>(|event| async move {
+        match event {
+            JobEvent::Started { job, .. }    => metrics::started(&job.queue),
+            JobEvent::Completed { duration, .. } => metrics::completed(duration),
+            JobEvent::Exhausted { error, .. } => alert::job_failed(&error),
+            _ => {}
+        }
+    })
+    .build()?;
+```
+
+`on_event::<T>()` gives you typed `args`; `on_event_kind("send_email", ...)`
+gives an untyped handler keyed by the kind string. Multiple hooks may be
+registered for the same kind; they stack and run sequentially.
+
+## Events
+
+| Event | Fires when |
+|---|---|
+| `Started` | the claim transaction commits, just before the handler runs (`job.state == running`) |
+| `WaitingForCallback` | the handler returned `WaitForCallback` and the job parked (`job.state == waiting_external`; `job.callback_id` is set) |
+| `Completed` | the job finished successfully |
+| `Retried` | the attempt failed (or `RetryAfter`) and the job will run again |
+| `Exhausted` | the job exhausted its retries, or failed terminally, and moved to `failed` |
+| `Cancelled` | the job was cancelled |
+
+How `JobResult` / outcomes map to events:
+
+| Outcome | Event |
+|---|---|
+| claim commits | `Started` |
+| `Ok(Completed)` | `Completed` |
+| `Ok(RetryAfter)` / retryable `Err` (retries left) | `Retried` |
+| retries exhausted, or `Err(Terminal)` | `Exhausted` |
+| `Ok(Cancel)` | `Cancelled` |
+| `Ok(Snooze)` | none — an internal reschedule, not an outcome |
+| `Ok(WaitForCallback)` | `WaitingForCallback` |
+
+## Callbacks
+
+A job that returns `WaitForCallback` parks in `waiting_external` and emits
+`WaitingForCallback`. The terminal event fires later, when the callback is
+resolved — **but only if you resolve it through the worker `Client`**, which
+owns the hook registry:
+
+```rust
+// In your callback endpoint (same process as the worker Client):
+let outcome = client.resolve_callback(callback_id, payload, default_action, None).await?;
+// or the lower-level forms:
+client.complete_external(callback_id, payload, None).await?; // -> Completed
+client.fail_external(callback_id, error, None).await?;       // -> Exhausted
+client.retry_external(callback_id, None).await?;             // -> Retried
+```
+
+Resolving through the bare `awa_model::admin::*` functions (or the CLI, or a
+process that has no worker `Client`) still transitions the job correctly but
+fires no hook — hooks are an in-process, worker-side facility. Dispatch happens
+once, in the process that performs the resolution, mirroring how an inline
+outcome fires once from the worker that claimed the job.
+
+For a callback-driven `Completed`, `duration` is `Duration::ZERO` (no handler
+ran during the parked phase).
+
+A callback that *resumes* the job to `running` emits no event itself; the job
+re-enters execution and emits `Started` plus a terminal event as usual.
+
+## Semantics
+
+Hooks are **best-effort, in-process notifications** — not a durable workflow
+mechanism:
+
+- They observe **committed** state. An outcome hook carries the post-transition
+  `JobRow`; a stale/rejected finalization emits no outcome event (though a
+  `Started` may already have fired for that attempt).
+- They do not block executor progress or queue capacity, and `shutdown()` does
+  not wait for them. They can be lost on process crash or shutdown.
+- `Started` is dispatched detached, so a very fast job may finish before its
+  `Started` hook completes — do not rely on strict started-before-outcome
+  ordering for short jobs.
+- A panicking hook is logged; later hooks for the same kind still run.
+
+If a side effect must be durable or retried, enqueue another job from the hook
+instead of relying on the hook itself.
+
+See [ADR-015](adr/015-post-commit-lifecycle-hooks.md) for the design rationale.

--- a/docs/lifecycle-hooks.md
+++ b/docs/lifecycle-hooks.md
@@ -94,12 +94,19 @@ mechanism:
   `Started` may already have fired for that attempt).
 - They do not block executor progress or queue capacity, and `shutdown()` does
   not wait for them. They can be lost on process crash or shutdown.
+- **Dispatch is not atomic with the state transition.** The hook runs *after*
+  the job's transition commits, as a separate in-process step — it is not a
+  transactional outbox. If the process dies between the commit and the
+  dispatch, the job state is durable but the event is lost. The same applies to
+  callback resolution: `complete_external` / `resolve_callback` commit the
+  outcome first, then dispatch.
 - `Started` is dispatched detached, so a very fast job may finish before its
   `Started` hook completes — do not rely on strict started-before-outcome
   ordering for short jobs.
 - A panicking hook is logged; later hooks for the same kind still run.
 
-If a side effect must be durable or retried, enqueue another job from the hook
-instead of relying on the hook itself.
+If a side effect must fire exactly once or survive a crash, do not rely on a
+hook — enqueue another Awa job from the resolving transaction (a real outbox),
+or have the hook enqueue follow-up work whose own delivery Awa guarantees.
 
 See [ADR-015](adr/015-post-commit-lifecycle-hooks.md) for the design rationale.


### PR DESCRIPTION
## Summary

Closes the lifecycle-hook gap for callback-driven jobs. A job that returned `WaitForCallback` previously fired `Started` and then went silent through to its terminal state — invisible to hooks — even though ADR-015's stated intent was that the callback outcome should be the observable event.

Design was reviewed first (docs commit); this PR adds the implementation.

## What changed

- **`WaitingForCallback` event** added to `JobEvent` / `UntypedJobEvent`, emitted by the executor when the `waiting_external` transition commits (both canonical and queue-storage paths). Carries the parked `JobRow`, so observers see `callback_id` / `callback_timeout_at`.
- **Worker-`Client` resolution methods** — `resolve_callback`, `complete_external`, `fail_external`, `retry_external` — wrap the `awa_model::admin` functions and dispatch the matching terminal event (`Completed` / `Exhausted` / `Retried`) in-process after the transition commits.
- `Snooze` remains event-free (unchanged).

## Design rationale

Resolution lives in `awa_model::admin` (storage layer, no handler registry, callable from non-worker processes), so it stays event-free. Dispatch happens at the **worker-`Client`** call site instead:

- **At-most-once**, matching inline hooks: exactly one process performs a given resolution → exactly one dispatch. A NOTIFY/broadcast fan-out (as used for `awa:cancel`) was rejected because it would re-fire the hook in every process holding handlers.
- **Boundary:** resolving through the bare `admin::*` functions, the CLI, or a process without the worker `Client` transitions the job correctly but fires no hook — consistent with hooks being a worker-side, best-effort, in-process facility.
- Callback-driven `Completed` carries `duration == Duration::ZERO` (no handler ran during the parked phase); overloading it with wait-time was rejected.

Full rationale in the amended [ADR-015](docs/adr/015-post-commit-lifecycle-hooks.md) and the new [docs/lifecycle-hooks.md](docs/lifecycle-hooks.md).

## Test plan

- [x] `cargo fmt --all --check` clean
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean
- [x] `lifecycle_hook_test` — 14 pass, incl. new `WaitingForCallback`-on-park and `Client` complete/fail dispatch tests
- [x] `external_wait_test` (38) and `awa-worker` lib (21) — no regression on the modified park branch