### PR TITLE
feat(adr-029): transactional follow-up jobs for durable lifecycle effects

### DIFF
--- a/awa-model/src/queue_storage.rs
+++ b/awa-model/src/queue_storage.rs
@@ -9127,6 +9127,23 @@ impl QueueStorage {
         run_lease: i64,
         callback_id: Uuid,
     ) -> Result<bool, AwaError> {
+        let mut tx = pool.begin().await.map_err(map_sqlx_error)?;
+        let entered = self
+            .enter_callback_wait_in_tx(&mut tx, job_id, run_lease, callback_id)
+            .await?;
+        tx.commit().await.map_err(map_sqlx_error)?;
+        Ok(entered)
+    }
+
+    /// Transaction-aware variant of [`Self::enter_callback_wait`] (ADR-029).
+    /// Returns whether the row transitioned to `waiting_external`.
+    pub async fn enter_callback_wait_in_tx(
+        &self,
+        tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+        job_id: i64,
+        run_lease: i64,
+        callback_id: Uuid,
+    ) -> Result<bool, AwaError> {
         let result = sqlx::query(&format!(
             r#"
             UPDATE {}
@@ -9143,7 +9160,7 @@ impl QueueStorage {
         .bind(job_id)
         .bind(run_lease)
         .bind(callback_id)
-        .execute(pool)
+        .execute(tx.as_mut())
         .await
         .map_err(map_sqlx_error)?;
         Ok(result.rows_affected() > 0)
@@ -9781,14 +9798,31 @@ impl QueueStorage {
         progress: Option<serde_json::Value>,
     ) -> Result<Option<JobRow>, AwaError> {
         let mut tx = pool.begin().await.map_err(map_sqlx_error)?;
+        let result = self
+            .retry_after_in_tx(&mut tx, job_id, run_lease, retry_after, progress)
+            .await?;
+        tx.commit().await.map_err(map_sqlx_error)?;
+        Ok(result)
+    }
+
+    /// Transaction-aware variant of [`Self::retry_after`]. Caller owns the
+    /// transaction lifecycle so the move can commit atomically alongside
+    /// follow-up `INSERT`s (ADR-029).
+    pub async fn retry_after_in_tx(
+        &self,
+        tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+        job_id: i64,
+        run_lease: i64,
+        retry_after: Duration,
+        progress: Option<serde_json::Value>,
+    ) -> Result<Option<JobRow>, AwaError> {
         let Some(moved) = self
-            .take_running_attempt_tx(&mut tx, job_id, run_lease, "retryable")
+            .take_running_attempt_tx(tx, job_id, run_lease, "retryable")
             .await?
         else {
-            tx.commit().await.map_err(map_sqlx_error)?;
             return Ok(None);
         };
-        let now = self.current_timestamp_tx(&mut tx).await?;
+        let now = self.current_timestamp_tx(tx).await?;
 
         let payload =
             Self::with_progress(moved.payload.clone(), progress.or(moved.progress.clone()))?;
@@ -9800,9 +9834,8 @@ impl QueueStorage {
             Some(now),
             payload,
         );
-        self.insert_deferred_rows_tx(&mut tx, vec![deferred.clone()], Some(moved.state))
+        self.insert_deferred_rows_tx(tx, vec![deferred.clone()], Some(moved.state))
             .await?;
-        tx.commit().await.map_err(map_sqlx_error)?;
         Ok(Some(deferred.into_job_row()?))
     }
 
@@ -9849,11 +9882,26 @@ impl QueueStorage {
         progress: Option<serde_json::Value>,
     ) -> Result<Option<JobRow>, AwaError> {
         let mut tx = pool.begin().await.map_err(map_sqlx_error)?;
+        let result = self
+            .cancel_running_in_tx(&mut tx, job_id, run_lease, reason, progress)
+            .await?;
+        tx.commit().await.map_err(map_sqlx_error)?;
+        Ok(result)
+    }
+
+    /// Transaction-aware variant of [`Self::cancel_running`] (ADR-029).
+    pub async fn cancel_running_in_tx(
+        &self,
+        tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+        job_id: i64,
+        run_lease: i64,
+        reason: &str,
+        progress: Option<serde_json::Value>,
+    ) -> Result<Option<JobRow>, AwaError> {
         let Some(moved) = self
-            .take_running_attempt_tx(&mut tx, job_id, run_lease, "cancelled")
+            .take_running_attempt_tx(tx, job_id, run_lease, "cancelled")
             .await?
         else {
-            tx.commit().await.map_err(map_sqlx_error)?;
             return Ok(None);
         };
 
@@ -9870,9 +9918,8 @@ impl QueueStorage {
             moved
                 .clone()
                 .into_done_row(JobState::Cancelled, Utc::now(), payload.into_json());
-        self.insert_done_rows_tx(&mut tx, std::slice::from_ref(&done), Some(moved.state))
+        self.insert_done_rows_tx(tx, std::slice::from_ref(&done), Some(moved.state))
             .await?;
-        tx.commit().await.map_err(map_sqlx_error)?;
         Ok(Some(done.into_job_row()?))
     }
 
@@ -9885,11 +9932,26 @@ impl QueueStorage {
         progress: Option<serde_json::Value>,
     ) -> Result<Option<JobRow>, AwaError> {
         let mut tx = pool.begin().await.map_err(map_sqlx_error)?;
+        let result = self
+            .fail_terminal_in_tx(&mut tx, job_id, run_lease, error, progress)
+            .await?;
+        tx.commit().await.map_err(map_sqlx_error)?;
+        Ok(result)
+    }
+
+    /// Transaction-aware variant of [`Self::fail_terminal`] (ADR-029).
+    pub async fn fail_terminal_in_tx(
+        &self,
+        tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+        job_id: i64,
+        run_lease: i64,
+        error: &str,
+        progress: Option<serde_json::Value>,
+    ) -> Result<Option<JobRow>, AwaError> {
         let Some(moved) = self
-            .take_running_attempt_tx(&mut tx, job_id, run_lease, "failed")
+            .take_running_attempt_tx(tx, job_id, run_lease, "failed")
             .await?
         else {
-            tx.commit().await.map_err(map_sqlx_error)?;
             return Ok(None);
         };
 
@@ -9901,9 +9963,8 @@ impl QueueStorage {
         let done = moved
             .clone()
             .into_done_row(JobState::Failed, Utc::now(), payload.into_json());
-        self.insert_done_rows_tx(&mut tx, std::slice::from_ref(&done), Some(moved.state))
+        self.insert_done_rows_tx(tx, std::slice::from_ref(&done), Some(moved.state))
             .await?;
-        tx.commit().await.map_err(map_sqlx_error)?;
         Ok(Some(done.into_job_row()?))
     }
 
@@ -9917,11 +9978,27 @@ impl QueueStorage {
         progress: Option<serde_json::Value>,
     ) -> Result<Option<JobRow>, AwaError> {
         let mut tx = pool.begin().await.map_err(map_sqlx_error)?;
+        let result = self
+            .fail_to_dlq_in_tx(&mut tx, job_id, run_lease, dlq_reason, error, progress)
+            .await?;
+        tx.commit().await.map_err(map_sqlx_error)?;
+        Ok(result)
+    }
+
+    /// Transaction-aware variant of [`Self::fail_to_dlq`] (ADR-029).
+    pub async fn fail_to_dlq_in_tx(
+        &self,
+        tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+        job_id: i64,
+        run_lease: i64,
+        dlq_reason: &str,
+        error: &str,
+        progress: Option<serde_json::Value>,
+    ) -> Result<Option<JobRow>, AwaError> {
         let Some(moved) = self
-            .take_running_attempt_tx(&mut tx, job_id, run_lease, "dlq")
+            .take_running_attempt_tx(tx, job_id, run_lease, "dlq")
             .await?
         else {
-            tx.commit().await.map_err(map_sqlx_error)?;
             return Ok(None);
         };
 
@@ -9938,9 +10015,8 @@ impl QueueStorage {
             dlq_reason.to_string(),
             dlq_at,
         );
-        self.insert_dlq_rows_tx(&mut tx, std::slice::from_ref(&dlq_row), Some(moved.state))
+        self.insert_dlq_rows_tx(tx, std::slice::from_ref(&dlq_row), Some(moved.state))
             .await?;
-        tx.commit().await.map_err(map_sqlx_error)?;
         Ok(Some(dlq_row.into_job_row()?))
     }
 
@@ -10316,11 +10392,26 @@ impl QueueStorage {
         progress: Option<serde_json::Value>,
     ) -> Result<Option<JobRow>, AwaError> {
         let mut tx = pool.begin().await.map_err(map_sqlx_error)?;
+        let result = self
+            .fail_retryable_in_tx(&mut tx, job_id, run_lease, error, progress)
+            .await?;
+        tx.commit().await.map_err(map_sqlx_error)?;
+        Ok(result)
+    }
+
+    /// Transaction-aware variant of [`Self::fail_retryable`] (ADR-029).
+    pub async fn fail_retryable_in_tx(
+        &self,
+        tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+        job_id: i64,
+        run_lease: i64,
+        error: &str,
+        progress: Option<serde_json::Value>,
+    ) -> Result<Option<JobRow>, AwaError> {
         let Some(moved) = self
-            .take_running_attempt_tx(&mut tx, job_id, run_lease, "retryable")
+            .take_running_attempt_tx(tx, job_id, run_lease, "retryable")
             .await?
         else {
-            tx.commit().await.map_err(map_sqlx_error)?;
             return Ok(None);
         };
 
@@ -10336,22 +10427,20 @@ impl QueueStorage {
                 moved
                     .clone()
                     .into_done_row(JobState::Failed, Utc::now(), payload.into_json());
-            self.insert_done_rows_tx(&mut tx, std::slice::from_ref(&done), Some(moved.state))
+            self.insert_done_rows_tx(tx, std::slice::from_ref(&done), Some(moved.state))
                 .await?;
-            tx.commit().await.map_err(map_sqlx_error)?;
             return Ok(Some(done.into_job_row()?));
         }
 
         let deferred = moved.clone().into_deferred_row(
             JobState::Retryable,
-            self.backoff_at_tx(&mut tx, moved.attempt, moved.max_attempts)
+            self.backoff_at_tx(tx, moved.attempt, moved.max_attempts)
                 .await?,
             Some(Utc::now()),
             payload.into_json(),
         );
-        self.insert_deferred_rows_tx(&mut tx, vec![deferred.clone()], Some(moved.state))
+        self.insert_deferred_rows_tx(tx, vec![deferred.clone()], Some(moved.state))
             .await?;
-        tx.commit().await.map_err(map_sqlx_error)?;
         Ok(Some(deferred.into_job_row()?))
     }
 

--- a/awa-model/src/queue_storage.rs
+++ b/awa-model/src/queue_storage.rs
@@ -9120,6 +9120,74 @@ impl QueueStorage {
         Ok(true)
     }
 
+    /// Load the currently-active lease row for `job_id` (running or
+    /// waiting_external) inside a caller-owned transaction. Used by ADR-029
+    /// helpers that need the post-park snapshot — including the
+    /// `callback_id` and `callback_timeout_at` written by
+    /// `register_callback()` — without leaving the transaction that just
+    /// performed the parking UPDATE.
+    pub async fn load_active_lease_in_tx(
+        &self,
+        tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+        job_id: i64,
+        run_lease: i64,
+    ) -> Result<Option<JobRow>, AwaError> {
+        let schema = self.schema();
+        let row: Option<LeaseJobRow> = sqlx::query_as(&format!(
+            r#"
+            SELECT
+                lease.ready_slot,
+                lease.ready_generation,
+                lease.job_id,
+                ready.kind,
+                ready.queue,
+                ready.args,
+                lease.state,
+                lease.priority,
+                lease.attempt,
+                lease.run_lease,
+                lease.max_attempts,
+                lease.lane_seq,
+                ready.run_at,
+                lease.heartbeat_at,
+                lease.deadline_at,
+                lease.attempted_at,
+                NULL::timestamptz AS finalized_at,
+                ready.created_at,
+                ready.unique_key,
+                ready.unique_states,
+                lease.callback_id,
+                lease.callback_timeout_at,
+                attempt.callback_filter,
+                attempt.callback_on_complete,
+                attempt.callback_on_fail,
+                attempt.callback_transform,
+                COALESCE(ready.payload, '{{}}'::jsonb) AS payload,
+                attempt.progress,
+                attempt.callback_result
+            FROM {schema}.leases AS lease
+            JOIN {schema}.ready_entries AS ready
+              ON ready.ready_slot = lease.ready_slot
+             AND ready.ready_generation = lease.ready_generation
+             AND ready.queue = lease.queue
+             AND ready.priority = lease.priority
+             AND ready.enqueue_shard = lease.enqueue_shard
+             AND ready.lane_seq = lease.lane_seq
+            LEFT JOIN {schema}.attempt_state AS attempt
+              ON attempt.job_id = lease.job_id
+             AND attempt.run_lease = lease.run_lease
+            WHERE lease.job_id = $1
+              AND lease.run_lease = $2
+            "#,
+        ))
+        .bind(job_id)
+        .bind(run_lease)
+        .fetch_optional(tx.as_mut())
+        .await
+        .map_err(map_sqlx_error)?;
+        row.map(LeaseJobRow::into_job_row).transpose()
+    }
+
     pub async fn enter_callback_wait(
         &self,
         pool: &PgPool,

--- a/awa-model/src/queue_storage.rs
+++ b/awa-model/src/queue_storage.rs
@@ -6309,12 +6309,29 @@ impl QueueStorage {
         pool: &PgPool,
         claimed: &[ClaimedRuntimeJob],
     ) -> Result<Vec<(i64, i64)>, AwaError> {
+        let mut tx = pool.begin().await.map_err(map_sqlx_error)?;
+        let result = self
+            .complete_runtime_batch_slow_in_tx(&mut tx, claimed)
+            .await?;
+        tx.commit().await.map_err(map_sqlx_error)?;
+        Ok(result)
+    }
+
+    /// Same as [`Self::complete_runtime_batch_slow`] but runs on the caller's
+    /// transaction so additional writes — for example ADR-029 follow-up job
+    /// inserts — can join the same commit. The caller is responsible for
+    /// `commit()` / `rollback()`. Handles both receipt-claimed and
+    /// materialised leases.
+    pub async fn complete_runtime_batch_slow_in_tx(
+        &self,
+        tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+        claimed: &[ClaimedRuntimeJob],
+    ) -> Result<Vec<(i64, i64)>, AwaError> {
         if claimed.is_empty() {
             return Ok(Vec::new());
         }
 
         let schema = self.schema();
-        let mut tx = pool.begin().await.map_err(map_sqlx_error)?;
 
         let claimed_map: BTreeMap<(i64, i64), ClaimedRuntimeJob> = claimed
             .iter()
@@ -6393,7 +6410,7 @@ impl QueueStorage {
                         }
                     }
 
-                    self.insert_done_rows_tx(&mut tx, &done_rows, Some(JobState::Running))
+                    self.insert_done_rows_tx(tx, &done_rows, Some(JobState::Running))
                         .await?;
                     updated_all.extend(updated);
                 }
@@ -6519,12 +6536,11 @@ impl QueueStorage {
                         }
                     }
 
-                    self.insert_done_rows_tx(&mut tx, &done_rows, Some(JobState::Running))
+                    self.insert_done_rows_tx(tx, &done_rows, Some(JobState::Running))
                         .await?;
                 }
             }
 
-            tx.commit().await.map_err(map_sqlx_error)?;
             return Ok(updated_all);
         }
 
@@ -6617,7 +6633,6 @@ impl QueueStorage {
         .map_err(map_sqlx_error)?;
 
         if deleted.is_empty() {
-            tx.commit().await.map_err(map_sqlx_error)?;
             return Ok(Vec::new());
         }
 
@@ -6634,10 +6649,8 @@ impl QueueStorage {
             }
         }
 
-        self.insert_done_rows_tx(&mut tx, &done_rows, Some(JobState::Running))
+        self.insert_done_rows_tx(tx, &done_rows, Some(JobState::Running))
             .await?;
-
-        tx.commit().await.map_err(map_sqlx_error)?;
         Ok(updated)
     }
 

--- a/awa-model/src/queue_storage.rs
+++ b/awa-model/src/queue_storage.rs
@@ -6653,9 +6653,28 @@ impl QueueStorage {
         if completions.is_empty() {
             return Ok(Vec::new());
         }
+        let mut tx = pool.begin().await.map_err(map_sqlx_error)?;
+        let result = self
+            .complete_job_batch_by_id_in_tx(&mut tx, completions)
+            .await?;
+        tx.commit().await.map_err(map_sqlx_error)?;
+        Ok(result)
+    }
+
+    /// Same as [`Self::complete_job_batch_by_id`] but runs on the caller's
+    /// transaction so additional writes — for example ADR-029 follow-up job
+    /// inserts — can join the same commit. The caller is responsible for
+    /// `commit()` / `rollback()`.
+    pub async fn complete_job_batch_by_id_in_tx(
+        &self,
+        tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+        completions: &[(i64, i64)],
+    ) -> Result<Vec<(i64, i64)>, AwaError> {
+        if completions.is_empty() {
+            return Ok(Vec::new());
+        }
 
         let schema = self.schema();
-        let mut tx = pool.begin().await.map_err(map_sqlx_error)?;
 
         let job_ids: Vec<i64> = completions.iter().map(|(job_id, _)| *job_id).collect();
         let run_leases: Vec<i64> = completions
@@ -6698,11 +6717,10 @@ impl QueueStorage {
         .map_err(map_sqlx_error)?;
 
         if deleted.is_empty() {
-            tx.commit().await.map_err(map_sqlx_error)?;
             return Ok(Vec::new());
         }
 
-        let moved = self.hydrate_deleted_leases_tx(&mut tx, deleted).await?;
+        let moved = self.hydrate_deleted_leases_tx(tx, deleted).await?;
 
         let finalized_at = Utc::now();
         let mut done_rows = Vec::with_capacity(moved.len());
@@ -6719,9 +6737,8 @@ impl QueueStorage {
             ));
         }
 
-        self.insert_done_rows_tx(&mut tx, &done_rows, Some(JobState::Running))
+        self.insert_done_rows_tx(tx, &done_rows, Some(JobState::Running))
             .await?;
-        tx.commit().await.map_err(map_sqlx_error)?;
         Ok(moved
             .into_iter()
             .map(|entry| (entry.job_id, entry.run_lease))

--- a/awa-worker/src/client.rs
+++ b/awa-worker/src/client.rs
@@ -348,14 +348,27 @@ impl ClientBuilder {
     /// [`Self::on_completed_enqueue_with`] to override queue, priority, or
     /// other insert options.
     ///
-    /// The follow-up is `INSERT`ed in the *same database transaction* as the
-    /// completion's state change, so the trigger and the follow-up commit or
-    /// roll back together — see ADR-029. This is the durable counterpart to
-    /// [`Self::on_event`]: hooks are best-effort, in-process; this enqueue is
-    /// at-least-once and rides Awa's existing retry/DLQ machinery.
+    /// # Atomicity
+    ///
+    /// When the trigger completes from the worker handler (`Ok(Completed)`),
+    /// the follow-up `INSERT`s in the *same database transaction* as the
+    /// completion's state change, so the trigger and the follow-up commit
+    /// or roll back together (ADR-029, ADR-013 run-lease guard).
+    ///
+    /// When the trigger completes via callback resolution
+    /// ([`Client::complete_external`], [`Client::resolve_callback`] with a
+    /// `Complete` action), the follow-up dispatch runs in a *separate*
+    /// transaction *after* the resolution commits — a spec INSERT failure
+    /// leaves the job resolved without a follow-up (logged at error
+    /// level). Don't predicate a workflow on a callback-driven follow-up
+    /// landing.
+    ///
+    /// This is the durable counterpart to [`Self::on_event`]: hooks are
+    /// best-effort, in-process; this enqueue is at-least-once and rides
+    /// Awa's existing retry/DLQ machinery.
     ///
     /// Multiple registrations for the same kind stack and all run in the
-    /// finalization transaction.
+    /// same dispatch.
     pub fn on_completed_enqueue<T, F, MakeFn>(self, make: MakeFn) -> Self
     where
         T: JobArgs + DeserializeOwned + Send + Sync + 'static,
@@ -399,7 +412,10 @@ impl ClientBuilder {
     /// `make` receives the trigger's args, its post-retry `JobRow`, the error
     /// string, the previous attempt number, and the next-run-at timestamp.
     ///
-    /// See [`Self::on_completed_enqueue`] for the same-transaction semantics.
+    /// Atomicity matches [`Self::on_completed_enqueue`]: worker-driven
+    /// retries dispatch in the transition's transaction; a retry driven by
+    /// [`Client::retry_external`] or [`Client::resolve_callback`] dispatches
+    /// in a separate transaction (best-effort) after the resolution commits.
     pub fn on_retried_enqueue<T, F, MakeFn>(self, make: MakeFn) -> Self
     where
         T: JobArgs + DeserializeOwned + Send + Sync + 'static,
@@ -451,7 +467,11 @@ impl ClientBuilder {
     /// `make` receives the trigger's args, its post-failure `JobRow`, the
     /// error string, and the attempt number.
     ///
-    /// See [`Self::on_completed_enqueue`] for the same-transaction semantics.
+    /// Atomicity matches [`Self::on_completed_enqueue`]: worker-driven
+    /// exhaustion dispatches in the transition's transaction; an
+    /// exhaustion driven by [`Client::fail_external`] or
+    /// [`Client::resolve_callback`] with a `Fail` action dispatches in a
+    /// separate transaction (best-effort) after the resolution commits.
     pub fn on_exhausted_enqueue<T, F, MakeFn>(self, make: MakeFn) -> Self
     where
         T: JobArgs + DeserializeOwned + Send + Sync + 'static,
@@ -581,7 +601,14 @@ impl ClientBuilder {
     /// deadline exceeded). `make` receives the trigger's args, its post-rescue
     /// `JobRow`, and the [`RescueReason`](crate::events::RescueReason).
     ///
-    /// See [`Self::on_completed_enqueue`] for the same-transaction semantics.
+    /// **Atomicity: best-effort, separate transaction.** Maintenance rescues
+    /// commit the rescue UPDATE before this dispatcher runs; the follow-up
+    /// dispatch opens its own transaction afterwards. If the spec INSERT
+    /// fails the rescue stands and the failure is logged. Don't predicate
+    /// a workflow on a rescue-driven follow-up landing — for compensation
+    /// after a stuck attempt, build the follow-up handler to be safely
+    /// re-runnable. The atomic variant is tracked as an open extension in
+    /// ADR-029.
     pub fn on_rescued_enqueue<T, F, MakeFn>(self, make: MakeFn) -> Self
     where
         T: JobArgs + DeserializeOwned + Send + Sync + 'static,

--- a/awa-worker/src/client.rs
+++ b/awa-worker/src/client.rs
@@ -576,6 +576,53 @@ impl ClientBuilder {
         self
     }
 
+    /// Register a durable follow-up Awa job to enqueue when a job of type `T`
+    /// is rescued by maintenance (expired callback, stale heartbeat, or
+    /// deadline exceeded). `make` receives the trigger's args, its post-rescue
+    /// `JobRow`, and the [`RescueReason`](crate::events::RescueReason).
+    ///
+    /// See [`Self::on_completed_enqueue`] for the same-transaction semantics.
+    pub fn on_rescued_enqueue<T, F, MakeFn>(self, make: MakeFn) -> Self
+    where
+        T: JobArgs + DeserializeOwned + Send + Sync + 'static,
+        F: JobArgs + Send + Sync + 'static,
+        MakeFn: Fn(T, &awa_model::JobRow, crate::events::RescueReason) -> F + Send + Sync + 'static,
+    {
+        self.on_rescued_enqueue_with::<T, F, _>(move |args, job, reason| {
+            crate::enqueue_specs::EnqueueRequest::new(make(args, job, reason))
+        })
+    }
+
+    /// Like [`Self::on_rescued_enqueue`] but the closure returns an
+    /// [`EnqueueRequest`](crate::EnqueueRequest) with `InsertOpts` overrides.
+    pub fn on_rescued_enqueue_with<T, F, MakeFn>(mut self, make: MakeFn) -> Self
+    where
+        T: JobArgs + DeserializeOwned + Send + Sync + 'static,
+        F: JobArgs + Send + Sync + 'static,
+        MakeFn: Fn(
+                T,
+                &awa_model::JobRow,
+                crate::events::RescueReason,
+            ) -> crate::enqueue_specs::EnqueueRequest<F>
+            + Send
+            + Sync
+            + 'static,
+    {
+        let kind = T::kind().to_string();
+        let spec: crate::enqueue_specs::BoxedEnqueueSpec =
+            Arc::new(crate::enqueue_specs::RescuedFollowUp::<T, F, _> {
+                make,
+                _phantom: std::marker::PhantomData,
+            });
+        self.enqueue_specs
+            .entry(crate::enqueue_specs::Outcome::Rescued)
+            .or_default()
+            .entry(kind)
+            .or_default()
+            .push(spec);
+        self
+    }
+
     /// Register a raw worker implementation.
     pub fn register_worker(mut self, worker: impl Worker + 'static) -> Self {
         let kind = worker.kind().to_string();
@@ -1446,6 +1493,8 @@ impl Client {
             self.periodic_jobs.clone(),
             self.in_flight.clone(),
             effective_storage.clone(),
+            self.enqueue_specs.clone(),
+            self.lifecycle_handlers.clone(),
         )
         .promote_interval(self.promote_interval);
         if let Some(interval) = self.heartbeat_rescue_interval {

--- a/awa-worker/src/client.rs
+++ b/awa-worker/src/client.rs
@@ -125,6 +125,7 @@ pub struct ClientBuilder {
     job_kind_descriptors: HashMap<String, JobKindDescriptor>,
     workers: HashMap<String, BoxedWorker>,
     lifecycle_handlers: HashMap<String, Vec<BoxedUntypedEventHandler>>,
+    enqueue_specs: HashMap<String, Vec<crate::enqueue_specs::BoxedEnqueueSpec>>,
     state: HashMap<TypeId, Box<dyn Any + Send + Sync>>,
     heartbeat_interval: Duration,
     promote_interval: Duration,
@@ -175,6 +176,7 @@ impl ClientBuilder {
             job_kind_descriptors: HashMap::new(),
             workers: HashMap::new(),
             lifecycle_handlers: HashMap::new(),
+            enqueue_specs: HashMap::new(),
             state: HashMap::new(),
             heartbeat_interval: Duration::from_secs(30),
             promote_interval: Duration::from_millis(250),
@@ -331,6 +333,37 @@ impl ClientBuilder {
             .entry(kind)
             .or_default()
             .push(erased);
+        self
+    }
+
+    /// Register a durable follow-up Awa job to enqueue when a job of type `T`
+    /// completes successfully.
+    ///
+    /// `make` receives the trigger's deserialised args plus its post-completion
+    /// [`awa_model::JobRow`] and returns the follow-up job's `JobArgs`. The
+    /// follow-up is `INSERT`ed in the *same database transaction* as the
+    /// completion's state change, so the trigger and the follow-up commit or
+    /// roll back together — see ADR-029. This is the durable counterpart to
+    /// [`Self::on_event`]: hooks are best-effort, in-process; this enqueue is
+    /// at-least-once and rides Awa's existing retry/DLQ machinery.
+    ///
+    /// Multiple registrations for the same kind stack and all run in the
+    /// finalization transaction.
+    pub fn on_completed_enqueue<T, F, MakeFn>(mut self, make: MakeFn) -> Self
+    where
+        T: JobArgs + DeserializeOwned + Send + Sync + 'static,
+        F: JobArgs + Send + Sync + 'static,
+        MakeFn: Fn(T, &awa_model::JobRow) -> F + Send + Sync + 'static,
+    {
+        let kind = T::kind().to_string();
+        let spec: crate::enqueue_specs::BoxedEnqueueSpec =
+            Arc::new(crate::enqueue_specs::CompletedFollowUp::<T, F, _> {
+                make: move |args: T, job: &awa_model::JobRow| {
+                    (make(args, job), awa_model::InsertOpts::default())
+                },
+                _phantom: std::marker::PhantomData,
+            });
+        self.enqueue_specs.entry(kind).or_default().push(spec);
         self
     }
 
@@ -680,6 +713,7 @@ impl ClientBuilder {
             job_kind_descriptors: self.job_kind_descriptors,
             workers: Arc::new(self.workers),
             lifecycle_handlers: Arc::new(self.lifecycle_handlers),
+            enqueue_specs: Arc::new(self.enqueue_specs),
             state: Arc::new(self.state),
             heartbeat_interval: self.heartbeat_interval,
             promote_interval: self.promote_interval,
@@ -767,6 +801,7 @@ pub struct Client {
     job_kind_descriptors: HashMap<String, JobKindDescriptor>,
     workers: Arc<HashMap<String, BoxedWorker>>,
     lifecycle_handlers: Arc<HashMap<String, Vec<BoxedUntypedEventHandler>>>,
+    enqueue_specs: Arc<HashMap<String, Vec<crate::enqueue_specs::BoxedEnqueueSpec>>>,
     state: Arc<HashMap<TypeId, Box<dyn Any + Send + Sync>>>,
     heartbeat_interval: Duration,
     promote_interval: Duration,
@@ -1145,6 +1180,7 @@ impl Client {
             self.pool.clone(),
             self.workers.clone(),
             self.lifecycle_handlers.clone(),
+            self.enqueue_specs.clone(),
             self.in_flight.clone(),
             self.queue_in_flight.clone(),
             self.state.clone(),

--- a/awa-worker/src/client.rs
+++ b/awa-worker/src/client.rs
@@ -1169,27 +1169,6 @@ impl Client {
             *guard = effective_storage.clone();
         }
 
-        // ADR-029: on_*_enqueue specs are wired through the canonical executor
-        // path only at this stage. The queue-storage completion path uses a
-        // receipt-plane fast-complete (ADR-023) we can't currently join from
-        // a tx held by the executor; making it tx-aware is a separate
-        // follow-up. Fail fast here so callers can't ship code that silently
-        // never enqueues follow-ups under queue storage (the default runtime).
-        if !self.enqueue_specs.is_empty()
-            && matches!(
-                effective_storage,
-                crate::storage::RuntimeStorage::QueueStorage(_)
-            )
-        {
-            let kinds: Vec<&str> = self.enqueue_specs.keys().map(String::as_str).collect();
-            return Err(awa_model::AwaError::Validation(format!(
-                "follow-up enqueue specs ({kinds:?}) are registered, but this runtime is using \
-                 queue storage. ADR-029 queue-storage wiring is a separate follow-up; for now \
-                 use ClientBuilder::canonical_storage() on the process that performs the \
-                 triggering state transition."
-            )));
-        }
-
         self.log_transition_startup_status(&effective_storage)
             .await?;
 

--- a/awa-worker/src/client.rs
+++ b/awa-worker/src/client.rs
@@ -1674,6 +1674,33 @@ impl Client {
             }),
             awa_model::ResolveOutcome::Ignored { .. } => None,
         };
+        // ADR-029 best-effort: dispatch follow-up specs in a separate tx
+        // *after* the resolution commits. See `dispatch_callback_followups`
+        // for the atomicity caveat. Resolution is the source of truth; if a
+        // spec INSERT fails we still consider the resolution successful.
+        match &outcome {
+            awa_model::ResolveOutcome::Completed { job, .. } => {
+                self.dispatch_callback_followups(
+                    job,
+                    crate::enqueue_specs::Outcome::Completed,
+                    None,
+                )
+                .await;
+            }
+            awa_model::ResolveOutcome::Failed { job } => {
+                let outcome_ctx = crate::enqueue_specs::OutcomeContext::Exhausted {
+                    error: latest_error_message(job),
+                    attempt: job.attempt,
+                };
+                self.dispatch_callback_followups(
+                    job,
+                    crate::enqueue_specs::Outcome::Exhausted,
+                    Some(outcome_ctx),
+                )
+                .await;
+            }
+            awa_model::ResolveOutcome::Ignored { .. } => {}
+        }
         if let Some(event) = event {
             self.dispatch_callback_event(event).await;
         }
@@ -1688,6 +1715,8 @@ impl Client {
         run_lease: Option<i64>,
     ) -> Result<awa_model::JobRow, awa_model::AwaError> {
         let job = admin::complete_external(&self.pool, callback_id, payload, run_lease).await?;
+        self.dispatch_callback_followups(&job, crate::enqueue_specs::Outcome::Completed, None)
+            .await;
         self.dispatch_callback_event(UntypedJobEvent::Completed {
             job: job.clone(),
             duration: Duration::ZERO,
@@ -1704,6 +1733,16 @@ impl Client {
         run_lease: Option<i64>,
     ) -> Result<awa_model::JobRow, awa_model::AwaError> {
         let job = admin::fail_external(&self.pool, callback_id, error, run_lease).await?;
+        let outcome_ctx = crate::enqueue_specs::OutcomeContext::Exhausted {
+            error: error.to_string(),
+            attempt: job.attempt,
+        };
+        self.dispatch_callback_followups(
+            &job,
+            crate::enqueue_specs::Outcome::Exhausted,
+            Some(outcome_ctx),
+        )
+        .await;
         self.dispatch_callback_event(UntypedJobEvent::Exhausted {
             job: job.clone(),
             error: error.to_string(),
@@ -1737,10 +1776,23 @@ impl Client {
         .await?;
 
         let job = admin::retry_external(&self.pool, callback_id, run_lease).await?;
+        let attempt = parked_attempt.unwrap_or(job.attempt);
+        let error_msg = latest_error_message(&job);
+        let outcome_ctx = crate::enqueue_specs::OutcomeContext::Retried {
+            error: error_msg.clone(),
+            attempt,
+            next_run_at: job.run_at,
+        };
+        self.dispatch_callback_followups(
+            &job,
+            crate::enqueue_specs::Outcome::Retried,
+            Some(outcome_ctx),
+        )
+        .await;
         self.dispatch_callback_event(UntypedJobEvent::Retried {
             job: job.clone(),
-            error: latest_error_message(&job),
-            attempt: parked_attempt.unwrap_or(job.attempt),
+            error: error_msg,
+            attempt,
             next_run_at: job.run_at,
         })
         .await;
@@ -1750,6 +1802,78 @@ impl Client {
     async fn dispatch_callback_event(&self, event: UntypedJobEvent) {
         let kind = event.job().kind.clone();
         crate::executor::dispatch_lifecycle_event(&self.lifecycle_handlers, &kind, event).await;
+    }
+
+    /// ADR-029 callback-resolution follow-up dispatch.
+    ///
+    /// **Atomicity caveat:** unlike worker-driven outcomes which dispatch
+    /// specs in the same transaction as the state transition, callback
+    /// resolution dispatches follow-ups in a *separate* transaction after
+    /// the resolution has already committed. If a spec INSERT fails (DB
+    /// disconnect, constraint violation, deserialisation error), the job
+    /// is still resolved but the follow-up is *not* enqueued — the error
+    /// is logged and the caller's `Result` remains `Ok`.
+    ///
+    /// Fully atomic callback resolution + follow-up enqueue requires
+    /// tx-aware admin variants (`complete_external_in_tx`, etc.) on both
+    /// canonical and queue-storage paths; tracked as a follow-up.
+    async fn dispatch_callback_followups(
+        &self,
+        job: &awa_model::JobRow,
+        outcome: crate::enqueue_specs::Outcome,
+        outcome_context: Option<crate::enqueue_specs::OutcomeContext>,
+    ) {
+        let Some(specs) = self
+            .enqueue_specs
+            .get(&outcome)
+            .and_then(|by_kind| by_kind.get(&job.kind))
+            .cloned()
+        else {
+            return;
+        };
+        if specs.is_empty() {
+            return;
+        }
+        let mut tx = match self.pool.begin().await {
+            Ok(tx) => tx,
+            Err(err) => {
+                tracing::error!(
+                    job_id = job.id,
+                    kind = %job.kind,
+                    error = %err,
+                    "callback follow-up dispatch: failed to begin transaction"
+                );
+                return;
+            }
+        };
+        let dispatch_result = crate::enqueue_specs::dispatch_specs_in_tx(
+            &mut tx,
+            job,
+            &specs,
+            outcome_context.as_ref(),
+        )
+        .await;
+        match dispatch_result {
+            Ok(()) => {
+                if let Err(err) = tx.commit().await {
+                    tracing::error!(
+                        job_id = job.id,
+                        kind = %job.kind,
+                        error = %err,
+                        "callback follow-up dispatch: commit failed"
+                    );
+                }
+            }
+            Err(err) => {
+                tracing::error!(
+                    job_id = job.id,
+                    kind = %job.kind,
+                    error = %err,
+                    "callback follow-up dispatch: spec INSERT failed; rolling back"
+                );
+                let _ = tx.rollback().await;
+            }
+        }
     }
 
     /// Health check.

--- a/awa-worker/src/client.rs
+++ b/awa-worker/src/client.rs
@@ -125,7 +125,10 @@ pub struct ClientBuilder {
     job_kind_descriptors: HashMap<String, JobKindDescriptor>,
     workers: HashMap<String, BoxedWorker>,
     lifecycle_handlers: HashMap<String, Vec<BoxedUntypedEventHandler>>,
-    enqueue_specs: HashMap<String, Vec<crate::enqueue_specs::BoxedEnqueueSpec>>,
+    enqueue_specs: HashMap<
+        crate::enqueue_specs::Outcome,
+        HashMap<String, Vec<crate::enqueue_specs::BoxedEnqueueSpec>>,
+    >,
     state: HashMap<TypeId, Box<dyn Any + Send + Sync>>,
     heartbeat_interval: Duration,
     promote_interval: Duration,
@@ -382,7 +385,194 @@ impl ClientBuilder {
                 make,
                 _phantom: std::marker::PhantomData,
             });
-        self.enqueue_specs.entry(kind).or_default().push(spec);
+        self.enqueue_specs
+            .entry(crate::enqueue_specs::Outcome::Completed)
+            .or_default()
+            .entry(kind)
+            .or_default()
+            .push(spec);
+        self
+    }
+
+    /// Register a durable follow-up Awa job to enqueue when a job of type `T`
+    /// is retried (whether via `Ok(RetryAfter)` or a retryable `Err`).
+    /// `make` receives the trigger's args, its post-retry `JobRow`, the error
+    /// string, the previous attempt number, and the next-run-at timestamp.
+    ///
+    /// See [`Self::on_completed_enqueue`] for the same-transaction semantics.
+    pub fn on_retried_enqueue<T, F, MakeFn>(self, make: MakeFn) -> Self
+    where
+        T: JobArgs + DeserializeOwned + Send + Sync + 'static,
+        F: JobArgs + Send + Sync + 'static,
+        MakeFn: Fn(T, &awa_model::JobRow, &str, i16, chrono::DateTime<chrono::Utc>) -> F
+            + Send
+            + Sync
+            + 'static,
+    {
+        self.on_retried_enqueue_with::<T, F, _>(move |args, job, error, attempt, next_run_at| {
+            crate::enqueue_specs::EnqueueRequest::new(make(args, job, error, attempt, next_run_at))
+        })
+    }
+
+    /// Like [`Self::on_retried_enqueue`] but the closure returns an
+    /// [`EnqueueRequest`](crate::EnqueueRequest) with `InsertOpts` overrides.
+    pub fn on_retried_enqueue_with<T, F, MakeFn>(mut self, make: MakeFn) -> Self
+    where
+        T: JobArgs + DeserializeOwned + Send + Sync + 'static,
+        F: JobArgs + Send + Sync + 'static,
+        MakeFn: Fn(
+                T,
+                &awa_model::JobRow,
+                &str,
+                i16,
+                chrono::DateTime<chrono::Utc>,
+            ) -> crate::enqueue_specs::EnqueueRequest<F>
+            + Send
+            + Sync
+            + 'static,
+    {
+        let kind = T::kind().to_string();
+        let spec: crate::enqueue_specs::BoxedEnqueueSpec =
+            Arc::new(crate::enqueue_specs::RetriedFollowUp::<T, F, _> {
+                make,
+                _phantom: std::marker::PhantomData,
+            });
+        self.enqueue_specs
+            .entry(crate::enqueue_specs::Outcome::Retried)
+            .or_default()
+            .entry(kind)
+            .or_default()
+            .push(spec);
+        self
+    }
+
+    /// Register a durable follow-up Awa job to enqueue when a job of type `T`
+    /// is exhausted (retries used up *or* `Err(JobError::Terminal)`).
+    /// `make` receives the trigger's args, its post-failure `JobRow`, the
+    /// error string, and the attempt number.
+    ///
+    /// See [`Self::on_completed_enqueue`] for the same-transaction semantics.
+    pub fn on_exhausted_enqueue<T, F, MakeFn>(self, make: MakeFn) -> Self
+    where
+        T: JobArgs + DeserializeOwned + Send + Sync + 'static,
+        F: JobArgs + Send + Sync + 'static,
+        MakeFn: Fn(T, &awa_model::JobRow, &str, i16) -> F + Send + Sync + 'static,
+    {
+        self.on_exhausted_enqueue_with::<T, F, _>(move |args, job, error, attempt| {
+            crate::enqueue_specs::EnqueueRequest::new(make(args, job, error, attempt))
+        })
+    }
+
+    /// Like [`Self::on_exhausted_enqueue`] but the closure returns an
+    /// [`EnqueueRequest`](crate::EnqueueRequest) with `InsertOpts` overrides.
+    pub fn on_exhausted_enqueue_with<T, F, MakeFn>(mut self, make: MakeFn) -> Self
+    where
+        T: JobArgs + DeserializeOwned + Send + Sync + 'static,
+        F: JobArgs + Send + Sync + 'static,
+        MakeFn: Fn(T, &awa_model::JobRow, &str, i16) -> crate::enqueue_specs::EnqueueRequest<F>
+            + Send
+            + Sync
+            + 'static,
+    {
+        let kind = T::kind().to_string();
+        let spec: crate::enqueue_specs::BoxedEnqueueSpec =
+            Arc::new(crate::enqueue_specs::ExhaustedFollowUp::<T, F, _> {
+                make,
+                _phantom: std::marker::PhantomData,
+            });
+        self.enqueue_specs
+            .entry(crate::enqueue_specs::Outcome::Exhausted)
+            .or_default()
+            .entry(kind)
+            .or_default()
+            .push(spec);
+        self
+    }
+
+    /// Register a durable follow-up Awa job to enqueue when a job of type `T`
+    /// is cancelled via `Ok(JobResult::Cancel(reason))`. `make` receives the
+    /// trigger's args, its post-cancellation `JobRow`, and the reason string.
+    ///
+    /// See [`Self::on_completed_enqueue`] for the same-transaction semantics.
+    pub fn on_cancelled_enqueue<T, F, MakeFn>(self, make: MakeFn) -> Self
+    where
+        T: JobArgs + DeserializeOwned + Send + Sync + 'static,
+        F: JobArgs + Send + Sync + 'static,
+        MakeFn: Fn(T, &awa_model::JobRow, &str) -> F + Send + Sync + 'static,
+    {
+        self.on_cancelled_enqueue_with::<T, F, _>(move |args, job, reason| {
+            crate::enqueue_specs::EnqueueRequest::new(make(args, job, reason))
+        })
+    }
+
+    /// Like [`Self::on_cancelled_enqueue`] but the closure returns an
+    /// [`EnqueueRequest`](crate::EnqueueRequest) with `InsertOpts` overrides.
+    pub fn on_cancelled_enqueue_with<T, F, MakeFn>(mut self, make: MakeFn) -> Self
+    where
+        T: JobArgs + DeserializeOwned + Send + Sync + 'static,
+        F: JobArgs + Send + Sync + 'static,
+        MakeFn: Fn(T, &awa_model::JobRow, &str) -> crate::enqueue_specs::EnqueueRequest<F>
+            + Send
+            + Sync
+            + 'static,
+    {
+        let kind = T::kind().to_string();
+        let spec: crate::enqueue_specs::BoxedEnqueueSpec =
+            Arc::new(crate::enqueue_specs::CancelledFollowUp::<T, F, _> {
+                make,
+                _phantom: std::marker::PhantomData,
+            });
+        self.enqueue_specs
+            .entry(crate::enqueue_specs::Outcome::Cancelled)
+            .or_default()
+            .entry(kind)
+            .or_default()
+            .push(spec);
+        self
+    }
+
+    /// Register a durable follow-up Awa job to enqueue when a job of type `T`
+    /// parks on an external callback (`Ok(JobResult::WaitForCallback)`).
+    /// `make` receives the trigger's args plus the parked `JobRow`
+    /// (`job.callback_id` and `job.callback_timeout_at` identify the
+    /// pending callback).
+    ///
+    /// See [`Self::on_completed_enqueue`] for the same-transaction semantics.
+    pub fn on_waiting_for_callback_enqueue<T, F, MakeFn>(self, make: MakeFn) -> Self
+    where
+        T: JobArgs + DeserializeOwned + Send + Sync + 'static,
+        F: JobArgs + Send + Sync + 'static,
+        MakeFn: Fn(T, &awa_model::JobRow) -> F + Send + Sync + 'static,
+    {
+        self.on_waiting_for_callback_enqueue_with::<T, F, _>(move |args, job| {
+            crate::enqueue_specs::EnqueueRequest::new(make(args, job))
+        })
+    }
+
+    /// Like [`Self::on_waiting_for_callback_enqueue`] but the closure returns
+    /// an [`EnqueueRequest`](crate::EnqueueRequest) with `InsertOpts` overrides.
+    pub fn on_waiting_for_callback_enqueue_with<T, F, MakeFn>(mut self, make: MakeFn) -> Self
+    where
+        T: JobArgs + DeserializeOwned + Send + Sync + 'static,
+        F: JobArgs + Send + Sync + 'static,
+        MakeFn: Fn(T, &awa_model::JobRow) -> crate::enqueue_specs::EnqueueRequest<F>
+            + Send
+            + Sync
+            + 'static,
+    {
+        let kind = T::kind().to_string();
+        let spec: crate::enqueue_specs::BoxedEnqueueSpec = Arc::new(
+            crate::enqueue_specs::WaitingForCallbackFollowUp::<T, F, _> {
+                make,
+                _phantom: std::marker::PhantomData,
+            },
+        );
+        self.enqueue_specs
+            .entry(crate::enqueue_specs::Outcome::WaitingForCallback)
+            .or_default()
+            .entry(kind)
+            .or_default()
+            .push(spec);
         self
     }
 
@@ -820,7 +1010,12 @@ pub struct Client {
     job_kind_descriptors: HashMap<String, JobKindDescriptor>,
     workers: Arc<HashMap<String, BoxedWorker>>,
     lifecycle_handlers: Arc<HashMap<String, Vec<BoxedUntypedEventHandler>>>,
-    enqueue_specs: Arc<HashMap<String, Vec<crate::enqueue_specs::BoxedEnqueueSpec>>>,
+    enqueue_specs: Arc<
+        HashMap<
+            crate::enqueue_specs::Outcome,
+            HashMap<String, Vec<crate::enqueue_specs::BoxedEnqueueSpec>>,
+        >,
+    >,
     state: Arc<HashMap<TypeId, Box<dyn Any + Send + Sync>>>,
     heartbeat_interval: Duration,
     promote_interval: Duration,

--- a/awa-worker/src/client.rs
+++ b/awa-worker/src/client.rs
@@ -340,8 +340,12 @@ impl ClientBuilder {
     /// completes successfully.
     ///
     /// `make` receives the trigger's deserialised args plus its post-completion
-    /// [`awa_model::JobRow`] and returns the follow-up job's `JobArgs`. The
-    /// follow-up is `INSERT`ed in the *same database transaction* as the
+    /// [`awa_model::JobRow`] and returns the follow-up's `JobArgs` value. The
+    /// follow-up is enqueued with default [`awa_model::InsertOpts`] — use
+    /// [`Self::on_completed_enqueue_with`] to override queue, priority, or
+    /// other insert options.
+    ///
+    /// The follow-up is `INSERT`ed in the *same database transaction* as the
     /// completion's state change, so the trigger and the follow-up commit or
     /// roll back together — see ADR-029. This is the durable counterpart to
     /// [`Self::on_event`]: hooks are best-effort, in-process; this enqueue is
@@ -349,18 +353,33 @@ impl ClientBuilder {
     ///
     /// Multiple registrations for the same kind stack and all run in the
     /// finalization transaction.
-    pub fn on_completed_enqueue<T, F, MakeFn>(mut self, make: MakeFn) -> Self
+    pub fn on_completed_enqueue<T, F, MakeFn>(self, make: MakeFn) -> Self
     where
         T: JobArgs + DeserializeOwned + Send + Sync + 'static,
         F: JobArgs + Send + Sync + 'static,
         MakeFn: Fn(T, &awa_model::JobRow) -> F + Send + Sync + 'static,
     {
+        self.on_completed_enqueue_with::<T, F, _>(move |args, job| {
+            crate::enqueue_specs::EnqueueRequest::new(make(args, job))
+        })
+    }
+
+    /// Like [`Self::on_completed_enqueue`] but lets the closure return an
+    /// [`EnqueueRequest`](crate::EnqueueRequest) with explicit queue,
+    /// priority, or other [`awa_model::InsertOpts`] overrides.
+    pub fn on_completed_enqueue_with<T, F, MakeFn>(mut self, make: MakeFn) -> Self
+    where
+        T: JobArgs + DeserializeOwned + Send + Sync + 'static,
+        F: JobArgs + Send + Sync + 'static,
+        MakeFn: Fn(T, &awa_model::JobRow) -> crate::enqueue_specs::EnqueueRequest<F>
+            + Send
+            + Sync
+            + 'static,
+    {
         let kind = T::kind().to_string();
         let spec: crate::enqueue_specs::BoxedEnqueueSpec =
             Arc::new(crate::enqueue_specs::CompletedFollowUp::<T, F, _> {
-                make: move |args: T, job: &awa_model::JobRow| {
-                    (make(args, job), awa_model::InsertOpts::default())
-                },
+                make,
                 _phantom: std::marker::PhantomData,
             });
         self.enqueue_specs.entry(kind).or_default().push(spec);

--- a/awa-worker/src/client.rs
+++ b/awa-worker/src/client.rs
@@ -1169,11 +1169,12 @@ impl Client {
             *guard = effective_storage.clone();
         }
 
-        // ADR-029: on_*_enqueue specs are wired through the canonical
-        // executor path only at this stage. Fail fast when specs would
-        // otherwise be silently ignored under queue storage, so callers
-        // discover the limitation at startup rather than wondering why
-        // follow-ups never appear.
+        // ADR-029: on_*_enqueue specs are wired through the canonical executor
+        // path only at this stage. The queue-storage completion path uses a
+        // receipt-plane fast-complete (ADR-023) we can't currently join from
+        // a tx held by the executor; making it tx-aware is a separate
+        // follow-up. Fail fast here so callers can't ship code that silently
+        // never enqueues follow-ups under queue storage (the default runtime).
         if !self.enqueue_specs.is_empty()
             && matches!(
                 effective_storage,

--- a/awa-worker/src/client.rs
+++ b/awa-worker/src/client.rs
@@ -1150,6 +1150,26 @@ impl Client {
             *guard = effective_storage.clone();
         }
 
+        // ADR-029: on_*_enqueue specs are wired through the canonical
+        // executor path only at this stage. Fail fast when specs would
+        // otherwise be silently ignored under queue storage, so callers
+        // discover the limitation at startup rather than wondering why
+        // follow-ups never appear.
+        if !self.enqueue_specs.is_empty()
+            && matches!(
+                effective_storage,
+                crate::storage::RuntimeStorage::QueueStorage(_)
+            )
+        {
+            let kinds: Vec<&str> = self.enqueue_specs.keys().map(String::as_str).collect();
+            return Err(awa_model::AwaError::Validation(format!(
+                "follow-up enqueue specs ({kinds:?}) are registered, but this runtime is using \
+                 queue storage. ADR-029 queue-storage wiring is a separate follow-up; for now \
+                 use ClientBuilder::canonical_storage() on the process that performs the \
+                 triggering state transition."
+            )));
+        }
+
         self.log_transition_startup_status(&effective_storage)
             .await?;
 

--- a/awa-worker/src/enqueue_specs.rs
+++ b/awa-worker/src/enqueue_specs.rs
@@ -58,9 +58,9 @@ impl<F: JobArgs> EnqueueRequest<F> {
         self
     }
 
-    /// Replace the follow-up's [`InsertOpts`] wholesale (for callers who need
-    /// fields the builder methods above do not yet cover — `metadata`, `tags`,
-    /// `unique`, `run_at`, `deadline_duration`, `ordering_key`).
+    /// Replace the follow-up's [`InsertOpts`] wholesale — useful for fields
+    /// without dedicated builder methods (`metadata`, `tags`, `unique`,
+    /// `run_at`, `deadline_duration`, `ordering_key`).
     pub fn with_opts(mut self, opts: InsertOpts) -> Self {
         self.opts = opts;
         self

--- a/awa-worker/src/enqueue_specs.rs
+++ b/awa-worker/src/enqueue_specs.rs
@@ -148,6 +148,36 @@ fn decode_trigger_args<T: DeserializeOwned>(job: &JobRow) -> Result<T, AwaError>
     })
 }
 
+/// Invoke a user-supplied `make` closure, converting any panic into an
+/// `AwaError` so the spec dispatcher can roll back its transaction and
+/// log the failure the same way it would for a returned error. Without
+/// this, a panic in user code would unwind:
+/// - on worker-driven outcomes, the executor's completion task (the
+///   transition tx would still roll back via Drop, but the worker would
+///   log a JoinError rather than the typed spec failure);
+/// - on callback-resolution paths, the resolver task (after the
+///   resolution itself has already committed) — observers and in-process
+///   hooks downstream of the panic point never run;
+/// - on rescue paths, the maintenance task — likewise dropping the
+///   detached hook spawn for that rescue.
+fn catch_make_panic<R>(
+    kind: &str,
+    f: impl FnOnce() -> R + std::panic::UnwindSafe,
+) -> Result<R, AwaError> {
+    std::panic::catch_unwind(f).map_err(|panic| {
+        let detail = if let Some(msg) = panic.downcast_ref::<&'static str>() {
+            (*msg).to_string()
+        } else if let Some(msg) = panic.downcast_ref::<String>() {
+            msg.clone()
+        } else {
+            "panic payload not a string".to_string()
+        };
+        AwaError::Validation(format!(
+            "follow-up enqueue closure for kind {kind} panicked: {detail}"
+        ))
+    })
+}
+
 /// Spec for the `Completed` outcome. Captures a typed closure that maps the
 /// trigger's deserialised args plus its post-completion `JobRow` to an
 /// [`EnqueueRequest<F>`] describing the follow-up.
@@ -170,7 +200,10 @@ where
     ) -> Pin<Box<dyn Future<Output = Result<(), AwaError>> + Send + 'a>> {
         Box::pin(async move {
             let args: T = decode_trigger_args(job)?;
-            let request = (self.make)(args, job);
+            let request = catch_make_panic(
+                &job.kind,
+                std::panic::AssertUnwindSafe(|| (self.make)(args, job)),
+            )?;
             insert_with(&mut *conn, &request.args, request.opts).await?;
             Ok(())
         })
@@ -210,7 +243,12 @@ where
                 ));
             };
             let args: T = decode_trigger_args(job)?;
-            let request = (self.make)(args, job, error, *attempt, *next_run_at);
+            let request = catch_make_panic(
+                &job.kind,
+                std::panic::AssertUnwindSafe(|| {
+                    (self.make)(args, job, error, *attempt, *next_run_at)
+                }),
+            )?;
             insert_with(&mut *conn, &request.args, request.opts).await?;
             Ok(())
         })
@@ -242,7 +280,10 @@ where
                 ));
             };
             let args: T = decode_trigger_args(job)?;
-            let request = (self.make)(args, job, error, *attempt);
+            let request = catch_make_panic(
+                &job.kind,
+                std::panic::AssertUnwindSafe(|| (self.make)(args, job, error, *attempt)),
+            )?;
             insert_with(&mut *conn, &request.args, request.opts).await?;
             Ok(())
         })
@@ -274,7 +315,10 @@ where
                 ));
             };
             let args: T = decode_trigger_args(job)?;
-            let request = (self.make)(args, job, reason);
+            let request = catch_make_panic(
+                &job.kind,
+                std::panic::AssertUnwindSafe(|| (self.make)(args, job, reason)),
+            )?;
             insert_with(&mut *conn, &request.args, request.opts).await?;
             Ok(())
         })
@@ -301,7 +345,10 @@ where
     ) -> Pin<Box<dyn Future<Output = Result<(), AwaError>> + Send + 'a>> {
         Box::pin(async move {
             let args: T = decode_trigger_args(job)?;
-            let request = (self.make)(args, job);
+            let request = catch_make_panic(
+                &job.kind,
+                std::panic::AssertUnwindSafe(|| (self.make)(args, job)),
+            )?;
             insert_with(&mut *conn, &request.args, request.opts).await?;
             Ok(())
         })
@@ -335,7 +382,10 @@ where
                 ));
             };
             let args: T = decode_trigger_args(job)?;
