### PR TITLE
feat(callbacks): callback-only receiver router and CLI (#279)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -510,6 +510,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sqlx",
+ "thiserror 2.0.18",
  "tokio",
  "tower",
  "tower-http",

--- a/awa-cli/src/main.rs
+++ b/awa-cli/src/main.rs
@@ -107,6 +107,60 @@ enum Commands {
         #[arg(long, env = "AWA_READ_ONLY")]
         read_only: bool,
     },
+    /// Callback receiver subcommands
+    Callbacks {
+        #[command(subcommand)]
+        command: CallbackCommands,
+    },
+}
+
+#[derive(Subcommand)]
+enum CallbackCommands {
+    /// Start a callback-only receiver (no admin UI, no admin API).
+    ///
+    /// Use this when callbacks must be externally reachable but the admin
+    /// surface must remain private. See ADR-027 and docs/http-callbacks.md.
+    Serve {
+        /// Host to bind to
+        #[arg(long, default_value = "127.0.0.1")]
+        host: String,
+        /// Port to listen on
+        #[arg(long, default_value = "4000")]
+        port: u16,
+        /// Maximum number of database connections
+        #[arg(long, default_value = "10", env = "AWA_POOL_MAX")]
+        pool_max: u32,
+        /// Minimum idle connections kept open
+        #[arg(long, default_value = "2", env = "AWA_POOL_MIN")]
+        pool_min: u32,
+        /// Seconds before an idle connection is closed
+        #[arg(long, default_value = "300", env = "AWA_POOL_IDLE_TIMEOUT")]
+        pool_idle_timeout: u64,
+        /// Maximum lifetime of a connection in seconds
+        #[arg(long, default_value = "1800", env = "AWA_POOL_MAX_LIFETIME")]
+        pool_max_lifetime: u64,
+        /// Seconds to wait when acquiring a connection
+        #[arg(long, default_value = "10", env = "AWA_POOL_ACQUIRE_TIMEOUT")]
+        pool_acquire_timeout: u64,
+        /// Hex-encoded 32-byte key used to verify callback signatures.
+        /// Required unless `--allow-unsigned` is set.
+        #[arg(long, env = "AWA_CALLBACK_HMAC_SECRET")]
+        callback_hmac_secret: Option<String>,
+        /// Path prefix the callback routes are mounted under. Defaults to
+        /// `/api/callbacks`, matching the built-in `awa serve` layout.
+        #[arg(
+            long,
+            default_value = "/api/callbacks",
+            env = "AWA_CALLBACK_PATH_PREFIX"
+        )]
+        path_prefix: String,
+        /// Accept inbound requests without `X-Awa-Signature` verification.
+        /// Only safe when the receiver is reachable from a trusted network
+        /// (mTLS at the load balancer, IP allow-list, private VPC, etc.).
+        /// Mutually exclusive with `--callback-hmac-secret`.
+        #[arg(long, env = "AWA_CALLBACK_ALLOW_UNSIGNED")]
+        allow_unsigned: bool,
+    },
 }
 
 fn parse_callback_hmac_secret(secret: &str) -> Result<[u8; 32], String> {
@@ -410,6 +464,66 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             axum::serve(listener, app).await?;
         }
 
