### PR TITLE
docs: propose callback ingress and maintenance ADRs

### DIFF
--- a/docs/adr/027-callback-ingress-surface.md
+++ b/docs/adr/027-callback-ingress-surface.md
@@ -155,11 +155,13 @@ layers to expose framework-native routes without reverse-proxy rewriting.
 Callback ingress resolves callback state. It must not assume a co-located
 `Client` runtime or local in-process lifecycle hook registry.
 
-If callback completion should produce lifecycle notifications beyond the
-storage transition itself, that mechanism needs to be durable or otherwise
-runtime-independent. The callback receiver should call a shared resolution
-service and inherit whatever durable side effects the model layer guarantees,
-rather than invoking process-local hooks directly.
+Durable side effects triggered by callback resolution are delivered through
+the transactional follow-up enqueue mechanism in ADR-029: the callback
+receiver inserts the follow-up Awa job in the same transaction that commits
+the callback resolution, and an ordinary worker (anywhere) picks it up. The
+callback receiver does not invoke process-local hooks directly; observation-
+only hooks (ADR-015) continue to fire only in processes that perform the
+resolution themselves via the worker `Client`.
 
 ## Consequences
 
@@ -222,6 +224,9 @@ smaller upstream to protect.
   narrows into its own deployable surface.
 - ADR-021 defines callback completion, sequential waits, and heartbeats. This
   ADR changes HTTP exposure, not callback semantics.
-- ADR-015 defines builder-side lifecycle hooks. Callback ingress should not
-  depend on process-local hook registries unless a future ADR makes those
-  effects durable or runtime-independent.
+- ADR-015 defines builder-side lifecycle hooks. Callback ingress does not
+  depend on process-local hook registries; observation hooks stay in the
+  worker process.
+- ADR-029 defines transactional follow-up jobs, the runtime-independent
+  mechanism callback ingress uses for durable side effects triggered by a
+  resolution.

