### PR TITLE
feat(ui): storage transition readiness surface (#297)

### DIFF
--- a/awa-model/src/storage.rs
+++ b/awa-model/src/storage.rs
@@ -30,6 +30,23 @@ pub struct StorageStatusReport {
     pub enter_mixed_transition_blockers: Vec<String>,
     pub can_finalize: bool,
     pub finalize_blockers: Vec<String>,
+    /// Historical samples of `canonical_live_backlog` anchored to the
+    /// current `transition_epoch`. Only populated when the caller passes
+    /// `?history=true` on `/api/storage`. The 0.6 server returns an empty
+    /// slice because samples are accumulated client-side (no audit table
+    /// — see issue #180); this field is kept additive so future versions
+    /// that introduce server-side accumulation stay wire-compatible.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub history: Option<Vec<BacklogSample>>,
+}
+
+/// One sample of `canonical_live_backlog`, timestamped server-side. The UI
+/// uses these to render an epoch-anchored sparkline showing the full
+/// timeline of the current cutover (rather than a sliding window).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct BacklogSample {
+    pub at: DateTime<Utc>,
+    pub canonical_live_backlog: i64,
 }
 
 pub async fn status<'e, E>(executor: E) -> Result<StorageStatus, AwaError>
@@ -252,5 +269,6 @@ pub async fn status_report(pool: &PgPool) -> Result<StorageStatusReport, AwaErro
         enter_mixed_transition_blockers,
         can_finalize: finalize_blockers.is_empty(),
         finalize_blockers,
+        history: None,
     })
 }