+        // Callback-only receiver. See ADR-027 and docs/http-callbacks.md.
+        Commands::Callbacks {
+            command:
+                CallbackCommands::Serve {
+                    host,
+                    port,
+                    pool_max,
+                    pool_min,
+                    pool_idle_timeout,
+                    pool_max_lifetime,
+                    pool_acquire_timeout,
+                    callback_hmac_secret,
+                    path_prefix,
+                    allow_unsigned,
+                },
+        } => {
+            let auth = match (callback_hmac_secret.as_deref(), allow_unsigned) {
+                (Some(_), true) => {
+                    return Err(
+                        "--callback-hmac-secret and --allow-unsigned are mutually exclusive".into(),
+                    );
+                }
+                (Some(hex), false) => {
+                    let secret = parse_callback_hmac_secret(hex)
+                        .map_err(|err| format!("invalid callback secret: {err}"))?;
+                    awa_ui::callback_router::CallbackAuth::Signed(secret)
+                }
+                (None, true) => awa_ui::callback_router::CallbackAuth::Unsigned,
+                (None, false) => {
+                    return Err(
+                        "a callback signing secret is required by default; pass --callback-hmac-secret <hex32> or, for a trusted-network deployment, --allow-unsigned"
+                            .into(),
+                    );
+                }
+            };
+
+            let db_url = require_pool(&cli.database_url)?;
+            let pool = PgPoolOptions::new()
+                .max_connections(pool_max)
+                .min_connections(pool_min)
+                .idle_timeout(Duration::from_secs(pool_idle_timeout))
+                .max_lifetime(Duration::from_secs(pool_max_lifetime))
+                .acquire_timeout(Duration::from_secs(pool_acquire_timeout))
+                .connect(&db_url)
+                .await?;
+
+            let config = awa_ui::callback_router::CallbackReceiverConfig { auth, path_prefix };
+            let app = awa_ui::callback_router(pool, config).await?;
+            let addr = format!("{host}:{port}");
+            let listener = tokio::net::TcpListener::bind(&addr).await?;
+            if allow_unsigned {
+                tracing::warn!(
+                    "AWA callback receiver listening on http://{addr} (UNSIGNED — only safe on a trusted network)"
+                );
+            } else {
+                tracing::info!("AWA callback receiver listening on http://{addr}");
+            }
+            axum::serve(listener, app).await?;
+        }
+
         // Most remaining CLI commands are single-shot (one query, then exit)
         // so a small pool is sufficient. `storage prepare-queue-storage-schema`
         // is the exception: it acquires an advisory-lock connection and then
