### PR TITLE
feat(cli): awa storage finalize --wait and --check (#296)

### DIFF
--- a/awa-cli/src/main.rs
+++ b/awa-cli/src/main.rs
@@ -4,6 +4,8 @@ use chrono::{DateTime, Utc};
 use clap::{Parser, Subcommand};
 use sqlx::postgres::PgPoolOptions;
 
+mod storage_wait;
+
 #[derive(Parser)]
 #[command(
     name = "awa",
@@ -258,7 +260,19 @@ enum StorageCommands {
     /// Enter mixed transition and begin routing new writes to the prepared engine
     EnterMixedTransition,
     /// Finalize the storage transition once drain and capability gates pass
-    Finalize,
+    Finalize {
+        /// Dry-run: print the readiness report and exit. Exits 0 when
+        /// ready to finalize, exits 2 when one or more blockers remain.
+        /// No SQL state change.
+        #[arg(long, conflicts_with = "wait")]
+        check: bool,
+        /// Poll the readiness gates until they stay clear for a few
+        /// consecutive checks, then invoke finalize. Optional duration
+        /// cap (e.g. `10m`, `2h30m`, `90s`). Without a value, waits
+        /// indefinitely. Polls every 5s by default.
+        #[arg(long, value_name = "DURATION", num_args = 0..=1, default_missing_value = "")]
+        wait: Option<String>,
+    },
 }
 
 #[derive(Subcommand)]
@@ -755,10 +769,60 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                         let report = awa_model::storage::status_report(&pool).await?;
                         println!("{}", serde_json::to_string_pretty(&report)?);
                     }
-                    StorageCommands::Finalize => {
-                        awa_model::storage::finalize(&pool).await?;
-                        let report = awa_model::storage::status_report(&pool).await?;
-                        println!("{}", serde_json::to_string_pretty(&report)?);
+                    StorageCommands::Finalize { check, wait } => {
+                        if check {
+                            // Dry-run: print the same readiness report as
+                            // `awa storage status` plus a concise blocker
+                            // summary, and exit non-zero (2) if blocked.
+                            let report = awa_model::storage::status_report(&pool).await?;
+                            println!("{}", serde_json::to_string_pretty(&report)?);
+                            if report.can_finalize {
+                                eprintln!("storage finalize: ready");
+                            } else {
+                                eprintln!(
+                                    "storage finalize: blocked ({} blocker{})",
+                                    report.finalize_blockers.len(),
+                                    if report.finalize_blockers.len() == 1 {
+                                        ""
+                                    } else {
+                                        "s"
+                                    }
+                                );
+                                for blocker in &report.finalize_blockers {
+                                    eprintln!("  - {blocker}");
+                                }
+                                std::process::exit(2);
+                            }
+                        } else if let Some(wait_arg) = wait {
+                            let cap = if wait_arg.is_empty() {
+                                None
+                            } else {
+                                Some(storage_wait::parse_duration(&wait_arg).map_err(|e| {
+                                    format!("--wait: invalid duration {wait_arg:?}: {e}")
+                                })?)
+                            };
+                            match storage_wait::wait_for_finalize(&pool, cap).await? {
+                                storage_wait::WaitOutcome::Finalized(report) => {
+                                    println!("{}", serde_json::to_string_pretty(&report)?);
+                                }
+                                storage_wait::WaitOutcome::TimedOut(report) => {
+                                    println!("{}", serde_json::to_string_pretty(&report)?);
+                                    eprintln!(
+                                        "storage finalize --wait: timed out after {:?} with {} blocker(s)",
+                                        cap.unwrap_or_default(),
+                                        report.finalize_blockers.len()
+                                    );
+                                    for blocker in &report.finalize_blockers {
+                                        eprintln!("  - {blocker}");
+                                    }
+                                    std::process::exit(2);
+                                }
+                            }
+                        } else {
+                            awa_model::storage::finalize(&pool).await?;
+                            let report = awa_model::storage::status_report(&pool).await?;
+                            println!("{}", serde_json::to_string_pretty(&report)?);
+                        }
                     }
                 },
 