-            let request = (self.make)(args, job, *reason);
+            let request = catch_make_panic(
+                &job.kind,
+                std::panic::AssertUnwindSafe(|| (self.make)(args, job, *reason)),
+            )?;
             insert_with(&mut *conn, &request.args, request.opts).await?;
             Ok(())
         })

--- a/awa-worker/src/enqueue_specs.rs
+++ b/awa-worker/src/enqueue_specs.rs
@@ -1,10 +1,14 @@
 //! Transactional follow-up enqueue specs (ADR-029).
 //!
-//! A spec is a per-(outcome, kind) registration that, when its triggering
-//! state transition commits, inserts a follow-up Awa job in the same database
-//! transaction. The follow-up rides Awa's existing durability (at-least-once,
-//! retries, DLQ, admin visibility), so the side effect cannot be lost between
-//! the state commit and the hook dispatch the way an in-process hook can.
+//! A spec is a per-(outcome, kind) registration that fires when its
+//! triggering state transition commits. Worker-driven outcomes dispatch
+//! the follow-up `INSERT` in the same transaction as the state UPDATE
+//! (atomic with the trigger). Callback-resolution and maintenance-rescue
+//! outcomes dispatch in a separate transaction after the trigger
+//! transaction commits (best-effort — a failed `INSERT` is logged and
+//! the trigger stands). Either way, once the follow-up `INSERT` commits
+//! the row is a regular Awa job: at-least-once, retried, DLQ-aware,
+//! visible to admin tooling.
 //!
 //! Specs are type-erased here so the executor can dispatch them without
 //! knowing the trigger or follow-up types statically. The user-facing

--- a/awa-worker/src/enqueue_specs.rs
+++ b/awa-worker/src/enqueue_specs.rs
@@ -89,6 +89,9 @@ pub enum Outcome {
     Exhausted,
     Cancelled,
     WaitingForCallback,
+    /// Maintenance rescued the job (expired callback, stale heartbeat, or
+    /// exceeded deadline). See [`crate::events::RescueReason`].
+    Rescued,
 }
 
 /// Per-outcome runtime context handed to non-`Completed` follow-up closures
@@ -110,6 +113,9 @@ pub enum OutcomeContext {
         reason: String,
     },
     WaitingForCallback,
+    Rescued {
+        reason: crate::events::RescueReason,
+    },
 }
 
 /// Type-erased follow-up-enqueue spec for one (outcome, kind) pair.
@@ -292,6 +298,40 @@ where
         Box::pin(async move {
             let args: T = decode_trigger_args(job)?;
             let request = (self.make)(args, job);
+            insert_with(&mut *conn, &request.args, request.opts).await?;
+            Ok(())
+        })
+    }
+}
+
+/// Spec for the `Rescued` outcome. `make` receives the trigger's args,
+/// post-rescue `JobRow`, and the [`RescueReason`](crate::events::RescueReason).
+pub(crate) struct RescuedFollowUp<T, F, MakeFn> {
+    pub(crate) make: MakeFn,
+    pub(crate) _phantom: PhantomData<fn() -> (T, F)>,
+}
+
+impl<T, F, MakeFn> EnqueueFollowUp for RescuedFollowUp<T, F, MakeFn>
+where
+    T: JobArgs + DeserializeOwned + Send + Sync + 'static,
+    F: JobArgs + Send + Sync + 'static,
+    MakeFn:
+        Fn(T, &JobRow, crate::events::RescueReason) -> EnqueueRequest<F> + Send + Sync + 'static,
+{
+    fn run<'a>(
+        &'a self,
+        conn: &'a mut PgConnection,
+        job: &'a JobRow,
+        outcome_context: Option<&'a OutcomeContext>,
+    ) -> Pin<Box<dyn Future<Output = Result<(), AwaError>> + Send + 'a>> {
+        Box::pin(async move {
+            let Some(OutcomeContext::Rescued { reason }) = outcome_context else {
+                return Err(AwaError::Validation(
+                    "RescuedFollowUp dispatched without a Rescued OutcomeContext".into(),
+                ));
+            };
+            let args: T = decode_trigger_args(job)?;
+            let request = (self.make)(args, job, *reason);
             insert_with(&mut *conn, &request.args, request.opts).await?;
             Ok(())
         })

