### PR TITLE
feat(queue_storage): read live terminal counts + rename to QueueCounts.terminal (#290)

### DIFF
--- a/awa-model/src/queue_storage.rs
+++ b/awa-model/src/queue_storage.rs
@@ -193,7 +193,14 @@ impl ClaimedRuntimeJob {
 pub struct QueueCounts {
     pub available: i64,
     pub running: i64,
-    pub completed: i64,
+    /// Count of rows in *any* terminal state (`completed`, `failed`, or
+    /// `cancelled`) for the queue. The name reflects what the field
+    /// actually counts: it is `count(*) FROM done_entries` semantics, not
+    /// `count(*) WHERE state = 'completed'`. The historical name
+    /// `completed` was a misnomer — `queue_counts_exact` has always
+    /// included failed and cancelled terminals; renamed in #290 along
+    /// with the counter-backed read path.
+    pub terminal: i64,
 }
 
 /// Cheap available-only signal used by the dispatcher's claimer-sizing
@@ -205,7 +212,7 @@ pub struct QueueCounts {
 /// This is intentionally a separate type from [`QueueCounts`]: the
 /// dispatcher claim hot path only consumes the available count, and
 /// returning a `QueueCounts` with two perpetually-zero fields would
-/// invite future code to read `.running` or `.completed` and silently
+/// invite future code to read `.running` or `.terminal` and silently
 /// get wrong answers. Code that legitimately needs the full counts
 /// should call [`QueueStorage::queue_counts`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -7124,15 +7131,21 @@ impl QueueStorage {
                     ), 0)
                 )::bigint AS running
             ),
+            -- #290: read live terminal counts from the denormalised
+            -- counter instead of scanning `done_entries`. The counter is
+            -- maintained in lockstep with done_entries by the increment/
+            -- decrement sites and folded into queue_terminal_rollups at
+            -- prune time, so this sum + pruned_terminal is the exact
+            -- count of all terminal rows ever recorded for the queue.
             live_terminal AS (
-                SELECT count(*)::bigint AS completed
-                FROM {schema}.done_entries
+                SELECT COALESCE(SUM(live_terminal_count), 0)::bigint AS terminal
+                FROM {schema}.queue_terminal_live_counts
                 WHERE queue = ANY($1)
             )
             SELECT
                 lane_counts.available,
                 live_running.running,
-                pruned_terminal.completed + live_terminal.completed AS completed
+                pruned_terminal.completed + live_terminal.terminal AS terminal
             FROM lane_counts
             CROSS JOIN pruned_terminal
             CROSS JOIN live_running
@@ -7144,11 +7157,11 @@ impl QueueStorage {
         .await
         .map_err(map_sqlx_error)?;
 
-        let (available, running, completed) = row;
+        let (available, running, terminal) = row;
         Ok(QueueCounts {
             available,
             running,
-            completed,
+            terminal,
         })
     }
 