--- a/awa-cli/src/storage_wait.rs
+++ b/awa-cli/src/storage_wait.rs
@@ -1,0 +1,224 @@
+//! `awa storage finalize --wait` polling loop and supporting helpers.
+//!
+//! `finalize --wait` is the operator-friendly counterpart to the one-shot
+//! `finalize` command: it polls the same readiness gates that
+//! [`awa_model::storage::status_report`] computes, and only invokes the
+//! SQL finalize once the blocker list has stayed empty for several
+//! consecutive checks. The intent is to give an operator a single
+//! command they can leave running during a multi-hour rolling upgrade
+//! instead of `watch -n 5 psql …`.
+//!
+//! Progress output uses the `tracing` macros (the operator may want
+//! structured logs); `--check` (in `main.rs`) uses `println!`/`eprintln!`
+//! because its output is a one-shot report for a human.
+
+use std::time::{Duration, Instant};
+
+use awa_model::storage::{self, StorageStatusReport};
+use sqlx::PgPool;
+use tracing::{info, warn};
+
+/// How often to re-fetch the readiness report while waiting.
+const POLL_INTERVAL: Duration = Duration::from_secs(5);
+
+/// How many consecutive "ready" observations we want before pulling
+/// the trigger. Guards against a single optimistic reading caused by
+/// e.g. a runtime momentarily failing to heartbeat between snapshots.
+const REQUIRED_READY_STREAK: u32 = 2;
+
+/// Result of `wait_for_finalize`.
+pub enum WaitOutcome {
+    /// Finalize succeeded; the report is the post-finalize status.
+    Finalized(StorageStatusReport),
+    /// Wait cap expired before the readiness gates cleared; the report
+    /// is the last observation.
+    TimedOut(StorageStatusReport),
+}
+
+/// Poll readiness, then finalize. `cap` is the optional total wait
+/// budget; `None` means wait indefinitely.
+pub async fn wait_for_finalize(
+    pool: &PgPool,
+    cap: Option<Duration>,
+) -> Result<WaitOutcome, awa_model::AwaError> {
+    let started = Instant::now();
+    let mut ready_streak: u32 = 0;
+    let mut iteration: u64 = 0;
+
+    info!(
+        poll_interval_secs = POLL_INTERVAL.as_secs(),
+        required_ready_streak = REQUIRED_READY_STREAK,
+        wait_cap_secs = cap.map(|d| d.as_secs()),
+        "storage finalize --wait: starting"
+    );
+
+    loop {
+        iteration += 1;
+        let report = storage::status_report(pool).await?;
+
+        if report.can_finalize {
+            ready_streak += 1;
+            info!(
+                iteration,
+                ready_streak,
+                required_ready_streak = REQUIRED_READY_STREAK,
+                state = %report.status.state,
+                "storage finalize --wait: ready observation"
+            );
+            if ready_streak >= REQUIRED_READY_STREAK {
+                info!(
+                    iteration,
+                    elapsed_secs = started.elapsed().as_secs(),
+                    "storage finalize --wait: gates clear, invoking finalize"
+                );
+                storage::finalize(pool).await?;
+                let post = storage::status_report(pool).await?;
+                return Ok(WaitOutcome::Finalized(post));
+            }
+        } else {
+            // Reset on any blocker so a flap doesn't count toward the
+            // streak.
+            if ready_streak > 0 {
+                warn!(
+                    iteration,
+                    blocker_count = report.finalize_blockers.len(),
+                    "storage finalize --wait: readiness regressed, resetting streak"
+                );
+            }
+            ready_streak = 0;
+            info!(
+                iteration,
+                state = %report.status.state,
+                canonical_live_backlog = report.canonical_live_backlog,
+                blocker_count = report.finalize_blockers.len(),
+                blockers = ?report.finalize_blockers,
+                "storage finalize --wait: still blocked"
+            );
+        }
+
+        if let Some(cap) = cap {
+            let elapsed = started.elapsed();
+            if elapsed >= cap {
+                warn!(
+                    iteration,
+                    elapsed_secs = elapsed.as_secs(),
+                    cap_secs = cap.as_secs(),
+                    "storage finalize --wait: cap reached"
+                );
+                // Re-fetch once more so the caller always reports the
+                // freshest observation alongside the timeout message.
+                let final_report = storage::status_report(pool).await?;
+                return Ok(WaitOutcome::TimedOut(final_report));
+            }
+            // Don't oversleep past the cap.
+            let remaining = cap - elapsed;
+            tokio::time::sleep(POLL_INTERVAL.min(remaining)).await;
+        } else {
+            tokio::time::sleep(POLL_INTERVAL).await;
+        }
+    }
+}
+
+/// Parse a tiny subset of duration strings: e.g. `30s`, `5m`, `2h`,
+/// `2h30m`, `1500ms`. Numeric-only inputs are rejected to avoid
+/// ambiguity between "seconds" and "milliseconds".
+pub fn parse_duration(input: &str) -> Result<Duration, String> {
+    let trimmed = input.trim();
+    if trimmed.is_empty() {
+        return Err("empty duration".to_string());
+    }
+
+    let mut total = Duration::ZERO;
+    let mut digits = String::new();
+    let mut units = String::new();
+    let mut seen_unit = false;
+
+    let mut chars = trimmed.chars().peekable();
+    while let Some(&ch) = chars.peek() {
+        if ch.is_ascii_digit() {
+            digits.push(ch);
+            chars.next();
+        } else if ch.is_ascii_alphabetic() {
+            units.clear();
+            while let Some(&ch) = chars.peek() {
+                if ch.is_ascii_alphabetic() {
+                    units.push(ch);
+                    chars.next();
+                } else {
+                    break;
+                }
+            }
+            if digits.is_empty() {
+                return Err(format!("unit '{units}' has no number before it"));
+            }
+            let value: u64 = digits
+                .parse()
+                .map_err(|err| format!("bad number {digits:?}: {err}"))?;
+            let multiplier_ms: u64 = match units.as_str() {
+                "ms" => 1,
+                "s" => 1_000,
+                "m" => 60 * 1_000,
+                "h" => 3_600 * 1_000,
+                other => return Err(format!("unknown unit '{other}' (expected ms/s/m/h)")),
+            };
+            total = total
+                .checked_add(Duration::from_millis(
+                    value
+                        .checked_mul(multiplier_ms)
+                        .ok_or("duration overflow")?,
+                ))
+                .ok_or("duration overflow")?;
+            digits.clear();
+            seen_unit = true;
+        } else {
+            return Err(format!("unexpected character {ch:?}"));
+        }
+    }
+
+    if !digits.is_empty() {
+        return Err(format!(
+            "trailing number {digits:?} has no unit (use s/m/h/ms)"
+        ));
+    }
+    if !seen_unit {
+        return Err("duration must include a unit (s/m/h/ms)".to_string());
+    }
+    Ok(total)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_simple_units() {
+        assert_eq!(parse_duration("30s").unwrap(), Duration::from_secs(30));
+        assert_eq!(parse_duration("5m").unwrap(), Duration::from_secs(300));
+        assert_eq!(parse_duration("2h").unwrap(), Duration::from_secs(7200));
+        assert_eq!(
+            parse_duration("1500ms").unwrap(),
+            Duration::from_millis(1500)
+        );
+    }
+
+    #[test]
+    fn parse_compound_units() {
+        assert_eq!(
+            parse_duration("2h30m").unwrap(),
+            Duration::from_secs(2 * 3600 + 30 * 60)
+        );
+        assert_eq!(
+            parse_duration("1h2m3s").unwrap(),
+            Duration::from_secs(3600 + 120 + 3)
+        );
+    }
+
+    #[test]
+    fn rejects_unitless_or_unknown() {
+        assert!(parse_duration("").is_err());
+        assert!(parse_duration("10").is_err());
+        assert!(parse_duration("10x").is_err());
+        assert!(parse_duration("abc").is_err());
+        assert!(parse_duration("s30").is_err());
+    }
+}