--- a/docs/adr/027-callback-ingress-surface.md
+++ b/docs/adr/027-callback-ingress-surface.md
@@ -1,0 +1,227 @@
+# ADR-027: Callback ingress as a deployable surface
+
+## Status
+
+Proposed
+
+## Context
+
+Awa currently exposes HTTP-worker callback endpoints through `awa-ui`.
+`awa serve` builds one axum router that contains:
+
+- the operator UI static assets,
+- the admin REST API under `/api`,
+- the HTTP-worker callback receiver under `/api/callbacks`.
+
+That bundling is convenient for development, but it mixes surfaces with
+different exposure requirements.
+
+The admin UI and REST API are an operator surface. They should normally be
+private, authenticated by deployment infrastructure, and reachable only from
+trusted networks. The callback receiver is different: when using
+`HttpWorker` async mode, the remote function must be able to reach it to
+complete, fail, or heartbeat a parked job. In many deployments that means the
+callback receiver is public or partner-facing, even when the admin UI is not.
+
+Today users have two imperfect options:
+
+1. Run `awa serve` and expose only `/api/callbacks` through a reverse proxy.
+   This works, but the process still contains the whole admin/UI surface and
+   permissive UI CORS configuration.
+2. Implement their own callback endpoint around `admin::complete_external`,
+   `admin::fail_external`, and `admin::heartbeat_callback`. This gives them
+   control over FastAPI, axum, Django, or another framework, but forces them
+   to reimplement Awa's callback signature contract, payload parsing, error
+   mapping, and future compatibility rules.
+
+ADR-018 deliberately made HTTP workers possible without new storage
+primitives, and ADR-021 defines the callback semantics. This ADR narrows the
+HTTP deployment surface so those semantics can be exposed safely without
+requiring the admin UI.
+
+## Decision
+
+Make callback ingress a first-class Awa surface, separate from the admin UI.
+
+### Surface split
+
+Awa's HTTP-facing pieces should be documented and structured as distinct
+surfaces:
+
+| Surface | Purpose | Expected exposure |
+|---|---|---|
+| Admin UI / admin REST API | Operator inspection and mutation | Private operator network |
+| Callback receiver | Complete, fail, and heartbeat callback waits | Public or partner-facing, signed |
+| Worker runtime | Claim and execute jobs | Internal |
+| Maintenance runtime | Promote, rescue, prune, and refresh runtime state | Internal |
+
+`awa serve` remains the admin/UI command. It may continue to mount callback
+routes for backward compatibility, but the callback receiver should no longer
+be treated as an incidental part of the UI crate.
+
+### Shared callback contract and auth
+
+Extract the HTTP callback contract into a shared module or crate that is not
+owned by `awa-ui`:
+
+- request and response types for `complete`, `fail`, and `heartbeat`,
+- the `X-Awa-Signature` header name,
+- BLAKE3 keyed-hash signing and verification,
+- 32-byte secret parsing,
+- timeout validation and error mapping,
+- contract tests shared by every HTTP integration.
+
+The worker-side signer and receiver-side verifier must use the same
+implementation. The option name `hmac_secret` may remain for compatibility,
+but docs and new APIs should describe the algorithm precisely as BLAKE3 keyed
+hashing.
+
+### Callback-only axum router
+
+Expose a callback-only axum router, for example:
+
+```rust
+let router = awa_callbacks::router(pool, CallbackReceiverConfig {
+    secret: Some(callback_secret),
+    path_prefix: "/api/callbacks".into(),
+    ..Default::default()
+});
+```
+
+The callback-only router should:
+
+- mount only callback routes,
+- serve no UI assets,
+- expose no admin REST routes,
+- avoid permissive CORS by default,
+- require writable database access,
+- require a callback signing secret by default unless the caller explicitly
+  opts into unsigned callbacks.
+
+This router can be mounted by Awa's own CLI, by an existing axum application,
+or by users who want a minimal callback receiver binary.
+
+### Framework-neutral service layer
+
+Provide lower-level callback receiver functions that can be used outside
+axum:
+
+- `complete_callback(pool, callback_id, signature, payload)`,
+- `fail_callback(pool, callback_id, signature, error)`,
+- `heartbeat_callback(pool, callback_id, signature, timeout)`.
+
+The service layer should own validation and signature verification, then call
+the storage/admin APIs. This lets Rust frameworks share one implementation and
+gives the Python package a clear contract to mirror for FastAPI, Starlette,
+Django, or Flask examples.
+
+Python helpers should at minimum expose signature verification and typed
+request parsing examples. If the Python admin/client API grows a callback
+receiver helper, it should preserve the same contract and tests.
+
+### CLI
+
+Add a callback-only command:
+
+```text
+awa callbacks serve
+```
+
+The command should accept the normal database/pool options plus callback
+receiver configuration:
+
+- host and port,
+- callback signing secret,
+- path prefix,
+- optional explicit unsigned mode for private-network deployments.
+
+It should not inherit `awa serve`'s admin routes, static file fallback, or UI
+CORS behavior.
+
+### Callback URL construction
+
+`HttpWorker` should stop hard-coding callback URLs as:
+
+```text
+{callback_base_url}/api/callbacks/{callback_id}/complete
+```
+
+Keep that as the compatibility default, but add configuration for a path
+prefix or URL template. That allows callback-only servers and user-owned API
+layers to expose framework-native routes without reverse-proxy rewriting.
+
+### Lifecycle hooks
+
+Callback ingress resolves callback state. It must not assume a co-located
+`Client` runtime or local in-process lifecycle hook registry.
+
+If callback completion should produce lifecycle notifications beyond the
+storage transition itself, that mechanism needs to be durable or otherwise
+runtime-independent. The callback receiver should call a shared resolution
+service and inherit whatever durable side effects the model layer guarantees,
+rather than invoking process-local hooks directly.
+
+## Consequences
+
+### Positive
+
+- The recommended secure deployment becomes obvious: public callback ingress,
+  private admin UI, internal workers and maintenance.
+- Users can embed Awa callbacks in FastAPI, axum, or another application
+  without copying the signature algorithm and payload contract from docs.
+- Minimal callback deployments no longer carry the embedded frontend or admin
+  REST surface.
+- `HttpWorker` async mode becomes easier to operate behind real routing
+  schemes instead of relying on the UI path layout.
+
+### Negative / Risks
+
+- There is one more public surface to version and test.
+- The split overlaps with, but does not replace, the broader `awa-api` /
+  `awa-ui` separation discussed elsewhere. Keeping this narrowly scoped is
+  important.
+- Tightening callback-only defaults to require signatures is safer but may
+  surprise users who expect the old `awa serve` behavior where missing secrets
+  disable verification. Compatibility docs and explicit opt-out flags are
+  required.
+- Lifecycle hook behavior around externally resolved jobs must be stated
+  precisely so users do not assume the callback receiver runs in the same
+  process as their worker hooks.
+
+## Alternatives considered
+
+### Keep callback routes inside `awa serve`
+
+This is the smallest implementation, and it works when deployments can rely on
+private networking or a reverse proxy. It keeps the security guidance awkward:
+the process users need to expose for callbacks also contains admin mutation
+routes and UI concerns.
+
+### Split all API handlers into a new `awa-api` crate first
+
+A broader API/UI split may still be useful, especially if Awa ships an
+API-only image. It is more work than the callback problem requires. Callback
+ingress has a distinct security boundary and should be separable even if the
+admin API remains in `awa-ui` for now.
+
+### Require every application to implement callbacks itself
+
+This gives maximum framework flexibility, but makes every integration
+responsible for reproducing auth, parsing, and compatibility behavior. That is
+exactly the glue ADR-018 tried to remove for HTTP workers.
+
+### Rely on reverse-proxy path filtering
+
+Path filtering is still useful defense-in-depth, but it should not be the only
+way to avoid exposing the admin UI. A callback-only router gives the proxy a
+smaller upstream to protect.
+
+## Relationship to other ADRs
+
+- ADR-018 introduced `HttpWorker` and the callback receiver contract this ADR
+  narrows into its own deployable surface.
+- ADR-021 defines callback completion, sequential waits, and heartbeats. This
+  ADR changes HTTP exposure, not callback semantics.
+- ADR-015 defines builder-side lifecycle hooks. Callback ingress should not
+  depend on process-local hook registries unless a future ADR makes those
+  effects durable or runtime-independent.