--- a/awa-worker/src/enqueue_specs.rs
+++ b/awa-worker/src/enqueue_specs.rs
@@ -19,6 +19,59 @@ use std::marker::PhantomData;
 use std::pin::Pin;
 use std::sync::Arc;
 
+/// Description of a follow-up job to enqueue when an `on_*_enqueue` spec
+/// fires. Carries the follow-up's `JobArgs` and the [`InsertOpts`] applied to
+/// the `INSERT`. For the common "default opts" case, users can return the
+/// `JobArgs` value directly from their closure — `EnqueueRequest::from(args)`
+/// is invoked automatically.
+#[derive(Debug, Clone)]
+pub struct EnqueueRequest<F> {
+    pub(crate) args: F,
+    pub(crate) opts: InsertOpts,
+}
+
+impl<F: JobArgs> EnqueueRequest<F> {
+    /// Build a request with default [`InsertOpts`].
+    pub fn new(args: F) -> Self {
+        Self {
+            args,
+            opts: InsertOpts::default(),
+        }
+    }
+
+    /// Override the follow-up's queue.
+    pub fn queue(mut self, queue: impl Into<String>) -> Self {
+        self.opts.queue = queue.into();
+        self
+    }
+
+    /// Override the follow-up's priority.
+    pub fn priority(mut self, priority: i16) -> Self {
+        self.opts.priority = priority;
+        self
+    }
+
+    /// Override the follow-up's `max_attempts`.
+    pub fn max_attempts(mut self, max_attempts: i16) -> Self {
+        self.opts.max_attempts = max_attempts;
+        self
+    }
+
+    /// Replace the follow-up's [`InsertOpts`] wholesale (for callers who need
+    /// fields the builder methods above do not yet cover — `metadata`, `tags`,
+    /// `unique`, `run_at`, `deadline_duration`, `ordering_key`).
+    pub fn with_opts(mut self, opts: InsertOpts) -> Self {
+        self.opts = opts;
+        self
+    }
+}
+
+impl<F: JobArgs> From<F> for EnqueueRequest<F> {
+    fn from(args: F) -> Self {
+        Self::new(args)
+    }
+}
+
 /// Type-erased follow-up-enqueue spec for one (trigger kind, outcome) pair.
 ///
 /// Implementors deserialise the trigger's args from the committed `JobRow`,
@@ -36,8 +89,8 @@ pub(crate) trait EnqueueFollowUp: Send + Sync {
 pub(crate) type BoxedEnqueueSpec = Arc<dyn EnqueueFollowUp + 'static>;
 
 /// Spec for the `Completed` outcome. Captures a typed closure that maps the
-/// trigger's deserialised args plus its post-completion `JobRow` to a
-/// follow-up `JobArgs` + `InsertOpts`.
+/// trigger's deserialised args plus its post-completion `JobRow` to an
+/// [`EnqueueRequest<F>`] describing the follow-up.
 pub(crate) struct CompletedFollowUp<T, F, MakeFn> {
     pub(crate) make: MakeFn,
     pub(crate) _phantom: PhantomData<fn() -> (T, F)>,
@@ -47,7 +100,7 @@ impl<T, F, MakeFn> EnqueueFollowUp for CompletedFollowUp<T, F, MakeFn>
 where
     T: JobArgs + DeserializeOwned + Send + Sync + 'static,
     F: JobArgs + Send + Sync + 'static,
-    MakeFn: Fn(T, &JobRow) -> (F, InsertOpts) + Send + Sync + 'static,
+    MakeFn: Fn(T, &JobRow) -> EnqueueRequest<F> + Send + Sync + 'static,
 {
     fn run<'a>(
         &'a self,
@@ -65,8 +118,8 @@ where
                     job.kind
                 ))
             })?;
-            let (follow_args, opts) = (self.make)(args, job);
-            insert_with(&mut *conn, &follow_args, opts).await?;
+            let request = (self.make)(args, job);
+            insert_with(&mut *conn, &request.args, request.opts).await?;
             Ok(())
         })
     }

--- a/awa-worker/src/enqueue_specs.rs
+++ b/awa-worker/src/enqueue_specs.rs
@@ -1,7 +1,7 @@
 //! Transactional follow-up enqueue specs (ADR-029).
 //!
-//! A spec is a per-kind registration that, when its triggering state
-//! transition commits, inserts a follow-up Awa job in the same database
+//! A spec is a per-(outcome, kind) registration that, when its triggering
+//! state transition commits, inserts a follow-up Awa job in the same database
 //! transaction. The follow-up rides Awa's existing durability (at-least-once,
 //! retries, DLQ, admin visibility), so the side effect cannot be lost between
 //! the state commit and the hook dispatch the way an in-process hook can.
@@ -9,7 +9,8 @@
 //! Specs are type-erased here so the executor can dispatch them without
 //! knowing the trigger or follow-up types statically. The user-facing
 //! `ClientBuilder::on_*_enqueue` methods wrap their typed closures into
-//! impls of [`EnqueueFollowUp`] and accumulate them in a per-kind map.
+//! impls of [`EnqueueFollowUp`] and accumulate them in a two-level
+//! `outcome -> kind -> specs` registry.
 
 use awa_model::{insert_with, AwaError, InsertOpts, JobArgs, JobRow};
 use serde::de::DeserializeOwned;
@@ -72,21 +73,70 @@ impl<F: JobArgs> From<F> for EnqueueRequest<F> {
     }
 }
 
-/// Type-erased follow-up-enqueue spec for one (trigger kind, outcome) pair.
+/// The outcome whose state-commit triggers a registered spec.
 ///
-/// Implementors deserialise the trigger's args from the committed `JobRow`,
-/// apply the user's closure to produce the follow-up's `JobArgs` and
-/// [`InsertOpts`], then insert through the supplied executor — which the
-/// caller scopes to the same transaction as the triggering state commit.
+/// One spec is tied to exactly one outcome; the registry is keyed on this so
+/// the executor can look up specs for the specific branch it just took
+/// without filtering.
+///
+/// `Started` is intentionally excluded (see ADR-029): claim-time follow-up
+/// enqueue would join the dispatcher's hot path and the durable-side-effect
+/// use case for "job started" is uncommon. Observation belongs to hooks.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Outcome {
+    Completed,
+    Retried,
+    Exhausted,
+    Cancelled,
+    WaitingForCallback,
+}
+
+/// Per-outcome runtime context handed to non-`Completed` follow-up closures
+/// so they can specialise on outcome-specific fields (error / attempt /
+/// reason / next_run_at). Variants mirror the corresponding
+/// `UntypedJobEvent` variants in shape.
+#[derive(Debug, Clone)]
+pub enum OutcomeContext {
+    Retried {
+        error: String,
+        attempt: i16,
+        next_run_at: chrono::DateTime<chrono::Utc>,
+    },
+    Exhausted {
+        error: String,
+        attempt: i16,
+    },
+    Cancelled {
+        reason: String,
+    },
+    WaitingForCallback,
+}
+
+/// Type-erased follow-up-enqueue spec for one (outcome, kind) pair.
+///
+/// `Completed` specs receive `outcome_context: None` (no extra context beyond
+/// the JobRow). Non-Completed specs receive `Some(ctx)` with the matching
+/// variant — the registry guarantees the variant matches because the spec is
+/// registered under its outcome key.
 pub(crate) trait EnqueueFollowUp: Send + Sync {
     fn run<'a>(
         &'a self,
         conn: &'a mut PgConnection,
         job: &'a JobRow,
+        outcome_context: Option<&'a OutcomeContext>,
     ) -> Pin<Box<dyn Future<Output = Result<(), AwaError>> + Send + 'a>>;
 }
 
 pub(crate) type BoxedEnqueueSpec = Arc<dyn EnqueueFollowUp + 'static>;
+
+fn decode_trigger_args<T: DeserializeOwned>(job: &JobRow) -> Result<T, AwaError> {
+    serde_json::from_value(job.args.clone()).map_err(|err| {
+        AwaError::Validation(format!(
+            "follow-up enqueue: failed to decode trigger args for kind {}: {err}",
+            job.kind
+        ))
+    })
+}
 
 /// Spec for the `Completed` outcome. Captures a typed closure that maps the
 /// trigger's deserialised args plus its post-completion `JobRow` to an
@@ -106,21 +156,158 @@ where
         &'a self,
         conn: &'a mut PgConnection,
         job: &'a JobRow,
+        _outcome_context: Option<&'a OutcomeContext>,
     ) -> Pin<Box<dyn Future<Output = Result<(), AwaError>> + Send + 'a>> {
         Box::pin(async move {
-            // Deserialise the trigger args from the committed snapshot. If
-            // they don't decode, treat it as a configuration error in the
-            // hook rather than a job failure — the trigger has already
-            // committed by the time this runs.
-            let args: T = serde_json::from_value(job.args.clone()).map_err(|err| {
-                AwaError::Validation(format!(
-                    "follow-up enqueue: failed to decode trigger args for kind {}: {err}",
-                    job.kind
-                ))
-            })?;
+            let args: T = decode_trigger_args(job)?;
             let request = (self.make)(args, job);
             insert_with(&mut *conn, &request.args, request.opts).await?;
             Ok(())
         })
     }
+}
+
+/// Spec for the `Retried` outcome.
+pub(crate) struct RetriedFollowUp<T, F, MakeFn> {
+    pub(crate) make: MakeFn,
+    pub(crate) _phantom: PhantomData<fn() -> (T, F)>,
+}
+
+impl<T, F, MakeFn> EnqueueFollowUp for RetriedFollowUp<T, F, MakeFn>
+where
+    T: JobArgs + DeserializeOwned + Send + Sync + 'static,
+    F: JobArgs + Send + Sync + 'static,
+    MakeFn: Fn(T, &JobRow, &str, i16, chrono::DateTime<chrono::Utc>) -> EnqueueRequest<F>
+        + Send
+        + Sync
+        + 'static,
+{
+    fn run<'a>(
+        &'a self,
+        conn: &'a mut PgConnection,
+        job: &'a JobRow,
+        outcome_context: Option<&'a OutcomeContext>,
+    ) -> Pin<Box<dyn Future<Output = Result<(), AwaError>> + Send + 'a>> {
+        Box::pin(async move {
+            let Some(OutcomeContext::Retried {
+                error,
+                attempt,
+                next_run_at,
+            }) = outcome_context
+            else {
+                return Err(AwaError::Validation(
+                    "RetriedFollowUp dispatched without a Retried OutcomeContext".into(),
+                ));
+            };
+            let args: T = decode_trigger_args(job)?;
+            let request = (self.make)(args, job, error, *attempt, *next_run_at);
+            insert_with(&mut *conn, &request.args, request.opts).await?;
+            Ok(())
+        })
+    }
+}
+
+/// Spec for the `Exhausted` outcome (retries-exhausted or terminal-error).
+pub(crate) struct ExhaustedFollowUp<T, F, MakeFn> {
+    pub(crate) make: MakeFn,
+    pub(crate) _phantom: PhantomData<fn() -> (T, F)>,
+}
+
+impl<T, F, MakeFn> EnqueueFollowUp for ExhaustedFollowUp<T, F, MakeFn>
+where
+    T: JobArgs + DeserializeOwned + Send + Sync + 'static,
+    F: JobArgs + Send + Sync + 'static,
+    MakeFn: Fn(T, &JobRow, &str, i16) -> EnqueueRequest<F> + Send + Sync + 'static,
+{
+    fn run<'a>(
+        &'a self,
+        conn: &'a mut PgConnection,
+        job: &'a JobRow,
+        outcome_context: Option<&'a OutcomeContext>,
+    ) -> Pin<Box<dyn Future<Output = Result<(), AwaError>> + Send + 'a>> {
+        Box::pin(async move {
+            let Some(OutcomeContext::Exhausted { error, attempt }) = outcome_context else {
+                return Err(AwaError::Validation(
+                    "ExhaustedFollowUp dispatched without an Exhausted OutcomeContext".into(),
+                ));
+            };
+            let args: T = decode_trigger_args(job)?;
+            let request = (self.make)(args, job, error, *attempt);
+            insert_with(&mut *conn, &request.args, request.opts).await?;
+            Ok(())
+        })
+    }
+}
+
+/// Spec for the `Cancelled` outcome.
+pub(crate) struct CancelledFollowUp<T, F, MakeFn> {
+    pub(crate) make: MakeFn,
+    pub(crate) _phantom: PhantomData<fn() -> (T, F)>,
+}
+
+impl<T, F, MakeFn> EnqueueFollowUp for CancelledFollowUp<T, F, MakeFn>
+where
+    T: JobArgs + DeserializeOwned + Send + Sync + 'static,
+    F: JobArgs + Send + Sync + 'static,
+    MakeFn: Fn(T, &JobRow, &str) -> EnqueueRequest<F> + Send + Sync + 'static,
+{
+    fn run<'a>(
+        &'a self,
+        conn: &'a mut PgConnection,
+        job: &'a JobRow,
+        outcome_context: Option<&'a OutcomeContext>,
+    ) -> Pin<Box<dyn Future<Output = Result<(), AwaError>> + Send + 'a>> {
+        Box::pin(async move {
+            let Some(OutcomeContext::Cancelled { reason }) = outcome_context else {
+                return Err(AwaError::Validation(
+                    "CancelledFollowUp dispatched without a Cancelled OutcomeContext".into(),
+                ));
+            };
+            let args: T = decode_trigger_args(job)?;
+            let request = (self.make)(args, job, reason);
+            insert_with(&mut *conn, &request.args, request.opts).await?;
+            Ok(())
+        })
+    }
+}
+
+/// Spec for the `WaitingForCallback` outcome.
+pub(crate) struct WaitingForCallbackFollowUp<T, F, MakeFn> {
+    pub(crate) make: MakeFn,
+    pub(crate) _phantom: PhantomData<fn() -> (T, F)>,
+}
+
+impl<T, F, MakeFn> EnqueueFollowUp for WaitingForCallbackFollowUp<T, F, MakeFn>
+where
+    T: JobArgs + DeserializeOwned + Send + Sync + 'static,
+    F: JobArgs + Send + Sync + 'static,
+    MakeFn: Fn(T, &JobRow) -> EnqueueRequest<F> + Send + Sync + 'static,
+{
+    fn run<'a>(
+        &'a self,
+        conn: &'a mut PgConnection,
+        job: &'a JobRow,
+        _outcome_context: Option<&'a OutcomeContext>,
+    ) -> Pin<Box<dyn Future<Output = Result<(), AwaError>> + Send + 'a>> {
+        Box::pin(async move {
+            let args: T = decode_trigger_args(job)?;
+            let request = (self.make)(args, job);
+            insert_with(&mut *conn, &request.args, request.opts).await?;
+            Ok(())
+        })
+    }
+}
+
+/// Helper used by the executor (and other emission sites) to drive a list of
+/// specs against a connection inside an already-open transaction.
+pub(crate) async fn dispatch_specs_in_tx(
+    conn: &mut PgConnection,
+    job: &JobRow,
+    specs: &[BoxedEnqueueSpec],
+    outcome_context: Option<&OutcomeContext>,
+) -> Result<(), AwaError> {
+    for spec in specs {
+        spec.run(conn, job, outcome_context).await?;
+    }
+    Ok(())
 }

--- a/awa-worker/src/enqueue_specs.rs
+++ b/awa-worker/src/enqueue_specs.rs
@@ -1,0 +1,73 @@
+//! Transactional follow-up enqueue specs (ADR-029).
+//!
+//! A spec is a per-kind registration that, when its triggering state
+//! transition commits, inserts a follow-up Awa job in the same database
+//! transaction. The follow-up rides Awa's existing durability (at-least-once,
+//! retries, DLQ, admin visibility), so the side effect cannot be lost between
+//! the state commit and the hook dispatch the way an in-process hook can.
+//!
+//! Specs are type-erased here so the executor can dispatch them without
+//! knowing the trigger or follow-up types statically. The user-facing
+//! `ClientBuilder::on_*_enqueue` methods wrap their typed closures into
+//! impls of [`EnqueueFollowUp`] and accumulate them in a per-kind map.
+
+use awa_model::{insert_with, AwaError, InsertOpts, JobArgs, JobRow};
+use serde::de::DeserializeOwned;
+use sqlx::PgConnection;
+use std::future::Future;
+use std::marker::PhantomData;
+use std::pin::Pin;
+use std::sync::Arc;
+
+/// Type-erased follow-up-enqueue spec for one (trigger kind, outcome) pair.
+///
+/// Implementors deserialise the trigger's args from the committed `JobRow`,
+/// apply the user's closure to produce the follow-up's `JobArgs` and
+/// [`InsertOpts`], then insert through the supplied executor — which the
+/// caller scopes to the same transaction as the triggering state commit.
+pub(crate) trait EnqueueFollowUp: Send + Sync {
+    fn run<'a>(
+        &'a self,
+        conn: &'a mut PgConnection,
+        job: &'a JobRow,
+    ) -> Pin<Box<dyn Future<Output = Result<(), AwaError>> + Send + 'a>>;
+}
+
+pub(crate) type BoxedEnqueueSpec = Arc<dyn EnqueueFollowUp + 'static>;
+
+/// Spec for the `Completed` outcome. Captures a typed closure that maps the
+/// trigger's deserialised args plus its post-completion `JobRow` to a
+/// follow-up `JobArgs` + `InsertOpts`.
+pub(crate) struct CompletedFollowUp<T, F, MakeFn> {
+    pub(crate) make: MakeFn,
+    pub(crate) _phantom: PhantomData<fn() -> (T, F)>,
+}
+
+impl<T, F, MakeFn> EnqueueFollowUp for CompletedFollowUp<T, F, MakeFn>
+where
+    T: JobArgs + DeserializeOwned + Send + Sync + 'static,
+    F: JobArgs + Send + Sync + 'static,
+    MakeFn: Fn(T, &JobRow) -> (F, InsertOpts) + Send + Sync + 'static,
+{
+    fn run<'a>(
+        &'a self,
+        conn: &'a mut PgConnection,
+        job: &'a JobRow,
+    ) -> Pin<Box<dyn Future<Output = Result<(), AwaError>> + Send + 'a>> {
+        Box::pin(async move {
+            // Deserialise the trigger args from the committed snapshot. If
+            // they don't decode, treat it as a configuration error in the
+            // hook rather than a job failure — the trigger has already
+            // committed by the time this runs.
+            let args: T = serde_json::from_value(job.args.clone()).map_err(|err| {
+                AwaError::Validation(format!(
+                    "follow-up enqueue: failed to decode trigger args for kind {}: {err}",
+                    job.kind
+                ))
+            })?;
+            let (follow_args, opts) = (self.make)(args, job);
+            insert_with(&mut *conn, &follow_args, opts).await?;
+            Ok(())
+        })
+    }
+}

--- a/awa-worker/src/events.rs
+++ b/awa-worker/src/events.rs
@@ -43,6 +43,38 @@ pub enum JobEvent<T> {
         job: JobRow,
         reason: String,
     },
+    /// Job was rescued by maintenance — either its callback wait expired,
+    /// its heartbeat went stale (presumed crashed worker), or its deadline
+    /// was exceeded. `reason` identifies the rescue path. The post-rescue
+    /// `job.state` is `retryable` or `failed` (when retries are exhausted)
+    /// or `dlq` (when DLQ routing was enabled).
+    Rescued {
+        args: T,
+        job: JobRow,
+        reason: RescueReason,
+    },
+}
+
+/// Why maintenance rescued the job.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RescueReason {
+    /// The external callback's `callback_timeout_at` elapsed without resolution.
+    ExpiredCallback,
+    /// The job's heartbeat went stale (worker presumed crashed or stuck).
+    StaleHeartbeat,
+    /// The job's `deadline_at` elapsed.
+    DeadlineExceeded,
+}
+
+impl RescueReason {
+    /// Stable identifier suitable for logs / spec dispatch context.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            RescueReason::ExpiredCallback => "expired_callback",
+            RescueReason::StaleHeartbeat => "stale_heartbeat",
+            RescueReason::DeadlineExceeded => "deadline_exceeded",
+        }
+    }
 }
 
 impl<T> JobEvent<T> {
@@ -54,7 +86,8 @@ impl<T> JobEvent<T> {
             | JobEvent::Completed { job, .. }
             | JobEvent::Retried { job, .. }
             | JobEvent::Exhausted { job, .. }
-            | JobEvent::Cancelled { job, .. } => job,
+            | JobEvent::Cancelled { job, .. }
+            | JobEvent::Rescued { job, .. } => job,
         }
     }
 }
@@ -83,6 +116,8 @@ pub enum UntypedJobEvent {
     },
     /// Job was cancelled by the handler.
     Cancelled { job: JobRow, reason: String },
+    /// Job was rescued by maintenance. See [`JobEvent::Rescued`].
+    Rescued { job: JobRow, reason: RescueReason },
 }
 
 impl UntypedJobEvent {
@@ -94,7 +129,8 @@ impl UntypedJobEvent {
             | UntypedJobEvent::Completed { job, .. }
             | UntypedJobEvent::Retried { job, .. }
             | UntypedJobEvent::Exhausted { job, .. }
-            | UntypedJobEvent::Cancelled { job, .. } => job,
+            | UntypedJobEvent::Cancelled { job, .. }
+            | UntypedJobEvent::Rescued { job, .. } => job,
         }
     }
 
@@ -132,6 +168,7 @@ impl UntypedJobEvent {
                 attempt,
             },
             UntypedJobEvent::Cancelled { job, reason } => JobEvent::Cancelled { args, job, reason },
+            UntypedJobEvent::Rescued { job, reason } => JobEvent::Rescued { args, job, reason },
         }
     }
 }