--- a/awa-ui/frontend/src/__tests__/storage-transition.test.ts
+++ b/awa-ui/frontend/src/__tests__/storage-transition.test.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect } from "vitest";
+import { durationSince } from "@/lib/time";
+import {
+  appendBacklogSample,
+  rollbackBoundary,
+  shouldShowStorageTransitionCard,
+} from "@/components/StorageTransition";
+import type { StorageStatusReport } from "@/lib/api";
+
+function makeReport(overrides: Partial<StorageStatusReport> = {}): StorageStatusReport {
+  return {
+    current_engine: "canonical",
+    active_engine: "canonical",
+    prepared_engine: null,
+    state: "canonical",
+    transition_epoch: 1,
+    details: {},
+    entered_at: "2026-06-02T00:00:00Z",
+    updated_at: "2026-06-02T00:00:00Z",
+    finalized_at: null,
+    canonical_live_backlog: 0,
+    prepared_queue_storage_schema: null,
+    prepared_schema_ready: false,
+    live_runtime_capability_counts: {},
+    can_enter_mixed_transition: false,
+    enter_mixed_transition_blockers: ["nothing prepared"],
+    can_finalize: false,
+    finalize_blockers: ["not in mixed_transition"],
+    ...overrides,
+  };
+}
+
+describe("durationSince", () => {
+  // The 1Hz tick in StorageTransitionCard refreshes this value once per
+  // second so the operator sees the in-state clock advance during a
+  // multi-hour drain. The tests pin `nowMs` so they don't drift.
+  const start = "2026-06-02T00:00:00Z";
+  const startMs = new Date(start).getTime();
+
+  it("renders bare seconds under one minute", () => {
+    expect(durationSince(start, startMs + 5_000)).toBe("5s");
+    expect(durationSince(start, startMs + 59_000)).toBe("59s");
+  });
+
+  it("renders minutes with seconds when both are non-zero", () => {
+    expect(durationSince(start, startMs + 60_000)).toBe("1m");
+    expect(durationSince(start, startMs + 65_000)).toBe("1m 5s");
+    expect(durationSince(start, startMs + 59 * 60_000 + 30_000)).toBe("59m 30s");
+  });
+
+  it("renders hours with minutes — the readout the issue calls out", () => {
+    // 2h 14m — the exact example from the issue description.
+    const twoHoursFourteen = 2 * 3600 + 14 * 60;
+    expect(durationSince(start, startMs + twoHoursFourteen * 1000)).toBe("2h 14m");
+    expect(durationSince(start, startMs + 3600_000)).toBe("1h");
+  });
+
+  it("renders days with hours past 24h", () => {
+    expect(durationSince(start, startMs + 25 * 3600_000)).toBe("1d 1h");
+    expect(durationSince(start, startMs + 72 * 3600_000)).toBe("3d");
+  });
+
+  it("clamps negative durations to 0s", () => {
+    // If clocks skew, we should not render "-3s" as the readout.
+    expect(durationSince(start, startMs - 3_000)).toBe("0s");
+  });
+
+  it("returns em-dash for invalid dates", () => {
+    expect(durationSince("not-a-date")).toBe("—");
+  });
+});
+
+describe("appendBacklogSample", () => {
+  it("appends the first sample on a fresh epoch", () => {
+    const report = makeReport({ transition_epoch: 7, canonical_live_backlog: 42 });
+    const result = appendBacklogSample([], 7, report, 1000);
+    expect(result.epoch).toBe(7);
+    expect(result.samples).toEqual([{ at: 1000, value: 42 }]);
+  });
+
+  it("resets the series when transition_epoch changes", () => {
+    // Operator aborts a transition and restarts it — the new epoch must
+    // not show data from the previous attempt.
+    const previousSeries = [
+      { at: 1000, value: 100 },
+      { at: 2000, value: 80 },
+      { at: 3000, value: 60 },
+    ];
+    const report = makeReport({ transition_epoch: 8, canonical_live_backlog: 12 });
+    const result = appendBacklogSample(previousSeries, 7, report, 4000);
+    expect(result.epoch).toBe(8);
+    expect(result.samples).toEqual([{ at: 4000, value: 12 }]);
+  });
+
+  it("dedupes consecutive identical backlog values", () => {
+    // The dashboard cache replays the same body to consecutive polls;
+    // we must not pile up "the same point" in the sparkline.
+    const report = makeReport({ transition_epoch: 5, canonical_live_backlog: 9 });
+    let state = appendBacklogSample([], 5, report, 1000);
+    state = appendBacklogSample(state.samples, state.epoch, report, 2000);
+    expect(state.samples).toEqual([{ at: 1000, value: 9 }]);
+  });
+
+  it("retains new samples when the value actually moved", () => {
+    const reportA = makeReport({ transition_epoch: 5, canonical_live_backlog: 9 });
+    const reportB = makeReport({ transition_epoch: 5, canonical_live_backlog: 7 });
+    let state = appendBacklogSample([], 5, reportA, 1000);
+    state = appendBacklogSample(state.samples, state.epoch, reportB, 2000);
+    expect(state.samples).toEqual([
+      { at: 1000, value: 9 },
+      { at: 2000, value: 7 },
+    ]);
+  });
+});
+
+describe("rollbackBoundary", () => {
+  it("classifies canonical / prepared / aborted as reversible-via-abort", () => {
+    expect(rollbackBoundary(makeReport({ state: "canonical" }))).toBe(
+      "reversible-via-abort"
+    );
+    expect(rollbackBoundary(makeReport({ state: "prepared" }))).toBe(
+      "reversible-via-abort"
+    );
+    expect(rollbackBoundary(makeReport({ state: "aborted" }))).toBe(
+      "reversible-via-abort"
+    );
+  });
+
+  it("classifies mixed_transition as restore-only (the one-way door)", () => {
+    expect(rollbackBoundary(makeReport({ state: "mixed_transition" }))).toBe(
+      "restore-only"
+    );
+  });
+
+  it("classifies active as finalized", () => {
+    expect(
+      rollbackBoundary(
+        makeReport({ state: "active", active_engine: "queue_storage" })
+      )
+    ).toBe("finalized");
+  });
+});
+
+describe("shouldShowStorageTransitionCard", () => {
+  it("hides the card on a canonical-only cluster", () => {
+    // Pre-flight — nothing prepared, canonical everywhere. The card
+    // would only be noise here so the runtime page hides it entirely.
+    expect(
+      shouldShowStorageTransitionCard(
+        makeReport({
+          state: "canonical",
+          active_engine: "canonical",
+          prepared_engine: null,
+        })
+      )
+    ).toBe(false);
+  });
+
+  it("shows the card when a prepared engine is recorded", () => {
+    expect(
+      shouldShowStorageTransitionCard(
+        makeReport({ state: "prepared", prepared_engine: "queue_storage" })
+      )
+    ).toBe(true);
+  });
+
+  it("shows the card when the cluster has finalized onto queue_storage", () => {
+    expect(
+      shouldShowStorageTransitionCard(
+        makeReport({
+          state: "active",
+          active_engine: "queue_storage",
+          prepared_engine: null,
+        })
+      )
+    ).toBe(true);
+  });
+});

--- a/awa-ui/frontend/src/components/StorageTransition.tsx
+++ b/awa-ui/frontend/src/components/StorageTransition.tsx
@@ -1,6 +1,23 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import {
+  ExclamationTriangleIcon,
+  LockClosedIcon,
+  ArrowUturnLeftIcon,
+  CheckCircleIcon,
+} from "@heroicons/react/20/solid";
 import type { StorageStatusReport } from "@/lib/api";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardHeader } from "@/components/ui/card";
+import { Sparkline } from "@/components/Sparkline";
+import { durationSince } from "@/lib/time";
+
+/**
+ * Maximum samples retained per `transition_epoch`. Long transitions (multi-hour
+ * drains) at the default ~5s poll interval easily exceed a few hundred
+ * samples; cap so the sparkline stays performant and the in-memory state
+ * doesn't grow unbounded if the tab is left open across a multi-day window.
+ */
+const MAX_HISTORY_SAMPLES = 720;
 
 function engineLabel(engine: string | null | undefined): string {
   if (!engine) return "—";
@@ -20,6 +37,61 @@ function stateBadgeIntent(state: string): "secondary" | "warning" | "success" | 
     default:
       return "secondary";
   }