--- a/docs/adr/028-maintenance-only-runtime-role.md
+++ b/docs/adr/028-maintenance-only-runtime-role.md
@@ -1,0 +1,213 @@
+# ADR-028: Maintenance-only runtime role
+
+## Status
+
+Proposed
+
+## Context
+
+Awa's normal runtime process does several jobs:
+
+- claims and executes user work,
+- runs in-process Rust or Python handlers,
+- dispatches `HttpWorker` jobs,
+- promotes scheduled and retryable jobs,
+- rescues stale heartbeats, expired deadlines, and expired callbacks,
+- rotates and prunes queue-storage structures,
+- refreshes admin metadata and runtime snapshots.
+
+That composition is sensible for a traditional worker deployment: if a worker
+process is running, it can also own the maintenance leader duties.
+
+Callback-only ingress changes the deployment shape. A team may want:
+
+- a public callback receiver,
+- private admin UI,
+- HTTP workers that dispatch to serverless functions,
+- application-owned API servers such as FastAPI or axum,
+- no public `awa serve` process,
+- maintenance duties running somewhere predictable.
+
+The callback receiver cannot replace the worker runtime or maintenance
+runtime. It only resolves external waits. If no runtime performs maintenance,
+scheduled jobs may not promote, retryable jobs may not become available,
+stale heartbeats may not rescue, expired callbacks may remain parked, and
+storage hygiene may drift.
+
+There are related but distinct efforts:
+
+- isolating user-visible maintenance lanes from background hygiene,
+- serverless-friendly bounded `tick()` execution,
+- splitting callback ingress away from the UI.
+
+This ADR defines a persistent maintenance-only role that composes with those
+efforts without requiring it to claim user jobs.
+
+## Decision
+
+Add a maintenance-only runtime role. It runs Awa maintenance loops and leader
+election but does not claim or execute ordinary jobs.
+
+### Public shape
+
+Expose the role through both library and CLI APIs.
+
+Library:
+
+```rust
+Client::builder(pool)
+    .maintenance_only()
+    .build()?
+    .run()
+    .await?;
+```
+
+CLI:
+
+```text
+awa maintenance run
+```
+
+The library API is for applications that declare cron jobs, queue
+descriptors, job-kind descriptors, or other code-owned runtime metadata. The
+CLI command is for pool-only maintenance where no application-specific
+handlers or declarations are needed.
+
+### What maintenance-only runs
+
+The maintenance-only role should run internal state maintenance that does not
+require executing user handler code:
+
+- scheduled and retryable promotion,
+- stale heartbeat rescue,
+- expired deadline rescue,
+- expired callback rescue,
+- queue-storage rotation and pruning,
+- completed / failed / DLQ cleanup,
+- admin metadata refresh,
+- runtime liveness publication for the maintenance process itself.
+
+When constructed from `ClientBuilder`, it may also run configured
+declaration-owned work:
+
+- cron scheduling for cron definitions registered on that builder,
+- descriptor publication for queues and job kinds declared by that builder.
+
+The pool-only CLI form must not invent application declarations. It should not
+publish descriptors or schedule cron jobs unless those definitions are
+provided through a future explicit config format.
+
+### What maintenance-only does not run
+
+Maintenance-only mode must not:
+
+- claim available jobs for execution,
+- invoke Rust or Python user handlers,
+- dispatch `HttpWorker` function calls,
+- expose HTTP callback or admin routes by itself,
+- hide the fact that a separate dispatcher is still required for normal job
+  execution.
+
+For HTTP-worker deployments, a dispatcher process is still needed to claim jobs
+and POST to the remote function URL. Maintenance-only keeps time-based and
+hygiene guarantees moving; it is not a serverless dispatcher.
+
+### Composition with callback ingress
+
+Callback-only servers may optionally run maintenance in the same process for
+small deployments:
+
+```text
+awa callbacks serve --with-maintenance
+```
+
+That option should be implemented by composing the same maintenance runtime,
+not by embedding a separate maintenance loop in the callback server. Larger
+deployments should run callback ingress and maintenance as separate roles.
+
+### Leadership and cancellation
+
+Maintenance-only mode uses the same leader-election semantics as the normal
+runtime. Maintenance tasks start only while the process owns the maintenance
+lock and stop promptly when leadership is lost or the process shuts down.
+
+The internal lane isolation work should still apply: user-visible maintenance
+such as promotion and rescue should not be blocked by slower admin hygiene or
+cleanup branches.
+
+### Relationship to bounded tick execution
+
+The persistent maintenance-only role does not replace a future bounded
+`tick()` API. They serve different deployment models:
+
+- `maintenance run`: persistent, leader-elected, predictable internal role,
+- `tick()`: bounded, externally invoked, useful for scale-to-zero or very
+  low-traffic deployments.
+
+Both should share the same underlying maintenance steps where possible.
+
+## Consequences
+
+### Positive
+
+- Deployments can keep maintenance guarantees without running a job-executing
+  worker in the same process.
+- Callback-only ingress has an obvious companion role for time-based rescue
+  and storage hygiene.
+- The role split makes operational docs clearer: admin UI, callback ingress,
+  workers, and maintenance can be scaled and exposed independently.
+- Library users with code-declared cron jobs or descriptors can still publish
+  those declarations without registering handlers.
+
+### Negative / Risks
+
+- Operators may confuse maintenance-only with a full worker. The CLI and docs
+  must be explicit that it does not dispatch or execute user jobs.
+- Pool-only CLI maintenance cannot know application-defined cron jobs or
+  descriptors. That limitation must be documented.
+- More runtime modes increase test matrix size around shutdown, leadership
+  loss, and task cancellation.
+- Running maintenance alongside callback ingress is convenient but can blur
+  deployment boundaries if presented as the default.
+
+## Alternatives considered
+
+### Keep maintenance only inside normal workers
+
+This is simple and works for traditional deployments. It forces users who only
+need maintenance to run a process that is also capable of claiming and
+executing jobs, which is unnecessarily broad for callback/API-heavy
+deployments.
+
+### Put maintenance inside the callback receiver
+
+This is convenient for the callback-only story but creates the wrong
+ownership. HTTP routing and database maintenance are separate concerns. The
+callback server may compose maintenance, but it should not own the
+implementation.
+
+### Only build bounded `tick()`
+
+`tick()` is attractive for low-traffic and scale-to-zero deployments, but it
+depends on an external caller and has tick-interval latency. A persistent
+maintenance role is still useful for production systems that want timely
+promotion and rescue without job execution in that process.
+
+### Use database-native scheduling only
+
+Database schedulers such as `pg_cron` can trigger maintenance calls, but they
+do not solve application-defined cron descriptors, runtime metadata, or
+portable deployment across Postgres providers. They may be a driver for
+bounded `tick()`, not a replacement for the runtime role.
+
+## Relationship to other ADRs
+
+- ADR-027 separates callback ingress from the admin UI. This ADR defines the
+  internal maintenance role that may accompany that deployment.
+- ADR-018 explains that HTTP-worker async mode still requires an always-on
+  dispatcher. Maintenance-only does not change that requirement.
+- ADR-021 relies on expired callback rescue. This ADR gives deployments a way
+  to run that rescue without also executing handlers in the same process.
+- ADR-019 owns queue-storage maintenance concerns such as rotation and
+  pruning. Maintenance-only runs those existing storage tasks; it does not
+  redefine the storage engine.

