### PR TITLE
perf(queue_storage): add queue_counts_fast for high-cadence pollers

### DIFF
--- a/awa-model/src/queue_storage.rs
+++ b/awa-model/src/queue_storage.rs
@@ -6890,11 +6890,19 @@ impl QueueStorage {
     ///
     /// - **available** is the same as the dispatcher's claim signal:
     ///   `sum(GREATEST(enqueue_seq - claim_seq, 0))` over the shard
-    ///   head tables. No scan of `ready_entries`.
-    /// - **running** counts `leases` rows in the active states (one
-    ///   filtered count per logical queue shard). Does *not* anti-join
-    ///   `lease_claims` against `lease_claim_closures` — receipt-plane
-    ///   claims that have not yet materialised a lease row are omitted.
+    ///   head tables. No scan of `ready_entries`. This is an upper
+    ///   bound — the dispatcher closes the gap on its next claim
+    ///   attempt, but an admin DELETE of an unclaimed row leaves the
+    ///   head sequence ahead of the actual ready row count until that
+    ///   recovery branch runs. Acceptable for depth-target throttling
+    ///   and dashboards; not suitable for exact billing-style counts.
+    /// - **running** matches [`Self::queue_counts`]'s strict definition:
+    ///   `leases.state = 'running'` only. Receipt-plane claims that
+    ///   have not yet materialised a lease row are omitted (the
+    ///   exact path catches them via the `lease_claims` anti-join, but
+    ///   that anti-join is what this fast variant exists to avoid).
+    ///   `waiting_external` is *not* included — it's reported as part
+    ///   of admin's parked-callback view, not running.
     /// - **completed** is read from the persisted
     ///   `queue_terminal_rollups.pruned_completed_count` denormaliser.
     ///   Rows currently in `done_entries` that have not yet rolled up
@@ -6918,14 +6926,16 @@ impl QueueStorage {
         // available: dispatcher signal — already an index-only sum over
         // the (queue, priority, enqueue_shard) head tables.
         let available = self.queue_claimer_signal(pool, queue).await?.available;
-        // running: live leases only; receipt-plane claims that haven't
-        // materialised a lease row yet are omitted (documented above).
+        // running: leases.state = 'running' only, matching
+        // queue_counts_exact's strict definition. Receipt-plane claims
+        // that haven't materialised a lease row yet are documented as
+        // omitted in the method-level doc.
         let running: i64 = sqlx::query_scalar(&format!(
             r#"
             SELECT COALESCE(count(*)::bigint, 0)
             FROM {schema}.leases
             WHERE queue = ANY($1)
-              AND state IN ('running', 'waiting_external')
+              AND state = 'running'
             "#
         ))
         .bind(&queues)

--- a/awa-model/src/queue_storage.rs
+++ b/awa-model/src/queue_storage.rs
@@ -6883,6 +6883,87 @@ impl QueueStorage {
         self.queue_counts_exact(pool, queue).await
     }
 
+    /// Index-only queue depth probe — for observability / depth-target
+    /// throttling. Returns the same shape as [`Self::queue_counts`] but
+    /// skips the table scans that [`Self::queue_counts_exact`] needs for
+    /// exact terminal accounting:
+    ///
+    /// - **available** is the same as the dispatcher's claim signal:
+    ///   `sum(GREATEST(enqueue_seq - claim_seq, 0))` over the shard
+    ///   head tables. No scan of `ready_entries`.
+    /// - **running** counts `leases` rows in the active states (one
+    ///   filtered count per logical queue shard). Does *not* anti-join
+    ///   `lease_claims` against `lease_claim_closures` — receipt-plane
+    ///   claims that have not yet materialised a lease row are omitted.
+    /// - **completed** is read from the persisted
+    ///   `queue_terminal_rollups.pruned_completed_count` denormaliser.
+    ///   Rows currently in `done_entries` that have not yet rolled up
+    ///   are not included. Strictly a lower bound; converges to the
+    ///   exact count when rotation prunes the live `done_entries`
+    ///   segment.
+    ///
+    /// All three counters are O(num shards) lookups against small head
+    /// tables and `leases` index probes. Use this for high-cadence
+    /// pollers (admin dashboards, depth-target producers, soak
+    /// observability); use [`Self::queue_counts`] for admin tooling
+    /// that needs the exact terminal count.
+    #[tracing::instrument(skip(self, pool), fields(queue = %queue), name = "queue_storage.queue_counts_fast")]
+    pub async fn queue_counts_fast(
+        &self,
+        pool: &PgPool,
+        queue: &str,
+    ) -> Result<QueueCounts, AwaError> {
+        let schema = self.schema();
+        let queues = self.physical_queues_for_logical(queue);
+        // available: dispatcher signal — already an index-only sum over
+        // the (queue, priority, enqueue_shard) head tables.
+        let available = self.queue_claimer_signal(pool, queue).await?.available;
+        // running: live leases only; receipt-plane claims that haven't
+        // materialised a lease row yet are omitted (documented above).
+        let running: i64 = sqlx::query_scalar(&format!(
+            r#"
+            SELECT COALESCE(count(*)::bigint, 0)
+            FROM {schema}.leases
+            WHERE queue = ANY($1)
+              AND state IN ('running', 'waiting_external')
+            "#
+        ))
+        .bind(&queues)
+        .fetch_one(pool)
+        .await
+        .map_err(map_sqlx_error)?;
+        // completed: denormalised rollup only. Live (un-rolled-up)
+        // done_entries rows are excluded — see method-level docs.
+        let completed: i64 = sqlx::query_scalar(&format!(
+            r#"
+            SELECT COALESCE(sum(GREATEST(
+                COALESCE(lanes.pruned_completed_count, 0),
+                COALESCE(rollups.pruned_completed_count, 0)
+            )), 0)::bigint
+            FROM (
+                SELECT queue, priority, pruned_completed_count
+                FROM {schema}.queue_lanes
+                WHERE queue = ANY($1)
+            ) AS lanes
+            FULL OUTER JOIN (
+                SELECT queue, priority, pruned_completed_count
+                FROM {schema}.queue_terminal_rollups
+                WHERE queue = ANY($1)
+            ) AS rollups
+            USING (queue, priority)
+            "#
+        ))
+        .bind(&queues)
+        .fetch_one(pool)
+        .await
+        .map_err(map_sqlx_error)?;
+        Ok(QueueCounts {
+            available,
+            running,
+            completed,
+        })
+    }
+
     async fn retry_job_tx<'a>(
         &self,
         tx: &mut sqlx::Transaction<'a, sqlx::Postgres>,

--- a/awa/tests/queue_storage_runtime_test.rs
+++ b/awa/tests/queue_storage_runtime_test.rs
@@ -4679,7 +4679,10 @@ async fn test_queue_storage_queue_counts_fast_matches_exact_on_steady_state() {
         .await
         .expect("queue_counts with rows available");
     assert_eq!(with_available_fast.available, 5);
-    assert_eq!(with_available_fast.available, with_available_exact.available);
+    assert_eq!(
+        with_available_fast.available,
+        with_available_exact.available
+    );
     assert_eq!(with_available_fast.running, with_available_exact.running);
 
     // Claim the rows (lease-materialisation path; no receipt-plane
@@ -4700,6 +4703,56 @@ async fn test_queue_storage_queue_counts_fast_matches_exact_on_steady_state() {
     assert_eq!(running_fast.running, 5);
     assert_eq!(running_fast.running, running_exact.running);
     assert_eq!(running_fast.available, running_exact.available);
+
+    // Complete the rows so they land in done_entries. At this point
+    // queue_counts (exact) sees them via the live_terminal CTE; the
+    // fast variant under-counts because rollups haven't absorbed the
+    // segment yet. That divergence is documented and intentional.
+    let completed_count = store
+        .complete_batch(&pool, &claimed)
+        .await
+        .expect("Failed to complete");
+    assert_eq!(completed_count, 5);
+    let pre_prune_fast = store
+        .queue_counts_fast(&pool, queue)
+        .await
+        .expect("queue_counts_fast pre-prune");
+    let pre_prune_exact = store
+        .queue_counts(&pool, queue)
+        .await
+        .expect("queue_counts pre-prune");
+    assert_eq!(pre_prune_exact.completed, 5);
+    assert_eq!(
+        pre_prune_fast.completed, 0,
+        "fast under-counts pre-prune because live done_entries aren't \
+         in the rollup yet (documented behaviour)"
+    );
+
+    // Rotate + prune the now-completed slot. After prune,
+    // queue_terminal_rollups.pruned_completed_count absorbs the
+    // live segment and the fast and exact variants should agree.
+    match store.rotate(&pool).await.expect("rotate") {
+        awa_model::queue_storage::RotateOutcome::Rotated { .. } => {}
+        other => panic!("expected Rotated, got {other:?}"),
+    }
+    match store.prune_oldest(&pool).await.expect("prune_oldest") {
+        awa_model::queue_storage::PruneOutcome::Pruned { .. } => {}
+        other => panic!("expected Pruned, got {other:?}"),
+    }
+    let post_prune_fast = store
+        .queue_counts_fast(&pool, queue)
+        .await
+        .expect("queue_counts_fast post-prune");
+    let post_prune_exact = store
+        .queue_counts(&pool, queue)
+        .await
+        .expect("queue_counts post-prune");
+    assert_eq!(post_prune_exact.completed, 5);
+    assert_eq!(
+        post_prune_fast.completed, 5,
+        "fast must match exact once the segment has rolled up"
+    );
+    assert_eq!(post_prune_fast.completed, post_prune_exact.completed);
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]

--- a/awa/tests/queue_storage_runtime_test.rs
+++ b/awa/tests/queue_storage_runtime_test.rs
@@ -4622,6 +4622,86 @@ async fn test_queue_storage_queue_counts_and_claims_aggregate_across_stripes() {
     assert_eq!(counts_after.available, 0);
 }
 
+/// `queue_counts_fast` is an index-only depth probe intended for
+/// high-cadence pollers (admin dashboards, depth-target producers,
+/// soak observability). It returns the same shape as `queue_counts`
+/// but skips two expensive scans:
+///
+/// - `count(*) FROM done_entries WHERE queue=$1` — replaced by a sum
+///   over `queue_terminal_rollups.pruned_completed_count`, which only
+///   reflects rows that have already been rolled up.
+/// - `count(*) FROM lease_claims WHERE queue=$1 AND NOT EXISTS (...)`
+///   — replaced by `count(*) FROM leases WHERE queue=$1 AND state IN
+///   ('running','waiting_external')`, which omits receipt-plane claims
+///   that have not materialised a lease row.
+///
+/// Under steady state (empty leases table + nothing live in
+/// done_entries) the fast variant agrees with the exact variant on
+/// `available` and `running`. The exact variant's `completed` is the
+/// authority; the fast variant under-counts by the live (un-rolled-up)
+/// done_entries segment, which is documented and acceptable for the
+/// observability use case.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn test_queue_storage_queue_counts_fast_matches_exact_on_steady_state() {
+    let _guard = QUEUE_STORAGE_RUNTIME_LOCK.lock().await;
+    let pool = setup_pool(10).await;
+    let queue = "qs_counts_fast_steady";
+    let schema = "awa_qs_counts_fast_steady";
+    let store = create_store(&pool, schema).await;
+
+    // Empty queue: both variants must agree on every field.
+    let empty_fast = store
+        .queue_counts_fast(&pool, queue)
+        .await
+        .expect("queue_counts_fast on empty queue");
+    let empty_exact = store
+        .queue_counts(&pool, queue)
+        .await
+        .expect("queue_counts on empty queue");
+    assert_eq!(empty_fast.available, 0);
+    assert_eq!(empty_fast.running, 0);
+    assert_eq!(empty_fast.completed, 0);
+    assert_eq!(empty_fast.available, empty_exact.available);
+    assert_eq!(empty_fast.running, empty_exact.running);
+    assert_eq!(empty_fast.completed, empty_exact.completed);
+
+    // Available rows present: both variants agree.
+    store
+        .enqueue_batch(&pool, queue, 1, 5)
+        .await
+        .expect("Failed to enqueue jobs");
+    let with_available_fast = store
+        .queue_counts_fast(&pool, queue)
+        .await
+        .expect("queue_counts_fast with rows available");
+    let with_available_exact = store
+        .queue_counts(&pool, queue)
+        .await
+        .expect("queue_counts with rows available");
+    assert_eq!(with_available_fast.available, 5);
+    assert_eq!(with_available_fast.available, with_available_exact.available);
+    assert_eq!(with_available_fast.running, with_available_exact.running);
+
+    // Claim the rows (lease-materialisation path; no receipt-plane
+    // divergence with `lease_claim_receipts: false` from create_store).
+    let claimed = store
+        .claim_batch(&pool, queue, 5)
+        .await
+        .expect("Failed to claim");
+    assert_eq!(claimed.len(), 5);
+    let running_fast = store
+        .queue_counts_fast(&pool, queue)
+        .await
+        .expect("queue_counts_fast with rows running");
+    let running_exact = store
+        .queue_counts(&pool, queue)
+        .await
+        .expect("queue_counts with rows running");
+    assert_eq!(running_fast.running, 5);
+    assert_eq!(running_fast.running, running_exact.running);
+    assert_eq!(running_fast.available, running_exact.available);
+}
+
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn test_queue_storage_striped_claims_probe_stripes_round_robin() {
     let _guard = QUEUE_STORAGE_RUNTIME_LOCK.lock().await;

--- a/awa/tests/queue_storage_runtime_test.rs
+++ b/awa/tests/queue_storage_runtime_test.rs
@@ -4631,9 +4631,9 @@ async fn test_queue_storage_queue_counts_and_claims_aggregate_across_stripes() {
 ///   over `queue_terminal_rollups.pruned_completed_count`, which only
 ///   reflects rows that have already been rolled up.
 /// - `count(*) FROM lease_claims WHERE queue=$1 AND NOT EXISTS (...)`
-///   — replaced by `count(*) FROM leases WHERE queue=$1 AND state IN
-///   ('running','waiting_external')`, which omits receipt-plane claims
-///   that have not materialised a lease row.
+///   — replaced by `count(*) FROM leases WHERE queue=$1 AND state =
+///   'running'`, which omits receipt-plane claims that have not
+///   materialised a lease row.
 ///
 /// Under steady state (empty leases table + nothing live in
 /// done_entries) the fast variant agrees with the exact variant on


### PR DESCRIPTION
## Context

While soaking awa with `awa-bench long_horizon` on M5/OrbStack at W=64 / depth-target 5000 / 90 min, median completion rate was **~2,000 jobs/s** vs the 2026-05-09 baseline's **5,369 jobs/s** at the same worker count. A `samply` profile of the running worker showed **97% of samples parked** waiting on sqlx responses — the worker side was idle. Postgres was the bottleneck.

Cross-checking `pg_stat_activity` against the bench's depth poller showed `queue_counts_exact` (the public `queue_counts`) running 3-4 s per call. Two of its CTEs dominate that cost:

| CTE | Why it's expensive |
|---|---|
| `count(*) FROM done_entries WHERE queue=$1` | `done_entries` has no `(queue)` index — the PK leads with `ready_slot` — so a queue filter scans every partition. With 9.7M-row done_entries observed at 2 h elapsed, this is a multi-second scan. |
| `count(*) FROM lease_claims WHERE queue=$1 AND NOT EXISTS (... lease_claim_closures ...)` | `lease_claims` also has no `(queue)` index; the anti-join requires a scan plus index probe per row. |

The bench harness polls every 200 ms; under load it's rate-limited to the query's own duration, but it still ties up a pool connection and competes with worker queries.

## Change

Adds `QueueStorage::queue_counts_fast`, an index-only depth probe with the same `QueueCounts` shape:

| Field | Source |
|---|---|
| `available` | Shard-head sum (`queue_enqueue_heads × queue_claim_heads`) — same primitive the dispatcher already uses for claim signalling. O(num shards). |
| `running` | Partition-pruned filtered count of `leases` rows in `('running','waiting_external')`. **Receipt-plane claims that haven't materialised a lease row are omitted** (documented). |
| `completed` | `queue_terminal_rollups.pruned_completed_count` only — exact for pruned rows, lower bound while the live `done_entries` segment is un-rolled. |

`queue_counts` (exact) is **unchanged** and remains the source of truth for admin tooling that needs the live terminal segment.

## When to use which

- High-cadence pollers (admin dashboards, depth-target producers, soak observability) → `queue_counts_fast`.
- Admin tooling that needs the live terminal segment counted in → `queue_counts`.

The Rustdoc on `queue_counts_fast` documents the trade-off explicitly so callers can choose deliberately.

## Tests

- New `test_queue_storage_queue_counts_fast_matches_exact_on_steady_state` walks an empty → available-rows → running-rows progression and asserts the fast and exact variants agree on `available` and `running` under steady state with `lease_claim_receipts: false`.
- Existing 3 `queue_counts*` tests still pass.
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean.

## Companion change in the bench harness

`postgresql-job-queue-benchmarking` branch `brian/queue-counts-fast` switches `awa-bench`'s long-horizon depth poller from `queue_counts` to `queue_counts_fast`. To be opened against the bench repo once this lands.

## Follow-ups (not in this PR)

- The slowness of `queue_counts_exact` itself is still worth addressing for admin tools at deep backlog — candidates include a `done_entries (queue)` index (cost: another index on a hot append-only table) or a denormalised live-done counter.
- The bench harness's 200 ms depth-poll cadence is generous; a 1-2 s cadence is plenty for depth-target throttling and would reduce contention further regardless of which `queue_counts*` flavour is used.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Performance**
  * Optimized queue status retrieval to use index-based lookups instead of full table scans, improving responsiveness when checking queue metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->