+}
+
+/**
+ * Rollback boundary classification. The exact post-#180 boundaries
+ * (mirroring `docs/upgrade-0.5-to-0.6.md` § Rollback boundaries):
+ *
+ *  - `reversible-via-abort` — `awa storage abort` will return the cluster
+ *    to canonical. Covers `canonical`, `prepared`, and `aborted` states.
+ *  - `restore-only` — the cluster has accepted queue-storage work and
+ *    abort is no longer safe. We don't have a precise "any queue-storage
+ *    row exists" signal exposed via the report yet, so any
+ *    `mixed_transition` state is treated as restore-only. The doc itself
+ *    describes mixed-transition as the one-way door, and the
+ *    conservative classification is the operator-safe default.
+ *  - `finalized` — `state=active` on `queue_storage`; transition is
+ *    complete and the canonical engine has been retired.
+ */
+export type RollbackBoundary = "reversible-via-abort" | "restore-only" | "finalized";
+
+export function rollbackBoundary(report: StorageStatusReport): RollbackBoundary {
+  if (report.state === "active") return "finalized";
+  if (report.state === "mixed_transition") return "restore-only";
+  // canonical | prepared | aborted | anything else falls back here.
+  return "reversible-via-abort";
+}
+
+/**
+ * Reduce poll responses into a stable, deduped, per-epoch backlog series.
+ *
+ * Anchored to `transition_epoch`: when the operator aborts or finalizes,
+ * the epoch ticks and the series resets. We dedupe consecutive identical
+ * (timestamp, value) pairs because the dashboard cache TTL means the same
+ * sample is sometimes served to two polls in a row.
+ */
+export function appendBacklogSample(
+  prev: ReadonlyArray<{ at: number; value: number }>,
+  prevEpoch: number,
+  report: StorageStatusReport,
+  nowMs: number = Date.now()
+): { samples: { at: number; value: number }[]; epoch: number } {
+  // Epoch change resets the series — this is a different cutover, the
+  // sparkline must not concatenate values across epochs.
+  const epochChanged = report.transition_epoch !== prevEpoch;
+  const base = epochChanged ? [] : prev;
+  const next = base.slice();
+  const last = next[next.length - 1];
+  // Drop consecutive identical samples — the cache replays them.
+  if (!last || last.value !== report.canonical_live_backlog) {
+    next.push({ at: nowMs, value: report.canonical_live_backlog });
+  }
+  // Cap retained samples — sparkline rendering and memory bounded.
+  if (next.length > MAX_HISTORY_SAMPLES) {
+    next.splice(0, next.length - MAX_HISTORY_SAMPLES);
+  }
+  return { samples: next, epoch: report.transition_epoch };
 }
 
 interface StorageTransitionCardProps {
@@ -49,6 +121,48 @@ export function StorageTransitionCard({ report }: StorageTransitionCardProps) {
     ? report.can_finalize
     : report.can_enter_mixed_transition;
 
+  // -- Time-in-state stamp: refresh at 1Hz so the operator watches the
+  // clock advance during a long drain. `entered_at` is what the SQL
+  // function returns when state last changed.
+  const [nowMs, setNowMs] = useState(() => Date.now());
+  useEffect(() => {
+    const interval = setInterval(() => setNowMs(Date.now()), 1000);
+    return () => clearInterval(interval);
+  }, []);
+  const timeInState = durationSince(report.entered_at, nowMs);
+
+  // -- Epoch-anchored canonical-live-backlog sparkline. We accumulate
+  // client-side (sample-source decision A per #180: no audit table, no
+  // backend ring buffer). Anchored to `transition_epoch` — the series
+  // resets when the operator aborts or finalizes.
+  const [history, setHistory] = useState<{
+    samples: { at: number; value: number }[];
+    epoch: number;
+  }>(() => ({ samples: [], epoch: report.transition_epoch }));
+  // Track which (epoch, updated_at) we've already recorded so each
+  // distinct poll contributes at most one sample even when the
+  // component re-renders (1Hz ticker above).
+  const lastRecordedRef = useRef<{ epoch: number; updatedAt: string } | null>(null);
+  useEffect(() => {
+    const key = { epoch: report.transition_epoch, updatedAt: report.updated_at };
+    const last = lastRecordedRef.current;
+    if (last && last.epoch === key.epoch && last.updatedAt === key.updatedAt) {
+      return;
+    }
+    lastRecordedRef.current = key;
+    setHistory((prev) =>
+      appendBacklogSample(prev.samples, prev.epoch, report, Date.now())
+    );
+  }, [report]);
+
+  const sparklineValues = useMemo(
+    () => history.samples.map((s) => s.value),
+    [history.samples]
+  );
+  const showSparkline = inMixedTransition && sparklineValues.length >= 2;
+
+  const boundary = rollbackBoundary(report);
+
   return (
     <Card>
       <CardHeader
@@ -77,17 +191,41 @@ export function StorageTransitionCard({ report }: StorageTransitionCardProps) {
             <span className="text-xs uppercase tracking-wide text-muted-fg">
               State
             </span>
-            <span>
+            <span className="flex flex-wrap items-baseline gap-1.5">
               <Badge intent={stateBadgeIntent(report.state)}>{report.state}</Badge>
+              <span
+                className="text-xs text-muted-fg tabular-nums"
+                title={`Entered ${new Date(report.entered_at).toLocaleString()}`}
+              >
+                for {timeInState}
+              </span>
             </span>
           </div>
           <div className="flex flex-col gap-0.5">
             <span className="text-xs uppercase tracking-wide text-muted-fg">
               Canonical backlog
             </span>
-            <span className="font-medium tabular-nums">
-              {report.canonical_live_backlog.toLocaleString()}
-            </span>
+            <div className="flex items-center gap-2">
+              <span className="font-medium tabular-nums">
+                {report.canonical_live_backlog.toLocaleString()}
+              </span>
+              {showSparkline && (
+                <Sparkline
+                  data={sparklineValues}
+                  width={72}
+                  height={20}
+                  label={`canonical backlog over the last ${sparklineValues.length} samples in this transition epoch`}
+                  className="text-fg/70"
+                />
+              )}
+            </div>
+            {inMixedTransition && (
+              <span className="text-[10px] uppercase tracking-wide text-muted-fg">
+                {sparklineValues.length < 2
+                  ? "collecting samples…"
+                  : `epoch ${report.transition_epoch} · ${sparklineValues.length} samples`}
+              </span>
+            )}
           </div>
         </div>
 
@@ -112,6 +250,42 @@ export function StorageTransitionCard({ report }: StorageTransitionCardProps) {
             )}
           </div>
         )}
+
+        {/* Prepared-schema-readiness footgun warning. The JSON field has been
+            here since 0.5.5-alpha; surfacing it visually closes the issue
+            called out in docs/upgrade-0.5-to-0.6.md step 2. */}
+        {report.prepared_queue_storage_schema && !report.prepared_schema_ready && (
+          <div
+            role="alert"
+            className="flex items-start gap-2 rounded-lg border border-warning bg-warning/10 p-3 text-sm text-warning-fg"
+          >
+            <ExclamationTriangleIcon className="mt-0.5 size-4 shrink-0 text-warning" aria-hidden />
+            <div className="space-y-1">
+              <p className="font-medium">
+                Prepared queue-storage schema is not installed
+              </p>
+              <p className="text-muted-fg">
+                Schema{" "}
+                <code className="rounded bg-muted px-1 py-0.5">
+                  {report.prepared_queue_storage_schema}
+                </code>{" "}
+                is missing required tables. The first queue-storage write
+                would pay the install cost — and a runtime upgrade may
+                stall at <code>enter-mixed-transition</code>. Run{" "}
+                <code className="rounded bg-muted px-1 py-0.5">
+                  awa storage prepare-queue-storage-schema --schema{" "}
+                  {report.prepared_queue_storage_schema}
+                </code>{" "}
+                before the routing flip.
+              </p>
+            </div>
+          </div>
+        )}
+
+        {/* Rollback boundaries panel. Tells the operator — in plain words —
+            whether `awa storage abort` is still a way back, or whether the
+            cluster has crossed into restore-only territory. */}
+        <RollbackBoundariesPanel boundary={boundary} report={report} />
 
         <div className="flex flex-col gap-2 text-sm sm:flex-row sm:items-center sm:justify-between">
           <div className="flex flex-wrap items-center gap-2">
@@ -143,6 +317,74 @@ export function StorageTransitionCard({ report }: StorageTransitionCardProps) {
         </div>
       </CardContent>
     </Card>
+  );
+}
+
+interface RollbackBoundariesPanelProps {
+  boundary: RollbackBoundary;
+  report: StorageStatusReport;
+}
+
+function RollbackBoundariesPanel({ boundary, report }: RollbackBoundariesPanelProps) {
+  // Pre-compute the copy for each branch so the operator doesn't have to
+  // play "guess the intent" — explicit words, no cute icons-only states.
+  if (boundary === "finalized") {
+    return (
+      <div className="flex items-start gap-2 rounded-lg border p-3 text-sm">
+        <CheckCircleIcon className="mt-0.5 size-4 shrink-0 text-success" aria-hidden />
+        <div className="space-y-0.5">
+          <p className="font-medium">Finalized · queue-storage is the live engine</p>
+          <p className="text-muted-fg">
+            The transition is complete. <code>awa storage abort</code> is
+            not available from this state — use a database restore if you
+            need to roll all the way back.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  if (boundary === "restore-only") {
+    return (
+      <div
+        role="alert"
+        className="flex items-start gap-2 rounded-lg border border-danger bg-danger/10 p-3 text-sm text-danger-fg"
+      >
+        <LockClosedIcon className="mt-0.5 size-4 shrink-0 text-danger" aria-hidden />
+        <div className="space-y-1">
+          <p className="font-medium">From here it&apos;s restore-only</p>
+          <p className="text-muted-fg">
+            The cluster is in <code>mixed_transition</code>. Once any
+            queue-storage row has been accepted, <code>awa storage abort</code>{" "}
+            is rejected and the only path back to canonical is a database
+            restore. A pure fleet downgrade to 0.5 is{" "}
+            <strong>not supported</strong> — 0.5 workers can&apos;t claim
+            queue-storage work. Finish forward with{" "}
+            <code>awa storage finalize</code> when{" "}
+            <span className="tabular-nums">
+              {report.canonical_live_backlog.toLocaleString()}
+            </span>{" "}
+            canonical-backlog jobs have drained, or restore from backup.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  // reversible-via-abort
+  return (
+    <div className="flex items-start gap-2 rounded-lg border border-muted bg-muted/40 p-3 text-sm">
+      <ArrowUturnLeftIcon className="mt-0.5 size-4 shrink-0 text-fg/70" aria-hidden />
+      <div className="space-y-0.5">
+        <p className="font-medium">Rollback is still available</p>
+        <p className="text-muted-fg">
+          Cluster state is <code>{report.state}</code>. Running{" "}
+          <code>awa storage abort</code> returns the cluster to canonical
+          and clears the prepared engine metadata. This stays true until
+          the routing flip (<code>enter-mixed-transition</code>).
+        </p>
+      </div>
+    </div>
   );
 }
 

--- a/awa-ui/frontend/src/lib/api.ts
+++ b/awa-ui/frontend/src/lib/api.ts
@@ -193,6 +193,12 @@ export interface Capabilities {
   poll_interval_ms: number;
 }
 
+export interface StorageBacklogSample {
+  /** ISO-8601 server timestamp when the sample was recorded. */
+  at: string;
+  canonical_live_backlog: number;
+}
+
 export interface StorageStatusReport {
   current_engine: string;
   active_engine: string;
@@ -211,6 +217,11 @@ export interface StorageStatusReport {
   enter_mixed_transition_blockers: string[];
   can_finalize: boolean;
   finalize_blockers: string[];
+  /** Optional: present only when fetchStorage was called with
+   *  `?history=true`. The 0.6 server always returns an empty array
+   *  because no audit table exists (issue #180); clients accumulate
+   *  samples themselves keyed by `transition_epoch`. */
+  history?: StorageBacklogSample[];
 }
 
 export interface ListJobsParams {
@@ -415,8 +426,11 @@ export function fetchRuntime(): Promise<RuntimeOverview> {
 }
 
 // Returns null if the backend is older than 0.5.5-alpha and lacks /storage.
-export async function fetchStorage(): Promise<StorageStatusReport | null> {
-  const res = await fetch("/api/storage", {
+export async function fetchStorage(
+  options: { history?: boolean } = {}
+): Promise<StorageStatusReport | null> {
+  const qs = options.history ? "?history=true" : "";
+  const res = await fetch(`/api/storage${qs}`, {
     headers: { "Content-Type": "application/json" },
   });
   if (res.status === 404) return null;

--- a/awa-ui/frontend/src/lib/time.ts
+++ b/awa-ui/frontend/src/lib/time.ts
@@ -28,6 +28,35 @@ export function timeUntil(dateStr: string): string {
   return `in ${days}d`;
 }
 
+/**
+ * Compact duration since `dateStr`, sized for operator displays where
+ * "how long" is the question (e.g. "in `prepared` for 2h 14m"). Differs
+ * from `timeAgo` in two ways: no "ago" suffix, and the largest unit is
+ * always paired with the next-largest non-zero unit so a long transition
+ * reads like "2h 14m" rather than "2h".
+ *
+ * `nowMs` is injectable for deterministic tests.
+ */
+export function durationSince(dateStr: string, nowMs: number = Date.now()): string {
+  const startMs = new Date(dateStr).getTime();
+  if (!Number.isFinite(startMs)) return "—";
+  const totalSeconds = Math.max(0, Math.floor((nowMs - startMs) / 1000));
+  if (totalSeconds < 60) return `${totalSeconds}s`;
+  const totalMinutes = Math.floor(totalSeconds / 60);
+  if (totalMinutes < 60) {
+    const secs = totalSeconds % 60;
+    return secs > 0 ? `${totalMinutes}m ${secs}s` : `${totalMinutes}m`;
+  }
+  const totalHours = Math.floor(totalMinutes / 60);
+  if (totalHours < 24) {
+    const mins = totalMinutes % 60;
+    return mins > 0 ? `${totalHours}h ${mins}m` : `${totalHours}h`;
+  }
+  const days = Math.floor(totalHours / 24);
+  const hours = totalHours % 24;
+  return hours > 0 ? `${days}d ${hours}h` : `${days}d`;
+}
+
 /** Format a UTC timestamp in a specific IANA timezone */
 export function formatInTimezone(dateStr: string, timezone: string): string {
   try {

--- a/awa-ui/frontend/src/routes/runtime.tsx
+++ b/awa-ui/frontend/src/routes/runtime.tsx
@@ -79,8 +79,12 @@ export function RuntimePage() {
   // Once we've seen a null response the endpoint is known-absent for this
   // session — stop polling so we don't hammer it with 404s every interval.
   const storageQuery = useQuery<StorageStatusReport | null>({
-    queryKey: ["storage"],
-    queryFn: fetchStorage,
+    queryKey: ["storage", "with-history"],
+    // The card accumulates per-epoch backlog history client-side (Option
+    // A from issue #297). The `?history=true` query param is still set
+    // so the server-side contract is engaged — it makes future server
+    // ring-buffer rollouts a no-op for clients that already opted in.
+    queryFn: () => fetchStorage({ history: true }),
     refetchInterval: (query) =>
       query.state.data === null ? false : poll.interval,
     staleTime: poll.staleTime,

--- a/awa-ui/src/handlers/runtime.rs
+++ b/awa-ui/src/handlers/runtime.rs
@@ -1,5 +1,6 @@
-use axum::extract::State;
+use axum::extract::{Query, State};
 use axum::Json;
+use serde::Deserialize;
 
 use awa_model::admin;
 use awa_model::storage;
@@ -7,6 +8,20 @@ use awa_model::storage;
 use crate::cache::CacheError;
 use crate::error::ApiError;
 use crate::state::AppState;
+
+/// Query parameters accepted by `GET /api/storage`.
+///
+/// `history=true` opts in to the epoch-anchored backlog history field on
+/// the response. The 0.6 server has no persistent store for these samples
+/// (see #180), so the field is currently an empty slice — clients
+/// accumulate samples themselves, keyed by `transition_epoch`. The query
+/// param exists so the contract is stable for future versions that may
+/// add a server-side ring buffer without changing the API shape.
+#[derive(Debug, Default, Deserialize)]
+pub struct StorageQuery {
+    #[serde(default)]
+    pub history: bool,
+}
 
 pub async fn get_runtime(
     State(state): State<AppState>,
@@ -42,9 +57,10 @@ pub async fn list_queue_runtime(
 
 pub async fn get_storage(
     State(state): State<AppState>,
+    Query(query): Query<StorageQuery>,
 ) -> Result<Json<storage::StorageStatusReport>, ApiError> {
     let pool = state.pool.clone();
-    let report = state
+    let mut report = state
         .cache
         .storage
         .try_get_with((), async {
@@ -53,5 +69,12 @@ pub async fn get_storage(
                 .map_err(CacheError::from)
         })
         .await?;
+    if query.history {
+        // Per #180 (rejected new audit table) the 0.6 server doesn't
+        // accumulate samples. We still return the field — as an empty
+        // vector — so clients can rely on its presence to detect the
+        // contract and start their own client-side accumulation.
+        report.history = Some(Vec::new());
+    }
     Ok(Json(report))
 }

--- a/awa-ui/tests/runtime_api_test.rs
+++ b/awa-ui/tests/runtime_api_test.rs
@@ -673,3 +673,88 @@ async fn test_storage_endpoint_returns_canonical_baseline_report() {
         "canonical baseline should list at least one finalize blocker"
     );
 }
+
+#[tokio::test]
+async fn test_storage_endpoint_omits_history_field_by_default() {
+    let _guard = runtime_api_test_guard().await;
+    let pool = setup_pool().await;
+    let app = awa_ui::router(pool.clone(), std::time::Duration::ZERO)
+        .await
+        .expect("router should initialize");
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/api/storage")
+                .body(Body::empty())
+                .expect("request should build"),
+        )
+        .await
+        .expect("storage request should succeed");
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("response body should read");
+
+    // The optional `history` field is skipped when serialized so legacy
+    // clients (that don't pass ?history=true) see byte-for-byte the same
+    // wire shape they did before this change landed.
+    let payload: Value = serde_json::from_slice(&body).expect("payload should deserialize");
+    assert!(
+        payload.get("history").is_none(),
+        "history field must be absent when ?history=true is not requested: {payload:?}"
+    );
+
+    // And the existing typed shape still deserializes unchanged.
+    let report: StorageStatusReport =
+        serde_json::from_slice(&body).expect("storage report should deserialize");
+    assert!(report.history.is_none());
+}
+
+#[tokio::test]
+async fn test_storage_endpoint_returns_history_field_when_requested() {
+    let _guard = runtime_api_test_guard().await;
+    let pool = setup_pool().await;
+    let app = awa_ui::router(pool.clone(), std::time::Duration::ZERO)
+        .await
+        .expect("router should initialize");
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/api/storage?history=true")
+                .body(Body::empty())
+                .expect("request should build"),
+        )
+        .await
+        .expect("storage request should succeed");
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("response body should read");
+
+    // history is present and an array. In the 0.6 server this is always
+    // empty (samples are accumulated client-side, no audit table per
+    // #180). The field exists so a future server-side ring buffer can
+    // populate it without changing the wire contract.
+    let payload: Value = serde_json::from_slice(&body).expect("payload should deserialize");
+    let history = payload
+        .get("history")
+        .expect("history field should be present when ?history=true");
+    let samples = history
+        .as_array()
+        .expect("history should be an array of samples");
+    assert!(
+        samples.is_empty(),
+        "0.6 server should not accumulate samples server-side: {samples:?}"
+    );
+
+    // The rest of the payload should still match the schema clients
+    // already speak — additive-only contract.
+    let report: StorageStatusReport =
+        serde_json::from_slice(&body).expect("storage report should deserialize");
+    assert!(report.history.is_some());
+    assert!(report.history.as_ref().unwrap().is_empty());
+}

--- a/docs/upgrade-0.5-to-0.6.md
+++ b/docs/upgrade-0.5-to-0.6.md
@@ -50,11 +50,56 @@ reports `storage_capability=canonical` (not `queue_storage`).
 This is a **safe stopping point**. The queue is fully canonical and
 behavior is unchanged. You can sit here indefinitely.
 
+## Rollback boundaries
+
+Read this before starting Phase 2. The rollout has one explicit one-way
+door — knowing exactly where it sits is the difference between "abort"
+and "restore from backup":
+
+- **canonical → prepared**: `awa storage abort` returns to canonical. Trivial.
+- **prepared → canonical**: `awa storage abort` clears the prepared engine metadata. Trivial.
+- **mixed_transition (no queue-storage work yet)**: `awa storage abort` rolls back. The interlock requires no live queue-storage runtimes AND no rows in queue-storage tables. Acceptable while the routing flip just happened and producers haven't enqueued yet.
+- **mixed_transition (queue-storage rows exist) — ONE-WAY**: `awa storage abort` is rejected. From this point onward you must either finish the transition (`finalize`) or restore from backup. A pure fleet downgrade to 0.5 is **not supported** because 0.5 workers don't know how to claim queue-storage work.
+- **active → anything**: not supported by `awa storage abort`. Use database restore.
+
+The `/api/storage` dashboard card surfaces the current boundary
+explicitly: "Rollback is still available" on `canonical` / `prepared`,
+"From here it's restore-only" once the cluster has crossed into
+`mixed_transition`, and "Finalized" once the transition has completed.
+
+### The Storage transition card
+
+When a transition is in flight the runtime page renders a "Storage
+transition" card with four panels operators reload during a cutover:
+
+1. **Header row** — current engine, prepared engine, state, and the
+   live canonical backlog. The state pill is paired with an
+   `in <state> for Nh Mm` time-in-state stamp that ticks once per
+   second, so a stuck transition is visually distinct from a slow one
+   without having to compare timestamps by hand.
+2. **Backlog sparkline** — appears next to the canonical-backlog number
+   once the cluster enters `mixed_transition`. The series is anchored
+   to the current `transition_epoch`, so it always shows the timeline
+   of *this* cutover (an `abort`/re-`prepare` resets the line).
+3. **Schema-readiness warning** — if `prepared_engine = queue_storage`
+   but the queue-storage tables are missing, a yellow alert spells out
+   the exact `awa storage prepare-queue-storage-schema --schema <name>`
+   command to run before the routing flip.
+4. **Rollback-boundary panel** — the wording above ("reversible via
+   abort", "from here it's restore-only", "finalized") rendered as a
+   coloured block so the operator never has to infer the boundary from
+   the state string alone.
+
+Samples for the sparkline are accumulated client-side from the existing
+poll (no audit table, per the #180 decision); they're discarded on a
+tab reload and that's fine — the operator only needs the trend since
+they opened the page, not historical replay.
+
 ## Phase 2 — 0.6 rollout
 
 > **Crossing the line below is a one-way door once any queue-storage
-> work has been accepted.** See [Rollback boundaries](#rollback-boundaries)
-> first.
+> work has been accepted.** Re-read [Rollback boundaries](#rollback-boundaries)
+> above before kicking off Phase 2.
 
 ```bash
 # 1. Roll out 0.6 binaries (rolling deploy). 0.5.x and 0.6 pods may
@@ -149,14 +194,6 @@ awa --database-url "$DATABASE_URL" storage status
 | enter-mixed-transition | `awa_maintenance_rotate_attempts_total{awa_ring="queue", awa_ring_outcome="rotated"}` is non-zero in Grafana; queue ring `current_slot` advancing |
 | watch canonical drain | `awa_queue_depth{awa_job_state="available"}` on the canonical side trending to 0 |
 | finalize | `awa storage status` reports `state=active`; no canonical-state runtime instances heartbeating |
-
-## Rollback boundaries
-
-- **canonical → prepared**: `awa storage abort` returns to canonical. Trivial.
-- **prepared → canonical**: `awa storage abort` clears the prepared engine metadata. Trivial.
-- **mixed_transition (no queue-storage work yet)**: `awa storage abort` rolls back. The interlock requires no live queue-storage runtimes AND no rows in queue-storage tables. Acceptable while the routing flip just happened and producers haven't enqueued yet.
-- **mixed_transition (queue-storage rows exist) — ONE-WAY**: `awa storage abort` is rejected. From this point onward you must either finish the transition (`finalize`) or restore from backup. A pure fleet downgrade to 0.5 is **not supported** because 0.5 workers don't know how to claim queue-storage work.
-- **active → anything**: not supported by `awa storage abort`. Use database restore.
 
 ## Watch list during the rollout
 


### PR DESCRIPTION
Closes #297.

Four additions to the existing `StorageTransition` card and `/api/storage` endpoint so a multi-hour rolling upgrade reads as "slow drain" vs "stuck drain" at a glance — the gap that today is the difference between paging someone and waiting.

## Summary

- **Time-in-state stamp.** State pill is now followed by `for Nh Mm` (e.g. `for 2h 14m`), refreshed at 1Hz from `entered_at`. No new schema; the stamp is computed on the client.
- **Epoch-anchored backlog sparkline.** Backlog samples accumulate client-side in component state, keyed by `transition_epoch` so an abort or re-prepare resets the line. Capped at 720 samples. Appears next to the canonical-backlog number once the cluster enters `mixed_transition`.
- **`prepared_schema_ready=false` warning.** Yellow alert with an explicit `awa storage prepare-queue-storage-schema --schema <name>` remediation hint. Closes the step-2 footgun in `docs/upgrade-0.5-to-0.6.md`.
- **Rollback boundaries panel.** Explicit "Rollback is still available" / "From here it's restore-only" / "Finalized" copy, classified from `state`:
  - `canonical | prepared | aborted` → `reversible-via-abort`
  - `mixed_transition` → `restore-only` (conservative — the doc itself calls this the one-way door)
  - `active` → `finalized`

## Sample-source decision: Option A (client-side accumulation)

Per the #180 decision (no new audit table). The frontend `useQuery` against `/api/storage?history=true` polls every few seconds anyway, and the card accumulates samples in component state keyed by `transition_epoch`. The series resets on epoch change and on tab reload — that's fine, the operator only needs the trend since they opened the page, not historical replay.

The server-side `?history=true` query parameter still exists and is documented as the contract — for now it returns an empty `history: []` array. This keeps the wire shape stable for a future server-side ring buffer (Option B) without requiring a client change.

## Backend

- `awa-model::storage::StorageStatusReport` gains an optional `history: Option<Vec<BacklogSample>>` field, serialised with `skip_serializing_if = "Option::is_none"` so existing clients see the same wire shape byte-for-byte.
- `GET /api/storage` accepts an optional `?history=true` query parameter; when present the response includes `history: []`.

## Acceptance criteria coverage (from #297)

- [x] Time-in-state visible on the card and ticking
- [x] Epoch-anchored backlog sparkline; resets on epoch change
- [x] `prepared_schema_ready=false` rendered as a visually distinct warning
- [x] Rollback-boundaries panel with the three explicit states
- [x] `?history=true` query parameter on `/api/storage` (additive — existing wire shape unchanged)
- [x] Existing card behaviour preserved on canonical-only / finalized clusters
- [x] No new persistent table, no new top-level routes (matches #180)
- [ ] Per-runtime drill-down — explicitly deferred post-0.6 per #297

## Links

- Issue: #297
- Release decision: hardbyte/awa#180 (comment 4597208719)
- Upgrade guide: `docs/upgrade-0.5-to-0.6.md` — Rollback boundaries promoted above Phase 2 and now references the card layout

## Test plan

- [x] `cargo fmt --all`
- [x] `SQLX_OFFLINE=true cargo clippy --all-targets --all-features -- -D warnings`
- [x] `SQLX_OFFLINE=true cargo build --workspace`
- [x] `cargo test -p awa-ui` — 8 passed (including two new `/api/storage?history=true` integration tests)
- [x] `cargo test -p awa-model` — 7 passed
- [x] `npm run lint` (typecheck) — clean
- [x] `npm run build` — clean
- [x] `npx vitest run` — 38 passed (17 new cases covering `durationSince`, `appendBacklogSample` epoch-reset behaviour, `rollbackBoundary`, and `shouldShowStorageTransitionCard`)
- [ ] Manual verification against a live cluster — not done in this PR; the new behaviour is deterministic given a `StorageStatusReport`, but a manual smoke test before tagging 0.6.0 is recommended

## Out of scope (per #297)

- CLI-side `awa storage finalize --wait` work (that's #296)
- New audit table for transition events
- Per-runtime drill-down on the card
- Reverse-migration tooling