--- a/docs/adr/028-maintenance-only-runtime-role.md
+++ b/docs/adr/028-maintenance-only-runtime-role.md
@@ -211,3 +211,8 @@ bounded `tick()`, not a replacement for the runtime role.
 - ADR-019 owns queue-storage maintenance concerns such as rotation and
   pruning. Maintenance-only runs those existing storage tasks; it does not
   redefine the storage engine.
+- ADR-029 defines transactional follow-up jobs. Maintenance-only uses that
+  mechanism to emit durable lifecycle effects for rescues (expired callback,
+  stale heartbeat, exceeded deadline) — enqueuing follow-up Awa jobs in the
+  same transaction as the rescue UPDATE, closing the rescue/timeout event
+  gap without requiring a handler registry in the maintenance process.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -39,6 +39,8 @@ in-place as historical context.
 | 024 | Deferred `done_entries` materialisation | Rejected | Investigated as a rotation guard; reverted in `053fec1` once a simpler integration test gave equivalent coverage | Historical |
 | 025 | [Sharded enqueue heads](025-sharded-enqueue-heads.md) | Accepted | Per-queue `enqueue_shards` (default 1) spreads `queue_enqueue_heads` row-lock contention across N rows; FIFO becomes per-shard at S>1 | Refines ADR-019 enqueue path |
 | 026 | [Narrow terminal history](026-narrow-terminal-history.md) | Accepted | Ready-backed terminal rows store only terminal facts and hydrate immutable body fields from retained `ready_entries` until queue prune | Refines ADR-019 terminal path |