@@ -7177,12 +7190,15 @@ impl QueueStorage {
     ///   that anti-join is what this fast variant exists to avoid).
     ///   `waiting_external` is *not* included — it's reported as part
     ///   of admin's parked-callback view, not running.
-    /// - **completed** is read from the persisted
+    /// - **terminal** is read from the persisted
     ///   `queue_terminal_rollups.pruned_completed_count` denormaliser.
     ///   Rows currently in `done_entries` that have not yet rolled up
     ///   are not included. Strictly a lower bound; converges to the
     ///   exact count when rotation prunes the live `done_entries`
-    ///   segment.
+    ///   segment. (The name `terminal` is honest — this number counts
+    ///   `completed`, `failed`, and `cancelled` rows in done_entries,
+    ///   the same semantics as [`Self::queue_counts_exact`]; renamed
+    ///   from `completed` in #290.)
     ///
     /// All three counters are O(num shards) lookups against small head
     /// tables and `leases` index probes. Use this for high-cadence
@@ -7216,9 +7232,9 @@ impl QueueStorage {
         .fetch_one(pool)
         .await
         .map_err(map_sqlx_error)?;
-        // completed: denormalised rollup only. Live (un-rolled-up)
+        // terminal: denormalised rollup only. Live (un-rolled-up)
         // done_entries rows are excluded — see method-level docs.
-        let completed: i64 = sqlx::query_scalar(&format!(
+        let terminal: i64 = sqlx::query_scalar(&format!(
             r#"
             SELECT COALESCE(sum(GREATEST(
                 COALESCE(lanes.pruned_completed_count, 0),
@@ -7244,7 +7260,7 @@ impl QueueStorage {
         Ok(QueueCounts {
             available,
             running,
-            completed,
+            terminal,
         })
     }
 

--- a/awa-model/src/queue_storage.rs
+++ b/awa-model/src/queue_storage.rs
@@ -3408,6 +3408,28 @@ impl QueueStorage {
             .await
             .map_err(map_sqlx_error)?;
 
+            // #290: queue-leading index so `queue_counts_exact`'s
+            // `WHERE queue = ANY($1)` scan is an index range probe over
+            // the requested queue's rows instead of a full-table scan
+            // across every queue's counters. The PK leads with
+            // `ready_slot`, which is the right shape for the row-level
+            // UPSERT path (one row per group) but the wrong shape for
+            // the read aggregation. Including `priority` as the second
+            // column keeps the index narrow while supporting any future
+            // per-priority drill-down. Notably we do NOT INCLUDE
+            // `live_terminal_count` here — that would block HOT updates
+            // on the very column the increment/decrement path mutates,
+            // re-introducing the v016 bloat shape #290 is trying to
+            // avoid.
+            sqlx::query(&format!(
+                "CREATE INDEX IF NOT EXISTS \
+                 idx_{schema}_queue_terminal_live_counts_queue \
+                 ON {schema}.queue_terminal_live_counts (queue, priority)"
+            ))
+            .execute(install_tx.as_mut())
+            .await
+            .map_err(map_sqlx_error)?;
+
             sqlx::query(&format!(
                 r#"
             ALTER TABLE {schema}.queue_terminal_live_counts SET (

--- a/awa/tests/benchmark_test.rs
+++ b/awa/tests/benchmark_test.rs
@@ -805,7 +805,7 @@ async fn test_throughput_rust_workers_queue_storage() {
                 .expect("Failed to sample queue storage queue counts");
             panic!(
                 "Vacuum-aware timeout after 30s: completed={}/{} available={} running={}",
-                counts.completed, total_jobs, counts.available, counts.running
+                counts.terminal, total_jobs, counts.available, counts.running
             );
         }
 
@@ -815,7 +815,7 @@ async fn test_throughput_rust_workers_queue_storage() {
             .await
             .expect("Failed to sample queue storage queue counts");
 
-        if counts.completed == total_jobs {
+        if counts.terminal == total_jobs {
             let processing_elapsed = processing_start.elapsed();
             let throughput = total_jobs as f64 / processing_elapsed.as_secs_f64();
             let end_to_end_elapsed = benchmark_start.elapsed();
@@ -951,17 +951,17 @@ async fn test_throughput_rust_workers_queue_storage() {
             return;
         }
 
-        if counts.completed == last_completed {
+        if counts.terminal == last_completed {
             stall_checks += 1;
             if stall_checks > 50 {
                 panic!(
                     "Vacuum-aware processing stalled at {}/{} completed jobs",
-                    counts.completed, total_jobs
+                    counts.terminal, total_jobs
                 );
             }
         } else {
             stall_checks = 0;
-            last_completed = counts.completed;
+            last_completed = counts.terminal;
         }
     }
 }
@@ -1117,12 +1117,12 @@ async fn test_queue_storage_runtime_offered_rate() {
             .queue_counts(&pool, queue)
             .await
             .expect("Failed to sample queue storage offered-rate counts");
-        let completed_delta = counts.completed.saturating_sub(previous_completed);
-        previous_completed = counts.completed;
+        let completed_delta = counts.terminal.saturating_sub(previous_completed);
+        previous_completed = counts.terminal;
         println!(
             "[bench-va-offered] second={second:>2} seeded={} completed={} (+{}) available={} running={}",
             seeded.load(Ordering::Relaxed),
-            counts.completed,
+            counts.terminal,
             completed_delta,
             counts.available,
             counts.running,
@@ -1130,7 +1130,7 @@ async fn test_queue_storage_runtime_offered_rate() {
         samples.push(OfferedRateSample {
             second,
             seeded: seeded.load(Ordering::Relaxed),
-            completed: counts.completed,
+            completed: counts.terminal,
             completed_delta,
             available: counts.available,
             running: counts.running,
@@ -1149,7 +1149,7 @@ async fn test_queue_storage_runtime_offered_rate() {
             .queue_counts(&pool, queue)
             .await
             .expect("Failed to sample final offered-rate counts");
-        if counts.completed >= seeded_total
+        if counts.terminal >= seeded_total
             || drain_start.elapsed() >= Duration::from_secs(drain_timeout_secs)
         {
             break counts;
@@ -1170,13 +1170,13 @@ async fn test_queue_storage_runtime_offered_rate() {
         actual_enqueue_per_s,
         completed_per_s,
         seeded_total,
-        final_counts.completed,
+        final_counts.terminal,
         final_backlog,
         elapsed.as_secs_f64(),
     );
 
     let mut outcomes = HashMap::new();
-    outcomes.insert("completed".to_string(), final_counts.completed as u64);
+    outcomes.insert("completed".to_string(), final_counts.terminal as u64);
     outcomes.insert("available".to_string(), final_counts.available as u64);
     outcomes.insert("running".to_string(), final_counts.running as u64);
 
@@ -1203,7 +1203,7 @@ async fn test_queue_storage_runtime_offered_rate() {
     });
     if let Some(start) = db_profile_start.as_ref() {
         if let Some(db_profile) = capture_db_profile_delta(&pool, start).await {
-            let completed = final_counts.completed.max(1);
+            let completed = final_counts.terminal.max(1);
             if let Some(wal_bytes) = db_profile
                 .get("wal_bytes")
                 .and_then(serde_json::Value::as_i64)

--- a/awa/tests/queue_storage_benchmark_test.rs
+++ b/awa/tests/queue_storage_benchmark_test.rs
@@ -350,7 +350,7 @@ async fn sample_snapshot(
     QueueStorageSnapshot {
         available: counts.available,
         running: counts.running,
-        completed: counts.completed,
+        completed: counts.terminal,
         queue_lanes_dead_tup,
         ready_dead_tup,
         done_dead_tup,
@@ -759,7 +759,7 @@ async fn test_queue_storage_round_trip_smoke() {
         .expect("Failed to sample smoke counts");
     assert_eq!(counts.available, 6);
     assert_eq!(counts.running, 4);
-    assert_eq!(counts.completed, 0);
+    assert_eq!(counts.terminal, 0);
 
     let completed = store
         .complete_batch(&pool, &claimed)
@@ -809,7 +809,7 @@ async fn test_queue_storage_round_trip_smoke() {
         .expect("Failed to sample final smoke counts");
     assert_eq!(final_counts.available, 0);
     assert_eq!(final_counts.running, 0);
-    assert_eq!(final_counts.completed, 10);
+    assert_eq!(final_counts.terminal, 10);
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 6)]

--- a/awa/tests/queue_storage_runtime_test.rs
+++ b/awa/tests/queue_storage_runtime_test.rs
@@ -4113,7 +4113,7 @@ async fn test_queue_storage_prune_skips_live_ready_slot_until_completion() {
         .expect("Failed to sample queue counts after pruning completed slot");
     assert_eq!(counts_after_prune.available, 0);
     assert_eq!(counts_after_prune.running, 0);
-    assert_eq!(counts_after_prune.completed, 1);
+    assert_eq!(counts_after_prune.terminal, 1);
 
     client.shutdown(Duration::from_secs(5)).await;
 }
@@ -4218,7 +4218,7 @@ async fn test_queue_storage_prune_pending_ready_match_is_scoped_by_enqueue_shard
         .expect("Failed to sample queue counts");
     assert_eq!(counts.available, 1);
     assert_eq!(counts.running, 0);
-    assert_eq!(counts.completed, 1);
+    assert_eq!(counts.terminal, 1);
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
@@ -4252,7 +4252,7 @@ async fn test_queue_storage_queue_counts_reads_legacy_lane_rollups_and_backfills
         .queue_counts(&pool, queue)
         .await
         .expect("Failed to read queue counts before backfill");
-    assert_eq!(counts_before_backfill.completed, 7);
+    assert_eq!(counts_before_backfill.terminal, 7);
 
     store
         .prepare_schema(&pool)
@@ -4281,7 +4281,7 @@ async fn test_queue_storage_queue_counts_reads_legacy_lane_rollups_and_backfills
         .queue_counts(&pool, queue)
         .await
         .expect("Failed to read queue counts after backfill");
-    assert_eq!(counts_after_backfill.completed, 7);
+    assert_eq!(counts_after_backfill.terminal, 7);
 }
 
 /// Pin that prepare_schema removes the legacy queue_count_snapshots
@@ -4601,7 +4601,7 @@ async fn test_queue_storage_queue_counts_and_claims_aggregate_across_stripes() {
         .expect("Failed to aggregate queue counts across stripes");
     assert_eq!(counts.available, 8);
     assert_eq!(counts.running, 0);
-    assert_eq!(counts.completed, 0);
+    assert_eq!(counts.terminal, 0);
 
     let claimed = store
         .claim_batch(&pool, queue, 8)
@@ -4660,10 +4660,10 @@ async fn test_queue_storage_queue_counts_fast_matches_exact_on_steady_state() {
         .expect("queue_counts on empty queue");
     assert_eq!(empty_fast.available, 0);
     assert_eq!(empty_fast.running, 0);
-    assert_eq!(empty_fast.completed, 0);
+    assert_eq!(empty_fast.terminal, 0);
     assert_eq!(empty_fast.available, empty_exact.available);
     assert_eq!(empty_fast.running, empty_exact.running);
-    assert_eq!(empty_fast.completed, empty_exact.completed);
+    assert_eq!(empty_fast.terminal, empty_exact.terminal);
 
     // Available rows present: both variants agree.
     store
@@ -4721,9 +4721,9 @@ async fn test_queue_storage_queue_counts_fast_matches_exact_on_steady_state() {
         .queue_counts(&pool, queue)
         .await
         .expect("queue_counts pre-prune");
-    assert_eq!(pre_prune_exact.completed, 5);
+    assert_eq!(pre_prune_exact.terminal, 5);
     assert_eq!(
-        pre_prune_fast.completed, 0,
+        pre_prune_fast.terminal, 0,
         "fast under-counts pre-prune because live done_entries aren't \
          in the rollup yet (documented behaviour)"
     );
@@ -4747,12 +4747,12 @@ async fn test_queue_storage_queue_counts_fast_matches_exact_on_steady_state() {
         .queue_counts(&pool, queue)
         .await
         .expect("queue_counts post-prune");
-    assert_eq!(post_prune_exact.completed, 5);
+    assert_eq!(post_prune_exact.terminal, 5);
     assert_eq!(
-        post_prune_fast.completed, 5,
+        post_prune_fast.terminal, 5,
         "fast must match exact once the segment has rolled up"
     );
-    assert_eq!(post_prune_fast.completed, post_prune_exact.completed);
+    assert_eq!(post_prune_fast.terminal, post_prune_exact.terminal);
 }
 
 /// #290 PR A1 invariant: every terminal-row insert path increments
@@ -6528,7 +6528,7 @@ async fn test_queue_storage_admin_discard_failed_releases_unique_claims_from_don
             .queue_counts(&pool, queue)
             .await
             .expect("Failed to sample queue counts")
-            .completed,
+            .terminal,
         1
     );
 
@@ -6542,7 +6542,7 @@ async fn test_queue_storage_admin_discard_failed_releases_unique_claims_from_don
             .queue_counts(&pool, queue)
             .await
             .expect("Failed to resample queue counts")
-            .completed,
+            .terminal,
         0
     );
 


### PR DESCRIPTION
## Summary

Stacks on #304. Switches \`queue_counts_exact\` to read live terminal counts from the denormalised \`queue_terminal_live_counts\` table that #304 wires, and renames \`QueueCounts.completed\` → \`QueueCounts.terminal\` to honestly reflect that the count includes failed and cancelled terminals, not just completed ones.

This is the last load-bearing piece of #290. After this lands the headline regressor in the long_horizon evidence on #169 — the O(done_entries) scan inside \`queue_counts_exact\` — is gone.

## What ships

**Read switch**

The \`live_terminal\` CTE in \`queue_counts_exact\` used to be:

\`\`\`sql
SELECT count(*)::bigint AS completed
FROM {schema}.done_entries
WHERE queue = ANY($1)
\`\`\`

…O(done_entries-for-queue). Now reads:

\`\`\`sql
SELECT COALESCE(SUM(live_terminal_count), 0)::bigint AS terminal
FROM {schema}.queue_terminal_live_counts
WHERE queue = ANY($1)
\`\`\`

…O(num counter rows for queue) — at most \`queue_slot_count * priorities * enqueue_shards\` rows.

The \`pruned_terminal + live_terminal\` sum at the outer SELECT is unchanged; the rollup column already accumulates per-slot folds from prune (#304), and the live counter holds everything not yet pruned.

**Rename \`QueueCounts.completed\` → \`QueueCounts.terminal\`**

The historical name was a misnomer: \`queue_counts_exact\` has always returned \`count(*) FROM done_entries\`, which includes \`failed\` and \`cancelled\` rows alongside \`completed\`. The field doc spells out the semantic. \`queue_counts_fast\` got the same rename + a clarifying note that the historical name was wrong.

The change is internal-only — the struct doesn't derive \`Serialize\`, so no JSON wire shape changes. Test/bench callers are updated. The bench output's local \`QueueStorageSnapshot.completed\` field is preserved so downstream bench-dashboard scripts that consume the JSON don't break; only the RHS \`<queue_counts>.completed\` accesses are renamed.

## Stacked PR

Base: \`brian/issue-290-live-terminal-counters\` (the #304 branch). Once that lands the base will auto-retarget to main; the diff will stay the same since this PR's commits are additive on top of #304's. The stacked-PR squash hazards from the callback ingress series have been noted — when #304 merges I'll rebase this onto main to drop the duplicated commits before requesting a re-review.

## Refs

- Refs #290. With this PR + #304 merged, the #290 implementation is complete except for: single-shard worst-case bench (PR C) and docs/MAPPING.md flip (PR D).

## Test plan

- [x] \`cargo fmt --all\`
- [x] \`cargo clippy --workspace --all-targets --all-features -- -D warnings\`
- [x] \`cargo build --workspace --all-targets\` (all 32 \`.completed\` field-access compile errors resolved by the rename)
- [x] \`cargo test -p awa --test queue_storage_runtime_test queue_counts\` against Postgres — **3 existing tests still pass**, proving the counter-backed read returns the same values as the old scan
- [x] \`cargo test -p awa --test queue_storage_runtime_test test_queue_terminal_live_counts\` — **4 invariant tests from #304 still pass**, implicitly also verifying the read path (any drift would show as a divergence between \`queue_counts_exact.terminal\` and the test's direct \`count(*) FROM done_entries\` reference)
- [ ] CI for full matrix (running on this push)