--- a/awa-worker/src/events.rs
+++ b/awa-worker/src/events.rs
@@ -46,8 +46,8 @@ pub enum JobEvent<T> {
     /// Job was rescued by maintenance — either its callback wait expired,
     /// its heartbeat went stale (presumed crashed worker), or its deadline
     /// was exceeded. `reason` identifies the rescue path. The post-rescue
-    /// `job.state` is `retryable` or `failed` (when retries are exhausted)
-    /// or `dlq` (when DLQ routing was enabled).
+    /// `job.state` is `retryable` when retries remain or `failed` when the
+    /// attempt that was rescued exhausted its retry budget.
     Rescued {
         args: T,
         job: JobRow,

--- a/awa-worker/src/executor.rs
+++ b/awa-worker/src/executor.rs
@@ -208,7 +208,12 @@ pub struct JobExecutor {
     pool: PgPool,
     workers: Arc<HashMap<String, BoxedWorker>>,
     lifecycle_handlers: Arc<HashMap<String, Vec<BoxedUntypedEventHandler>>>,
-    enqueue_specs: Arc<HashMap<String, Vec<crate::enqueue_specs::BoxedEnqueueSpec>>>,
+    enqueue_specs: Arc<
+        HashMap<
+            crate::enqueue_specs::Outcome,
+            HashMap<String, Vec<crate::enqueue_specs::BoxedEnqueueSpec>>,
+        >,
+    >,
     in_flight: InFlightMap,
     queue_in_flight: Arc<HashMap<String, Arc<AtomicU32>>>,
     state: Arc<HashMap<std::any::TypeId, Box<dyn Any + Send + Sync>>>,
@@ -224,7 +229,12 @@ impl JobExecutor {
         pool: PgPool,
         workers: Arc<HashMap<String, BoxedWorker>>,
         lifecycle_handlers: Arc<HashMap<String, Vec<BoxedUntypedEventHandler>>>,
-        enqueue_specs: Arc<HashMap<String, Vec<crate::enqueue_specs::BoxedEnqueueSpec>>>,
+        enqueue_specs: Arc<
+            HashMap<
+                crate::enqueue_specs::Outcome,
+                HashMap<String, Vec<crate::enqueue_specs::BoxedEnqueueSpec>>,
+            >,
+        >,
         in_flight: InFlightMap,
         queue_in_flight: Arc<HashMap<String, Arc<AtomicU32>>>,
         state: Arc<HashMap<std::any::TypeId, Box<dyn Any + Send + Sync>>>,
@@ -468,7 +478,12 @@ async fn complete_job(
     progress_snapshot: Option<serde_json::Value>,
     duration: Duration,
     needs_event: bool,
-    enqueue_specs: &Arc<HashMap<String, Vec<crate::enqueue_specs::BoxedEnqueueSpec>>>,
+    enqueue_specs: &Arc<
+        HashMap<
+            crate::enqueue_specs::Outcome,
+            HashMap<String, Vec<crate::enqueue_specs::BoxedEnqueueSpec>>,
+        >,
+    >,
     storage: &RuntimeStorage,
     dlq_enabled: bool,
     metrics: &crate::metrics::AwaMetrics,
@@ -519,7 +534,12 @@ async fn complete_job_canonical(
     progress_snapshot: Option<serde_json::Value>,
     duration: Duration,
     needs_event: bool,
-    enqueue_specs: &Arc<HashMap<String, Vec<crate::enqueue_specs::BoxedEnqueueSpec>>>,
+    enqueue_specs: &Arc<
+        HashMap<
+            crate::enqueue_specs::Outcome,
+            HashMap<String, Vec<crate::enqueue_specs::BoxedEnqueueSpec>>,
+        >,
+    >,
     _dlq_enabled: bool,
     _metrics: &crate::metrics::AwaMetrics,
 ) -> Result<CompletionOutcome, AwaError> {
@@ -532,7 +552,10 @@ async fn complete_job_canonical(
             // completion through a dedicated transaction so the UPDATE and
             // the follow-up INSERTs commit atomically. The batched path
             // can't carry per-job follow-ups, so we bypass it here.
-            let kind_specs = enqueue_specs.get(&job.kind).cloned();
+            let kind_specs = enqueue_specs
+                .get(&crate::enqueue_specs::Outcome::Completed)
+                .and_then(|by_kind| by_kind.get(&job.kind))
+                .cloned();
             if let Some(specs) = kind_specs.filter(|s| !s.is_empty()) {
                 let outcome = complete_canonical_with_followups(pool, job, &specs).await?;
                 return match outcome {
@@ -606,6 +629,51 @@ async fn complete_job_canonical(
                 retry_after_secs = seconds,
                 "Job requested retry after duration"
             );
+
+            // ADR-029: caller-requested retry. The Retried OutcomeContext
+            // carries an empty error string (parity with the event emitted
+            // below) and the attempt / next_run_at read from the post-UPDATE
+            // row.
+            let kind_specs = enqueue_specs
+                .get(&crate::enqueue_specs::Outcome::Retried)
+                .and_then(|by_kind| by_kind.get(&job.kind))
+                .cloned();
+            if let Some(specs) = kind_specs.filter(|s| !s.is_empty()) {
+                let result = retry_after_canonical_with_followups(
+                    pool,
+                    job,
+                    seconds,
+                    progress_snapshot.as_ref(),
+                    &specs,
+                )
+                .await?;
+                return match result {
+                    None => {
+                        warn!(
+                            job_id = job.id,
+                            "Job already rescued/cancelled, retry ignored"
+                        );
+                        Ok(CompletionOutcome::IgnoredStale)
+                    }
+                    Some(updated_job) => {
+                        let event = if needs_event {
+                            Some(UntypedJobEvent::Retried {
+                                job: updated_job.clone(),
+                                error: String::new(),
+                                attempt: updated_job.attempt,
+                                next_run_at: updated_job.run_at,
+                            })
+                        } else {
+                            None
+                        };
+                        Ok(CompletionOutcome::Applied {
+                            event,
+                            terminal: false,
+                        })
+                    }
+                };
+            }
+
             let result = sqlx::query(
                 r#"
                 UPDATE awa.jobs
@@ -691,12 +759,59 @@ async fn complete_job_canonical(
         }
 
         Ok(JobResult::Cancel(reason)) => {
+            tracing::Span::current().record("otel.status_code", "OK");
             info!(
                 job_id = job.id,
                 kind = %job.kind,
                 reason = %reason,
                 "Job cancelled by handler"
             );
+
+            // ADR-029: when this kind has Cancelled specs registered, drive
+            // the cancellation through a transaction so the UPDATE and the
+            // follow-up `INSERT`s commit atomically.
+            let kind_specs = enqueue_specs
+                .get(&crate::enqueue_specs::Outcome::Cancelled)
+                .and_then(|by_kind| by_kind.get(&job.kind))
+                .cloned();
+            let outcome_ctx = crate::enqueue_specs::OutcomeContext::Cancelled {
+                reason: reason.clone(),
+            };
+            if let Some(specs) = kind_specs.filter(|s| !s.is_empty()) {
+                let result = cancel_canonical_with_followups(
+                    pool,
+                    job,
+                    reason,
+                    progress_snapshot.as_ref(),
+                    &specs,
+                    &outcome_ctx,
+                )
+                .await?;
+                return match result {
+                    None => {
+                        warn!(
+                            job_id = job.id,
+                            "Job already rescued/cancelled, cancel ignored"
+                        );
+                        Ok(CompletionOutcome::IgnoredStale)
+                    }
+                    Some(updated_job) => {
+                        let event = if needs_event {
+                            Some(UntypedJobEvent::Cancelled {
+                                job: updated_job,
+                                reason: reason.clone(),
+                            })
+                        } else {
+                            None
+                        };
+                        Ok(CompletionOutcome::Applied {
+                            event,
+                            terminal: false,
+                        })
+                    }
+                };
+            }
+
             let result = sqlx::query(
                 r#"
                 UPDATE awa.jobs
@@ -750,6 +865,33 @@ async fn complete_job_canonical(
                 kind = %job.kind,
                 "Job waiting for external callback"
             );
+
+            // ADR-029: WaitingForCallback follow-up enqueue. The triggering
+            // UPDATE and the follow-up INSERTs commit in the same transaction.
+            // Race / missing-callback paths below are unchanged and dispatch
+            // no follow-ups because the row didn't actually park.
+            let kind_specs = enqueue_specs
+                .get(&crate::enqueue_specs::Outcome::WaitingForCallback)
+                .and_then(|by_kind| by_kind.get(&job.kind))
+                .cloned();
+            if let Some(specs) = kind_specs.filter(|s| !s.is_empty()) {
+                let parked =
+                    park_canonical_with_followups(pool, job, progress_snapshot.as_ref(), &specs)
+                        .await?;
+                if let Some(parked_job) = parked {
+                    let event = if needs_event {
+                        Some(UntypedJobEvent::WaitingForCallback { job: parked_job })
+                    } else {
+                        None
+                    };
+                    return Ok(CompletionOutcome::Applied {
+                        event,
+                        terminal: false,
+                    });
+                }
+                // Fall through to the existing rows_affected == 0 handling.
+            }
+
             let result = sqlx::query(
                 r#"
                 UPDATE awa.jobs
@@ -847,6 +989,48 @@ async fn complete_job_canonical(
                 error = %msg,
                 "Job failed terminally"
             );
+
+            // ADR-029: terminal error counts as Exhausted (the error is
+            // fatal; no further attempts will run).
+            let kind_specs = enqueue_specs
+                .get(&crate::enqueue_specs::Outcome::Exhausted)
+                .and_then(|by_kind| by_kind.get(&job.kind))
+                .cloned();
+            if let Some(specs) = kind_specs.filter(|s| !s.is_empty()) {
+                let result = terminal_canonical_with_followups(
+                    pool,
+                    job,
+                    msg,
+                    progress_snapshot.as_ref(),
+                    &specs,
+                )
+                .await?;
+                return match result {
+                    None => {
+                        warn!(
+                            job_id = job.id,
+                            "Job already rescued/cancelled, terminal failure ignored"
+                        );
+                        Ok(CompletionOutcome::IgnoredStale)
+                    }
+                    Some(updated_job) => {
+                        let event = if needs_event {
+                            Some(UntypedJobEvent::Exhausted {
+                                job: updated_job,
+                                error: msg.clone(),
+                                attempt: job.attempt,
+                            })
+                        } else {
+                            None
+                        };
+                        Ok(CompletionOutcome::Applied {
+                            event,
+                            terminal: true,
+                        })
+                    }
+                };
+            }
+
             let result = sqlx::query(
                 r#"
                 UPDATE awa.jobs
@@ -908,6 +1092,47 @@ async fn complete_job_canonical(
                     error = %error_msg,
                     "Job failed (max attempts exhausted)"
                 );
+
+                // ADR-029: retries exhausted -> Exhausted outcome.
+                let kind_specs = enqueue_specs
+                    .get(&crate::enqueue_specs::Outcome::Exhausted)
+                    .and_then(|by_kind| by_kind.get(&job.kind))
+                    .cloned();
+                if let Some(specs) = kind_specs.filter(|s| !s.is_empty()) {
+                    let result = exhaust_canonical_with_followups(
+                        pool,
+                        job,
+                        &error_msg,
+                        progress_snapshot.as_ref(),
+                        &specs,
+                    )
+                    .await?;
+                    return match result {
+                        None => {
+                            warn!(
+                                job_id = job.id,
+                                "Job already rescued/cancelled, failure ignored"
+                            );
+                            Ok(CompletionOutcome::IgnoredStale)
+                        }
+                        Some(updated_job) => {
+                            let event = if needs_event {
+                                Some(UntypedJobEvent::Exhausted {
+                                    job: updated_job,
+                                    error: error_msg,
+                                    attempt: job.attempt,
+                                })
+                            } else {
+                                None
+                            };
+                            Ok(CompletionOutcome::Applied {
+                                event,
+                                terminal: true,
+                            })
+                        }
+                    };
+                }
+
                 let result = sqlx::query(
                     r#"
                     UPDATE awa.jobs
@@ -963,6 +1188,48 @@ async fn complete_job_canonical(
                     error = %error_msg,
                     "Job failed (will retry)"
                 );
+
+                // ADR-029: retryable error with backoff -> Retried outcome.
+                let kind_specs = enqueue_specs
+                    .get(&crate::enqueue_specs::Outcome::Retried)
+                    .and_then(|by_kind| by_kind.get(&job.kind))
+                    .cloned();
+                if let Some(specs) = kind_specs.filter(|s| !s.is_empty()) {
+                    let result = retry_backoff_canonical_with_followups(
+                        pool,
+                        job,
+                        &error_msg,
+                        progress_snapshot.as_ref(),
+                        &specs,
+                    )
+                    .await?;
+                    return match result {
+                        None => {
+                            warn!(
+                                job_id = job.id,
+                                "Job already rescued/cancelled, retry ignored"
+                            );
+                            Ok(CompletionOutcome::IgnoredStale)
+                        }
+                        Some(updated_job) => {
+                            let event = if needs_event {
+                                Some(UntypedJobEvent::Retried {
+                                    job: updated_job.clone(),
+                                    error: error_msg,
+                                    attempt: job.attempt,
+                                    next_run_at: updated_job.run_at,
+                                })
+                            } else {
+                                None
+                            };
+                            Ok(CompletionOutcome::Applied {
+                                event,
+                                terminal: false,
+                            })
+                        }
+                    };
+                }
+
                 let result = sqlx::query(
                     r#"
                     UPDATE awa.jobs
@@ -1033,7 +1300,12 @@ async fn complete_job_queue_storage(
     progress_snapshot: Option<serde_json::Value>,
     duration: Duration,
     needs_event: bool,
-    enqueue_specs: &Arc<HashMap<String, Vec<crate::enqueue_specs::BoxedEnqueueSpec>>>,
+    enqueue_specs: &Arc<
+        HashMap<
+            crate::enqueue_specs::Outcome,
+            HashMap<String, Vec<crate::enqueue_specs::BoxedEnqueueSpec>>,
+        >,
+    >,
     dlq_enabled: bool,
     metrics: &crate::metrics::AwaMetrics,
 ) -> Result<CompletionOutcome, AwaError> {
@@ -1049,7 +1321,10 @@ async fn complete_job_queue_storage(
             // fast-complete (ADR-023) can't carry per-job follow-ups, so we
             // bypass it for spec'd jobs and use the slow path's tx-aware
             // variant.
-            let kind_specs = enqueue_specs.get(&job.kind).cloned();
+            let kind_specs = enqueue_specs
+                .get(&crate::enqueue_specs::Outcome::Completed)
+                .and_then(|by_kind| by_kind.get(&job.kind))
+                .cloned();
             if let Some(specs) = kind_specs.filter(|s| !s.is_empty()) {
                 let outcome = complete_queue_storage_with_followups(
                     runtime,
@@ -1592,9 +1867,7 @@ async fn complete_queue_storage_with_followups(
     updated_job.finalized_at = Some(chrono::Utc::now());
     updated_job.progress = None;
 
-    for spec in specs {
-        spec.run(&mut *tx, &updated_job).await?;
-    }
+    crate::enqueue_specs::dispatch_specs_in_tx(&mut tx, &updated_job, specs, None).await?;
 
     tx.commit().await?;
     Ok(Some(updated_job))
@@ -1722,9 +1995,347 @@ async fn complete_canonical_with_followups(
         return Ok(None);
     };
 
-    for spec in specs {
-        spec.run(&mut *tx, &updated_job).await?;
-    }
+    crate::enqueue_specs::dispatch_specs_in_tx(&mut tx, &updated_job, specs, None).await?;
+
+    tx.commit().await?;
+    Ok(Some(updated_job))
+}
+
+/// Cancelled-outcome equivalent: cancel the running canonical row and
+/// dispatch any registered `Cancelled` follow-ups inside the same
+/// transaction. Returns the post-update [`JobRow`] for event emission, or
+/// `None` when the row was already finalised by another writer.
+async fn cancel_canonical_with_followups(
+    pool: &PgPool,
+    job: &JobRow,
+    reason: &str,
+    progress_snapshot: Option<&serde_json::Value>,
+    specs: &[crate::enqueue_specs::BoxedEnqueueSpec],
+    outcome_ctx: &crate::enqueue_specs::OutcomeContext,
+) -> Result<Option<JobRow>, AwaError> {
+    let mut tx = pool.begin().await?;
+
+    let updated_job: Option<JobRow> = sqlx::query_as(
+        r#"
+        UPDATE awa.jobs_hot
+        SET state = 'cancelled',
+            finalized_at = now(),
+            errors = errors || $2::jsonb,
+            progress = $4
+        WHERE id = $1 AND state = 'running' AND run_lease = $3
+        RETURNING *
+        "#,
+    )
+    .bind(job.id)
+    .bind(serde_json::json!({
+        "error": format!("cancelled: {}", reason),
+        "attempt": job.attempt,
+        "at": chrono::Utc::now().to_rfc3339()
+    }))
+    .bind(job.run_lease)
+    .bind(progress_snapshot)
+    .fetch_optional(&mut *tx)
+    .await?;
+
+    let Some(updated_job) = updated_job else {
+        tx.rollback().await?;
+        return Ok(None);
+    };
+
+    crate::enqueue_specs::dispatch_specs_in_tx(&mut tx, &updated_job, specs, Some(outcome_ctx))
+        .await?;
+
+    tx.commit().await?;
+    Ok(Some(updated_job))
+}
+
+/// Park the running canonical row into `waiting_external` and dispatch any
+/// registered `WaitingForCallback` follow-ups inside the same transaction.
+/// Returns the parked [`JobRow`] for event emission, or `None` when the
+/// guarded UPDATE matched zero rows (caller falls back to the existing race
+/// / missing-callback handling).
+async fn park_canonical_with_followups(
+    pool: &PgPool,
+    job: &JobRow,
+    progress_snapshot: Option<&serde_json::Value>,
+    specs: &[crate::enqueue_specs::BoxedEnqueueSpec],
+) -> Result<Option<JobRow>, AwaError> {
+    let mut tx = pool.begin().await?;
+
+    let parked_job: Option<JobRow> = sqlx::query_as(
+        r#"
+        UPDATE awa.jobs_hot
+        SET state = 'waiting_external',
+            heartbeat_at = NULL,
+            deadline_at = NULL,
+            progress = $3
+        WHERE id = $1 AND state = 'running' AND run_lease = $2 AND callback_id IS NOT NULL
+        RETURNING *
+        "#,
+    )
+    .bind(job.id)
+    .bind(job.run_lease)
+    .bind(progress_snapshot)
+    .fetch_optional(&mut *tx)
+    .await?;
+
+    let Some(parked_job) = parked_job else {
+        tx.rollback().await?;
+        return Ok(None);
+    };
+
+    crate::enqueue_specs::dispatch_specs_in_tx(
+        &mut tx,
+        &parked_job,
+        specs,
+        Some(&crate::enqueue_specs::OutcomeContext::WaitingForCallback),
+    )
+    .await?;
+
+    tx.commit().await?;
+    Ok(Some(parked_job))
+}
+
+/// Caller-requested retry (RetryAfter) + Retried follow-ups.
+///
+/// `retryable` is forbidden in `awa.jobs_hot` (CHECK constraint); the row
+/// must move to `awa.scheduled_jobs`. We do the DELETE+INSERT explicitly
+/// in a CTE so the move plus the follow-up enqueue commit atomically. This
+/// mirrors what the `INSTEAD OF UPDATE` trigger on `awa.jobs` would do —
+/// avoiding the view keeps us correct under canonical-drain mode, where the
+/// view's trigger rejects UPDATEs while queue-storage is the active
+/// engine.
+async fn retry_after_canonical_with_followups(
+    pool: &PgPool,
+    job: &JobRow,
+    seconds: f64,
+    progress_snapshot: Option<&serde_json::Value>,
+    specs: &[crate::enqueue_specs::BoxedEnqueueSpec],
+) -> Result<Option<JobRow>, AwaError> {
+    let mut tx = pool.begin().await?;
+
+    let updated_job: Option<JobRow> = sqlx::query_as(
+        r#"
+        WITH deleted AS (
+            DELETE FROM awa.jobs_hot
+            WHERE id = $1 AND state = 'running' AND run_lease = $3
+            RETURNING *
+        )
+        INSERT INTO awa.scheduled_jobs (
+            id, kind, queue, args, state, priority, attempt, max_attempts,
+            run_at, heartbeat_at, deadline_at, attempted_at, finalized_at,
+            created_at, errors, metadata, tags, unique_key, unique_states,
+            callback_id, callback_timeout_at, callback_filter,
+            callback_on_complete, callback_on_fail, callback_transform,
+            run_lease, progress
+        )
+        SELECT
+            id, kind, queue, args,
+            'retryable'::awa.job_state,
+            priority, attempt, max_attempts,
+            now() + make_interval(secs => $2),
+            heartbeat_at, deadline_at, attempted_at,
+            now(),
+            created_at, errors, metadata, tags, unique_key, unique_states,
+            callback_id, callback_timeout_at, callback_filter,
+            callback_on_complete, callback_on_fail, callback_transform,
+            run_lease, $4
+        FROM deleted
+        RETURNING *
+        "#,
+    )
+    .bind(job.id)
+    .bind(seconds)
+    .bind(job.run_lease)
+    .bind(progress_snapshot)
+    .fetch_optional(&mut *tx)
+    .await?;
+
+    let Some(updated_job) = updated_job else {
+        tx.rollback().await?;
+        return Ok(None);
+    };
+
+    let outcome_ctx = crate::enqueue_specs::OutcomeContext::Retried {
+        error: String::new(),
+        attempt: updated_job.attempt,
+        next_run_at: updated_job.run_at,
+    };
+    crate::enqueue_specs::dispatch_specs_in_tx(&mut tx, &updated_job, specs, Some(&outcome_ctx))
+        .await?;
+
+    tx.commit().await?;
+    Ok(Some(updated_job))
+}
+
+/// Terminal error -> failed + Exhausted follow-ups.
+async fn terminal_canonical_with_followups(
+    pool: &PgPool,
+    job: &JobRow,
+    msg: &str,
+    progress_snapshot: Option<&serde_json::Value>,
+    specs: &[crate::enqueue_specs::BoxedEnqueueSpec],
+) -> Result<Option<JobRow>, AwaError> {
+    let mut tx = pool.begin().await?;
+
+    let updated_job: Option<JobRow> = sqlx::query_as(
+        r#"
+        UPDATE awa.jobs_hot
+        SET state = 'failed',
+            finalized_at = now(),
+            errors = errors || $2::jsonb,
+            progress = $4
+        WHERE id = $1 AND state = 'running' AND run_lease = $3
+        RETURNING *
+        "#,
+    )
+    .bind(job.id)
+    .bind(serde_json::json!({
+        "error": msg,
+        "attempt": job.attempt,
+        "at": chrono::Utc::now().to_rfc3339(),
+        "terminal": true
+    }))
+    .bind(job.run_lease)
+    .bind(progress_snapshot)
+    .fetch_optional(&mut *tx)
+    .await?;
+
+    let Some(updated_job) = updated_job else {
+        tx.rollback().await?;
+        return Ok(None);
+    };
+
+    let outcome_ctx = crate::enqueue_specs::OutcomeContext::Exhausted {
+        error: msg.to_string(),
+        attempt: job.attempt,
+    };
+    crate::enqueue_specs::dispatch_specs_in_tx(&mut tx, &updated_job, specs, Some(&outcome_ctx))
+        .await?;
+
+    tx.commit().await?;
+    Ok(Some(updated_job))
+}
+
+/// Retries exhausted (attempt >= max_attempts) -> failed + Exhausted
+/// follow-ups. Differs from terminal in the error envelope (no `terminal`
+/// marker since exhaustion is not a fatal-by-handler-assertion).
+async fn exhaust_canonical_with_followups(
+    pool: &PgPool,
+    job: &JobRow,
+    error_msg: &str,
+    progress_snapshot: Option<&serde_json::Value>,
+    specs: &[crate::enqueue_specs::BoxedEnqueueSpec],
+) -> Result<Option<JobRow>, AwaError> {
+    let mut tx = pool.begin().await?;
+
+    let updated_job: Option<JobRow> = sqlx::query_as(
+        r#"
+        UPDATE awa.jobs_hot
+        SET state = 'failed',
+            finalized_at = now(),
+            errors = errors || $2::jsonb,
+            progress = $4
+        WHERE id = $1 AND state = 'running' AND run_lease = $3
+        RETURNING *
+        "#,
+    )
+    .bind(job.id)
+    .bind(serde_json::json!({
+        "error": error_msg,
+        "attempt": job.attempt,
+        "at": chrono::Utc::now().to_rfc3339()
+    }))
+    .bind(job.run_lease)
+    .bind(progress_snapshot)
+    .fetch_optional(&mut *tx)
+    .await?;
+
+    let Some(updated_job) = updated_job else {
+        tx.rollback().await?;
+        return Ok(None);
+    };
+
+    let outcome_ctx = crate::enqueue_specs::OutcomeContext::Exhausted {
+        error: error_msg.to_string(),
+        attempt: job.attempt,
+    };
+    crate::enqueue_specs::dispatch_specs_in_tx(&mut tx, &updated_job, specs, Some(&outcome_ctx))
+        .await?;
+
+    tx.commit().await?;
+    Ok(Some(updated_job))
+}
+
+/// Retryable error within budget -> retryable + Retried follow-ups, using
+/// the configured backoff function for run_at.
+async fn retry_backoff_canonical_with_followups(
+    pool: &PgPool,
+    job: &JobRow,
+    error_msg: &str,
+    progress_snapshot: Option<&serde_json::Value>,
+    specs: &[crate::enqueue_specs::BoxedEnqueueSpec],
+) -> Result<Option<JobRow>, AwaError> {
+    let mut tx = pool.begin().await?;
+
+    let updated_job: Option<JobRow> = sqlx::query_as(
+        r#"
+        WITH deleted AS (
+            DELETE FROM awa.jobs_hot
+            WHERE id = $1 AND state = 'running' AND run_lease = $5
+            RETURNING *
+        )
+        INSERT INTO awa.scheduled_jobs (
+            id, kind, queue, args, state, priority, attempt, max_attempts,
+            run_at, heartbeat_at, deadline_at, attempted_at, finalized_at,
+            created_at, errors, metadata, tags, unique_key, unique_states,
+            callback_id, callback_timeout_at, callback_filter,
+            callback_on_complete, callback_on_fail, callback_transform,
+            run_lease, progress
+        )
+        SELECT
+            id, kind, queue, args,
+            'retryable'::awa.job_state,
+            priority, attempt, max_attempts,
+            now() + awa.backoff_duration($2, $3),
+            NULL, NULL,
+            attempted_at,
+            now(),
+            created_at,
+            errors || $4::jsonb,
+            metadata, tags, unique_key, unique_states,
+            callback_id, callback_timeout_at, callback_filter,
+            callback_on_complete, callback_on_fail, callback_transform,
+            run_lease, $6
+        FROM deleted
+        RETURNING *
+        "#,
+    )
+    .bind(job.id)
+    .bind(job.attempt)
+    .bind(job.max_attempts)
+    .bind(serde_json::json!({
+        "error": error_msg,
+        "attempt": job.attempt,
+        "at": chrono::Utc::now().to_rfc3339()
+    }))
+    .bind(job.run_lease)
+    .bind(progress_snapshot)
+    .fetch_optional(&mut *tx)
+    .await?;
+
+    let Some(updated_job) = updated_job else {
+        tx.rollback().await?;
+        return Ok(None);
+    };
+
+    let outcome_ctx = crate::enqueue_specs::OutcomeContext::Retried {
+        error: error_msg.to_string(),
+        attempt: job.attempt,
+        next_run_at: updated_job.run_at,
+    };
+    crate::enqueue_specs::dispatch_specs_in_tx(&mut tx, &updated_job, specs, Some(&outcome_ctx))
+        .await?;
 
     tx.commit().await?;
     Ok(Some(updated_job))

--- a/awa-worker/src/executor.rs
+++ b/awa-worker/src/executor.rs
@@ -1578,33 +1578,33 @@ async fn complete_canonical_with_followups(
 ) -> Result<Option<JobRow>, AwaError> {
     let mut tx = pool.begin().await?;
 
-    let result = sqlx::query(
+    // `UPDATE ... RETURNING` against `awa.jobs_hot` directly (not the
+    // `awa.jobs` compatibility view): in canonical-drain mode the view is
+    // backed by the active queue-storage schema and would return RowNotFound
+    // for a canonical row, rolling back the just-applied completion and
+    // wedging the job. The hot table is the source of truth for canonical
+    // attempts regardless of routing mode.
+    let updated_job: Option<JobRow> = sqlx::query_as(
         r#"
         UPDATE awa.jobs_hot
         SET state = 'completed',
             finalized_at = now(),
             progress = NULL
         WHERE id = $1 AND state = 'running' AND run_lease = $2
+        RETURNING *
         "#,
     )
     .bind(job.id)
     .bind(job.run_lease)
-    .execute(&mut *tx)
+    .fetch_optional(&mut *tx)
     .await?;
 
-    if result.rows_affected() == 0 {
+    let Some(updated_job) = updated_job else {
         // Stale: another writer already finalised this attempt. Drop the
         // transaction without emitting follow-ups.
         tx.rollback().await?;
         return Ok(None);
-    }
-
-    // Refresh the row through the awa.jobs view so the follow-up closures see
-    // the post-completion snapshot (state = completed, finalized_at set).
-    let updated_job: JobRow = sqlx::query_as("SELECT * FROM awa.jobs WHERE id = $1")
-        .bind(job.id)
-        .fetch_one(&mut *tx)
-        .await?;
+    };
 
     for spec in specs {
         spec.run(&mut *tx, &updated_job).await?;

--- a/awa-worker/src/executor.rs
+++ b/awa-worker/src/executor.rs
@@ -490,15 +490,6 @@ async fn complete_job(
             .await
         }
         RuntimeStorage::QueueStorage(runtime) => {
-            // ADR-029 follow-up enqueue is currently wired only on the
-            // canonical path. The queue-storage completion path's
-            // receipt-plane fast-complete (ADR-023) doesn't pass through a
-            // single transaction we can join from here; a dedicated
-            // tx-aware variant of `complete_runtime_batch_slow` is a
-            // follow-up. `Client::start` returns an error if specs are
-            // registered under queue storage, so we never reach this branch
-            // with a non-empty registry today.
-            let _ = enqueue_specs;
             complete_job_queue_storage(
                 runtime,
                 pool,
@@ -510,6 +501,7 @@ async fn complete_job(
                 progress_snapshot,
                 duration,
                 needs_event,
+                enqueue_specs,
                 dlq_enabled,
                 metrics,
             )
@@ -1041,6 +1033,7 @@ async fn complete_job_queue_storage(
     progress_snapshot: Option<serde_json::Value>,
     duration: Duration,
     needs_event: bool,
+    enqueue_specs: &Arc<HashMap<String, Vec<crate::enqueue_specs::BoxedEnqueueSpec>>>,
     dlq_enabled: bool,
     metrics: &crate::metrics::AwaMetrics,
 ) -> Result<CompletionOutcome, AwaError> {
@@ -1048,6 +1041,50 @@ async fn complete_job_queue_storage(
         Ok(JobResult::Completed) => {
             tracing::Span::current().record("otel.status_code", "OK");
             info!(job_id = job.id, kind = %job.kind, attempt = job.attempt, "Job completed");
+
+            // ADR-029: when this kind has follow-up specs registered, drive
+            // completion through a dedicated transaction so the
+            // receipt-plane / lease cleanup + done_entries append +
+            // follow-up `INSERT`s commit atomically. The receipt-plane
+            // fast-complete (ADR-023) can't carry per-job follow-ups, so we
+            // bypass it for spec'd jobs and use the slow path's tx-aware
+            // variant.
+            let kind_specs = enqueue_specs.get(&job.kind).cloned();
+            if let Some(specs) = kind_specs.filter(|s| !s.is_empty()) {
+                let outcome = complete_queue_storage_with_followups(
+                    runtime,
+                    pool,
+                    job,
+                    queue_storage_claim,
+                    queue_storage_unique_states,
+                    &specs,
+                )
+                .await?;
+                return match outcome {
+                    None => {
+                        warn!(
+                            job_id = job.id,
+                            "Job already rescued/cancelled, completion ignored"
+                        );
+                        Ok(CompletionOutcome::IgnoredStale)
+                    }
+                    Some(updated_job) => {
+                        let event = if needs_event {
+                            Some(UntypedJobEvent::Completed {
+                                job: updated_job,
+                                duration,
+                            })
+                        } else {
+                            None
+                        };
+                        Ok(CompletionOutcome::Applied {
+                            event,
+                            terminal: false,
+                        })
+                    }
+                };
+            }
+
             let updated = match match queue_storage_claim {
                 Some(claim) => {
                     completion_batcher
@@ -1485,6 +1522,82 @@ async fn complete_job_queue_storage(
             }
         }
     }
+}
+
+/// Complete a queue-storage job and run its registered follow-up enqueue
+/// specs atomically with the completion (ADR-029).
+///
+/// Bypasses the receipt-plane fast-complete path and goes straight to the
+/// tx-aware slow path so the lease/receipt cleanup, `done_entries` append,
+/// and follow-up `INSERT`s all commit together. `complete_runtime_batch_slow`
+/// already handles both receipt-claimed and materialised leases, so the
+/// trade-off is purely losing receipt-plane fast-complete throughput for
+/// spec'd jobs — acceptable since spec'd jobs do extra DB work anyway.
+///
+/// Returns:
+/// - `Ok(None)` if the completion was stale — the lease was already rescued
+///   or cancelled. The transaction is rolled back; no follow-ups emitted.
+/// - `Ok(Some(updated_job))` if the completion committed; follow-ups have
+///   been INSERTed in the same transaction. The returned row is the
+///   post-completion snapshot, mirroring the fallback constructed elsewhere
+///   in this file when `runtime.store.load_job` doesn't return one.
+#[allow(clippy::explicit_auto_deref)]
+async fn complete_queue_storage_with_followups(
+    runtime: &QueueStorageRuntime,
+    pool: &PgPool,
+    job: &JobRow,
+    queue_storage_claim: Option<&ClaimedEntry>,
+    queue_storage_unique_states: Option<&str>,
+    specs: &[crate::enqueue_specs::BoxedEnqueueSpec],
+) -> Result<Option<JobRow>, AwaError> {
+    let Some(claim) = queue_storage_claim else {
+        // The slow path is keyed on `ClaimedEntry` (it needs `lease_slot`,
+        // `lane_seq`, `claim_slot`, etc. to clean up receipt-plane and
+        // materialised lease rows). The executor always passes a claim when
+        // it dispatches a queue-storage job, so this branch is normally
+        // unreachable; report as stale rather than silently dropping the
+        // outcome.
+        warn!(
+            job_id = job.id,
+            "queue-storage completion with follow-up specs but no claim — \
+             treating as stale"
+        );
+        return Ok(None);
+    };
+
+    let runtime_job = ClaimedRuntimeJob {
+        claim: claim.clone(),
+        job: job.clone(),
+        unique_states: queue_storage_unique_states.map(std::string::ToString::to_string),
+    };
+
+    let mut tx = pool.begin().await?;
+
+    let updated = runtime
+        .store
+        .complete_runtime_batch_slow_in_tx(&mut tx, std::slice::from_ref(&runtime_job))
+        .await?;
+
+    if updated.is_empty() {
+        tx.rollback().await?;
+        return Ok(None);
+    }
+
+    // Synthesise the post-completion snapshot — the store has just moved the
+    // lease into `done_entries` so a live SELECT would race with rotation.
+    // The happy-path fields are exactly those `complete_job_queue_storage`
+    // reconstructs when `load_job` returns None.
+    let mut updated_job = job.clone();
+    updated_job.state = JobState::Completed;
+    updated_job.finalized_at = Some(chrono::Utc::now());
+    updated_job.progress = None;
+
+    for spec in specs {
+        spec.run(&mut *tx, &updated_job).await?;
+    }
+
+    tx.commit().await?;
+    Ok(Some(updated_job))
 }
 
 async fn direct_complete_job_queue_storage(

--- a/awa-worker/src/executor.rs
+++ b/awa-worker/src/executor.rs
@@ -208,6 +208,7 @@ pub struct JobExecutor {
     pool: PgPool,
     workers: Arc<HashMap<String, BoxedWorker>>,
     lifecycle_handlers: Arc<HashMap<String, Vec<BoxedUntypedEventHandler>>>,
+    enqueue_specs: Arc<HashMap<String, Vec<crate::enqueue_specs::BoxedEnqueueSpec>>>,
     in_flight: InFlightMap,
     queue_in_flight: Arc<HashMap<String, Arc<AtomicU32>>>,
     state: Arc<HashMap<std::any::TypeId, Box<dyn Any + Send + Sync>>>,
@@ -223,6 +224,7 @@ impl JobExecutor {
         pool: PgPool,
         workers: Arc<HashMap<String, BoxedWorker>>,
         lifecycle_handlers: Arc<HashMap<String, Vec<BoxedUntypedEventHandler>>>,
+        enqueue_specs: Arc<HashMap<String, Vec<crate::enqueue_specs::BoxedEnqueueSpec>>>,
         in_flight: InFlightMap,
         queue_in_flight: Arc<HashMap<String, Arc<AtomicU32>>>,
         state: Arc<HashMap<std::any::TypeId, Box<dyn Any + Send + Sync>>>,
@@ -235,6 +237,7 @@ impl JobExecutor {
             pool,
             workers,
             lifecycle_handlers,
+            enqueue_specs,
             in_flight,
             queue_in_flight,
             state,
@@ -259,6 +262,7 @@ impl JobExecutor {
         let pool = self.pool.clone();
         let workers = self.workers.clone();
         let lifecycle_handlers = self.lifecycle_handlers.clone();
+        let enqueue_specs = self.enqueue_specs.clone();
         let in_flight = self.in_flight.clone();
         let queue_in_flight = self.queue_in_flight.clone();
         let state = self.state.clone();
@@ -365,6 +369,7 @@ impl JobExecutor {
                     progress_snapshot,
                     duration,
                     has_lifecycle_handlers,
+                    &enqueue_specs,
                     &storage,
                     dlq_enabled,
                     &metrics,
@@ -463,6 +468,7 @@ async fn complete_job(
     progress_snapshot: Option<serde_json::Value>,
     duration: Duration,
     needs_event: bool,
+    enqueue_specs: &Arc<HashMap<String, Vec<crate::enqueue_specs::BoxedEnqueueSpec>>>,
     storage: &RuntimeStorage,
     dlq_enabled: bool,
     metrics: &crate::metrics::AwaMetrics,
@@ -477,12 +483,19 @@ async fn complete_job(
                 progress_snapshot,
                 duration,
                 needs_event,
+                enqueue_specs,
                 dlq_enabled,
                 metrics,
             )
             .await
         }
         RuntimeStorage::QueueStorage(runtime) => {
+            // ADR-029 follow-up enqueue is currently wired only on the
+            // canonical path; queue-storage wiring is deferred to a follow-up
+            // PR. Specs for jobs running under queue storage are silently
+            // ignored for now — they will simply not produce follow-ups
+            // until the queue-storage finalization path is updated to honour
+            // them in the same transaction as its terminal append.
             complete_job_queue_storage(
                 runtime,
                 pool,
@@ -511,6 +524,7 @@ async fn complete_job_canonical(
     progress_snapshot: Option<serde_json::Value>,
     duration: Duration,
     needs_event: bool,
+    enqueue_specs: &Arc<HashMap<String, Vec<crate::enqueue_specs::BoxedEnqueueSpec>>>,
     _dlq_enabled: bool,
     _metrics: &crate::metrics::AwaMetrics,
 ) -> Result<CompletionOutcome, AwaError> {
@@ -518,6 +532,39 @@ async fn complete_job_canonical(
         Ok(JobResult::Completed) => {
             tracing::Span::current().record("otel.status_code", "OK");
             info!(job_id = job.id, kind = %job.kind, attempt = job.attempt, "Job completed");
+
+            // ADR-029: when this kind has follow-up specs registered, drive
+            // completion through a dedicated transaction so the UPDATE and
+            // the follow-up INSERTs commit atomically. The batched path
+            // can't carry per-job follow-ups, so we bypass it here.
+            let kind_specs = enqueue_specs.get(&job.kind).cloned();
+            if let Some(specs) = kind_specs.filter(|s| !s.is_empty()) {
+                let outcome = complete_canonical_with_followups(pool, job, &specs).await?;
+                return match outcome {
+                    None => {
+                        warn!(
+                            job_id = job.id,
+                            "Job already rescued/cancelled, completion ignored"
+                        );
+                        Ok(CompletionOutcome::IgnoredStale)
+                    }
+                    Some(updated_job) => {
+                        let event = if needs_event {
+                            Some(UntypedJobEvent::Completed {
+                                job: updated_job,
+                                duration,
+                            })
+                        } else {
+                            None
+                        };
+                        Ok(CompletionOutcome::Applied {
+                            event,
+                            terminal: false,
+                        })
+                    }
+                };
+            }
+
             let result = match completion_batcher.complete(job.id, job.run_lease).await {
                 Ok(updated) => updated,
                 Err(err) => {
@@ -1508,4 +1555,61 @@ async fn direct_complete_job(pool: &PgPool, job: &JobRow) -> Result<bool, AwaErr
     .await?;
 
     Ok(result.rows_affected() > 0)
+}
+
+/// Complete a canonical-storage job and run its registered follow-up enqueue
+/// specs atomically with the completion UPDATE (ADR-029).
+///
+/// Returns:
+/// - `Ok(None)` if the completion was stale (`rows_affected == 0`) — the job
+///   has already been rescued or cancelled, no follow-ups are emitted, no
+///   event should fire.
+/// - `Ok(Some(updated_job))` if the completion committed; follow-ups have
+///   been INSERTed in the same transaction. The returned row is the
+///   post-completion snapshot (state = `completed`, `finalized_at` set).
+// The follow-up loop reborrows `&mut *tx` per spec invocation so the same
+// transaction handle can be reused; clippy reads the `*tx` as a redundant
+// deref but `fetch_one`'s Executor bound requires the inner connection.
+#[allow(clippy::explicit_auto_deref)]
+async fn complete_canonical_with_followups(
+    pool: &PgPool,
+    job: &JobRow,
+    specs: &[crate::enqueue_specs::BoxedEnqueueSpec],
+) -> Result<Option<JobRow>, AwaError> {
+    let mut tx = pool.begin().await?;
+
+    let result = sqlx::query(
+        r#"
+        UPDATE awa.jobs_hot
+        SET state = 'completed',
+            finalized_at = now(),
+            progress = NULL
+        WHERE id = $1 AND state = 'running' AND run_lease = $2
+        "#,
+    )
+    .bind(job.id)
+    .bind(job.run_lease)
+    .execute(&mut *tx)
+    .await?;
+
+    if result.rows_affected() == 0 {
+        // Stale: another writer already finalised this attempt. Drop the
+        // transaction without emitting follow-ups.
+        tx.rollback().await?;
+        return Ok(None);
+    }
+
+    // Refresh the row through the awa.jobs view so the follow-up closures see
+    // the post-completion snapshot (state = completed, finalized_at set).
+    let updated_job: JobRow = sqlx::query_as("SELECT * FROM awa.jobs WHERE id = $1")
+        .bind(job.id)
+        .fetch_one(&mut *tx)
+        .await?;
+
+    for spec in specs {
+        spec.run(&mut *tx, &updated_job).await?;
+    }
+
+    tx.commit().await?;
+    Ok(Some(updated_job))
 }

--- a/awa-worker/src/executor.rs
+++ b/awa-worker/src/executor.rs
@@ -2289,13 +2289,29 @@ async fn park_queue_storage_with_followups(
         tx.rollback().await?;
         return Ok(None);
     }
-    // The parked row lives in the leases table; constructing the post-park
-    // snapshot from `job` matches the fallback `complete_job_queue_storage`
-    // already uses when `load_job` doesn't return a row.
-    let mut parked_job = job.clone();
-    parked_job.state = JobState::WaitingExternal;
-    parked_job.heartbeat_at = None;
-    parked_job.deadline_at = None;
+    // Re-read the parked row inside the same transaction. The input
+    // `job` is the snapshot the executor claimed earlier — it does not
+    // carry `callback_id` / `callback_timeout_at` written by
+    // `register_callback()` during the handler, and the parked-state
+    // fields (state, heartbeat_at, deadline_at) only land after the
+    // enter_callback_wait_in_tx UPDATE above. Fall back to a synthesised
+    // snapshot only if the SELECT misses (shouldn't happen because the
+    // UPDATE just matched, but defensive).
+    let parked_job = match runtime
+        .store
+        .load_active_lease_in_tx(&mut tx, job.id, job.run_lease)
+        .await?
+    {
+        Some(row) => row,
+        None => {
+            let mut parked = job.clone();
+            parked.state = JobState::WaitingExternal;
+            parked.heartbeat_at = None;
+            parked.deadline_at = None;
+            parked.callback_id = Some(callback_id);
+            parked
+        }
+    };
     crate::enqueue_specs::dispatch_specs_in_tx(
         &mut tx,
         &parked_job,

--- a/awa-worker/src/executor.rs
+++ b/awa-worker/src/executor.rs
@@ -2225,7 +2225,11 @@ async fn fail_queue_storage_with_followups(
     specs: &[crate::enqueue_specs::BoxedEnqueueSpec],
 ) -> Result<Option<JobRow>, AwaError> {
     let mut tx = pool.begin().await?;
-    let updated_job = if dlq_enabled {
+    // Track whether the row routed to DLQ so the metric records after a
+    // successful commit only — a spec-INSERT failure rolls the whole tx
+    // back, and a phantom DLQ count would lie about a transition that
+    // didn't actually happen.
+    let (updated_job, routed_to_dlq) = if dlq_enabled {
         let moved = runtime
             .store
             .fail_to_dlq_in_tx(
@@ -2237,15 +2241,14 @@ async fn fail_queue_storage_with_followups(
                 progress_snapshot,
             )
             .await?;
-        if moved.is_some() {
-            metrics.record_dlq_moved(&job.kind, &job.queue, dlq_reason);
-        }
-        moved
+        let routed = moved.is_some();
+        (moved, routed)
     } else {
-        runtime
+        let moved = runtime
             .store
             .fail_terminal_in_tx(&mut tx, job.id, job.run_lease, error_msg, progress_snapshot)
-            .await?
+            .await?;
+        (moved, false)
     };
     let Some(updated_job) = updated_job else {
         tx.rollback().await?;
@@ -2258,6 +2261,9 @@ async fn fail_queue_storage_with_followups(
     crate::enqueue_specs::dispatch_specs_in_tx(&mut tx, &updated_job, specs, Some(&outcome_ctx))
         .await?;
     tx.commit().await?;
+    if routed_to_dlq {
+        metrics.record_dlq_moved(&job.kind, &job.queue, dlq_reason);
+    }
     Ok(Some(updated_job))
 }
 

--- a/awa-worker/src/executor.rs
+++ b/awa-worker/src/executor.rs
@@ -1432,6 +1432,49 @@ async fn complete_job_queue_storage(
                 retry_after_secs = retry_duration.as_secs_f64(),
                 "Job requested retry after duration"
             );
+
+            // ADR-029: caller-requested retry on queue storage.
+            let kind_specs = enqueue_specs
+                .get(&crate::enqueue_specs::Outcome::Retried)
+                .and_then(|by_kind| by_kind.get(&job.kind))
+                .cloned();
+            if let Some(specs) = kind_specs.filter(|s| !s.is_empty()) {
+                let result = retry_after_queue_storage_with_followups(
+                    runtime,
+                    pool,
+                    job,
+                    *retry_duration,
+                    progress_snapshot.clone(),
+                    &specs,
+                )
+                .await?;
+                return match result {
+                    None => {
+                        warn!(
+                            job_id = job.id,
+                            "Job already rescued/cancelled, retry ignored"
+                        );
+                        Ok(CompletionOutcome::IgnoredStale)
+                    }
+                    Some(updated_job) => {
+                        let event = if needs_event {
+                            Some(UntypedJobEvent::Retried {
+                                job: updated_job.clone(),
+                                error: String::new(),
+                                attempt: updated_job.attempt,
+                                next_run_at: updated_job.run_at,
+                            })
+                        } else {
+                            None
+                        };
+                        Ok(CompletionOutcome::Applied {
+                            event,
+                            terminal: false,
+                        })
+                    }
+                };
+            }
+
             let Some(updated_job) = runtime
                 .store
                 .retry_after(
@@ -1504,6 +1547,47 @@ async fn complete_job_queue_storage(
                 reason = %reason,
                 "Job cancelled by handler"
             );
+
+            // ADR-029: queue-storage Cancelled follow-ups.
+            let kind_specs = enqueue_specs
+                .get(&crate::enqueue_specs::Outcome::Cancelled)
+                .and_then(|by_kind| by_kind.get(&job.kind))
+                .cloned();
+            if let Some(specs) = kind_specs.filter(|s| !s.is_empty()) {
+                let result = cancel_queue_storage_with_followups(
+                    runtime,
+                    pool,
+                    job,
+                    reason,
+                    progress_snapshot.clone(),
+                    &specs,
+                )
+                .await?;
+                return match result {
+                    None => {
+                        warn!(
+                            job_id = job.id,
+                            "Job already rescued/cancelled, cancel ignored"
+                        );
+                        Ok(CompletionOutcome::IgnoredStale)
+                    }
+                    Some(updated_job) => {
+                        let event = if needs_event {
+                            Some(UntypedJobEvent::Cancelled {
+                                job: updated_job,
+                                reason: reason.clone(),
+                            })
+                        } else {
+                            None
+                        };
+                        Ok(CompletionOutcome::Applied {
+                            event,
+                            terminal: false,
+                        })
+                    }
+                };
+            }
+
             let Some(updated_job) = runtime
                 .store
                 .cancel_running(
@@ -1543,6 +1627,32 @@ async fn complete_job_queue_storage(
                 kind = %job.kind,
                 "Job waiting for external callback"
             );
+
+            // ADR-029: queue-storage WaitingForCallback follow-ups. Race /
+            // missing-callback paths below remain unchanged — they dispatch
+            // no follow-ups because the row didn't actually park.
+            let kind_specs = enqueue_specs
+                .get(&crate::enqueue_specs::Outcome::WaitingForCallback)
+                .and_then(|by_kind| by_kind.get(&job.kind))
+                .cloned();
+            if let Some(specs) = kind_specs.filter(|s| !s.is_empty()) {
+                let parked =
+                    park_queue_storage_with_followups(runtime, pool, job, guard.id(), &specs)
+                        .await?;
+                if let Some(parked_job) = parked {
+                    let event = if needs_event {
+                        Some(UntypedJobEvent::WaitingForCallback { job: parked_job })
+                    } else {
+                        None
+                    };
+                    return Ok(CompletionOutcome::Applied {
+                        event,
+                        terminal: false,
+                    });
+                }
+                // Fall through to existing rows_affected == 0 handling.
+            }
+
             let entered = runtime
                 .store
                 .enter_callback_wait(pool, job.id, job.run_lease, guard.id())
@@ -1645,6 +1755,51 @@ async fn complete_job_queue_storage(
                 error = %msg,
                 "Job failed terminally"
             );
+
+            // ADR-029: queue-storage Exhausted follow-ups (Terminal counts).
+            let kind_specs = enqueue_specs
+                .get(&crate::enqueue_specs::Outcome::Exhausted)
+                .and_then(|by_kind| by_kind.get(&job.kind))
+                .cloned();
+            if let Some(specs) = kind_specs.filter(|s| !s.is_empty()) {
+                let result = fail_queue_storage_with_followups(
+                    runtime,
+                    pool,
+                    job,
+                    "terminal_error",
+                    msg,
+                    progress_snapshot.clone(),
+                    dlq_enabled,
+                    metrics,
+                    &specs,
+                )
+                .await?;
+                return match result {
+                    None => {
+                        warn!(
+                            job_id = job.id,
+                            "Job already rescued/cancelled, terminal failure ignored"
+                        );
+                        Ok(CompletionOutcome::IgnoredStale)
+                    }
+                    Some(updated_job) => {
+                        let event = if needs_event {
+                            Some(UntypedJobEvent::Exhausted {
+                                job: updated_job,
+                                error: msg.clone(),
+                                attempt: job.attempt,
+                            })
+                        } else {
+                            None
+                        };
+                        Ok(CompletionOutcome::Applied {
+                            event,
+                            terminal: true,
+                        })
+                    }
+                };
+            }
+
             let updated_job = if dlq_enabled {
                 let moved = runtime
                     .store
@@ -1703,6 +1858,51 @@ async fn complete_job_queue_storage(
                     error = %error_msg,
                     "Job failed (max attempts exhausted)"
                 );
+
+                // ADR-029: retries exhausted -> Exhausted outcome.
+                let kind_specs = enqueue_specs
+                    .get(&crate::enqueue_specs::Outcome::Exhausted)
+                    .and_then(|by_kind| by_kind.get(&job.kind))
+                    .cloned();
+                if let Some(specs) = kind_specs.filter(|s| !s.is_empty()) {
+                    let result = fail_queue_storage_with_followups(
+                        runtime,
+                        pool,
+                        job,
+                        "max_attempts_exhausted",
+                        &error_msg,
+                        progress_snapshot.clone(),
+                        dlq_enabled,
+                        metrics,
+                        &specs,
+                    )
+                    .await?;
+                    return match result {
+                        None => {
+                            warn!(
+                                job_id = job.id,
+                                "Job already rescued/cancelled, failure ignored"
+                            );
+                            Ok(CompletionOutcome::IgnoredStale)
+                        }
+                        Some(updated_job) => {
+                            let event = if needs_event {
+                                Some(UntypedJobEvent::Exhausted {
+                                    job: updated_job,
+                                    error: error_msg,
+                                    attempt: job.attempt,
+                                })
+                            } else {
+                                None
+                            };
+                            Ok(CompletionOutcome::Applied {
+                                event,
+                                terminal: true,
+                            })
+                        }
+                    };
+                }
+
                 let updated_job = if dlq_enabled {
                     let moved = runtime
                         .store
@@ -1761,6 +1961,49 @@ async fn complete_job_queue_storage(
                     error = %error_msg,
                     "Job failed (will retry)"
                 );
+
+                // ADR-029: retryable error with backoff -> Retried outcome.
+                let kind_specs = enqueue_specs
+                    .get(&crate::enqueue_specs::Outcome::Retried)
+                    .and_then(|by_kind| by_kind.get(&job.kind))
+                    .cloned();
+                if let Some(specs) = kind_specs.filter(|s| !s.is_empty()) {
+                    let result = retry_backoff_queue_storage_with_followups(
+                        runtime,
+                        pool,
+                        job,
+                        &error_msg,
+                        progress_snapshot.clone(),
+                        &specs,
+                    )
+                    .await?;
+                    return match result {
+                        None => {
+                            warn!(
+                                job_id = job.id,
+                                "Job already rescued/cancelled, retry ignored"
+                            );
+                            Ok(CompletionOutcome::IgnoredStale)
+                        }
+                        Some(updated_job) => {
+                            let event = if needs_event {
+                                Some(UntypedJobEvent::Retried {
+                                    job: updated_job.clone(),
+                                    error: error_msg,
+                                    attempt: job.attempt,
+                                    next_run_at: updated_job.run_at,
+                                })
+                            } else {
+                                None
+                            };
+                            Ok(CompletionOutcome::Applied {
+                                event,
+                                terminal: false,
+                            })
+                        }
+                    };
+                }
+
                 let Some(updated_job) = runtime
                     .store
                     .fail_retryable(
@@ -1871,6 +2114,191 @@ async fn complete_queue_storage_with_followups(
 
     tx.commit().await?;
     Ok(Some(updated_job))
+}
+
+/// Cancel a running queue-storage job and dispatch any Cancelled
+/// follow-ups in the same transaction (ADR-029).
+async fn cancel_queue_storage_with_followups(
+    runtime: &QueueStorageRuntime,
+    pool: &PgPool,
+    job: &JobRow,
+    reason: &str,
+    progress_snapshot: Option<serde_json::Value>,
+    specs: &[crate::enqueue_specs::BoxedEnqueueSpec],
+) -> Result<Option<JobRow>, AwaError> {
+    let mut tx = pool.begin().await?;
+    let Some(updated_job) = runtime
+        .store
+        .cancel_running_in_tx(&mut tx, job.id, job.run_lease, reason, progress_snapshot)
+        .await?
+    else {
+        tx.rollback().await?;
+        return Ok(None);
+    };
+    let outcome_ctx = crate::enqueue_specs::OutcomeContext::Cancelled {
+        reason: reason.to_string(),
+    };
+    crate::enqueue_specs::dispatch_specs_in_tx(&mut tx, &updated_job, specs, Some(&outcome_ctx))
+        .await?;
+    tx.commit().await?;
+    Ok(Some(updated_job))
+}
+
+/// RetryAfter on queue-storage + Retried follow-ups, in the same tx.
+async fn retry_after_queue_storage_with_followups(
+    runtime: &QueueStorageRuntime,
+    pool: &PgPool,
+    job: &JobRow,
+    retry_duration: Duration,
+    progress_snapshot: Option<serde_json::Value>,
+    specs: &[crate::enqueue_specs::BoxedEnqueueSpec],
+) -> Result<Option<JobRow>, AwaError> {
+    let mut tx = pool.begin().await?;
+    let Some(updated_job) = runtime
+        .store
+        .retry_after_in_tx(
+            &mut tx,
+            job.id,
+            job.run_lease,
+            retry_duration,
+            progress_snapshot,
+        )
+        .await?
+    else {
+        tx.rollback().await?;
+        return Ok(None);
+    };
+    // Mirror the canonical `RetryAfter` event: empty error string.
+    let outcome_ctx = crate::enqueue_specs::OutcomeContext::Retried {
+        error: String::new(),
+        attempt: updated_job.attempt,
+        next_run_at: updated_job.run_at,
+    };
+    crate::enqueue_specs::dispatch_specs_in_tx(&mut tx, &updated_job, specs, Some(&outcome_ctx))
+        .await?;
+    tx.commit().await?;
+    Ok(Some(updated_job))
+}
+
+/// Retryable error on queue-storage that backs off (attempt < max_attempts)
+/// plus Retried follow-ups, in the same tx.
+async fn retry_backoff_queue_storage_with_followups(
+    runtime: &QueueStorageRuntime,
+    pool: &PgPool,
+    job: &JobRow,
+    error_msg: &str,
+    progress_snapshot: Option<serde_json::Value>,
+    specs: &[crate::enqueue_specs::BoxedEnqueueSpec],
+) -> Result<Option<JobRow>, AwaError> {
+    let mut tx = pool.begin().await?;
+    let Some(updated_job) = runtime
+        .store
+        .fail_retryable_in_tx(&mut tx, job.id, job.run_lease, error_msg, progress_snapshot)
+        .await?
+    else {
+        tx.rollback().await?;
+        return Ok(None);
+    };
+    let outcome_ctx = crate::enqueue_specs::OutcomeContext::Retried {
+        error: error_msg.to_string(),
+        attempt: job.attempt,
+        next_run_at: updated_job.run_at,
+    };
+    crate::enqueue_specs::dispatch_specs_in_tx(&mut tx, &updated_job, specs, Some(&outcome_ctx))
+        .await?;
+    tx.commit().await?;
+    Ok(Some(updated_job))
+}
+
+/// Terminal failure (or retries exhausted) on queue-storage + Exhausted
+/// follow-ups, in the same tx. Honours DLQ routing if enabled.
+#[allow(clippy::too_many_arguments)]
+async fn fail_queue_storage_with_followups(
+    runtime: &QueueStorageRuntime,
+    pool: &PgPool,
+    job: &JobRow,
+    dlq_reason: &str,
+    error_msg: &str,
+    progress_snapshot: Option<serde_json::Value>,
+    dlq_enabled: bool,
+    metrics: &crate::metrics::AwaMetrics,
+    specs: &[crate::enqueue_specs::BoxedEnqueueSpec],
+) -> Result<Option<JobRow>, AwaError> {
+    let mut tx = pool.begin().await?;
+    let updated_job = if dlq_enabled {
+        let moved = runtime
+            .store
+            .fail_to_dlq_in_tx(
+                &mut tx,
+                job.id,
+                job.run_lease,
+                dlq_reason,
+                error_msg,
+                progress_snapshot,
+            )
+            .await?;
+        if moved.is_some() {
+            metrics.record_dlq_moved(&job.kind, &job.queue, dlq_reason);
+        }
+        moved
+    } else {
+        runtime
+            .store
+            .fail_terminal_in_tx(&mut tx, job.id, job.run_lease, error_msg, progress_snapshot)
+            .await?
+    };
+    let Some(updated_job) = updated_job else {
+        tx.rollback().await?;
+        return Ok(None);
+    };
+    let outcome_ctx = crate::enqueue_specs::OutcomeContext::Exhausted {
+        error: error_msg.to_string(),
+        attempt: job.attempt,
+    };
+    crate::enqueue_specs::dispatch_specs_in_tx(&mut tx, &updated_job, specs, Some(&outcome_ctx))
+        .await?;
+    tx.commit().await?;
+    Ok(Some(updated_job))
+}
+
+/// Park a queue-storage job in `waiting_external` and dispatch any
+/// WaitingForCallback follow-ups in the same tx (ADR-029).
+///
+/// Returns `Ok(Some(parked))` if the row transitioned. `Ok(None)` if the
+/// guarded UPDATE didn't match — caller falls back to the existing race /
+/// missing-callback handling.
+async fn park_queue_storage_with_followups(
+    runtime: &QueueStorageRuntime,
+    pool: &PgPool,
+    job: &JobRow,
+    callback_id: uuid::Uuid,
+    specs: &[crate::enqueue_specs::BoxedEnqueueSpec],
+) -> Result<Option<JobRow>, AwaError> {
+    let mut tx = pool.begin().await?;
+    let entered = runtime
+        .store
+        .enter_callback_wait_in_tx(&mut tx, job.id, job.run_lease, callback_id)
+        .await?;
+    if !entered {
+        tx.rollback().await?;
+        return Ok(None);
+    }
+    // The parked row lives in the leases table; constructing the post-park
+    // snapshot from `job` matches the fallback `complete_job_queue_storage`
+    // already uses when `load_job` doesn't return a row.
+    let mut parked_job = job.clone();
+    parked_job.state = JobState::WaitingExternal;
+    parked_job.heartbeat_at = None;
+    parked_job.deadline_at = None;
+    crate::enqueue_specs::dispatch_specs_in_tx(
+        &mut tx,
+        &parked_job,
+        specs,
+        Some(&crate::enqueue_specs::OutcomeContext::WaitingForCallback),
+    )
+    .await?;
+    tx.commit().await?;
+    Ok(Some(parked_job))
 }
 
 async fn direct_complete_job_queue_storage(

--- a/awa-worker/src/executor.rs
+++ b/awa-worker/src/executor.rs
@@ -491,11 +491,14 @@ async fn complete_job(
         }
         RuntimeStorage::QueueStorage(runtime) => {
             // ADR-029 follow-up enqueue is currently wired only on the
-            // canonical path; queue-storage wiring is deferred to a follow-up
-            // PR. Specs for jobs running under queue storage are silently
-            // ignored for now — they will simply not produce follow-ups
-            // until the queue-storage finalization path is updated to honour
-            // them in the same transaction as its terminal append.
+            // canonical path. The queue-storage completion path's
+            // receipt-plane fast-complete (ADR-023) doesn't pass through a
+            // single transaction we can join from here; a dedicated
+            // tx-aware variant of `complete_runtime_batch_slow` is a
+            // follow-up. `Client::start` returns an error if specs are
+            // registered under queue storage, so we never reach this branch
+            // with a non-empty registry today.
+            let _ = enqueue_specs;
             complete_job_queue_storage(
                 runtime,
                 pool,

--- a/awa-worker/src/lib.rs
+++ b/awa-worker/src/lib.rs
@@ -22,6 +22,7 @@ pub use client::{
 };
 pub use context::{CallbackGuard, CallbackToken, JobContext};
 pub use dispatcher::{QueueConfig, RateLimit};
+pub use enqueue_specs::EnqueueRequest;
 pub use events::{JobEvent, UntypedJobEvent};
 pub use executor::{JobError, JobResult, Worker};
 pub use maintenance::RetentionPolicy;

--- a/awa-worker/src/lib.rs
+++ b/awa-worker/src/lib.rs
@@ -3,6 +3,7 @@ pub mod client;
 mod completion;
 pub mod context;
 pub mod dispatcher;
+mod enqueue_specs;
 pub mod events;
 pub mod executor;
 pub mod heartbeat;

--- a/awa-worker/src/lib.rs
+++ b/awa-worker/src/lib.rs
@@ -23,7 +23,7 @@ pub use client::{
 pub use context::{CallbackGuard, CallbackToken, JobContext};
 pub use dispatcher::{QueueConfig, RateLimit};
 pub use enqueue_specs::EnqueueRequest;
-pub use events::{JobEvent, UntypedJobEvent};
+pub use events::{JobEvent, RescueReason, UntypedJobEvent};
 pub use executor::{JobError, JobResult, Worker};
 pub use maintenance::RetentionPolicy;
 pub use metrics::AwaMetrics;

--- a/awa-worker/src/maintenance.rs
+++ b/awa-worker/src/maintenance.rs
@@ -888,21 +888,23 @@ impl MaintenanceService {
         }
     }
 
-    /// Emit a Rescued lifecycle event (in-process hook) and dispatch any
-    /// registered Rescued follow-up specs. See
-    /// [`Self::dispatch_rescued_followups`] for the atomicity caveat on
-    /// the spec side.
+    /// Emit a Rescued notification: dispatch the durable follow-up specs
+    /// (best-effort, separate tx — see [`Self::dispatch_rescued_followups`])
+    /// then fire the in-process hook detached so a slow observer does not
+    /// gate the side-effect path or any work the caller does after this
+    /// (e.g. the callback-rescue DLQ move in
+    /// [`Self::rescue_expired_callbacks`]).
     async fn emit_rescued(&self, job: &JobRow, reason: crate::events::RescueReason) {
-        crate::executor::dispatch_lifecycle_event(
-            &self.lifecycle_handlers,
-            &job.kind,
-            crate::events::UntypedJobEvent::Rescued {
-                job: job.clone(),
-                reason,
-            },
-        )
-        .await;
         self.dispatch_rescued_followups(job, reason).await;
+        let handlers = self.lifecycle_handlers.clone();
+        let kind = job.kind.clone();
+        let event = crate::events::UntypedJobEvent::Rescued {
+            job: job.clone(),
+            reason,
+        };
+        tokio::spawn(async move {
+            crate::executor::dispatch_lifecycle_event(&handlers, &kind, event).await;
+        });
     }
 
     /// ADR-029 best-effort dispatch of `Rescued` follow-up specs.

--- a/awa-worker/src/maintenance.rs
+++ b/awa-worker/src/maintenance.rs
@@ -49,6 +49,18 @@ pub struct MaintenanceService {
     leader: Arc<AtomicBool>,
     alive: Arc<AtomicBool>,
     periodic_jobs: Arc<Vec<PeriodicJob>>,
+    /// ADR-029 follow-up specs registry — used to dispatch `Rescued`
+    /// follow-ups (best-effort, separate tx) when this service rescues
+    /// jobs from stale heartbeat / expired callback / exceeded deadline.
+    enqueue_specs: Arc<
+        HashMap<
+            crate::enqueue_specs::Outcome,
+            HashMap<String, Vec<crate::enqueue_specs::BoxedEnqueueSpec>>,
+        >,
+    >,
+    /// In-process `Rescued` lifecycle hooks (ADR-015), shared with the
+    /// executor. Best-effort fire-and-forget per rescued job.
+    lifecycle_handlers: Arc<HashMap<String, Vec<crate::events::BoxedUntypedEventHandler>>>,
     /// In-flight job cancellation flags — used to signal deadline/heartbeat rescue
     /// to running handlers on this worker instance.
     in_flight: InFlightMap,
@@ -98,6 +110,13 @@ impl MaintenanceService {
         periodic_jobs: Arc<Vec<PeriodicJob>>,
         in_flight: InFlightMap,
         storage: RuntimeStorage,
+        enqueue_specs: Arc<
+            HashMap<
+                crate::enqueue_specs::Outcome,
+                HashMap<String, Vec<crate::enqueue_specs::BoxedEnqueueSpec>>,
+            >,
+        >,
+        lifecycle_handlers: Arc<HashMap<String, Vec<crate::events::BoxedUntypedEventHandler>>>,
     ) -> Self {
         Self {
             pool,
@@ -108,6 +127,8 @@ impl MaintenanceService {
             periodic_jobs,
             in_flight,
             storage,
+            enqueue_specs,
+            lifecycle_handlers,
             heartbeat_rescue_interval: Duration::from_secs(30),
             deadline_rescue_interval: Duration::from_secs(30),
             callback_rescue_interval: Duration::from_secs(30),
@@ -637,6 +658,10 @@ impl MaintenanceService {
                 warn!(count = rescued.len(), "Rescued stale heartbeat jobs");
                 // Signal cancellation to any rescued jobs still running on this instance
                 self.signal_cancellation(&rescued).await;
+                for job in &rescued {
+                    self.emit_rescued(job, crate::events::RescueReason::StaleHeartbeat)
+                        .await;
+                }
             }
             Err(err) => {
                 error!(error = %err, "Failed to rescue stale heartbeat jobs");
@@ -694,6 +719,10 @@ impl MaintenanceService {
                 warn!(count = rescued.len(), "Rescued deadline-expired jobs");
                 // Signal cancellation so handlers see ctx.is_cancelled() == true
                 self.signal_cancellation(&rescued).await;
+                for job in &rescued {
+                    self.emit_rescued(job, crate::events::RescueReason::DeadlineExceeded)
+                        .await;
+                }
             }
             Err(err) => {
                 error!(error = %err, "Failed to rescue deadline-expired jobs");
@@ -752,6 +781,10 @@ impl MaintenanceService {
                     )],
                 );
                 warn!(count = rescued.len(), "Rescued callback-timed-out jobs");
+                for job in &rescued {
+                    self.emit_rescued(job, crate::events::RescueReason::ExpiredCallback)
+                        .await;
+                }
                 if let RuntimeStorage::QueueStorage(runtime) = &self.storage {
                     for job in &rescued {
                         if job.state != JobState::Failed || !self.dlq_policy.enabled_for(&job.queue)
@@ -851,6 +884,84 @@ impl MaintenanceService {
             if let Some(flag) = self.in_flight.get_cancel((job.id, job.run_lease)) {
                 flag.store(true, Ordering::SeqCst);
                 debug!(job_id = job.id, "Signalled cancellation for rescued job");
+            }
+        }
+    }
+
+    /// Emit a Rescued lifecycle event (in-process hook) and dispatch any
+    /// registered Rescued follow-up specs. See
+    /// [`Self::dispatch_rescued_followups`] for the atomicity caveat on
+    /// the spec side.
+    async fn emit_rescued(&self, job: &JobRow, reason: crate::events::RescueReason) {
+        crate::executor::dispatch_lifecycle_event(
+            &self.lifecycle_handlers,
+            &job.kind,
+            crate::events::UntypedJobEvent::Rescued {
+                job: job.clone(),
+                reason,
+            },
+        )
+        .await;
+        self.dispatch_rescued_followups(job, reason).await;
+    }
+
+    /// ADR-029 best-effort dispatch of `Rescued` follow-up specs.
+    ///
+    /// Like callback-resolution follow-ups, this runs in a *separate*
+    /// transaction from the rescue UPDATE — the rescue UPDATE has already
+    /// committed by the time we're here, so we can't be atomic without
+    /// teaching every rescue path to take a `&mut tx`. If a spec INSERT
+    /// fails it's logged; the rescue itself remains valid.
+    async fn dispatch_rescued_followups(&self, job: &JobRow, reason: crate::events::RescueReason) {
+        let Some(specs) = self
+            .enqueue_specs
+            .get(&crate::enqueue_specs::Outcome::Rescued)
+            .and_then(|by_kind| by_kind.get(&job.kind))
+            .cloned()
+        else {
+            return;
+        };
+        if specs.is_empty() {
+            return;
+        }
+        let mut tx = match self.pool.begin().await {
+            Ok(tx) => tx,
+            Err(err) => {
+                error!(
+                    job_id = job.id,
+                    kind = %job.kind,
+                    rescue_reason = reason.as_str(),
+                    error = %err,
+                    "Rescued follow-up dispatch: failed to begin transaction"
+                );
+                return;
+            }
+        };
+        let outcome_ctx = crate::enqueue_specs::OutcomeContext::Rescued { reason };
+        let result =
+            crate::enqueue_specs::dispatch_specs_in_tx(&mut tx, job, &specs, Some(&outcome_ctx))
+                .await;
+        match result {
+            Ok(()) => {
+                if let Err(err) = tx.commit().await {
+                    error!(
+                        job_id = job.id,
+                        kind = %job.kind,
+                        rescue_reason = reason.as_str(),
+                        error = %err,
+                        "Rescued follow-up dispatch: commit failed"
+                    );
+                }
+            }
+            Err(err) => {
+                error!(
+                    job_id = job.id,
+                    kind = %job.kind,
+                    rescue_reason = reason.as_str(),
+                    error = %err,
+                    "Rescued follow-up dispatch: spec INSERT failed; rolling back"
+                );
+                let _ = tx.rollback().await;
             }
         }
     }

--- a/awa/src/lib.rs
+++ b/awa/src/lib.rs
@@ -22,9 +22,9 @@ pub use awa_model::{
 // Re-export worker runtime
 pub use awa_worker::{
     self as worker, context::ProgressState, BuildError, CallbackGuard, CallbackToken, Client,
-    ClientBuilder, CronMissedFirePolicy, HealthCheck, JobContext, JobError, JobEvent, JobResult,
-    PeriodicJob, PeriodicJobBuilder, QueueCapacity, QueueConfig, QueueHealth, RateLimit,
-    RetentionPolicy, UntypedJobEvent, Worker,
+    ClientBuilder, CronMissedFirePolicy, EnqueueRequest, HealthCheck, JobContext, JobError,
+    JobEvent, JobResult, PeriodicJob, PeriodicJobBuilder, QueueCapacity, QueueConfig, QueueHealth,
+    RateLimit, RetentionPolicy, UntypedJobEvent, Worker,
 };
 
 #[cfg(feature = "http-worker")]

--- a/awa/src/lib.rs
+++ b/awa/src/lib.rs
@@ -24,7 +24,7 @@ pub use awa_worker::{
     self as worker, context::ProgressState, BuildError, CallbackGuard, CallbackToken, Client,
     ClientBuilder, CronMissedFirePolicy, EnqueueRequest, HealthCheck, JobContext, JobError,
     JobEvent, JobResult, PeriodicJob, PeriodicJobBuilder, QueueCapacity, QueueConfig, QueueHealth,
-    RateLimit, RetentionPolicy, UntypedJobEvent, Worker,
+    RateLimit, RescueReason, RetentionPolicy, UntypedJobEvent, Worker,
 };
 
 #[cfg(feature = "http-worker")]

--- a/awa/tests/enqueue_spec_test.rs
+++ b/awa/tests/enqueue_spec_test.rs
@@ -1,0 +1,136 @@
+//! ADR-029 integration tests: durable follow-up jobs enqueued in the same
+//! transaction as a triggering state commit.
+//!
+//! Set DATABASE_URL=postgres://postgres:test@localhost:15432/awa_test
+
+use awa::model::{admin, migrations};
+use awa::{Client, JobArgs, JobResult, JobState, QueueConfig};
+use serde::{Deserialize, Serialize};
+use sqlx::postgres::PgPoolOptions;
+use std::sync::{Arc, OnceLock};
+use std::time::Duration;
+use tokio::sync::Semaphore;
+
+fn database_url() -> String {
+    std::env::var("DATABASE_URL")
+        .unwrap_or_else(|_| "postgres://postgres:test@localhost:15432/awa_test".to_string())
+}
+
+async fn setup_pool_canonical() -> sqlx::PgPool {
+    let pool = PgPoolOptions::new()
+        .max_connections(5)
+        .acquire_timeout(Duration::from_secs(10))
+        .connect(&database_url())
+        .await
+        .expect("connect to test database");
+    sqlx::query("DROP SCHEMA IF EXISTS awa CASCADE")
+        .execute(&pool)
+        .await
+        .expect("drop awa schema");
+    migrations::run(&pool).await.expect("run migrations");
+    pool
+}
+
+fn test_gate() -> Arc<Semaphore> {
+    static GATE: OnceLock<Arc<Semaphore>> = OnceLock::new();
+    GATE.get_or_init(|| Arc::new(Semaphore::new(1))).clone()
+}
+
+async fn wait_for_state(pool: &sqlx::PgPool, job_id: i64, state: JobState) -> awa::JobRow {
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+    loop {
+        if let Ok(job) = admin::get_job(pool, job_id).await {
+            if job.state == state {
+                return job;
+            }
+        }
+        if tokio::time::Instant::now() >= deadline {
+            panic!("timed out waiting for job {job_id} to reach {state:?}");
+        }
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+}
+
+async fn first_follow_up(pool: &sqlx::PgPool, kind: &str) -> Option<awa::JobRow> {
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+    loop {
+        let row: Option<awa::JobRow> =
+            sqlx::query_as("SELECT * FROM awa.jobs WHERE kind = $1 ORDER BY id ASC LIMIT 1")
+                .bind(kind)
+                .fetch_optional(pool)
+                .await
+                .expect("query follow-up");
+        if row.is_some() {
+            return row;
+        }
+        if tokio::time::Instant::now() >= deadline {
+            return None;
+        }
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JobArgs)]
+struct EnqueueTrigger {
+    user_id: i64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JobArgs)]
+struct EnqueueFollowUp {
+    user_id: i64,
+    triggered_by_job_id: i64,
+}
+
+#[tokio::test]
+async fn on_completed_enqueue_inserts_follow_up_atomically() {
+    let _permit = test_gate().acquire_owned().await.unwrap();
+    let pool = setup_pool_canonical().await;
+    let queue = "enqueue_spec_trigger";
+
+    let client = Client::builder(pool.clone())
+        .canonical_storage()
+        .queue(
+            queue,
+            QueueConfig {
+                poll_interval: Duration::from_millis(25),
+                ..Default::default()
+            },
+        )
+        .register::<EnqueueTrigger, _, _>(|_args, _ctx| async move { Ok(JobResult::Completed) })
+        // The spec under test: when EnqueueTrigger completes, enqueue an
+        // EnqueueFollowUp in the same transaction.
+        .on_completed_enqueue::<EnqueueTrigger, EnqueueFollowUp, _>(|args, job| EnqueueFollowUp {
+            user_id: args.user_id,
+            triggered_by_job_id: job.id,
+        })
+        .build()
+        .unwrap();
+
+    let trigger_job = awa::insert_with(
+        &pool,
+        &EnqueueTrigger { user_id: 42 },
+        awa::InsertOpts {
+            queue: queue.to_string(),
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+
+    client.start().await.unwrap();
+    let completed = wait_for_state(&pool, trigger_job.id, JobState::Completed).await;
+    let follow_up = first_follow_up(&pool, EnqueueFollowUp::kind())
+        .await
+        .expect("follow-up job should be enqueued");
+    client.shutdown(Duration::from_secs(2)).await;
+
+    assert_eq!(completed.state, JobState::Completed);
+
+    // Decode the follow-up's args and check the make-args closure ran with
+    // the trigger's args and post-completion JobRow.
+    let follow_args: EnqueueFollowUp =
+        serde_json::from_value(follow_up.args.clone()).expect("decode follow-up args");
+    assert_eq!(follow_args.user_id, 42);
+    assert_eq!(follow_args.triggered_by_job_id, trigger_job.id);
+    assert_eq!(follow_up.state, JobState::Available);
+}

--- a/awa/tests/enqueue_spec_test.rs
+++ b/awa/tests/enqueue_spec_test.rs
@@ -214,9 +214,11 @@ async fn on_completed_enqueue_under_queue_storage_fails_fast() {
         .build()
         .unwrap();
 
-    // ADR-029 queue-storage wiring is a deferred follow-up. Until it lands,
-    // start() must refuse loud so callers can't ship code that silently
-    // never enqueues follow-ups.
+    // ADR-029 queue-storage wiring is a deferred follow-up — it needs a
+    // tx-aware variant of `complete_runtime_batch_slow` so the receipt-plane
+    // (ADR-023) lease completion can join the follow-up's transaction.
+    // Until that lands, start() refuses loud so callers can't ship code
+    // that silently never enqueues follow-ups.
     let err = client.start().await.expect_err("start should fail fast");
     let msg = err.to_string();
     assert!(

--- a/awa/tests/enqueue_spec_test.rs
+++ b/awa/tests/enqueue_spec_test.rs
@@ -448,6 +448,10 @@ async fn on_waiting_for_callback_enqueue_inserts_follow_up_atomically() {
     let pool = setup_pool_canonical().await;
     let queue = "enqueue_spec_wait_trigger";
 
+    let seen_callback_id: Arc<std::sync::Mutex<Option<uuid::Uuid>>> =
+        Arc::new(std::sync::Mutex::new(None));
+    let seen_callback_id_for_closure = seen_callback_id.clone();
+
     let client = Client::builder(pool.clone())
         .canonical_storage()
         .queue(
@@ -458,7 +462,8 @@ async fn on_waiting_for_callback_enqueue_inserts_follow_up_atomically() {
             },
         )
         .register_worker(WaitWorker)
-        .on_waiting_for_callback_enqueue::<WaitTrigger, EnqueueFollowUp, _>(|args, job| {
+        .on_waiting_for_callback_enqueue::<WaitTrigger, EnqueueFollowUp, _>(move |args, job| {
+            *seen_callback_id_for_closure.lock().unwrap() = job.callback_id;
             EnqueueFollowUp {
                 user_id: args.user_id,
                 triggered_by_job_id: job.id,
@@ -488,6 +493,12 @@ async fn on_waiting_for_callback_enqueue_inserts_follow_up_atomically() {
     let follow_args: EnqueueFollowUp = serde_json::from_value(follow_up.args.clone()).unwrap();
     assert_eq!(follow_args.user_id, 44);
     assert_eq!(follow_args.triggered_by_job_id, trigger_job.id);
+    let captured = seen_callback_id
+        .lock()
+        .unwrap()
+        .expect("closure should have observed a callback_id on the parked JobRow");
+    let parked = admin::get_job(&pool, trigger_job.id).await.unwrap();
+    assert_eq!(Some(captured), parked.callback_id);
 }
 
 #[tokio::test]
@@ -689,6 +700,15 @@ async fn on_waiting_for_callback_enqueue_inserts_follow_up_under_queue_storage()
     let pool = setup_pool_queue_storage().await;
     let queue = "enqueue_spec_qs_wait_trigger";
 
+    // Capture the parked JobRow the closure sees so we can assert that
+    // `register_callback()`'s writes (callback_id, callback_timeout_at)
+    // are visible — the dispatcher must reload the row from the leases
+    // table after `enter_callback_wait_in_tx`, not reuse the pre-park
+    // snapshot the executor claimed.
+    let seen_callback_id: Arc<std::sync::Mutex<Option<uuid::Uuid>>> =
+        Arc::new(std::sync::Mutex::new(None));
+    let seen_callback_id_for_closure = seen_callback_id.clone();
+
     let client = Client::builder(pool.clone())
         .queue(
             queue,
@@ -698,7 +718,8 @@ async fn on_waiting_for_callback_enqueue_inserts_follow_up_under_queue_storage()
             },
         )
         .register_worker(WaitWorker)
-        .on_waiting_for_callback_enqueue::<WaitTrigger, EnqueueFollowUp, _>(|args, job| {
+        .on_waiting_for_callback_enqueue::<WaitTrigger, EnqueueFollowUp, _>(move |args, job| {
+            *seen_callback_id_for_closure.lock().unwrap() = job.callback_id;
             EnqueueFollowUp {
                 user_id: args.user_id,
                 triggered_by_job_id: job.id,
@@ -728,6 +749,16 @@ async fn on_waiting_for_callback_enqueue_inserts_follow_up_under_queue_storage()
     let follow_args: EnqueueFollowUp = serde_json::from_value(follow_up.args.clone()).unwrap();
     assert_eq!(follow_args.user_id, 444);
     assert_eq!(follow_args.triggered_by_job_id, trigger_job.id);
+    let captured = seen_callback_id
+        .lock()
+        .unwrap()
+        .expect("closure should have observed a callback_id on the parked JobRow");
+    let parked = admin::get_job(&pool, trigger_job.id).await.unwrap();
+    assert_eq!(
+        Some(captured),
+        parked.callback_id,
+        "closure-visible callback_id must match the one written by register_callback()"
+    );
 }
 
 #[tokio::test]

--- a/awa/tests/enqueue_spec_test.rs
+++ b/awa/tests/enqueue_spec_test.rs
@@ -740,12 +740,12 @@ async fn fail_external_dispatches_exhausted_followup() {
             },
         )
         .register_worker(WaitWorker)
-        .on_exhausted_enqueue::<WaitTrigger, EnqueueFollowUp, _>(
-            |args, job, _error, _attempt| EnqueueFollowUp {
+        .on_exhausted_enqueue::<WaitTrigger, EnqueueFollowUp, _>(|args, job, _error, _attempt| {
+            EnqueueFollowUp {
                 user_id: args.user_id,
                 triggered_by_job_id: job.id,
-            },
-        )
+            }
+        })
         .build()
         .unwrap();
 
@@ -831,5 +831,75 @@ async fn retry_external_dispatches_retried_followup() {
 
     let follow_args: EnqueueFollowUp = serde_json::from_value(follow_up.args.clone()).unwrap();
     assert_eq!(follow_args.user_id, 503);
+    assert_eq!(follow_args.triggered_by_job_id, trigger_job.id);
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JobArgs)]
+struct ExpiringTrigger {
+    user_id: i64,
+}
+
+struct ShortCallbackWorker;
+
+#[async_trait::async_trait]
+impl awa::Worker for ShortCallbackWorker {
+    fn kind(&self) -> &'static str {
+        ExpiringTrigger::kind()
+    }
+    async fn perform(&self, ctx: &awa::JobContext) -> Result<awa::JobResult, awa::JobError> {
+        // Very short callback timeout so maintenance rescues it quickly.
+        let guard = ctx
+            .register_callback(Duration::from_millis(100))
+            .await
+            .map_err(awa::JobError::retryable)?;
+        Ok(JobResult::WaitForCallback(guard))
+    }
+}
+
+#[tokio::test]
+async fn on_rescued_enqueue_dispatches_followup_on_expired_callback() {
+    let _permit = test_gate().acquire_owned().await.unwrap();
+    let pool = setup_pool_canonical().await;
+    let queue = "enqueue_spec_rescued_trigger";
+
+    let client = Client::builder(pool.clone())
+        .canonical_storage()
+        .queue(
+            queue,
+            QueueConfig {
+                poll_interval: Duration::from_millis(25),
+                ..Default::default()
+            },
+        )
+        .callback_rescue_interval(Duration::from_millis(100))
+        .register_worker(ShortCallbackWorker)
+        .on_rescued_enqueue::<ExpiringTrigger, EnqueueFollowUp, _>(|args, job, _reason| {
+            EnqueueFollowUp {
+                user_id: args.user_id,
+                triggered_by_job_id: job.id,
+            }
+        })
+        .build()
+        .unwrap();
+
+    let trigger_job = awa::insert_with(
+        &pool,
+        &ExpiringTrigger { user_id: 601 },
+        awa::InsertOpts {
+            queue: queue.to_string(),
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+
+    client.start().await.unwrap();
+    let follow_up = first_follow_up(&pool, EnqueueFollowUp::kind())
+        .await
+        .expect("rescued follow-up should be enqueued");
+    client.shutdown(Duration::from_secs(2)).await;
+
+    let follow_args: EnqueueFollowUp = serde_json::from_value(follow_up.args.clone()).unwrap();
+    assert_eq!(follow_args.user_id, 601);
     assert_eq!(follow_args.triggered_by_job_id, trigger_job.id);
 }

--- a/awa/tests/enqueue_spec_test.rs
+++ b/awa/tests/enqueue_spec_test.rs
@@ -134,3 +134,42 @@ async fn on_completed_enqueue_inserts_follow_up_atomically() {
     assert_eq!(follow_args.triggered_by_job_id, trigger_job.id);
     assert_eq!(follow_up.state, JobState::Available);
 }
+
+#[tokio::test]
+async fn on_completed_enqueue_under_queue_storage_fails_fast() {
+    use awa::model::queue_storage::{QueueStorage, QueueStorageConfig};
+
+    let _permit = test_gate().acquire_owned().await.unwrap();
+    let pool = setup_pool_canonical().await;
+    QueueStorage::new(QueueStorageConfig::default())
+        .expect("build queue storage")
+        .install(&pool)
+        .await
+        .expect("install queue storage");
+
+    let client = Client::builder(pool.clone())
+        .queue(
+            "enqueue_spec_queue_storage",
+            QueueConfig {
+                poll_interval: Duration::from_millis(25),
+                ..Default::default()
+            },
+        )
+        .register::<EnqueueTrigger, _, _>(|_args, _ctx| async move { Ok(JobResult::Completed) })
+        .on_completed_enqueue::<EnqueueTrigger, EnqueueFollowUp, _>(|args, _job| EnqueueFollowUp {
+            user_id: args.user_id,
+            triggered_by_job_id: 0,
+        })
+        .build()
+        .unwrap();
+
+    // ADR-029 queue-storage wiring is a deferred follow-up. Until it lands,
+    // start() must refuse loud so callers can't ship code that silently
+    // never enqueues follow-ups.
+    let err = client.start().await.expect_err("start should fail fast");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("queue storage") && msg.contains("canonical_storage"),
+        "unexpected error message: {msg}"
+    );
+}

--- a/awa/tests/enqueue_spec_test.rs
+++ b/awa/tests/enqueue_spec_test.rs
@@ -135,6 +135,65 @@ async fn on_completed_enqueue_inserts_follow_up_atomically() {
     assert_eq!(follow_up.state, JobState::Available);
 }
 
+/// A panicking `on_*_enqueue` closure must not unwind the executor or
+/// leave the trigger committed when the spec dispatch ran in the
+/// finalization transaction. The dispatch catches the panic, converts
+/// it to an AwaError, rolls back the tx (so the trigger stays in
+/// `running` and the heartbeat-rescue will pick it up), and the worker
+/// keeps draining other jobs.
+#[tokio::test]
+async fn panicking_on_completed_enqueue_closure_is_caught_and_rolls_back() {
+    let _permit = test_gate().acquire_owned().await.unwrap();
+    let pool = setup_pool_canonical().await;
+    let queue = "enqueue_spec_panic_trigger";
+
+    let client = Client::builder(pool.clone())
+        .canonical_storage()
+        .queue(
+            queue,
+            QueueConfig {
+                poll_interval: Duration::from_millis(25),
+                ..Default::default()
+            },
+        )
+        .register::<EnqueueTrigger, _, _>(|_args, _ctx| async move { Ok(JobResult::Completed) })
+        .on_completed_enqueue::<EnqueueTrigger, EnqueueFollowUp, _>(|_args, _job| {
+            panic!("user closure exploded");
+        })
+        .build()
+        .unwrap();
+
+    let trigger_job = awa::insert_with(
+        &pool,
+        &EnqueueTrigger { user_id: 999 },
+        awa::InsertOpts {
+            queue: queue.to_string(),
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+
+    client.start().await.unwrap();
+    // Give the executor enough time to claim, perform, and attempt
+    // completion (which rolls back due to the panic).
+    tokio::time::sleep(Duration::from_millis(500)).await;
+    client.shutdown(Duration::from_secs(2)).await;
+
+    let trigger_after = admin::get_job(&pool, trigger_job.id).await.unwrap();
+    // Trigger must not be `completed` — the completion tx rolled back.
+    assert_ne!(
+        trigger_after.state,
+        JobState::Completed,
+        "panic in on_completed_enqueue closure leaked through and committed the trigger"
+    );
+    let follow_up = first_follow_up(&pool, EnqueueFollowUp::kind()).await;
+    assert!(
+        follow_up.is_none(),
+        "panicking closure must not have inserted a follow-up"
+    );
+}
+
 #[tokio::test]
 async fn on_completed_enqueue_routes_follow_up_to_custom_queue() {
     let _permit = test_gate().acquire_owned().await.unwrap();

--- a/awa/tests/enqueue_spec_test.rs
+++ b/awa/tests/enqueue_spec_test.rs
@@ -186,43 +186,59 @@ async fn on_completed_enqueue_routes_follow_up_to_custom_queue() {
     assert_eq!(follow_up.priority, 1);
 }
 
-#[tokio::test]
-async fn on_completed_enqueue_under_queue_storage_fails_fast() {
+async fn setup_pool_queue_storage() -> sqlx::PgPool {
     use awa::model::queue_storage::{QueueStorage, QueueStorageConfig};
-
-    let _permit = test_gate().acquire_owned().await.unwrap();
     let pool = setup_pool_canonical().await;
     QueueStorage::new(QueueStorageConfig::default())
         .expect("build queue storage")
         .install(&pool)
         .await
         .expect("install queue storage");
+    pool
+}
+
+#[tokio::test]
+async fn on_completed_enqueue_inserts_follow_up_under_queue_storage() {
+    let _permit = test_gate().acquire_owned().await.unwrap();
+    let pool = setup_pool_queue_storage().await;
+    let queue = "enqueue_spec_qs_trigger";
 
     let client = Client::builder(pool.clone())
         .queue(
-            "enqueue_spec_queue_storage",
+            queue,
             QueueConfig {
                 poll_interval: Duration::from_millis(25),
                 ..Default::default()
             },
         )
         .register::<EnqueueTrigger, _, _>(|_args, _ctx| async move { Ok(JobResult::Completed) })
-        .on_completed_enqueue::<EnqueueTrigger, EnqueueFollowUp, _>(|args, _job| EnqueueFollowUp {
+        .on_completed_enqueue::<EnqueueTrigger, EnqueueFollowUp, _>(|args, job| EnqueueFollowUp {
             user_id: args.user_id,
-            triggered_by_job_id: 0,
+            triggered_by_job_id: job.id,
         })
         .build()
         .unwrap();
 
-    // ADR-029 queue-storage wiring is a deferred follow-up — it needs a
-    // tx-aware variant of `complete_runtime_batch_slow` so the receipt-plane
-    // (ADR-023) lease completion can join the follow-up's transaction.
-    // Until that lands, start() refuses loud so callers can't ship code
-    // that silently never enqueues follow-ups.
-    let err = client.start().await.expect_err("start should fail fast");
-    let msg = err.to_string();
-    assert!(
-        msg.contains("queue storage") && msg.contains("canonical_storage"),
-        "unexpected error message: {msg}"
-    );
+    let trigger_job = awa::insert_with(
+        &pool,
+        &EnqueueTrigger { user_id: 99 },
+        awa::InsertOpts {
+            queue: queue.to_string(),
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+
+    client.start().await.unwrap();
+    wait_for_state(&pool, trigger_job.id, JobState::Completed).await;
+    let follow_up = first_follow_up(&pool, EnqueueFollowUp::kind())
+        .await
+        .expect("follow-up should be enqueued under queue storage");
+    client.shutdown(Duration::from_secs(2)).await;
+
+    let follow_args: EnqueueFollowUp =
+        serde_json::from_value(follow_up.args.clone()).expect("decode follow-up args");
+    assert_eq!(follow_args.user_id, 99);
+    assert_eq!(follow_args.triggered_by_job_id, trigger_job.id);
 }

--- a/awa/tests/enqueue_spec_test.rs
+++ b/awa/tests/enqueue_spec_test.rs
@@ -4,7 +4,7 @@
 //! Set DATABASE_URL=postgres://postgres:test@localhost:15432/awa_test
 
 use awa::model::{admin, migrations};
-use awa::{Client, JobArgs, JobResult, JobState, QueueConfig};
+use awa::{Client, EnqueueRequest, JobArgs, JobResult, JobState, QueueConfig};
 use serde::{Deserialize, Serialize};
 use sqlx::postgres::PgPoolOptions;
 use std::sync::{Arc, OnceLock};
@@ -133,6 +133,57 @@ async fn on_completed_enqueue_inserts_follow_up_atomically() {
     assert_eq!(follow_args.user_id, 42);
     assert_eq!(follow_args.triggered_by_job_id, trigger_job.id);
     assert_eq!(follow_up.state, JobState::Available);
+}
+
+#[tokio::test]
+async fn on_completed_enqueue_routes_follow_up_to_custom_queue() {
+    let _permit = test_gate().acquire_owned().await.unwrap();
+    let pool = setup_pool_canonical().await;
+    let trigger_queue = "enqueue_spec_custom_trigger";
+    let follow_queue = "enqueue_spec_custom_follow";
+
+    let follow_queue_for_closure = follow_queue.to_string();
+    let client = Client::builder(pool.clone())
+        .canonical_storage()
+        .queue(
+            trigger_queue,
+            QueueConfig {
+                poll_interval: Duration::from_millis(25),
+                ..Default::default()
+            },
+        )
+        .register::<EnqueueTrigger, _, _>(|_args, _ctx| async move { Ok(JobResult::Completed) })
+        .on_completed_enqueue_with::<EnqueueTrigger, EnqueueFollowUp, _>(move |args, job| {
+            EnqueueRequest::new(EnqueueFollowUp {
+                user_id: args.user_id,
+                triggered_by_job_id: job.id,
+            })
+            .queue(follow_queue_for_closure.clone())
+            .priority(1)
+        })
+        .build()
+        .unwrap();
+
+    let trigger_job = awa::insert_with(
+        &pool,
+        &EnqueueTrigger { user_id: 7 },
+        awa::InsertOpts {
+            queue: trigger_queue.to_string(),
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+
+    client.start().await.unwrap();
+    wait_for_state(&pool, trigger_job.id, JobState::Completed).await;
+    let follow_up = first_follow_up(&pool, EnqueueFollowUp::kind())
+        .await
+        .expect("follow-up job should be enqueued");
+    client.shutdown(Duration::from_secs(2)).await;
+
+    assert_eq!(follow_up.queue, follow_queue);
+    assert_eq!(follow_up.priority, 1);
 }
 
 #[tokio::test]

--- a/awa/tests/enqueue_spec_test.rs
+++ b/awa/tests/enqueue_spec_test.rs
@@ -198,6 +198,240 @@ async fn setup_pool_queue_storage() -> sqlx::PgPool {
 }
 
 #[tokio::test]
+async fn on_cancelled_enqueue_inserts_follow_up_atomically() {
+    let _permit = test_gate().acquire_owned().await.unwrap();
+    let pool = setup_pool_canonical().await;
+    let queue = "enqueue_spec_cancel_trigger";
+
+    let client = Client::builder(pool.clone())
+        .canonical_storage()
+        .queue(
+            queue,
+            QueueConfig {
+                poll_interval: Duration::from_millis(25),
+                ..Default::default()
+            },
+        )
+        .register::<EnqueueTrigger, _, _>(|_args, _ctx| async move {
+            Ok(JobResult::Cancel("user requested".to_string()))
+        })
+        .on_cancelled_enqueue::<EnqueueTrigger, EnqueueFollowUp, _>(|args, job, _reason| {
+            EnqueueFollowUp {
+                user_id: args.user_id,
+                triggered_by_job_id: job.id,
+            }
+        })
+        .build()
+        .unwrap();
+
+    let trigger_job = awa::insert_with(
+        &pool,
+        &EnqueueTrigger { user_id: 11 },
+        awa::InsertOpts {
+            queue: queue.to_string(),
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+
+    client.start().await.unwrap();
+    wait_for_state(&pool, trigger_job.id, JobState::Cancelled).await;
+    let follow_up = first_follow_up(&pool, EnqueueFollowUp::kind())
+        .await
+        .expect("cancelled follow-up should be enqueued");
+    client.shutdown(Duration::from_secs(2)).await;
+
+    let follow_args: EnqueueFollowUp = serde_json::from_value(follow_up.args.clone()).unwrap();
+    assert_eq!(follow_args.user_id, 11);
+    assert_eq!(follow_args.triggered_by_job_id, trigger_job.id);
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JobArgs)]
+struct ExhaustTrigger {
+    user_id: i64,
+}
+
+#[tokio::test]
+async fn on_exhausted_enqueue_inserts_follow_up_atomically() {
+    let _permit = test_gate().acquire_owned().await.unwrap();
+    let pool = setup_pool_canonical().await;
+    let queue = "enqueue_spec_exhaust_trigger";
+
+    let client = Client::builder(pool.clone())
+        .canonical_storage()
+        .queue(
+            queue,
+            QueueConfig {
+                poll_interval: Duration::from_millis(25),
+                ..Default::default()
+            },
+        )
+        .register::<ExhaustTrigger, _, _>(|_args, _ctx| async move {
+            Err(awa::JobError::Terminal("permanent failure".to_string()))
+        })
+        .on_exhausted_enqueue::<ExhaustTrigger, EnqueueFollowUp, _>(
+            |args, job, _error, _attempt| EnqueueFollowUp {
+                user_id: args.user_id,
+                triggered_by_job_id: job.id,
+            },
+        )
+        .build()
+        .unwrap();
+
+    let trigger_job = awa::insert_with(
+        &pool,
+        &ExhaustTrigger { user_id: 22 },
+        awa::InsertOpts {
+            queue: queue.to_string(),
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+
+    client.start().await.unwrap();
+    wait_for_state(&pool, trigger_job.id, JobState::Failed).await;
+    let follow_up = first_follow_up(&pool, EnqueueFollowUp::kind())
+        .await
+        .expect("exhausted follow-up should be enqueued");
+    client.shutdown(Duration::from_secs(2)).await;
+
+    let follow_args: EnqueueFollowUp = serde_json::from_value(follow_up.args.clone()).unwrap();
+    assert_eq!(follow_args.user_id, 22);
+    assert_eq!(follow_args.triggered_by_job_id, trigger_job.id);
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JobArgs)]
+struct RetryTrigger {
+    user_id: i64,
+}
+
+#[tokio::test]
+async fn on_retried_enqueue_inserts_follow_up_atomically() {
+    let _permit = test_gate().acquire_owned().await.unwrap();
+    let pool = setup_pool_canonical().await;
+    let queue = "enqueue_spec_retry_trigger";
+
+    let client = Client::builder(pool.clone())
+        .canonical_storage()
+        .queue(
+            queue,
+            QueueConfig {
+                poll_interval: Duration::from_millis(25),
+                ..Default::default()
+            },
+        )
+        // Always fail with retryable; max_attempts = 1 means the first
+        // failure should immediately Exhaust, so we set max_attempts = 5 to
+        // get a clean Retried event on the first run.
+        .register::<RetryTrigger, _, _>(|_args, _ctx| async move {
+            Err(awa::JobError::Retryable("flaky".into()))
+        })
+        .on_retried_enqueue::<RetryTrigger, EnqueueFollowUp, _>(
+            |args, job, _error, _attempt, _next_run_at| EnqueueFollowUp {
+                user_id: args.user_id,
+                triggered_by_job_id: job.id,
+            },
+        )
+        .build()
+        .unwrap();
+
+    let trigger_job = awa::insert_with(
+        &pool,
+        &RetryTrigger { user_id: 33 },
+        awa::InsertOpts {
+            queue: queue.to_string(),
+            max_attempts: 5,
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+
+    client.start().await.unwrap();
+    // The trigger may cycle through Retryable multiple times. We just need
+    // at least one follow-up to land.
+    let follow_up = first_follow_up(&pool, EnqueueFollowUp::kind())
+        .await
+        .expect("retried follow-up should be enqueued");
+    client.shutdown(Duration::from_secs(2)).await;
+
+    let follow_args: EnqueueFollowUp = serde_json::from_value(follow_up.args.clone()).unwrap();
+    assert_eq!(follow_args.user_id, 33);
+    assert_eq!(follow_args.triggered_by_job_id, trigger_job.id);
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JobArgs)]
+struct WaitTrigger {
+    user_id: i64,
+}
+
+struct WaitWorker;
+
+#[async_trait::async_trait]
+impl awa::Worker for WaitWorker {
+    fn kind(&self) -> &'static str {
+        WaitTrigger::kind()
+    }
+    async fn perform(&self, ctx: &awa::JobContext) -> Result<awa::JobResult, awa::JobError> {
+        let guard = ctx
+            .register_callback(Duration::from_secs(60))
+            .await
+            .map_err(awa::JobError::retryable)?;
+        Ok(JobResult::WaitForCallback(guard))
+    }
+}
+
+#[tokio::test]
+async fn on_waiting_for_callback_enqueue_inserts_follow_up_atomically() {
+    let _permit = test_gate().acquire_owned().await.unwrap();
+    let pool = setup_pool_canonical().await;
+    let queue = "enqueue_spec_wait_trigger";
+
+    let client = Client::builder(pool.clone())
+        .canonical_storage()
+        .queue(
+            queue,
+            QueueConfig {
+                poll_interval: Duration::from_millis(25),
+                ..Default::default()
+            },
+        )
+        .register_worker(WaitWorker)
+        .on_waiting_for_callback_enqueue::<WaitTrigger, EnqueueFollowUp, _>(|args, job| {
+            EnqueueFollowUp {
+                user_id: args.user_id,
+                triggered_by_job_id: job.id,
+            }
+        })
+        .build()
+        .unwrap();
+
+    let trigger_job = awa::insert_with(
+        &pool,
+        &WaitTrigger { user_id: 44 },
+        awa::InsertOpts {
+            queue: queue.to_string(),
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+
+    client.start().await.unwrap();
+    wait_for_state(&pool, trigger_job.id, JobState::WaitingExternal).await;
+    let follow_up = first_follow_up(&pool, EnqueueFollowUp::kind())
+        .await
+        .expect("waiting-for-callback follow-up should be enqueued");
+    client.shutdown(Duration::from_secs(2)).await;
+
+    let follow_args: EnqueueFollowUp = serde_json::from_value(follow_up.args.clone()).unwrap();
+    assert_eq!(follow_args.user_id, 44);
+    assert_eq!(follow_args.triggered_by_job_id, trigger_job.id);
+}
+
+#[tokio::test]
 async fn on_completed_enqueue_inserts_follow_up_under_queue_storage() {
     let _permit = test_gate().acquire_owned().await.unwrap();
     let pool = setup_pool_queue_storage().await;

--- a/awa/tests/enqueue_spec_test.rs
+++ b/awa/tests/enqueue_spec_test.rs
@@ -476,3 +476,197 @@ async fn on_completed_enqueue_inserts_follow_up_under_queue_storage() {
     assert_eq!(follow_args.user_id, 99);
     assert_eq!(follow_args.triggered_by_job_id, trigger_job.id);
 }
+
+#[tokio::test]
+async fn on_cancelled_enqueue_inserts_follow_up_under_queue_storage() {
+    let _permit = test_gate().acquire_owned().await.unwrap();
+    let pool = setup_pool_queue_storage().await;
+    let queue = "enqueue_spec_qs_cancel_trigger";
+
+    let client = Client::builder(pool.clone())
+        .queue(
+            queue,
+            QueueConfig {
+                poll_interval: Duration::from_millis(25),
+                ..Default::default()
+            },
+        )
+        .register::<EnqueueTrigger, _, _>(|_args, _ctx| async move {
+            Ok(JobResult::Cancel("user requested".to_string()))
+        })
+        .on_cancelled_enqueue::<EnqueueTrigger, EnqueueFollowUp, _>(|args, job, _reason| {
+            EnqueueFollowUp {
+                user_id: args.user_id,
+                triggered_by_job_id: job.id,
+            }
+        })
+        .build()
+        .unwrap();
+
+    let trigger_job = awa::insert_with(
+        &pool,
+        &EnqueueTrigger { user_id: 111 },
+        awa::InsertOpts {
+            queue: queue.to_string(),
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+
+    client.start().await.unwrap();
+    wait_for_state(&pool, trigger_job.id, JobState::Cancelled).await;
+    let follow_up = first_follow_up(&pool, EnqueueFollowUp::kind())
+        .await
+        .expect("queue-storage cancelled follow-up should be enqueued");
+    client.shutdown(Duration::from_secs(2)).await;
+
+    let follow_args: EnqueueFollowUp = serde_json::from_value(follow_up.args.clone()).unwrap();
+    assert_eq!(follow_args.user_id, 111);
+    assert_eq!(follow_args.triggered_by_job_id, trigger_job.id);
+}
+
+#[tokio::test]
+async fn on_exhausted_enqueue_inserts_follow_up_under_queue_storage() {
+    let _permit = test_gate().acquire_owned().await.unwrap();
+    let pool = setup_pool_queue_storage().await;
+    let queue = "enqueue_spec_qs_exhaust_trigger";
+
+    let client = Client::builder(pool.clone())
+        .queue(
+            queue,
+            QueueConfig {
+                poll_interval: Duration::from_millis(25),
+                ..Default::default()
+            },
+        )
+        .register::<ExhaustTrigger, _, _>(|_args, _ctx| async move {
+            Err(awa::JobError::Terminal("permanent failure".to_string()))
+        })
+        .on_exhausted_enqueue::<ExhaustTrigger, EnqueueFollowUp, _>(
+            |args, job, _error, _attempt| EnqueueFollowUp {
+                user_id: args.user_id,
+                triggered_by_job_id: job.id,
+            },
+        )
+        .build()
+        .unwrap();
+
+    let trigger_job = awa::insert_with(
+        &pool,
+        &ExhaustTrigger { user_id: 222 },
+        awa::InsertOpts {
+            queue: queue.to_string(),
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+
+    client.start().await.unwrap();
+    wait_for_state(&pool, trigger_job.id, JobState::Failed).await;
+    let follow_up = first_follow_up(&pool, EnqueueFollowUp::kind())
+        .await
+        .expect("queue-storage exhausted follow-up should be enqueued");
+    client.shutdown(Duration::from_secs(2)).await;
+
+    let follow_args: EnqueueFollowUp = serde_json::from_value(follow_up.args.clone()).unwrap();
+    assert_eq!(follow_args.user_id, 222);
+    assert_eq!(follow_args.triggered_by_job_id, trigger_job.id);
+}
+
+#[tokio::test]
+async fn on_retried_enqueue_inserts_follow_up_under_queue_storage() {
+    let _permit = test_gate().acquire_owned().await.unwrap();
+    let pool = setup_pool_queue_storage().await;
+    let queue = "enqueue_spec_qs_retry_trigger";
+
+    let client = Client::builder(pool.clone())
+        .queue(
+            queue,
+            QueueConfig {
+                poll_interval: Duration::from_millis(25),
+                ..Default::default()
+            },
+        )
+        .register::<RetryTrigger, _, _>(|_args, _ctx| async move {
+            Err(awa::JobError::Retryable("flaky".into()))
+        })
+        .on_retried_enqueue::<RetryTrigger, EnqueueFollowUp, _>(
+            |args, job, _error, _attempt, _next_run_at| EnqueueFollowUp {
+                user_id: args.user_id,
+                triggered_by_job_id: job.id,
+            },
+        )
+        .build()
+        .unwrap();
+
+    let trigger_job = awa::insert_with(
+        &pool,
+        &RetryTrigger { user_id: 333 },
+        awa::InsertOpts {
+            queue: queue.to_string(),
+            max_attempts: 5,
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+
+    client.start().await.unwrap();
+    let follow_up = first_follow_up(&pool, EnqueueFollowUp::kind())
+        .await
+        .expect("queue-storage retried follow-up should be enqueued");
+    client.shutdown(Duration::from_secs(2)).await;
+
+    let follow_args: EnqueueFollowUp = serde_json::from_value(follow_up.args.clone()).unwrap();
+    assert_eq!(follow_args.user_id, 333);
+    assert_eq!(follow_args.triggered_by_job_id, trigger_job.id);
+}
+
+#[tokio::test]
+async fn on_waiting_for_callback_enqueue_inserts_follow_up_under_queue_storage() {
+    let _permit = test_gate().acquire_owned().await.unwrap();
+    let pool = setup_pool_queue_storage().await;
+    let queue = "enqueue_spec_qs_wait_trigger";
+
+    let client = Client::builder(pool.clone())
+        .queue(
+            queue,
+            QueueConfig {
+                poll_interval: Duration::from_millis(25),
+                ..Default::default()
+            },
+        )
+        .register_worker(WaitWorker)
+        .on_waiting_for_callback_enqueue::<WaitTrigger, EnqueueFollowUp, _>(|args, job| {
+            EnqueueFollowUp {
+                user_id: args.user_id,
+                triggered_by_job_id: job.id,
+            }
+        })
+        .build()
+        .unwrap();
+
+    let trigger_job = awa::insert_with(
+        &pool,
+        &WaitTrigger { user_id: 444 },
+        awa::InsertOpts {
+            queue: queue.to_string(),
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+
+    client.start().await.unwrap();
+    wait_for_state(&pool, trigger_job.id, JobState::WaitingExternal).await;
+    let follow_up = first_follow_up(&pool, EnqueueFollowUp::kind())
+        .await
+        .expect("queue-storage waiting-for-callback follow-up should be enqueued");
+    client.shutdown(Duration::from_secs(2)).await;
+
+    let follow_args: EnqueueFollowUp = serde_json::from_value(follow_up.args.clone()).unwrap();
+    assert_eq!(follow_args.user_id, 444);
+    assert_eq!(follow_args.triggered_by_job_id, trigger_job.id);
+}

--- a/awa/tests/enqueue_spec_test.rs
+++ b/awa/tests/enqueue_spec_test.rs
@@ -670,3 +670,166 @@ async fn on_waiting_for_callback_enqueue_inserts_follow_up_under_queue_storage()
     assert_eq!(follow_args.user_id, 444);
     assert_eq!(follow_args.triggered_by_job_id, trigger_job.id);
 }
+
+#[tokio::test]
+async fn complete_external_dispatches_completed_followup() {
+    let _permit = test_gate().acquire_owned().await.unwrap();
+    let pool = setup_pool_canonical().await;
+    let queue = "enqueue_spec_cb_complete";
+
+    let client = Client::builder(pool.clone())
+        .canonical_storage()
+        .queue(
+            queue,
+            QueueConfig {
+                poll_interval: Duration::from_millis(25),
+                ..Default::default()
+            },
+        )
+        .register_worker(WaitWorker)
+        .on_completed_enqueue::<WaitTrigger, EnqueueFollowUp, _>(|args, job| EnqueueFollowUp {
+            user_id: args.user_id,
+            triggered_by_job_id: job.id,
+        })
+        .build()
+        .unwrap();
+
+    let trigger_job = awa::insert_with(
+        &pool,
+        &WaitTrigger { user_id: 501 },
+        awa::InsertOpts {
+            queue: queue.to_string(),
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+
+    client.start().await.unwrap();
+    let parked = wait_for_state(&pool, trigger_job.id, JobState::WaitingExternal).await;
+    let callback_id = parked.callback_id.expect("callback id set on parked job");
+
+    let _completed = client
+        .complete_external(callback_id, None, None)
+        .await
+        .expect("complete_external");
+
+    let follow_up = first_follow_up(&pool, EnqueueFollowUp::kind())
+        .await
+        .expect("callback Completed follow-up should be enqueued");
+    client.shutdown(Duration::from_secs(2)).await;
+
+    let follow_args: EnqueueFollowUp = serde_json::from_value(follow_up.args.clone()).unwrap();
+    assert_eq!(follow_args.user_id, 501);
+    assert_eq!(follow_args.triggered_by_job_id, trigger_job.id);
+}
+
+#[tokio::test]
+async fn fail_external_dispatches_exhausted_followup() {
+    let _permit = test_gate().acquire_owned().await.unwrap();
+    let pool = setup_pool_canonical().await;
+    let queue = "enqueue_spec_cb_fail";
+
+    let client = Client::builder(pool.clone())
+        .canonical_storage()
+        .queue(
+            queue,
+            QueueConfig {
+                poll_interval: Duration::from_millis(25),
+                ..Default::default()
+            },
+        )
+        .register_worker(WaitWorker)
+        .on_exhausted_enqueue::<WaitTrigger, EnqueueFollowUp, _>(
+            |args, job, _error, _attempt| EnqueueFollowUp {
+                user_id: args.user_id,
+                triggered_by_job_id: job.id,
+            },
+        )
+        .build()
+        .unwrap();
+
+    let trigger_job = awa::insert_with(
+        &pool,
+        &WaitTrigger { user_id: 502 },
+        awa::InsertOpts {
+            queue: queue.to_string(),
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+
+    client.start().await.unwrap();
+    let parked = wait_for_state(&pool, trigger_job.id, JobState::WaitingExternal).await;
+    let callback_id = parked.callback_id.expect("callback id");
+
+    let _failed = client
+        .fail_external(callback_id, "external rejected", None)
+        .await
+        .expect("fail_external");
+
+    let follow_up = first_follow_up(&pool, EnqueueFollowUp::kind())
+        .await
+        .expect("callback Exhausted follow-up should be enqueued");
+    client.shutdown(Duration::from_secs(2)).await;
+
+    let follow_args: EnqueueFollowUp = serde_json::from_value(follow_up.args.clone()).unwrap();
+    assert_eq!(follow_args.user_id, 502);
+    assert_eq!(follow_args.triggered_by_job_id, trigger_job.id);
+}
+
+#[tokio::test]
+async fn retry_external_dispatches_retried_followup() {
+    let _permit = test_gate().acquire_owned().await.unwrap();
+    let pool = setup_pool_canonical().await;
+    let queue = "enqueue_spec_cb_retry";
+
+    let client = Client::builder(pool.clone())
+        .canonical_storage()
+        .queue(
+            queue,
+            QueueConfig {
+                poll_interval: Duration::from_millis(25),
+                ..Default::default()
+            },
+        )
+        .register_worker(WaitWorker)
+        .on_retried_enqueue::<WaitTrigger, EnqueueFollowUp, _>(
+            |args, job, _error, _attempt, _next_run_at| EnqueueFollowUp {
+                user_id: args.user_id,
+                triggered_by_job_id: job.id,
+            },
+        )
+        .build()
+        .unwrap();
+
+    let trigger_job = awa::insert_with(
+        &pool,
+        &WaitTrigger { user_id: 503 },
+        awa::InsertOpts {
+            queue: queue.to_string(),
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+
+    client.start().await.unwrap();
+    let parked = wait_for_state(&pool, trigger_job.id, JobState::WaitingExternal).await;
+    let callback_id = parked.callback_id.expect("callback id");
+
+    let _retried = client
+        .retry_external(callback_id, None)
+        .await
+        .expect("retry_external");
+
+    let follow_up = first_follow_up(&pool, EnqueueFollowUp::kind())
+        .await
+        .expect("callback Retried follow-up should be enqueued");
+    client.shutdown(Duration::from_secs(2)).await;
+
+    let follow_args: EnqueueFollowUp = serde_json::from_value(follow_up.args.clone()).unwrap();
+    assert_eq!(follow_args.user_id, 503);
+    assert_eq!(follow_args.triggered_by_job_id, trigger_job.id);
+}

--- a/awa/tests/lifecycle_hook_test.rs
+++ b/awa/tests/lifecycle_hook_test.rs
@@ -676,6 +676,9 @@ async fn test_stale_completion_does_not_fire_event() {
                     JobEvent::WaitingForCallback { args, .. } => {
                         tx.send(format!("waiting:{}", args.value)).unwrap()
                     }
+                    JobEvent::Rescued { args, reason, .. } => tx
+                        .send(format!("rescued:{}:{}", args.value, reason.as_str()))
+                        .unwrap(),
                 }
             }
         })
@@ -817,6 +820,7 @@ async fn test_snooze_only_emits_started_event() {
                     JobEvent::Retried { .. } => "retried",
                     JobEvent::Exhausted { .. } => "exhausted",
                     JobEvent::Cancelled { .. } => "cancelled",
+                    JobEvent::Rescued { .. } => "rescued",
                 };
                 let _ = tx.send(label.to_string());
             }

--- a/docs/adr/027-callback-ingress-surface.md
+++ b/docs/adr/027-callback-ingress-surface.md
@@ -156,12 +156,15 @@ Callback ingress resolves callback state. It must not assume a co-located
 `Client` runtime or local in-process lifecycle hook registry.
 
 Durable side effects triggered by callback resolution are delivered through
-the transactional follow-up enqueue mechanism in ADR-029: the callback
-receiver inserts the follow-up Awa job in the same transaction that commits
-the callback resolution, and an ordinary worker (anywhere) picks it up. The
-callback receiver does not invoke process-local hooks directly; observation-
-only hooks (ADR-015) continue to fire only in processes that perform the
-resolution themselves via the worker `Client`.
+the transactional follow-up enqueue mechanism in ADR-029. The callback
+receiver dispatches the follow-up `INSERT` best-effort in a separate
+transaction after the resolution commits — a `INSERT` failure leaves the
+job resolved without the follow-up (logged); fully atomic
+resolution-plus-enqueue is tracked as an open extension in ADR-029.
+Once the follow-up commits an ordinary worker (anywhere) picks it up.
+The callback receiver does not invoke process-local hooks directly;
+observation-only hooks (ADR-015) continue to fire only in processes
+that perform the resolution themselves via the worker `Client`.
 
 ## Consequences
 

--- a/docs/adr/028-maintenance-only-runtime-role.md
+++ b/docs/adr/028-maintenance-only-runtime-role.md
@@ -212,7 +212,10 @@ bounded `tick()`, not a replacement for the runtime role.
   pruning. Maintenance-only runs those existing storage tasks; it does not
   redefine the storage engine.
 - ADR-029 defines transactional follow-up jobs. Maintenance-only uses that
-  mechanism to emit durable lifecycle effects for rescues (expired callback,
-  stale heartbeat, exceeded deadline) — enqueuing follow-up Awa jobs in the
-  same transaction as the rescue UPDATE, closing the rescue/timeout event
-  gap without requiring a handler registry in the maintenance process.
+  mechanism to dispatch durable lifecycle effects for rescues (expired
+  callback, stale heartbeat, exceeded deadline). The dispatch is
+  best-effort (in a separate transaction after the rescue UPDATE
+  commits — see ADR-029's atomicity matrix); once the follow-up
+  `INSERT` lands, the row is a regular Awa job. This closes the
+  rescue/timeout event gap without requiring a handler registry in the
+  maintenance process.

--- a/docs/adr/029-transactional-followup-jobs.md
+++ b/docs/adr/029-transactional-followup-jobs.md
@@ -359,6 +359,15 @@ follow-up — not a phantom follow-up.
 
 ### Future work / follow-up issues
 
+- **Python parity (deferred).** The Rust surface (`on_*_enqueue`,
+  `JobEvent::Rescued`, `RescueReason`) does not yet have a Python
+  binding. The implementation path is the same shape as `register_worker`
+  in `awa-python/src/worker.rs`: a `PythonFollowUp` type that wraps a
+  Python callable, takes the GIL inside `dispatch_specs_in_tx`,
+  serialises `JobRow + OutcomeContext` to Python, invokes the callable,
+  and decodes the returned dict to (`JobArgs`, `InsertOpts`) before the
+  underlying `insert_with` fires. ADR-015's hook surface (`@on_event`)
+  needs the same scaffold first. Tracking issue: TODO.
 - Fully atomic callback-resolution + follow-up enqueue: extract
   `admin::{complete,fail,retry,resume}_external_in_tx` and matching
   queue-storage store methods so `Client::*_external` can drive the

--- a/docs/adr/029-transactional-followup-jobs.md
+++ b/docs/adr/029-transactional-followup-jobs.md
@@ -345,7 +345,7 @@ positioning (ADR-001). Out of scope.
 - **Builder API.** Each outcome has a pair of builders:
   `on_<outcome>_enqueue` (closure returns `JobArgs`) and
   `on_<outcome>_enqueue_with` (closure returns
-  [`EnqueueRequest<F>`](#enqueuerequest) for `InsertOpts` overrides —
+  `EnqueueRequest<F>` for `InsertOpts` overrides —
   queue, priority, max_attempts, metadata, tags, unique, run_at,
   deadline_duration, ordering_key).
 - **Closure signatures** carry the per-outcome context:

--- a/docs/adr/029-transactional-followup-jobs.md
+++ b/docs/adr/029-transactional-followup-jobs.md
@@ -59,12 +59,17 @@ Keep ADR-015's in-process hooks unchanged for observation. Add a first-class
 ### Principle
 
 A side effect that must survive process crash, deployment, or a split
-deployment topology (per ADR-027) is delivered as an Awa job that is
-**enqueued in the same database transaction** as the triggering state
-transition. The follow-up job inherits Awa's existing durability properties:
+deployment topology (per ADR-027) is delivered as an Awa job. For
+worker-driven outcomes that follow-up `INSERT`s **in the same database
+transaction** as the triggering state transition — both commit together
+or both roll back. Callback resolution and maintenance rescue dispatch
+their follow-ups in a separate transaction (best-effort, see
+[Atomicity matrix](#atomicity-matrix)) because the resolution / rescue
+transition has already committed by the time the dispatcher sees it.
+Either way the follow-up inherits Awa's existing durability properties:
 at-least-once delivery, retries, dead-letter (ADR-020), DLQ replay,
-observability through the admin UI, and crash recovery via run-lease guarded
-finalization (ADR-013).
+observability through the admin UI, and crash recovery via run-lease
+guarded finalization (ADR-013).
 
 ### Builder API
 

--- a/docs/adr/029-transactional-followup-jobs.md
+++ b/docs/adr/029-transactional-followup-jobs.md
@@ -370,11 +370,16 @@ positioning (ADR-001). Out of scope.
 
 The asymmetry is deliberate: worker-driven outcomes are the dominant
 path and inherit ADR-013's run-lease guard (zero rows matched → tx
-rollback → no follow-up), giving exact-once delivery on the happy path.
-Tx-aware variants on every `admin::*` and rescue path are mechanically
-straightforward but invasive, and the best-effort path is correct enough
-for the supported guarantee: the trigger has already committed, so the
-worst case is a missing follow-up — not a phantom follow-up.
+rollback → no follow-up). The trigger transition and the follow-up
+`INSERT` either both commit or neither does, so each committed
+worker-driven outcome enqueues each registered follow-up exactly
+once. *Delivery* of the follow-up itself is at-least-once — once
+enqueued the row rides Awa's normal claim/retry semantics, and the
+follow-up handler must remain safe under re-execution. Tx-aware
+variants on every `admin::*` and rescue path are mechanically
+straightforward but invasive, and the best-effort path is correct
+enough for the supported guarantee: the trigger has already committed,
+so the worst case is a missing follow-up — not a phantom follow-up.
 
 ### Open extensions
 

--- a/docs/adr/029-transactional-followup-jobs.md
+++ b/docs/adr/029-transactional-followup-jobs.md
@@ -2,7 +2,9 @@
 
 ## Status
 
-Proposed
+Accepted — core implementation landed (worker-driven outcomes atomic;
+callback-resolution and maintenance-rescue follow-ups dispatched on a
+best-effort separate transaction; see *Implementation status* below).
 
 ## Context
 
@@ -311,20 +313,65 @@ positioning (ADR-001). Out of scope.
   (Postgres adapter / Python transaction bridge). The same transactional
   insert primitive is reused; nothing new is added to the bridge contract.
 
-## Open questions for follow-up issues
+## Implementation status
 
-These are deferred and intentionally not decided here:
+As shipped:
 
-- Exact `ClientBuilder` method names and the closure return type
-  (`Args`, `Option<Args>`, or `InsertParams` for finer control of queue /
-  scheduling / unique opts on the follow-up).
-- Whether follow-up specs may be conditional on the trigger's args / row
-  state in v1, or whether all conditioning must live in the follow-up
-  handler.
-- Python parity: how the same surface is expressed in the Python API
-  (likely via a decorator mirroring `@on_event` with an `enqueue=` form).
-- Whether the in-DB spec registry (deferred above) should be sketched in
-  a separate ADR before any production deployment is split across
-  versions.
-- The exact NOTIFY-as-wakeup-hint integration with the follow-up's queue
-  poll cadence — implementation-level, not architectural.
+- **Outcome surface.** `Outcome::{Completed, Retried, Exhausted,
+  Cancelled, WaitingForCallback, Rescued}`. `Started` is intentionally
+  excluded — claim-time enqueue would join the dispatcher's hot path,
+  and the durable-side-effect use case for "job started" is uncommon.
+  Observation belongs to `on_event`. A future `on_started_enqueue` is
+  not blocked by anything in this design but is not part of v1.
+- **Builder API.** Each outcome gets a pair of builders:
+  `on_<outcome>_enqueue` (closure returns `JobArgs`) and
+  `on_<outcome>_enqueue_with` (closure returns
+  [`EnqueueRequest<F>`](#enqueuerequest) for `InsertOpts` overrides —
+  queue, priority, max_attempts, metadata, tags, unique, run_at,
+  deadline_duration, ordering_key).
+- **Closure signatures** carry the per-outcome context:
+  Completed/WaitingForCallback: `(args, &job_row)`;
+  Cancelled: `(args, &job_row, &reason)`;
+  Retried: `(args, &job_row, &error, attempt, next_run_at)`;
+  Exhausted: `(args, &job_row, &error, attempt)`;
+  Rescued: `(args, &job_row, RescueReason)`.
+- **Rescued event variant.** Maintenance rescues fire a new
+  `JobEvent::Rescued { args, job, reason: RescueReason }` (alongside the
+  follow-up spec dispatch), keeping rescue context distinct from
+  Retried/Exhausted rather than overloading either.
+
+### Atomicity matrix
+
+| Emission site | Atomic with state commit? |
+|---|---|
+| Worker-driven outcomes on canonical storage | yes — `*_canonical_with_followups` helpers open one tx, run the state UPDATE (UPDATE...RETURNING on `awa.jobs_hot`; for `retryable` the DELETE+INSERT move into `awa.scheduled_jobs` is in a CTE), dispatch specs, commit |
+| Worker-driven outcomes on queue storage | yes — `*_queue_storage_with_followups` helpers run inside `complete_runtime_batch_slow_in_tx` / `cancel_running_in_tx` / `fail_*_in_tx` / `retry_*_in_tx` / `enter_callback_wait_in_tx` |
+| Callback resolution on `Client` (`complete_external`, `fail_external`, `retry_external`, `resolve_callback`) | **no — best-effort.** Spec dispatch runs in a separate tx after the resolution commits. If the spec INSERT fails the job remains resolved and the error is logged. Fully-atomic variant is tracked as follow-up (requires `_in_tx` versions of `admin::*_external` and the matching `store::*_external` paths). |
+| Maintenance rescue (stale heartbeat, deadline exceeded, expired callback) | **no — best-effort**, same shape and caveat as callback resolution |
+
+The asymmetry is deliberate: worker-driven outcomes are the dominant
+path and inherit ADR-013's run-lease guard (zero rows matched → tx
+rollback → no follow-up), giving exact-once delivery on the happy path.
+Adding tx-aware variants to every `admin::*` and rescue path is mechanically
+straightforward but invasive, and the best-effort path is correct enough
+for v1: the trigger has already committed, so the worst case is a missing
+follow-up — not a phantom follow-up.
+
+### Future work / follow-up issues
+
+- Fully atomic callback-resolution + follow-up enqueue: extract
+  `admin::{complete,fail,retry,resume}_external_in_tx` and matching
+  queue-storage store methods so `Client::*_external` can drive the
+  resolution and the spec dispatch in a single tx.
+- Fully atomic rescue + follow-up enqueue: thread `&mut tx` through
+  `maintenance::rescue_*` so the rescue UPDATE and the Rescued spec
+  dispatch commit together.
+- `on_started_enqueue`: not blocked by the design; explicitly out of
+  scope for v1 to keep the hot path unaffected.
+- Conditional spec dispatch (skip enqueue based on a predicate over the
+  triggering row) is not in v1 — apply conditioning inside the follow-up
+  handler instead.
+- In-DB spec registry — deferred; the in-process registry is acceptable
+  while specs are declared in one place per deployment.
+- NOTIFY-as-wakeup-hint integration with follow-up queue poll cadence
+  — implementation-level, not architectural.

--- a/docs/adr/029-transactional-followup-jobs.md
+++ b/docs/adr/029-transactional-followup-jobs.md
@@ -94,36 +94,44 @@ Client::builder(pool)
     });
 ```
 
-The closure returns a follow-up `JobArgs` value (or an `Option<...>` /
-`InsertParams` for conditional / option-bearing follow-ups; final shape is an
-implementation detail of the follow-up issue). The engine inserts the
-follow-up job in the transaction that commits the trigger's state change. If
-the transaction rolls back, the follow-up is not enqueued; if it commits,
-the follow-up is durably visible.
+The closure returns a follow-up `JobArgs` value (default `InsertOpts`) or
+an `EnqueueRequest<F>` with `InsertOpts` overrides. When the trigger is a
+worker-driven outcome the engine `INSERT`s the follow-up in the same
+transaction as the state `UPDATE`; the follow-up commits with the
+trigger or rolls back with it. For callback resolution and maintenance
+rescue the engine `INSERT`s the follow-up in a separate transaction
+opened *after* the trigger transaction commits (see
+[Atomicity matrix](#atomicity-matrix)). In either case, once the
+follow-up `INSERT` commits the row is durably visible and rides Awa's
+existing retry / DLQ machinery.
 
-Counterparts cover the same outcomes as the typed `JobEvent` variants:
-`on_started_enqueue`, `on_completed_enqueue`, `on_retried_enqueue`,
-`on_exhausted_enqueue`, `on_cancelled_enqueue`, and
-`on_waiting_for_callback_enqueue`. The `WaitingForCallback` variant is the
-park-time event introduced by the amendment to ADR-015 (PR #276); on `main`
-prior to that PR, the hook surface omits both `WaitingForCallback` and any
-parked-transition follow-up. `Snooze` continues to emit nothing on either
-surface.
+Counterparts cover the outcomes that benefit most from durable delivery:
+`on_completed_enqueue`, `on_retried_enqueue`, `on_exhausted_enqueue`,
+`on_cancelled_enqueue`, `on_waiting_for_callback_enqueue`, and
+`on_rescued_enqueue`. `Started` is intentionally excluded — claim-time
+enqueue would join the dispatcher's hot path and the use case for
+"job started" is observation, which `on_event` already covers.
+`Snooze` continues to emit nothing on either surface.
 
 ### Where the enqueue runs
 
-The enqueue is performed by whatever process performs the state transition:
+The enqueue is performed by whatever process performs the state
+transition:
 
-| Transition | Performed by | Follow-up enqueued by |
-|---|---|---|
-| Claim / inline outcomes (Started, Completed, Retried, Exhausted, Cancelled) | Worker executor | Worker executor, in the finalization transaction |
-| Callback resolution via worker `Client` | The resolving process | That process, in the resolution transaction |
-| Callback resolution via callback-only ingress (ADR-027) | Callback receiver | Callback receiver, in the resolution transaction |
-| Expired-callback / stale-heartbeat / deadline rescue (ADR-028) | Maintenance runtime | Maintenance runtime, in the rescue transaction |
+| Transition | Performed by | Follow-up enqueued by | Atomic? |
+|---|---|---|---|
+| Inline outcomes (Completed, Retried, Exhausted, Cancelled, WaitingForCallback) | Worker executor | Worker executor, in the finalization transaction | yes |
+| Callback resolution via worker `Client` | The resolving process | That process, in a separate transaction after the resolution commits | no — best-effort |
+| Callback resolution via callback-only ingress (ADR-027) | Callback receiver | Same as worker `Client` resolution: best-effort separate transaction | no — best-effort |
+| Expired-callback / stale-heartbeat / deadline rescue (ADR-028) | Maintenance runtime | Maintenance runtime, in a separate transaction after the rescue commits | no — best-effort |
 
-Every emitter shares one rule: the follow-up `INSERT` is in the same
-transaction as the state `UPDATE`. The follow-up is then claimed by an
-ordinary worker; the original transition does not need to wait for it.
+The atomicity asymmetry is deliberate: worker-driven outcomes inherit
+ADR-013's run-lease guard (zero rows matched → tx rollback → no
+follow-up). Tx-aware variants on every `admin::*` and rescue path are
+mechanically straightforward but invasive, so the best-effort path is
+accepted: the trigger has already committed, so the worst case is a
+missing follow-up — not a phantom follow-up. See
+[Atomicity matrix](#atomicity-matrix) for the call sites involved.
 
 ### Registry lives in process — for now
 
@@ -204,9 +212,12 @@ whose guarantees match the side effect.
   across every deployment role ADR-027 and ADR-028 introduce: inline
   outcomes, callback resolution (worker-`Client` or callback-only), rescue,
   and any future transition.
-- The rescue / timeout event gap closes naturally: a rescue transaction can
-  enqueue `job_failed_rescue` (or any user-defined follow-up) atomically
-  with the rescue UPDATE.
+- The rescue / timeout event gap closes: a rescue can dispatch
+  `job_failed_rescue` (or any user-defined follow-up) — best-effort,
+  in a separate transaction after the rescue commits, but the
+  follow-up itself is then a durable Awa job with full retry / DLQ
+  semantics. Closing this gap fully atomically is tracked as an open
+  extension.
 - The "what should be in a hook?" mistake disappears at the API level —
   observation and delivery have different names and obviously different
   guarantees.
@@ -297,24 +308,27 @@ positioning (ADR-001). Out of scope.
   ("enqueue another job") into a first-class API. ADR-015's hooks remain
   the correct mechanism for observation; this ADR adds the mechanism for
   delivery.
-- **ADR-027** (callback ingress, proposed). Resolves the open question
+- **ADR-027** (callback ingress, proposed). Addresses the open question
   ADR-027 punts on: durable callback notifications. A callback-only
-  ingress process enqueues follow-ups in the resolution transaction; no
-  in-process handler registry is required for delivery.
-- **ADR-028** (maintenance-only runtime, proposed). Gives rescue paths a
-  way to participate in lifecycle delivery without owning a handler
-  registry, closing the rescue / timeout event gap.
-- **ADR-013** (run-lease, guarded finalization). The follow-up enqueue
-  joins the same transaction as the guarded-finalization UPDATE; if the
-  UPDATE matches zero rows (stale outcome), the transaction rolls back and
-  the follow-up is not enqueued, preserving the at-most-once finalization
-  contract.
+  ingress process dispatches follow-ups best-effort after the
+  resolution commits; no in-process handler registry is required for
+  delivery.
+- **ADR-028** (maintenance-only runtime, proposed). Gives rescue paths
+  a way to dispatch durable lifecycle work without owning a handler
+  registry. The dispatch is best-effort (separate transaction); the
+  follow-up itself is a regular Awa job once enqueued.
+- **ADR-013** (run-lease, guarded finalization). For worker-driven
+  outcomes the follow-up enqueue joins the same transaction as the
+  guarded-finalization UPDATE; if the UPDATE matches zero rows (stale
+  outcome), the transaction rolls back and the follow-up is not
+  enqueued, preserving the at-most-once finalization contract.
 - **ADR-020** (DLQ). Follow-up jobs participate in the DLQ family
   unchanged; a side effect that exhausts retries lands in the DLQ with
   full args and history.
-- **ADR-021** (sequential callbacks, callback heartbeats). The callback
-  resolution surface remains as defined; this ADR adds a follow-up insert
-  to its resolving transaction.
+- **ADR-021** (sequential callbacks, callback heartbeats). The
+  callback resolution surface is unchanged; this ADR adds a follow-up
+  dispatch that runs in a separate transaction after the resolution
+  commits.
 - **ADR-006** (insert-only transaction bridge) and **ADR-016/017**
   (Postgres adapter / Python transaction bridge). The same transactional
   insert primitive is reused; nothing new is added to the bridge contract.

--- a/docs/adr/029-transactional-followup-jobs.md
+++ b/docs/adr/029-transactional-followup-jobs.md
@@ -2,9 +2,10 @@
 
 ## Status
 
-Accepted — core implementation landed (worker-driven outcomes atomic;
-callback-resolution and maintenance-rescue follow-ups dispatched on a
-best-effort separate transaction; see *Implementation status* below).
+Accepted. Worker-driven outcomes commit follow-ups atomically with the
+state transition; callback-resolution and maintenance-rescue paths
+dispatch follow-ups best-effort in a separate transaction (see
+[Atomicity matrix](#atomicity-matrix)).
 
 ## Context
 
@@ -313,17 +314,16 @@ positioning (ADR-001). Out of scope.
   (Postgres adapter / Python transaction bridge). The same transactional
   insert primitive is reused; nothing new is added to the bridge contract.
 
-## Implementation status
-
-As shipped:
+## Implementation
 
 - **Outcome surface.** `Outcome::{Completed, Retried, Exhausted,
   Cancelled, WaitingForCallback, Rescued}`. `Started` is intentionally
   excluded — claim-time enqueue would join the dispatcher's hot path,
   and the durable-side-effect use case for "job started" is uncommon.
-  Observation belongs to `on_event`. A future `on_started_enqueue` is
-  not blocked by anything in this design but is not part of v1.
-- **Builder API.** Each outcome gets a pair of builders:
+  Observation belongs to `on_event`. `on_started_enqueue` is not
+  blocked by anything in this design; whether to add it is left as an
+  open question rather than a v1 commitment.
+- **Builder API.** Each outcome has a pair of builders:
   `on_<outcome>_enqueue` (closure returns `JobArgs`) and
   `on_<outcome>_enqueue_with` (closure returns
   [`EnqueueRequest<F>`](#enqueuerequest) for `InsertOpts` overrides —
@@ -335,9 +335,9 @@ As shipped:
   Retried: `(args, &job_row, &error, attempt, next_run_at)`;
   Exhausted: `(args, &job_row, &error, attempt)`;
   Rescued: `(args, &job_row, RescueReason)`.
-- **Rescued event variant.** Maintenance rescues fire a new
-  `JobEvent::Rescued { args, job, reason: RescueReason }` (alongside the
-  follow-up spec dispatch), keeping rescue context distinct from
+- **Rescued event variant.** Maintenance rescues fire
+  `JobEvent::Rescued { args, job, reason: RescueReason }` alongside the
+  follow-up spec dispatch, keeping rescue context distinct from
   Retried/Exhausted rather than overloading either.
 
 ### Atomicity matrix
@@ -352,35 +352,37 @@ As shipped:
 The asymmetry is deliberate: worker-driven outcomes are the dominant
 path and inherit ADR-013's run-lease guard (zero rows matched → tx
 rollback → no follow-up), giving exact-once delivery on the happy path.
-Adding tx-aware variants to every `admin::*` and rescue path is mechanically
+Tx-aware variants on every `admin::*` and rescue path are mechanically
 straightforward but invasive, and the best-effort path is correct enough
-for v1: the trigger has already committed, so the worst case is a missing
-follow-up — not a phantom follow-up.
+for the supported guarantee: the trigger has already committed, so the
+worst case is a missing follow-up — not a phantom follow-up.
 
-### Future work / follow-up issues
+### Open extensions
 
-- **Python parity (deferred).** The Rust surface (`on_*_enqueue`,
-  `JobEvent::Rescued`, `RescueReason`) does not yet have a Python
-  binding. The implementation path is the same shape as `register_worker`
-  in `awa-python/src/worker.rs`: a `PythonFollowUp` type that wraps a
-  Python callable, takes the GIL inside `dispatch_specs_in_tx`,
-  serialises `JobRow + OutcomeContext` to Python, invokes the callable,
-  and decodes the returned dict to (`JobArgs`, `InsertOpts`) before the
-  underlying `insert_with` fires. ADR-015's hook surface (`@on_event`)
-  needs the same scaffold first. Tracking issue: TODO.
-- Fully atomic callback-resolution + follow-up enqueue: extract
+- **Python parity.** The Python binding does not yet expose
+  `on_*_enqueue` or `on_event`. The implementation path mirrors
+  `register_worker` in `awa-python/src/worker.rs`: a `PythonFollowUp`
+  type that wraps a Python callable, takes the GIL inside
+  `dispatch_specs_in_tx`, serialises `JobRow + OutcomeContext` to
+  Python, invokes the callable, and decodes the returned dict to
+  (`JobArgs`, `InsertOpts`) before the underlying `insert_with` fires.
+  ADR-015's hook surface (`@on_event`) needs the same scaffold first.
+- **Atomic callback-resolution + follow-up enqueue.** Requires
   `admin::{complete,fail,retry,resume}_external_in_tx` and matching
   queue-storage store methods so `Client::*_external` can drive the
   resolution and the spec dispatch in a single tx.
-- Fully atomic rescue + follow-up enqueue: thread `&mut tx` through
+- **Atomic rescue + follow-up enqueue.** Threads `&mut tx` through
   `maintenance::rescue_*` so the rescue UPDATE and the Rescued spec
   dispatch commit together.
-- `on_started_enqueue`: not blocked by the design; explicitly out of
-  scope for v1 to keep the hot path unaffected.
-- Conditional spec dispatch (skip enqueue based on a predicate over the
-  triggering row) is not in v1 — apply conditioning inside the follow-up
-  handler instead.
-- In-DB spec registry — deferred; the in-process registry is acceptable
-  while specs are declared in one place per deployment.
-- NOTIFY-as-wakeup-hint integration with follow-up queue poll cadence
-  — implementation-level, not architectural.
+- **`on_started_enqueue`.** Not blocked by the design; deliberately
+  out of scope to keep the claim/dispatch hot path uncontended. The
+  observation use case is already covered by `on_event`.
+- **Conditional spec dispatch.** Skipping enqueue based on a predicate
+  over the triggering row is not part of the API; conditioning belongs
+  inside the follow-up handler instead.
+- **In-DB spec registry.** Not part of the design; the in-process
+  registry is sufficient while specs are declared in one place per
+  deployment.
+- **NOTIFY-as-wakeup-hint for follow-up queue poll cadence.** An
+  implementation-level tuning lever rather than an architectural
+  concern.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -41,7 +41,7 @@ in-place as historical context.
 | 026 | [Narrow terminal history](026-narrow-terminal-history.md) | Accepted | Ready-backed terminal rows store only terminal facts and hydrate immutable body fields from retained `ready_entries` until queue prune | Refines ADR-019 terminal path |
 | 027 | [Callback ingress as a deployable surface](027-callback-ingress-surface.md) | Proposed | Separate signed callback ingress from the admin UI/API and expose callback-only embedding/CLI paths | Refines ADR-018 and ADR-021; uses ADR-029 for durable callback-driven side effects |
 | 028 | [Maintenance-only runtime role](028-maintenance-only-runtime-role.md) | Proposed | Run promotion, rescue, pruning, and metadata maintenance without claiming or executing user jobs | Complements ADR-027 and ADR-018; uses ADR-029 for durable rescue-driven side effects |
-| 029 | [Transactional follow-up jobs](029-transactional-followup-jobs.md) | Proposed | Durable lifecycle side effects are delivered by enqueuing follow-up Awa jobs in the same transaction as the triggering state commit; hooks remain for observation | Codifies ADR-015's "enqueue another job" guidance; resolves the durable-event punt in proposed ADRs 027/028 |
+| 029 | [Transactional follow-up jobs](029-transactional-followup-jobs.md) | Accepted | Durable lifecycle side effects are delivered by enqueuing follow-up Awa jobs — atomically with the triggering state UPDATE for worker-driven outcomes, best-effort in a separate transaction for callback resolution and maintenance rescue; hooks remain for observation | Codifies ADR-015's "enqueue another job" guidance; addresses the durable-event punt in ADRs 027/028 |
 
 ## Validation artifacts
 

--- a/docs/lifecycle-hooks.md
+++ b/docs/lifecycle-hooks.md
@@ -43,6 +43,7 @@ registered for the same kind; they stack and run sequentially.
 | `Retried` | the attempt failed (or `RetryAfter`) and the job will run again |
 | `Exhausted` | the job exhausted its retries, or failed terminally, and moved to `failed` |
 | `Cancelled` | the job was cancelled |
+| `Rescued` | maintenance rescued the job (expired callback, stale heartbeat, or exceeded deadline) — `reason: RescueReason` carries which |
 
 How `JobResult` / outcomes map to events:
 
@@ -107,10 +108,82 @@ mechanism:
 
 If a side effect must fire exactly once or survive a crash, do not drive it
 from a hook at all — the dispatch may never run, and enqueueing the follow-up
-work *from* the hook just inherits that same unreliability. Drive it from
-something durable instead: enqueue the follow-up as an Awa job inside a
-transaction you control — for a callback, the very transaction that resolves it
-(a transactional outbox) — or make the job handler perform the side effect
-idempotently so re-execution is safe.
+work *from* the hook just inherits that same unreliability. See the next
+section for the durable mechanism.
 
-See [ADR-015](adr/015-post-commit-lifecycle-hooks.md) for the design rationale.
+## Durable follow-up jobs (`on_*_enqueue`)
+
+For side effects that **must survive a process crash** — sending a welcome
+email after signup, kicking off downstream work, persisting an audit row —
+use the transactional follow-up API instead of an `on_event` hook. A
+follow-up enqueue commits in the **same database transaction** as the
+triggering state transition, so the follow-up either lands or the
+transition rolls back; there is no in-between.
+
+```rust
+use awa::{Client, EnqueueRequest, QueueConfig};
+
+let client = Client::builder(pool)
+    .queue("signup", QueueConfig::default())
+    .register::<Signup, _, _>(|_, _| async move { Ok(awa::JobResult::Completed) })
+    // When a Signup completes, enqueue a WelcomeEmail in the *same* tx.
+    // Closure receives the trigger args and the post-completion JobRow.
+    .on_completed_enqueue::<Signup, WelcomeEmail, _>(|args, job| WelcomeEmail {
+        user_id: args.user_id,
+        signup_job_id: job.id,
+    })
+    .build()?;
+```
+
+There is one builder per outcome, plus a `_with` variant whose closure
+returns `EnqueueRequest<F>` so you can override `InsertOpts` on the
+follow-up (queue, priority, max_attempts, metadata, tags, unique, run_at,
+deadline_duration, ordering_key):
+
+| Builder | Fires when | Closure signature |
+|---|---|---|
+| `on_completed_enqueue` | `JobResult::Completed` | `(args, &job)` |
+| `on_cancelled_enqueue` | `JobResult::Cancel(reason)` | `(args, &job, &reason)` |
+| `on_retried_enqueue` | retryable err (retries left) or `RetryAfter` | `(args, &job, &error, attempt, next_run_at)` |
+| `on_exhausted_enqueue` | retries exhausted, or `Err(Terminal)` | `(args, &job, &error, attempt)` |
+| `on_waiting_for_callback_enqueue` | `JobResult::WaitForCallback` | `(args, &job)` |
+| `on_rescued_enqueue` | maintenance rescue (expired callback / stale heartbeat / deadline) | `(args, &job, RescueReason)` |
+
+`on_*_enqueue_with` returns `EnqueueRequest<F>`:
+
+```rust
+.on_completed_enqueue_with::<Signup, WelcomeEmail, _>(|args, job| {
+    EnqueueRequest::new(WelcomeEmail { user_id: args.user_id })
+        .queue("email")
+        .priority(1)
+})
+```
+
+### Atomicity guarantees
+
+| Emission site | Atomic with state commit? |
+|---|---|
+| Worker-driven outcomes (handler returns `Ok`/`Err`) on either storage engine | **yes** — one transaction, one commit |
+| Callback resolution on `Client` (`complete_external`, `fail_external`, `retry_external`, `resolve_callback`) | **no — best-effort.** The resolution commits first, then specs dispatch in a separate tx. If the spec INSERT fails the job remains resolved and the error is logged. |
+| Maintenance rescue (stale heartbeat / deadline / expired callback) | **no — best-effort**, same shape and caveat |
+
+The asymmetry is deliberate: the worker-driven path inherits ADR-013's
+run-lease guard (stale outcome → tx rolls back → no follow-up), giving
+exact-once semantics on the happy path. The callback-resolution and
+maintenance paths are tracked for a future tx-aware variant.
+
+### When to choose which API
+
+- **Observation** (metrics, traces, alerts) → `on_event` — cheap, in-process,
+  acceptable to drop a sample on a crash.
+- **Side effect that must survive a crash** (send email, persist record,
+  kick off downstream work) → `on_*_enqueue` — slightly more expensive
+  (it's an Awa job) but durable, retried, DLQ'd, and visible in admin.
+
+If you can't tell which you want, use `on_*_enqueue`. The cost of an
+unnecessary follow-up is bounded; the cost of a lost reliable side effect
+is not.
+
+See [ADR-015](adr/015-post-commit-lifecycle-hooks.md) for hook rationale,
+and [ADR-029](adr/029-transactional-followup-jobs.md) for the follow-up
+enqueue design and atomicity matrix.

--- a/docs/lifecycle-hooks.md
+++ b/docs/lifecycle-hooks.md
@@ -115,10 +115,15 @@ section for the durable mechanism.
 
 For side effects that **must survive a process crash** — sending a welcome
 email after signup, kicking off downstream work, persisting an audit row —
-use the transactional follow-up API instead of an `on_event` hook. A
-follow-up enqueue commits in the **same database transaction** as the
+use the transactional follow-up API instead of an `on_event` hook. For
+worker-driven outcomes (the trigger handler returned `Ok`/`Err`) the
+follow-up `INSERT`s in the **same database transaction** as the
 triggering state transition, so the follow-up either lands or the
-transition rolls back; there is no in-between.
+transition rolls back; there is no in-between. Callback resolution
+(`Client::*_external`) and maintenance rescue dispatch follow-ups in a
+**separate transaction** (best-effort) — see the [atomicity table
+below](#atomicity-guarantees) before designing a workflow that depends
+on rescue-driven or callback-driven follow-ups landing.
 
 ```rust
 use awa::{Client, EnqueueRequest, QueueConfig};

--- a/docs/lifecycle-hooks.md
+++ b/docs/lifecycle-hooks.md
@@ -173,9 +173,13 @@ deadline_duration, ordering_key):
 | Maintenance rescue (stale heartbeat / deadline / expired callback) | **no — best-effort**, same shape and caveat |
 
 The asymmetry is deliberate: the worker-driven path inherits ADR-013's
-run-lease guard (stale outcome → tx rolls back → no follow-up), giving
-exact-once semantics on the happy path. The callback-resolution and
-maintenance paths are tracked for a future tx-aware variant.
+run-lease guard (stale outcome → tx rolls back → no follow-up). The
+trigger transition and the follow-up `INSERT` either both commit or
+neither does — exactly-once *enqueue* per committed worker outcome.
+The follow-up itself, once enqueued, is delivered with Awa's usual
+at-least-once semantics, so the follow-up handler still needs to be
+safe under re-execution. The callback-resolution and maintenance paths
+are tracked for a future tx-aware variant.
 
 ### When to choose which API
 


### PR DESCRIPTION
Implements [ADR-029](docs/adr/029-transactional-followup-jobs.md): durable lifecycle side effects via transactional follow-up Awa jobs.

## What

When a job's lifecycle transition commits, a registered follow-up Awa job is `INSERT`ed in the **same database transaction** for worker-driven outcomes, or in a separate transaction (best-effort) for callback-resolution and maintenance-rescue outcomes. The follow-up rides Awa's existing claim/retry/DLQ machinery.

```rust
Client::builder(pool)
    .register::<Signup, _, _>(handle_signup)
    .on_completed_enqueue::<Signup, SendWelcomeEmail, _>(|args, job| SendWelcomeEmail {
        user_id: args.user_id,
        triggered_by_job_id: job.id,
    })
    .build()?;
```

Builder pairs land per outcome (`_with` variant returns `EnqueueRequest<F>` for `InsertOpts` overrides — queue, priority, max_attempts, metadata, tags, unique, run_at, deadline_duration, ordering_key):

| Builder | Fires when |
|---|---|
| `on_completed_enqueue` | `JobResult::Completed` |
| `on_cancelled_enqueue` | `JobResult::Cancel(reason)` |
| `on_retried_enqueue` | retryable err (retries left) or `RetryAfter` |
| `on_exhausted_enqueue` | retries exhausted, or `Err(Terminal)` |
| `on_waiting_for_callback_enqueue` | `JobResult::WaitForCallback` |
| `on_rescued_enqueue` | maintenance rescue (expired callback / stale heartbeat / deadline) |

Also adds a `JobEvent::Rescued { args, job, reason: RescueReason }` variant (`ExpiredCallback`/`StaleHeartbeat`/`DeadlineExceeded`).

## Atomicity matrix

| Emission site | Atomic with state commit? |
|---|---|
| Worker-driven outcomes, canonical storage | yes — `*_canonical_with_followups` helpers (Retried uses CTE-based DELETE+INSERT into `awa.scheduled_jobs` because `jobs_hot` forbids `retryable`) |
| Worker-driven outcomes, queue storage | yes — new `_in_tx` variants on `QueueStorage` (`retry_after_in_tx`, `cancel_running_in_tx`, `fail_terminal_in_tx`, `fail_to_dlq_in_tx`, `fail_retryable_in_tx`, `enter_callback_wait_in_tx`) |
| Callback resolution on `Client` (`complete_external`, `fail_external`, `retry_external`, `resolve_callback`) | best-effort separate tx — failure leaves the job resolved without the follow-up; logged at error level |
| Maintenance rescue (stale heartbeat / deadline / expired callback) | best-effort separate tx |

The split is deliberate: worker-driven outcomes inherit ADR-013's run-lease guard (zero rows matched → tx rollback → no follow-up), giving exact-once delivery on the happy path. Fully-atomic callback-resolution and rescue paths are documented as open extensions in the ADR — they require `_in_tx` variants of every `admin::*_external` and rescue method, mechanically straightforward but invasive.

## Out of scope (open extensions, called out in the ADR)

- **Python parity.** The `awa-python` binding does not yet expose `on_*_enqueue` or `on_event`. Implementation path sketched in the ADR (PyO3 `PythonFollowUp` mirroring `PythonWorker`).
- Atomic callback-resolution / atomic rescue (see matrix).
- `on_started_enqueue` — deliberately excluded to keep the dispatcher hot path uncontended.
- Conditional spec dispatch — conditioning belongs inside the follow-up handler.

## Docs

- ADR-029 marked Accepted with implementation status, atomicity matrix, and open-extensions list.
- `docs/lifecycle-hooks.md` gains the `Rescued` event row and a full section on `on_*_enqueue` (per-outcome builders, atomicity guarantees, when-to-use-which-API guide).

## Test plan

- [x] `cargo fmt --all --check` clean
- [x] `SQLX_OFFLINE=true cargo clippy --workspace --all-targets --all-features -- -D warnings` clean
- [x] `cargo build --workspace` clean
- [x] `cargo test --test enqueue_spec_test` — 15/15 pass (every outcome × storage engine + 3 callback resolution paths + 1 rescue path)
- [x] `cargo test --test lifecycle_hook_test` — exhaustive matches updated for `JobEvent::Rescued`
- [x] TLA+ rerun: AwaCbk (48,975 distinct states), AwaCore, AwaDispatchClaim all pass. ADR-029 follow-up enqueues are atomic INSERTs in the existing tx and don't introduce new races over what AwaCbk already models.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Durable follow-up jobs can be registered for trigger outcomes (completion, retry, exhaustion, cancellation, waiting-for-callback, rescue); worker-driven follow-ups are enqueued atomically with the trigger when configured.
  * Added a configurable follow-up request type to customize queue, priority, and insert options.
  * New Rescued lifecycle event with explicit rescue reasons.

* **Behavior**
  * Callback-resolution and maintenance-rescue dispatch follow-ups best-effort in a separate transaction (original trigger still commits).

* **Tests**
  * Integration tests covering follow-up dispatch, routing, and failure modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->