+| 027 | [Callback ingress as a deployable surface](027-callback-ingress-surface.md) | Proposed | Separate signed callback ingress from the admin UI/API and expose callback-only embedding/CLI paths | Refines ADR-018 and ADR-021 |
+| 028 | [Maintenance-only runtime role](028-maintenance-only-runtime-role.md) | Proposed | Run promotion, rescue, pruning, and metadata maintenance without claiming or executing user jobs | Complements ADR-027 and ADR-018 |
 
 ## Validation artifacts
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -39,8 +39,8 @@ in-place as historical context.
 | 024 | Deferred `done_entries` materialisation | Rejected | Investigated as a rotation guard; reverted in `053fec1` once a simpler integration test gave equivalent coverage | Historical |
 | 025 | [Sharded enqueue heads](025-sharded-enqueue-heads.md) | Accepted | Per-queue `enqueue_shards` (default 1) spreads `queue_enqueue_heads` row-lock contention across N rows; FIFO becomes per-shard at S>1 | Refines ADR-019 enqueue path |
 | 026 | [Narrow terminal history](026-narrow-terminal-history.md) | Accepted | Ready-backed terminal rows store only terminal facts and hydrate immutable body fields from retained `ready_entries` until queue prune | Refines ADR-019 terminal path |
-| 027 | [Callback ingress as a deployable surface](027-callback-ingress-surface.md) | Proposed | Separate signed callback ingress from the admin UI/API and expose callback-only embedding/CLI paths | Refines ADR-018 and ADR-021 |
-| 028 | [Maintenance-only runtime role](028-maintenance-only-runtime-role.md) | Proposed | Run promotion, rescue, pruning, and metadata maintenance without claiming or executing user jobs | Complements ADR-027 and ADR-018 |
+| 027 | [Callback ingress as a deployable surface](027-callback-ingress-surface.md) | Proposed | Separate signed callback ingress from the admin UI/API and expose callback-only embedding/CLI paths | Refines ADR-018 and ADR-021; uses ADR-029 for durable callback-driven side effects |
+| 028 | [Maintenance-only runtime role](028-maintenance-only-runtime-role.md) | Proposed | Run promotion, rescue, pruning, and metadata maintenance without claiming or executing user jobs | Complements ADR-027 and ADR-018; uses ADR-029 for durable rescue-driven side effects |
 
 ## Validation artifacts
 


### PR DESCRIPTION
## Summary

- add ADR-027 proposing callback ingress as a deployable surface separate from `awa serve` / admin UI
- add ADR-028 proposing a maintenance-only runtime role that runs promotion, rescue, pruning, and metadata maintenance without claiming jobs
- update the ADR index

Both ADRs depended on a story for "how do durable lifecycle effects flow when the resolving / rescuing process has no handler registry?" That story is now ADR-029, proposed separately in #284, and the latest revision of this PR wires ADR-027 and ADR-028 to reference it explicitly (callback ingress and maintenance rescue both emit follow-up jobs in the same transaction as their state commit).

## Related design

- #284 — ADR-029: transactional follow-up jobs for durable lifecycle effects (the runtime-independent event mechanism ADR-027 punted on and ADR-028 implicitly needed)

## Follow-up issues

- #278 - Extract shared callback contract and signature helpers
- #279 - Add a callback-only receiver router and CLI
- #280 - Make HTTP-worker callback URLs path/template configurable
- #281 - Document and support user-owned callback API layers
- #282 - Add a maintenance-only runtime role
- #283 - Document Awa deployment roles and callback ingress security

## Validation

- \`git diff --check\`