@@ -424,7 +538,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 .await?;
 
             match command {
-                Commands::Migrate { .. } | Commands::Serve { .. } => unreachable!(),
+                Commands::Migrate { .. } | Commands::Serve { .. } | Commands::Callbacks { .. } => {
+                    unreachable!()
+                }
 
                 Commands::Job { command } => match command {
                     JobCommands::Dump { id } => {

--- a/awa-ui/Cargo.toml
+++ b/awa-ui/Cargo.toml
@@ -34,6 +34,7 @@ chrono.workspace = true
 uuid.workspace = true
 mime_guess = "2"
 moka = { version = "0.12.15", features = ["future"] }
+thiserror.workspace = true
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["full", "test-util"] }

--- a/awa-ui/src/callback_router.rs
+++ b/awa-ui/src/callback_router.rs
@@ -1,0 +1,144 @@
+//! Callback-only receiver router.
+//!
+//! Builds an axum router that exposes only the three callback ingress routes
+//! (`complete`, `fail`, `heartbeat`) — no admin REST, no static UI assets, no
+//! permissive CORS. Pair with the CLI subcommand `awa callbacks serve` to
+//! deploy callback ingress on its own host/port, separate from the admin UI.
+//!
+//! See ADR-027 for design rationale and the deployable-role split.
+//!
+//! ```no_run
+//! # use awa_ui::callback_router::{callback_router, CallbackReceiverConfig, CallbackAuth};
+//! # async fn build(pool: sqlx::PgPool) -> Result<axum::Router, Box<dyn std::error::Error>> {
+//! let secret = [7u8; 32];
+//! let router = callback_router(
+//!     pool,
+//!     CallbackReceiverConfig::new(CallbackAuth::Signed(secret)),
+//! )
+//! .await?;
+//! # Ok(router)
+//! # }
+//! ```
+
+use awa_model::callback_contract::DEFAULT_CALLBACK_PATH_PREFIX;
+use axum::routing::post;
+use axum::Router;
+use sqlx::PgPool;
+
+use crate::handlers;
+use crate::state::AppState;
+
+/// How an incoming callback request is authenticated.
+#[derive(Debug, Clone)]
+pub enum CallbackAuth {
+    /// BLAKE3 keyed-hash signature verification. Every request must carry a
+    /// valid `X-Awa-Signature` header. This is the only sensible mode for a
+    /// publicly-reachable callback receiver.
+    Signed([u8; 32]),
+    /// No signature verification. Callers must protect the receiver some
+    /// other way (private network, mTLS at the load balancer, IP allow-list,
+    /// etc.). The name is intentionally awkward — choose `Signed` unless you
+    /// have a clear story for the alternative.
+    Unsigned,
+}
+
+/// Configuration for the callback-only receiver router.
+#[derive(Debug, Clone)]
+pub struct CallbackReceiverConfig {
+    /// How inbound requests are authenticated.
+    pub auth: CallbackAuth,
+    /// Path prefix the three callback routes are mounted under. Defaults to
+    /// [`DEFAULT_CALLBACK_PATH_PREFIX`] (`/api/callbacks`), matching the
+    /// built-in `awa serve` layout so callback URLs produced by the worker
+    /// continue to work unchanged. Override when the receiver lives at a
+    /// different path (e.g. `/awa-cb`).
+    pub path_prefix: String,
+}
+
+impl CallbackReceiverConfig {
+    /// New config with the default `/api/callbacks` path prefix.
+    pub fn new(auth: CallbackAuth) -> Self {
+        Self {
+            auth,
+            path_prefix: DEFAULT_CALLBACK_PATH_PREFIX.to_string(),
+        }
+    }
+
+    pub fn with_path_prefix(mut self, prefix: impl Into<String>) -> Self {
+        self.path_prefix = prefix.into();
+        self
+    }
+}
+
+/// Build a router exposing only the callback ingress routes.
+///
+/// The returned router:
+/// - Mounts `POST {prefix}/{callback_id}/{complete,fail,heartbeat}`.
+/// - Does NOT serve static UI assets.
+/// - Does NOT expose admin REST routes.
+/// - Does NOT apply permissive CORS.
+/// - Requires writable database access — all three routes mutate job state.
+///   The pool is probed once at build time and the call fails if the pool
+///   reports `transaction_read_only = on`.
+pub async fn callback_router(
+    pool: PgPool,
+    config: CallbackReceiverConfig,
+) -> Result<Router, CallbackRouterBuildError> {
+    let read_only = crate::state::detect_read_only(&pool).await?;
+    if read_only {
+        return Err(CallbackRouterBuildError::ReadOnlyDatabase);
+    }
+
+    let secret = match config.auth {
+        CallbackAuth::Signed(secret) => Some(secret),
+        CallbackAuth::Unsigned => None,
+    };
+
+    // Cache TTL is unused on the callback path — pass any value; the handler
+    // does not touch the dashboard caches.
+    let state = AppState::new(pool, false, std::time::Duration::ZERO, secret);
+
+    let prefix = normalize_prefix(&config.path_prefix);
+    let routes = Router::new()
+        .route(
+            &format!("{prefix}/{{callback_id}}/complete"),
+            post(handlers::callbacks::complete_callback),
+        )
+        .route(
+            &format!("{prefix}/{{callback_id}}/fail"),
+            post(handlers::callbacks::fail_callback),
+        )
+        .route(
+            &format!("{prefix}/{{callback_id}}/heartbeat"),
+            post(handlers::callbacks::heartbeat_callback),
+        )
+        .with_state(state);
+
+    Ok(routes)
+}
+
+fn normalize_prefix(prefix: &str) -> String {
+    let trimmed = prefix.trim().trim_end_matches('/');
+    if trimmed.is_empty() {
+        String::new()
+    } else if trimmed.starts_with('/') {
+        trimmed.to_string()
+    } else {
+        format!("/{trimmed}")
+    }
+}
+
+/// Reasons `callback_router` can refuse to build.
+#[derive(Debug, thiserror::Error)]
+pub enum CallbackRouterBuildError {
+    /// The database pool resolves to a read-only connection. All three
+    /// callback routes mutate job state, so a read-only DB would surface as
+    /// runtime 503s on every request. Fail at build time instead.
+    #[error(
+        "callback receiver requires a writable database (pool reports transaction_read_only=on)"
+    )]
+    ReadOnlyDatabase,
+    /// Pool probe failure when reading `transaction_read_only`.
+    #[error("failed to probe database read-only state: {0}")]
+    Probe(#[from] sqlx::Error),
+}

--- a/awa-ui/src/lib.rs
+++ b/awa-ui/src/lib.rs
@@ -1,7 +1,12 @@
 pub mod cache;
+pub mod callback_router;
 pub mod error;
 pub mod handlers;
 pub mod state;
+
+pub use callback_router::{
+    callback_router, CallbackAuth, CallbackReceiverConfig, CallbackRouterBuildError,
+};
 
 use std::time::Duration;
 

--- a/awa-ui/tests/callback_router_test.rs
+++ b/awa-ui/tests/callback_router_test.rs
@@ -1,0 +1,242 @@
+//! Tests for the callback-only receiver router (`awa_ui::callback_router`).
+//!
+//! Verifies the deployable-role split: the router exposes only the three
+//! callback ingress endpoints, refuses requests without a valid signature
+//! when configured to do so, and does NOT serve admin REST or static UI.
+
+use awa_model::callback_contract;
+use awa_ui::callback_router::{CallbackAuth, CallbackReceiverConfig};
+use axum::body::{to_bytes, Body};
+use axum::http::{Request, StatusCode};
+use serde_json::{json, Value};
+use std::time::Duration;
+use tower::util::ServiceExt;
+
+async fn setup_pool() -> sqlx::PgPool {
+    let pool = awa_testing::setup::setup(4).await;
+    awa_model::migrations::run(&pool)
+        .await
+        .expect("failed to run migrations for callback router tests");
+    pool
+}
+
+async fn create_waiting_callback(pool: &sqlx::PgPool, queue: &str) -> (i64, uuid::Uuid) {
+    sqlx::query("DELETE FROM awa.jobs WHERE queue = $1")
+        .bind(queue)
+        .execute(pool)
+        .await
+        .expect("failed to clean queue");
+
+    let job_id: i64 = sqlx::query_scalar(
+        r#"
+        INSERT INTO awa.jobs_hot (
+            kind, queue, args, state, attempt, max_attempts, run_lease,
+            attempted_at, heartbeat_at, deadline_at
+        )
+        VALUES (
+            'callback_test', $1, '{}'::jsonb, 'running', 1, 5, 1,
+            now(), now(), now() + interval '5 minutes'
+        )
+        RETURNING id
+        "#,
+    )
+    .bind(queue)
+    .fetch_one(pool)
+    .await
+    .expect("failed to insert running job");
+
+    let callback_id = awa_model::admin::register_callback(pool, job_id, 1, Duration::from_secs(60))
+        .await
+        .expect("failed to register callback");
+
+    sqlx::query(
+        "UPDATE awa.jobs SET state = 'waiting_external', heartbeat_at = NULL, deadline_at = NULL WHERE id = $1",
+    )
+    .bind(job_id)
+    .execute(pool)
+    .await
+    .expect("failed to move job to waiting_external");
+
+    (job_id, callback_id)
+}
+
+async fn post_json(
+    app: &axum::Router,
+    path: &str,
+    body: Value,
+    signature: Option<&str>,
+) -> (StatusCode, Value) {
+    let mut request = Request::builder()
+        .method("POST")
+        .uri(path)
+        .header("content-type", "application/json");
+
+    if let Some(signature) = signature {
+        request = request.header(callback_contract::SIGNATURE_HEADER, signature);
+    }
+
+    let response = app
+        .clone()
+        .oneshot(
+            request
+                .body(Body::from(body.to_string()))
+                .expect("request should build"),
+        )
+        .await
+        .expect("request should succeed");
+
+    let status = response.status();
+    let body = to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("response body should read");
+    let json = serde_json::from_slice(&body).unwrap_or(Value::Null);
+    (status, json)
+}
+
+async fn get(app: &axum::Router, path: &str) -> StatusCode {
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri(path)
+                .body(Body::empty())
+                .expect("request should build"),
+        )
+        .await
+        .expect("request should succeed");
+    response.status()
+}
+
+#[tokio::test]
+async fn callback_router_complete_requires_valid_signature() {
+    let pool = setup_pool().await;
+    let (job_id, callback_id) = create_waiting_callback(&pool, "callback_router_complete").await;
+    let secret = [13u8; 32];
+    let app = awa_ui::callback_router(
+        pool.clone(),
+        CallbackReceiverConfig::new(CallbackAuth::Signed(secret)),
+    )
+    .await
+    .expect("router should build");
+
+    let path = format!("/api/callbacks/{callback_id}/complete");
+
+    let (status, body) = post_json(&app, &path, json!({"payload": {"ok": true}}), None).await;
+    assert_eq!(status, StatusCode::UNAUTHORIZED);
+    assert_eq!(body["error"], "missing X-Awa-Signature header");
+
+    let stale_state: String = sqlx::query_scalar("SELECT state::text FROM awa.jobs WHERE id = $1")
+        .bind(job_id)
+        .fetch_one(&pool)
+        .await
+        .expect("job lookup should succeed");
+    assert_eq!(stale_state, "waiting_external");
+
+    let signature = callback_contract::sign(&secret, &callback_id.to_string());
+    let (status, body) = post_json(
+        &app,
+        &path,
+        json!({"payload": {"ok": true}}),
+        Some(&signature),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["state"], "Completed");
+}
+
+#[tokio::test]
+async fn callback_router_fail_and_heartbeat_routes() {
+    let pool = setup_pool().await;
+    let (_, callback_id) = create_waiting_callback(&pool, "callback_router_fail").await;
+    let secret = [21u8; 32];
+    let app = awa_ui::callback_router(
+        pool.clone(),
+        CallbackReceiverConfig::new(CallbackAuth::Signed(secret)),
+    )
+    .await
+    .expect("router should build");
+
+    let signature = callback_contract::sign(&secret, &callback_id.to_string());
+
+    let heartbeat_path = format!("/api/callbacks/{callback_id}/heartbeat");
+    let (status, _) = post_json(
+        &app,
+        &heartbeat_path,
+        json!({"timeout_seconds": 120}),
+        Some(&signature),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+
+    let fail_path = format!("/api/callbacks/{callback_id}/fail");
+    let (status, body) = post_json(
+        &app,
+        &fail_path,
+        json!({"error": "rendered nothing"}),
+        Some(&signature),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert!(body["state"].as_str().is_some());
+}
+
+#[tokio::test]
+async fn callback_router_does_not_expose_admin_or_static() {
+    let pool = setup_pool().await;
+    let app = awa_ui::callback_router(
+        pool.clone(),
+        CallbackReceiverConfig::new(CallbackAuth::Unsigned),
+    )
+    .await
+    .expect("router should build");
+
+    assert_eq!(get(&app, "/api/stats").await, StatusCode::NOT_FOUND);
+    assert_eq!(get(&app, "/api/jobs").await, StatusCode::NOT_FOUND);
+    assert_eq!(get(&app, "/api/queues").await, StatusCode::NOT_FOUND);
+    assert_eq!(get(&app, "/api/dlq").await, StatusCode::NOT_FOUND);
+    assert_eq!(get(&app, "/api/runtime").await, StatusCode::NOT_FOUND);
+    assert_eq!(get(&app, "/api/capabilities").await, StatusCode::NOT_FOUND);
+    assert_eq!(get(&app, "/").await, StatusCode::NOT_FOUND);
+    assert_eq!(get(&app, "/index.html").await, StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn callback_router_unsigned_mode_accepts_unauthenticated_requests() {
+    let pool = setup_pool().await;
+    let (_, callback_id) = create_waiting_callback(&pool, "callback_router_unsigned").await;
+    let app = awa_ui::callback_router(
+        pool.clone(),
+        CallbackReceiverConfig::new(CallbackAuth::Unsigned),
+    )
+    .await
+    .expect("router should build");
+
+    let path = format!("/api/callbacks/{callback_id}/complete");
+    let (status, body) = post_json(&app, &path, json!({}), None).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["state"], "Completed");
+}
+
+#[tokio::test]
+async fn callback_router_custom_path_prefix() {
+    let pool = setup_pool().await;
+    let (_, callback_id) = create_waiting_callback(&pool, "callback_router_prefix").await;
+    let secret = [42u8; 32];
+    let app = awa_ui::callback_router(
+        pool.clone(),
+        CallbackReceiverConfig::new(CallbackAuth::Signed(secret)).with_path_prefix("/awa-cb"),
+    )
+    .await
+    .expect("router should build");
+
+    let signature = callback_contract::sign(&secret, &callback_id.to_string());
+
+    let custom_path = format!("/awa-cb/{callback_id}/complete");
+    let (status, _) = post_json(&app, &custom_path, json!({}), Some(&signature)).await;
+    assert_eq!(status, StatusCode::OK);
+
+    let default_path = format!("/api/callbacks/{callback_id}/complete");
+    let (status, _) = post_json(&app, &default_path, json!({}), Some(&signature)).await;
+    assert_eq!(status, StatusCode::NOT_FOUND);
+}

--- a/docs/http-callbacks.md
+++ b/docs/http-callbacks.md
@@ -197,6 +197,50 @@ The `complete` endpoint completes the job. It does not resume an in-process
 handler for sequential callback workflows; use the Rust/Python admin API
 `resume_external` path for that pattern.
 
+## Deploying callback ingress separately
+
+`awa serve` bundles the admin UI, admin REST API, static fallback, and the
+callback receiver behind a single router with permissive CORS. That is
+convenient for development but undesirable when callbacks must be
+externally reachable while the admin surface must stay private.
+
+For that case Awa ships a callback-only receiver as a deployable role
+(see [ADR-027](./adr/027-callback-ingress.md)):
+
+```text
+awa callbacks serve \
+  --host 0.0.0.0 --port 4000 \
+  --callback-hmac-secret "$AWA_CALLBACK_HMAC_SECRET" \
+  --path-prefix /api/callbacks
+```
+
+The router:
+
+- Mounts only `POST {prefix}/{callback_id}/{complete,fail,heartbeat}`.
+- Does not serve static UI assets or admin REST routes.
+- Does not apply permissive CORS.
+- Refuses to build against a read-only database (all three routes mutate
+  job state).
+- Requires a callback signing secret by default. Pass `--allow-unsigned`
+  only when the receiver lives on a trusted network (mTLS at the load
+  balancer, IP allow-list, private VPC, etc.).
+
+The same router is available as a Rust library for embedding:
+
+```rust
+use awa_ui::{callback_router, CallbackAuth, CallbackReceiverConfig};
+
+let router = callback_router(
+    pool,
+    CallbackReceiverConfig::new(CallbackAuth::Signed(secret)),
+)
+.await?;
+```
+
+Use [`HttpWorkerConfig::callback_path_prefix`](#configuration) on the
+worker side to match a non-default `--path-prefix` so the URLs the worker
+hands to your function point at the receiver.
+
 ## Function-side verification
 
 The signature primarily protects the Awa callback receiver from unauthorized


### PR DESCRIPTION
## Summary

Adds a callback-only deployable role — a router that exposes ONLY the three callback ingress endpoints, plus a CLI subcommand to run it standalone:

```bash
awa callbacks serve \
  --host 0.0.0.0 --port 4000 \
  --callback-hmac-secret \"\$AWA_CALLBACK_HMAC_SECRET\"
```

The library entry point is `awa_ui::callback_router(pool, CallbackReceiverConfig)`.

## Stacked on #291

This builds on the shared callback contract in #291 (#278/#280) — the router uses `awa_model::callback_contract::DEFAULT_CALLBACK_PATH_PREFIX` and the URL/auth helpers introduced there. Review #291 first; this branch's base is `brian/issue-278-callback-contract` and will retarget `main` when that lands.

## What the receiver does NOT do

By design, distinguishing it from `awa serve`:
- No static UI assets
- No admin REST routes (jobs, queues, DLQ, runtime, stats)
- No permissive CORS layer
- Refuses to build against a read-only pool (every route mutates job state — fail fast at build time instead of surfacing as runtime 503s)

## CallbackAuth is an explicit enum

```rust
pub enum CallbackAuth {
    Signed([u8; 32]),
    Unsigned,
}
```

So the security choice cannot be made by forgetting a setter. `Unsigned` is intentionally awkward — choose it only for trusted-network deployments (mTLS at the load balancer, IP allow-list, private VPC).

The CLI surface enforces this: `--callback-hmac-secret` and `--allow-unsigned` are mutually exclusive, and neither defaults to a permissive mode. A clear error fires when both are omitted:

```text
Error: \"a callback signing secret is required by default; pass --callback-hmac-secret <hex32> or, for a trusted-network deployment, --allow-unsigned\"
```

## Closes

- Closes #279

Refs #277 (design draft), ADR-027.

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo build --workspace --all-targets`
- [x] `cargo test -p awa-ui --test callback_router_test` against Postgres — 5 tests:
  - `callback_router_complete_requires_valid_signature` (valid signature + missing-signature 401)
  - `callback_router_fail_and_heartbeat_routes` (signed POSTs to the other two routes)
  - `callback_router_does_not_expose_admin_or_static` (404s on `/api/stats`, `/api/jobs`, `/`, etc.)
  - `callback_router_unsigned_mode_accepts_unauthenticated_requests`
  - `callback_router_custom_path_prefix` (custom mount; default 404s)
- [x] `cargo test -p awa-ui --test callback_api_test` — original 2 admin-router callback tests still green
- [x] `awa callbacks serve --help` — flags documented
- [x] CLI smoke: secret-and-unsigned-conflict and neither-supplied both fail with clear messages
- [x] `docs/http-callbacks.md` — new "Deploying callback ingress separately" section