### PR TITLE
test(chaos): convert remaining stdout sync points to DB observation (#167)

### DIFF
--- a/awa/tests/chaos_suite_test.rs
+++ b/awa/tests/chaos_suite_test.rs
@@ -1252,12 +1252,18 @@ async fn test_sustained_mixed_workload_survives_repeated_node_failures() {
     .await
     .expect("Failed to insert sentinel simple chaos job");
 
-    python_worker
-        .wait_for_line(
-            "START mode=worker_simple_chaos_job",
-            Duration::from_secs(10),
-        )
-        .await;
+    // Synchronize on the durable DB state instead of helper stdout: the sentinel
+    // job reaching `running` proves the Python worker has claimed it. Avoids
+    // pipe-buffered stderr scheduling flake from the helper.
+    wait_for_kind_state_count(
+        &pool,
+        &queue,
+        "simple_chaos_job",
+        "running",
+        1,
+        Duration::from_secs(10),
+    )
+    .await;
 
     async fn insert_wave(pool: &sqlx::PgPool, queue: &str, seq: &mut i64) {
         for _ in 0..2 {
@@ -1304,16 +1310,9 @@ async fn test_sustained_mixed_workload_survives_repeated_node_failures() {
     insert_wave(&pool, &queue, &mut seq).await;
     insert_wave(&pool, &queue, &mut seq).await;
 
-    // Confirm Python is mid-execution on at least one simple job. The stdout
-    // line proves the helper entered the handler; the database predicate is
-    // the durable synchronization point that makes the later rescue assertion
-    // independent of stdout scheduling.
-    python_worker
-        .wait_for_line(
-            "START mode=worker_simple_chaos_job",
-            Duration::from_secs(10),
-        )
-        .await;
+    // Confirm Python is mid-execution on at least one simple job. The DB
+    // predicate (`running` count) is the durable synchronization point that
+    // makes the later rescue assertion independent of helper stdout scheduling.
     let running_before_kill = wait_for_kind_state_count(
         &pool,
         &queue,


### PR DESCRIPTION
## Summary

Per the [#167 release decision](https://github.com/hardbyte/awa/issues/167#issuecomment-4597480941), the chaos suite was already substantially on DB-state observation. The remaining 0.6 acceptance was to convert the last two non-`READY` `wait_for_line` sites in `awa/tests/chaos_suite_test.rs`.

## What changed

- Line ~1256: previously waited on stdout `\"START mode=worker_simple_chaos_job\"`. Now uses `wait_for_kind_state_count(&pool, &queue, \"simple_chaos_job\", \"running\", 1, Duration::from_secs(10))` — the durable DB sync point.
- Line ~1312: previously waited on the same stdout line, then immediately called `wait_for_kind_state_count` anyway. The stdout call was redundant scaffolding; removed. Updated the surrounding comment to reflect that the DB predicate is now the sole sync point.

`READY` waits stay untouched (lines 1237 and 1548) — they're start-up handshakes, not state synchronisation, and were never the source of stdout-coupling flakes.

## Why now

Closing the loop on the #167 acceptance bar without the perpetual \"constrained 100x\" criterion. Nightly-chaos is green 14 of the last 15 runs; #252 closed cleanly via root-cause fixes in the post-#261 rescue work. The chaos suite is already functioning as a regression watchdog; this PR removes the last small stdout-coupling that the v0.6 acceptance criterion called out.

## Closes

- Closes #167

Refs the v0.7 architectural test-suite shape conversation (none yet — the substantively-done work is sufficient for 0.6 stable).

## Test plan

- [x] \`cargo fmt --all\`
- [x] \`cargo clippy -p awa --tests -- -D warnings\` (clean)
- [ ] CI runs the full \`test_sustained_mixed_workload_survives_repeated_node_failures\` test against the real DB.

Local verification of the targeted test was blocked by a Cargo workspace detection issue when running \`maturin develop\` from inside a worktree (the worktree's \`awa-python\` looks up to find the main repo's \`Cargo.toml\` which excludes it). The change itself is mechanical — \`wait_for_kind_state_count\` is used 14 other times in the same file — and CI runs the test in a properly-installed Python env. Reviewer can repro locally from main with \`DATABASE_URL=… cargo test --package awa --test chaos_suite_test test_sustained_mixed_workload_survives_repeated_node_failures -- --ignored --nocapture\` after maturin-developing \`awa-python\`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved chaos node-failure soak test synchronization and stability by refining the wait mechanism for worker progress tracking, reducing timing-related test flakiness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->