--- a/awa-cli/tests/storage_finalize_cli_test.rs
+++ b/awa-cli/tests/storage_finalize_cli_test.rs
@@ -1,0 +1,344 @@
+//! Integration tests for `awa storage finalize --check` / `--wait`.
+//!
+//! These tests drive the compiled `awa` binary against a dedicated
+//! Postgres database (`awa_finalize_cli_test`) so they don't have to
+//! contend with the shared `awa_test` storage-transition singleton
+//! row that the rest of the integration suite mutates. A
+//! process-local mutex plus an advisory lock keeps the tests in this
+//! file from racing against each other when cargo runs them
+//! concurrently.
+
+use std::str::FromStr;
+use std::sync::OnceLock;
+use std::time::Duration;
+
+use assert_cmd::Command;
+use awa_model::{migrations, storage, QueueStorage};
+use sqlx::postgres::{PgConnectOptions, PgConnection, PgPoolOptions};
+use sqlx::{Connection, PgPool};
+use tokio::sync::Mutex;
+use uuid::Uuid;
+
+const TEST_DB_NAME: &str = "awa_finalize_cli_test";
+const FINALIZE_TEST_LOCK_KEY: i64 = 0x6177616669636c69; // "awafinli" + slop
+
+static TEST_MUTEX: OnceLock<Mutex<()>> = OnceLock::new();
+
+fn test_mutex() -> &'static Mutex<()> {
+    TEST_MUTEX.get_or_init(|| Mutex::new(()))
+}
+
+struct TestGuard {
+    _local: tokio::sync::MutexGuard<'static, ()>,
+    _conn: PgConnection,
+}
+
+fn base_database_url() -> String {
+    std::env::var("DATABASE_URL")
+        .unwrap_or_else(|_| "postgres://postgres:test@localhost:15432/awa_test".to_string())
+}
+
+fn replace_database_name(url: &str, db_name: &str) -> String {
+    let (base, query) = match url.split_once('?') {
+        Some((base, query)) => (base, Some(query)),
+        None => (url, None),
+    };
+    let (prefix, _old_db) = base
+        .rsplit_once('/')
+        .expect("DATABASE_URL must include a database name");
+    let mut out = format!("{prefix}/{db_name}");
+    if let Some(query) = query {
+        out.push('?');
+        out.push_str(query);
+    }
+    out
+}
+
+fn test_database_url() -> String {
+    replace_database_name(&base_database_url(), TEST_DB_NAME)
+}
+
+fn admin_database_url() -> String {
+    replace_database_name(&base_database_url(), "postgres")
+}
+
+async fn ensure_test_database() {
+    let mut admin = PgConnection::connect(&admin_database_url())
+        .await
+        .expect("connect admin db");
+    let exists: bool =
+        sqlx::query_scalar("SELECT EXISTS(SELECT 1 FROM pg_database WHERE datname = $1)")
+            .bind(TEST_DB_NAME)
+            .fetch_one(&mut admin)
+            .await
+            .expect("check db existence");
+    if !exists {
+        // CREATE DATABASE does not support bind parameters.
+        sqlx::raw_sql(&format!("CREATE DATABASE {TEST_DB_NAME}"))
+            .execute(&mut admin)
+            .await
+            .expect("create finalize cli test db");
+    }
+}
+
+async fn acquire_guard() -> TestGuard {
+    let local = test_mutex().lock().await;
+    ensure_test_database().await;
+    let mut conn = PgConnection::connect(&test_database_url())
+        .await
+        .expect("lock conn");
+    sqlx::query("SELECT pg_advisory_lock($1)")
+        .bind(FINALIZE_TEST_LOCK_KEY)
+        .execute(&mut conn)
+        .await
+        .expect("acquire advisory lock");
+    TestGuard {
+        _local: local,
+        _conn: conn,
+    }
+}
+
+async fn pool() -> PgPool {
+    ensure_test_database().await;
+    let opts = PgConnectOptions::from_str(&test_database_url()).expect("parse test db url");
+    PgPoolOptions::new()
+        .max_connections(2)
+        .acquire_timeout(Duration::from_secs(5))
+        .connect_with(opts)
+        .await
+        .expect("connect test db")
+}
+
+async fn reset_schema(pool: &PgPool) {
+    sqlx::raw_sql("DROP SCHEMA IF EXISTS awa CASCADE")
+        .execute(pool)
+        .await
+        .expect("drop awa schema");
+    // Also clean up any prepared queue-storage schemas this test
+    // might have left over from a previous run.
+    sqlx::raw_sql("DROP SCHEMA IF EXISTS awa_finalize_cli_qs CASCADE")
+        .execute(pool)
+        .await
+        .expect("drop queue storage schema");
+}
+
+async fn prepare_queue_storage_schema(pool: &PgPool, schema: &str) {
+    sqlx::query(&format!("DROP SCHEMA IF EXISTS {schema} CASCADE"))
+        .execute(pool)
+        .await
+        .expect("drop qs schema");
+    let store = QueueStorage::from_existing_schema(schema).expect("qs schema validates");
+    store.prepare_schema(pool).await.expect("prepare qs schema");
+}
+
+async fn insert_runtime_instance(pool: &PgPool, capability: &str, transition_role: &str) {
+    sqlx::query(
+        r#"
+        INSERT INTO awa.runtime_instances (
+            instance_id, hostname, pid, version,
+            started_at, last_seen_at, snapshot_interval_ms,
+            healthy, postgres_connected, poll_loop_alive,
+            heartbeat_alive, maintenance_alive, shutting_down,
+            leader, global_max_workers, queues,
+            storage_capability, transition_role
+        )
+        VALUES (
+            $1, 'finalize-cli-test-host', 4242, '0.6.0-test',
+            now() - interval '1 minute', now(), 10000,
+            TRUE, TRUE, TRUE,
+            TRUE, TRUE, FALSE,
+            TRUE, NULL, '[]'::jsonb,
+            $2, $3
+        )
+        ON CONFLICT (instance_id) DO UPDATE
+            SET last_seen_at = EXCLUDED.last_seen_at,
+                storage_capability = EXCLUDED.storage_capability,
+                transition_role = EXCLUDED.transition_role
+        "#,
+    )
+    .bind(Uuid::new_v4())
+    .bind(capability)
+    .bind(transition_role)
+    .execute(pool)
+    .await
+    .expect("insert runtime instance");
+}
+
+fn run_cli(args: &[&str]) -> Command {
+    let mut command = Command::cargo_bin("awa").expect("awa binary should build");
+    command
+        .env("DATABASE_URL", test_database_url())
+        // Keep tracing chatter out of stderr unless the test wants it.
+        .env("RUST_LOG", "warn")
+        .args(args);
+    command
+}
+
+// ── --check ──────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn check_on_fresh_canonical_state_reports_blocked() {
+    // A fresh install sits in `state=canonical`; finalize is blocked
+    // because `state != mixed_transition`. `--check` should exit 2
+    // with a useful summary and NOT mutate state.
+    let _guard = acquire_guard().await;
+    let pool = pool().await;
+    reset_schema(&pool).await;
+    migrations::run(&pool).await.expect("migrate");
+
+    let assert = run_cli(&["storage", "finalize", "--check"])
+        .assert()
+        .code(2);
+    let stderr = String::from_utf8(assert.get_output().stderr.clone()).expect("stderr utf8");
+    assert!(
+        stderr.contains("blocked"),
+        "expected blocked summary, got: {stderr}"
+    );
+    assert!(
+        stderr.contains("expected 'mixed_transition'"),
+        "expected state blocker in summary, got: {stderr}"
+    );
+
+    // No state change.
+    let status = storage::status(&pool).await.expect("status");
+    assert_eq!(status.state, "canonical");
+}
+
+#[tokio::test]
+async fn check_when_ready_exits_zero_without_finalizing() {
+    let _guard = acquire_guard().await;
+    let pool = pool().await;
+    reset_schema(&pool).await;
+    migrations::run(&pool).await.expect("migrate");
+
+    let schema = "awa_finalize_cli_qs";
+    prepare_queue_storage_schema(&pool, schema).await;
+    storage::prepare(
+        &pool,
+        "queue_storage",
+        serde_json::json!({ "schema": schema }),
+    )
+    .await
+    .expect("storage prepare");
+    insert_runtime_instance(&pool, "queue_storage", "queue_storage_target").await;
+    storage::enter_mixed_transition(&pool)
+        .await
+        .expect("enter mixed transition");
+
+    // mixed_transition with no canonical-only / drain-only runtimes
+    // and an empty hot backlog → finalize is ready.
+    let report = storage::status_report(&pool).await.expect("report");
+    assert!(
+        report.can_finalize,
+        "test setup should reach can_finalize; blockers: {:?}",
+        report.finalize_blockers
+    );
+
+    run_cli(&["storage", "finalize", "--check"])
+        .assert()
+        .success();
+
+    // Crucially, --check must NOT advance state.
+    let status = storage::status(&pool).await.expect("status");
+    assert_eq!(status.state, "mixed_transition");
+}
+
+// ── --wait ───────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn wait_finalizes_immediately_when_ready() {
+    let _guard = acquire_guard().await;
+    let pool = pool().await;
+    reset_schema(&pool).await;
+    migrations::run(&pool).await.expect("migrate");
+
+    let schema = "awa_finalize_cli_qs";
+    prepare_queue_storage_schema(&pool, schema).await;
+    storage::prepare(
+        &pool,
+        "queue_storage",
+        serde_json::json!({ "schema": schema }),
+    )
+    .await
+    .expect("prepare");
+    insert_runtime_instance(&pool, "queue_storage", "queue_storage_target").await;
+    storage::enter_mixed_transition(&pool)
+        .await
+        .expect("enter mixed transition");
+
+    // Cap the wait so the test can't hang if something regresses.
+    run_cli(&["storage", "finalize", "--wait=30s"])
+        .timeout(Duration::from_secs(60))
+        .assert()
+        .success();
+
+    let status = storage::status(&pool).await.expect("status");
+    assert_eq!(status.state, "active");
+    assert_eq!(status.current_engine, "queue_storage");
+}
+
+#[tokio::test]
+async fn wait_times_out_with_blocker() {
+    // mixed_transition + a hot-backlog row that never goes away →
+    // `--wait` should poll, observe the persistent blocker, hit the
+    // duration cap, and exit 2 with the blocker described in stderr.
+    let _guard = acquire_guard().await;
+    let pool = pool().await;
+    reset_schema(&pool).await;
+    migrations::run(&pool).await.expect("migrate");
+
+    let schema = "awa_finalize_cli_qs";
+    prepare_queue_storage_schema(&pool, schema).await;
+    storage::prepare(
+        &pool,
+        "queue_storage",
+        serde_json::json!({ "schema": schema }),
+    )
+    .await
+    .expect("prepare");
+    insert_runtime_instance(&pool, "queue_storage", "queue_storage_target").await;
+    storage::enter_mixed_transition(&pool)
+        .await
+        .expect("enter mixed transition");
+
+    // Plant a non-terminal canonical row so canonical_live_backlog > 0.
+    sqlx::query(
+        "INSERT INTO awa.jobs_hot (kind, queue, args, state, priority) \
+         VALUES ('finalize_blocker', 'cli_finalize_wait', '{}'::jsonb, 'available', 2)",
+    )
+    .execute(&pool)
+    .await
+    .expect("insert backlog row");
+
+    let started = std::time::Instant::now();
+    let assert = run_cli(&["storage", "finalize", "--wait=2s"])
+        .timeout(Duration::from_secs(30))
+        .assert()
+        .code(2);
+    // Sanity-check the wait actually waited (within rounding).
+    let elapsed = started.elapsed();
+    assert!(
+        elapsed >= Duration::from_secs(2),
+        "expected at least 2s of waiting, got {elapsed:?}"
+    );
+
+    let stderr = String::from_utf8(assert.get_output().stderr.clone()).expect("stderr utf8");
+    assert!(
+        stderr.contains("timed out"),
+        "expected timeout summary, got: {stderr}"
+    );
+    assert!(
+        stderr.contains("canonical live backlog"),
+        "expected backlog blocker in summary, got: {stderr}"
+    );
+
+    // State should still be mixed_transition (finalize never ran).
+    let status = storage::status(&pool).await.expect("status");
+    assert_eq!(status.state, "mixed_transition");
+
+    // Cleanup so a later run starts fresh.
+    sqlx::query("DELETE FROM awa.jobs_hot WHERE queue = 'cli_finalize_wait'")
+        .execute(&pool)
+        .await
+        .expect("cleanup backlog");
+}

--- a/docs/upgrade-0.5-to-0.6.md
+++ b/docs/upgrade-0.5-to-0.6.md
@@ -118,20 +118,27 @@ psql "$DATABASE_URL" -c "
 # 7. Flip routing. New writes and cron enqueues go to queue storage.
 awa --database-url "$DATABASE_URL" storage enter-mixed-transition
 
-# 8. Watch canonical drain. `canonical_live_backlog()` sums non-terminal
-#    `jobs_hot` rows plus everything still in `scheduled_jobs` — the
-#    same number the gate uses internally.
-watch -n 5 'psql "$DATABASE_URL" -c "SELECT awa.canonical_live_backlog() AS canonical_backlog;"'
-#    → wait for canonical_backlog to reach 0
+# 8. Wait for canonical drain and finalize. `awa storage finalize --wait`
+#    polls every 5s and only invokes the SQL finalize once every
+#    readiness gate (`canonical_live_backlog`, no canonical or
+#    drain-only runtimes still heartbeating, etc.) has stayed clear
+#    for two consecutive observations. Default wait is unbounded;
+#    pass e.g. `--wait=2h` to cap. Polling progress is emitted via
+#    structured `tracing` logs (set `RUST_LOG=info` to see it).
+awa --database-url "$DATABASE_URL" storage finalize --wait
+#    → exits 0 once state=active; exits 2 if the wait cap expires
+#       while blockers remain.
 
-# 9. Finalize once canonical backlog is empty.
-awa --database-url "$DATABASE_URL" storage finalize
+# 8a. (Optional) Dry-run the readiness gates first without changing
+#     state. `--check` prints the same JSON `awa storage status`
+#     would, plus a one-line summary, and exits 2 if blocked.
+awa --database-url "$DATABASE_URL" storage finalize --check
 
-# 10. Verify active state.
+# 9. Verify active state.
 awa --database-url "$DATABASE_URL" storage status
 #    → current=queue_storage, active=queue_storage, prepared=NULL, state=active
 
-# 11. Once state=active, the queue-storage-target runtime is no longer
+# 10. Once state=active, the queue-storage-target runtime is no longer
 #     special — auto-role runtimes started from now on resolve to queue
 #     storage at startup. Either keep the explicit target running or
 #     redeploy it without --transition-role; behavior is identical


### PR DESCRIPTION
## Summary

Adds two operator ergonomics flags to `awa storage finalize`, closing the upgrade-path CLI gap called out in the [#180 release decision](https://github.com/hardbyte/awa/issues/180#issuecomment-4597208719):

- **`--check`** — dry-run: prints the same JSON `awa storage status` would, plus a one-line blocker summary on stderr; exits 0 when ready, exit 2 when blocked. No SQL state change.
- **`--wait[=duration]`** — polls the readiness gates every 5s and only invokes the SQL finalize once they have stayed clear for two consecutive observations. Optional duration cap (e.g. `2h`, `90s`, `1h30m`, `1500ms`); without a value, waits indefinitely. Exits 2 if the cap expires with blockers still present. Progress is emitted via structured `tracing` events (set `RUST_LOG=info` to see them).

The two flags are mutually exclusive at the clap level. The default no-flags behaviour (one-shot finalize, errors if blocked) is unchanged. The 0.5 → 0.6 upgrade guide now points at `awa storage finalize --wait` instead of `watch -n 5 psql …`.

No new audit table — per the #180 decision, the existing structured logs are sufficient.

## Acceptance criteria from #296

- [x] `awa storage finalize` with no flags keeps today's behaviour
- [x] `awa storage finalize --check` exits 0 when ready, non-zero (2) with a useful summary when blocked
- [x] `awa storage finalize --wait` polls until blockers are empty for N consecutive iterations, then finalizes; respects an optional duration cap
- [x] `--wait` and `--check` are mutually exclusive at the CLI level
- [x] Integration test covering fresh install / prepared-with-blocker / prepared-and-ready
- [x] `docs/upgrade-0.5-to-0.6.md` swapped for `awa storage finalize --wait`

## Test plan

Run from the worktree against the local Postgres (port 15432):

- [x] `cargo fmt --all`
- [x] `SQLX_OFFLINE=true cargo clippy --all-targets --all-features -- -D warnings`
- [x] `SQLX_OFFLINE=true cargo build --workspace`
- [x] `DATABASE_URL=postgres://postgres:test@localhost:15432/awa_test SQLX_OFFLINE=true cargo test -p awa-cli`
  - `storage_wait::tests::parse_simple_units` — ok
  - `storage_wait::tests::parse_compound_units` — ok
  - `storage_wait::tests::rejects_unitless_or_unknown` — ok
  - `storage_finalize_cli_test::check_on_fresh_canonical_state_reports_blocked` — ok
  - `storage_finalize_cli_test::check_when_ready_exits_zero_without_finalizing` — ok
  - `storage_finalize_cli_test::wait_finalizes_immediately_when_ready` — ok
  - `storage_finalize_cli_test::wait_times_out_with_blocker` — ok
  - (existing `inspection_cli_test` suite still passes)

The integration tests use a dedicated `awa_finalize_cli_test` database created on demand, plus a process mutex and advisory lock, so they don't fight the shared `awa.storage_transition_state` singleton in `awa_test`.

## Out of scope

- UI/API surfacing of the new flags (tracked separately on #297)
- Reverse-migration tooling (rejected in #180)
- New audit table (rejected in #180)

## Related

- Closes #296
- [#180 release decision comment](https://github.com/hardbyte/awa/issues/180#issuecomment-4597208719) — context for why this is a 0.6 release gate

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--check` flag to `awa storage finalize` for dry-run readiness reporting
  * Added `--wait DURATION` flag to poll and wait for readiness before finalizing, with optional timeout

* **Documentation**
  * Updated upgrade guide to reflect the new finalize workflow

<!-- end of auto-generated comment: release notes by coderabbit.ai -->