### PR TITLE
feat(queue_storage): read live terminal counts + queue-leading index + rename to QueueCounts.terminal (#290)

### DIFF
--- a/awa-model/src/queue_storage.rs
+++ b/awa-model/src/queue_storage.rs
@@ -2254,6 +2254,28 @@ impl QueueStorage {
             .await
             .map_err(map_sqlx_error)?;
 
+            // #290: live-terminal-counter trust marker. NULL = the
+            // counter has not yet been rebuilt under counter-aware code
+            // (set by `rebuild_terminal_counters` after a successful
+            // rebuild, or auto-marked at install time for fresh installs
+            // where done_entries is empty). `queue_counts_exact` reads
+            // this and falls back to scanning done_entries when NULL,
+            // so the "exact" naming stays honest during a rolling
+            // upgrade from a pre-#290 fleet. The trust marker lives on
+            // queue_ring_state — the natural per-schema singleton — so
+            // we don't add a new table for what is effectively one
+            // boolean. The column is updated only on schema install and
+            // on operator-driven rebuild, so it doesn't affect the
+            // existing HOT-update story for rotation writes to
+            // (current_slot, generation).
+            sqlx::query(&format!(
+                "ALTER TABLE {schema}.queue_ring_state \
+                 ADD COLUMN IF NOT EXISTS terminal_counter_trusted_at TIMESTAMPTZ"
+            ))
+            .execute(install_tx.as_mut())
+            .await
+            .map_err(map_sqlx_error)?;
+
             // Singleton row is rewritten on every queue rotation. Columns being
             // updated (current_slot, generation) are not indexed, so a low
             // fillfactor keeps the update in-page as a HOT update and the
@@ -3470,6 +3492,35 @@ impl QueueStorage {
             FROM {schema}.done_entries
             GROUP BY ready_slot, queue, priority, enqueue_shard
             ON CONFLICT (ready_slot, queue, priority, enqueue_shard) DO NOTHING
+            "#
+            ))
+            .execute(install_tx.as_mut())
+            .await
+            .map_err(map_sqlx_error)?;
+
+            // #290: auto-mark trusted for fresh installs. If
+            // `done_entries` is empty at this point AND the trust
+            // marker is still NULL, the counter is vacuously correct
+            // (nothing to drift) and the operator shouldn't have to
+            // run the rebuild CLI just to enable the perf path. On an
+            // existing install upgrading from a pre-#290 fleet, old
+            // binaries that wrote to done_entries before the new
+            // runtime booted would have left non-zero rows here, so
+            // we leave trusted_at NULL and the operator must
+            // explicitly rebuild after the rolling upgrade completes.
+            //
+            // The advisory lock held by prepare_schema gives us a
+            // tight window — concurrent writes from other schema
+            // preps are serialised on the lock, and any in-flight
+            // Rust writers are already counter-maintaining by
+            // definition (they built against this codebase).
+            sqlx::query(&format!(
+                r#"
+            UPDATE {schema}.queue_ring_state
+            SET terminal_counter_trusted_at = now()
+            WHERE singleton = TRUE
+              AND terminal_counter_trusted_at IS NULL
+              AND NOT EXISTS (SELECT 1 FROM {schema}.done_entries LIMIT 1)
             "#
             ))
             .execute(install_tx.as_mut())
@@ -7080,6 +7131,19 @@ impl QueueStorage {
     /// transient gap between admin DELETE of an unclaimed row and the
     /// dispatcher's next gap-recovery pass. Use [`Self::queue_claimer_signal`]
     /// for the dispatcher hot path.
+    ///
+    /// The live-terminal portion reads from `queue_terminal_live_counts`
+    /// (the #290 denormaliser) when [`Self::terminal_counter_trusted`]
+    /// returns true, and falls back to a `count(*) FROM done_entries`
+    /// scan when not. The fallback exists for the rolling-upgrade
+    /// window: a pre-#290 binary writing terminal rows would have
+    /// missed the counter, so reads against a fleet that hasn't yet
+    /// run `awa storage rebuild-terminal-counters` would otherwise
+    /// undercount. The trust marker is auto-set for fresh installs
+    /// (empty done_entries at prepare_schema time) and set explicitly
+    /// by the rebuild CLI; on an existing install before the operator
+    /// rebuilds, the trust marker stays NULL and the scan-based path
+    /// is used — "exact" stays honest.
     async fn queue_counts_exact(
         &self,
         pool: &PgPool,
@@ -7087,6 +7151,28 @@ impl QueueStorage {
     ) -> Result<QueueCounts, AwaError> {
         let schema = self.schema();
         let queues = self.physical_queues_for_logical(queue);
+        let counter_trusted = self.terminal_counter_trusted(pool).await?;
+        // The live-terminal CTE swaps between counter-fed and
+        // scan-fed depending on trust. Build it as a string so the
+        // outer query plan is otherwise identical between the two
+        // paths.
+        let live_terminal_cte = if counter_trusted {
+            format!(
+                "live_terminal AS (
+                    SELECT COALESCE(SUM(live_terminal_count), 0)::bigint AS terminal
+                    FROM {schema}.queue_terminal_live_counts
+                    WHERE queue = ANY($1)
+                )"
+            )
+        } else {
+            format!(
+                "live_terminal AS (
+                    SELECT count(*)::bigint AS terminal
+                    FROM {schema}.done_entries
+                    WHERE queue = ANY($1)
+                )"
+            )
+        };
         let row: (i64, i64, i64) = sqlx::query_as(&format!(
             r#"
             WITH lane_counts AS (
@@ -7153,17 +7239,7 @@ impl QueueStorage {
                     ), 0)
                 )::bigint AS running
             ),
-            -- #290: read live terminal counts from the denormalised
-            -- counter instead of scanning `done_entries`. The counter is
-            -- maintained in lockstep with done_entries by the increment/
-            -- decrement sites and folded into queue_terminal_rollups at
-            -- prune time, so this sum + pruned_terminal is the exact
-            -- count of all terminal rows ever recorded for the queue.
-            live_terminal AS (
-                SELECT COALESCE(SUM(live_terminal_count), 0)::bigint AS terminal
-                FROM {schema}.queue_terminal_live_counts
-                WHERE queue = ANY($1)
-            )
+            {live_terminal_cte}
             SELECT
                 lane_counts.available,
                 live_running.running,
@@ -11620,8 +11696,48 @@ impl QueueStorage {
         .await
         .map_err(map_sqlx_error)?;
 
+        // Flip the trust marker. From this point the read path
+        // (queue_counts_exact) uses the counter directly; before this
+        // call, it falls back to scanning done_entries.
+        sqlx::query(&format!(
+            r#"
+            UPDATE {schema}.queue_ring_state
+            SET terminal_counter_trusted_at = now()
+            WHERE singleton = TRUE
+            "#
+        ))
+        .execute(tx.as_mut())
+        .await
+        .map_err(map_sqlx_error)?;
+
         tx.commit().await.map_err(map_sqlx_error)?;
         Ok(inserted)
+    }
+
+    /// Check whether the live terminal counter has been marked trusted
+    /// for exact reads. Returns `true` for fresh installs (the trust
+    /// marker is auto-set by `prepare_schema` when `done_entries` is
+    /// empty) and after a successful
+    /// [`Self::rebuild_terminal_counters`]; returns `false` on an
+    /// existing install that has not yet been rebuilt under the new
+    /// counter-aware code path.
+    ///
+    /// `queue_counts_exact` consults this to decide between the
+    /// counter-fed fast path and the scan-based fallback. Single-row
+    /// PK fetch; negligible cost per call.
+    pub async fn terminal_counter_trusted(&self, pool: &PgPool) -> Result<bool, AwaError> {
+        let schema = self.schema();
+        let trusted: Option<bool> = sqlx::query_scalar(&format!(
+            "SELECT terminal_counter_trusted_at IS NOT NULL \
+             FROM {schema}.queue_ring_state WHERE singleton = TRUE"
+        ))
+        .fetch_optional(pool)
+        .await
+        .map_err(map_sqlx_error)?;
+        // Missing row = pre-#290 schema that hasn't run the new
+        // prepare_schema yet. Treat as untrusted; the scan path is
+        // still correct.
+        Ok(trusted.unwrap_or(false))
     }
 
     #[tracing::instrument(skip(self, pool), name = "queue_storage.prune_oldest")]

--- a/awa-model/src/queue_storage.rs
+++ b/awa-model/src/queue_storage.rs
@@ -193,7 +193,14 @@ impl ClaimedRuntimeJob {
 pub struct QueueCounts {
     pub available: i64,
     pub running: i64,
-    pub completed: i64,
+    /// Count of rows in *any* terminal state (`completed`, `failed`, or
+    /// `cancelled`) for the queue. The name reflects what the field
+    /// actually counts: it is `count(*) FROM done_entries` semantics, not
+    /// `count(*) WHERE state = 'completed'`. The historical name
+    /// `completed` was a misnomer — `queue_counts_exact` has always
+    /// included failed and cancelled terminals; renamed in #290 along
+    /// with the counter-backed read path.
+    pub terminal: i64,
 }
 
 /// Cheap available-only signal used by the dispatcher's claimer-sizing
@@ -205,7 +212,7 @@ pub struct QueueCounts {
 /// This is intentionally a separate type from [`QueueCounts`]: the
 /// dispatcher claim hot path only consumes the available count, and
 /// returning a `QueueCounts` with two perpetually-zero fields would
-/// invite future code to read `.running` or `.completed` and silently
+/// invite future code to read `.running` or `.terminal` and silently
 /// get wrong answers. Code that legitimately needs the full counts
 /// should call [`QueueStorage::queue_counts`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -7124,15 +7131,21 @@ impl QueueStorage {
                     ), 0)
                 )::bigint AS running
             ),
+            -- #290: read live terminal counts from the denormalised
+            -- counter instead of scanning `done_entries`. The counter is
+            -- maintained in lockstep with done_entries by the increment/
+            -- decrement sites and folded into queue_terminal_rollups at
+            -- prune time, so this sum + pruned_terminal is the exact
+            -- count of all terminal rows ever recorded for the queue.
             live_terminal AS (
-                SELECT count(*)::bigint AS completed
-                FROM {schema}.done_entries
+                SELECT COALESCE(SUM(live_terminal_count), 0)::bigint AS terminal
+                FROM {schema}.queue_terminal_live_counts
                 WHERE queue = ANY($1)
             )
             SELECT
                 lane_counts.available,
                 live_running.running,
-                pruned_terminal.completed + live_terminal.completed AS completed
+                pruned_terminal.completed + live_terminal.terminal AS terminal
             FROM lane_counts
             CROSS JOIN pruned_terminal
             CROSS JOIN live_running
@@ -7144,11 +7157,11 @@ impl QueueStorage {
         .await
         .map_err(map_sqlx_error)?;
 
-        let (available, running, completed) = row;
+        let (available, running, terminal) = row;
         Ok(QueueCounts {
             available,
             running,
-            completed,
+            terminal,
         })
     }
 
@@ -7177,12 +7190,15 @@ impl QueueStorage {
     ///   that anti-join is what this fast variant exists to avoid).
     ///   `waiting_external` is *not* included — it's reported as part
     ///   of admin's parked-callback view, not running.
-    /// - **completed** is read from the persisted
+    /// - **terminal** is read from the persisted
     ///   `queue_terminal_rollups.pruned_completed_count` denormaliser.
     ///   Rows currently in `done_entries` that have not yet rolled up
     ///   are not included. Strictly a lower bound; converges to the
     ///   exact count when rotation prunes the live `done_entries`
-    ///   segment.
+    ///   segment. (The name `terminal` is honest — this number counts
+    ///   `completed`, `failed`, and `cancelled` rows in done_entries,
+    ///   the same semantics as [`Self::queue_counts_exact`]; renamed
+    ///   from `completed` in #290.)
     ///
     /// All three counters are O(num shards) lookups against small head
     /// tables and `leases` index probes. Use this for high-cadence
@@ -7216,9 +7232,9 @@ impl QueueStorage {
         .fetch_one(pool)
         .await
         .map_err(map_sqlx_error)?;
-        // completed: denormalised rollup only. Live (un-rolled-up)
+        // terminal: denormalised rollup only. Live (un-rolled-up)
         // done_entries rows are excluded — see method-level docs.
-        let completed: i64 = sqlx::query_scalar(&format!(
+        let terminal: i64 = sqlx::query_scalar(&format!(
             r#"
             SELECT COALESCE(sum(GREATEST(
                 COALESCE(lanes.pruned_completed_count, 0),
@@ -7244,7 +7260,7 @@ impl QueueStorage {
         Ok(QueueCounts {
             available,
             running,
-            completed,
+            terminal,
         })
     }
 

--- a/awa-model/src/queue_storage.rs
+++ b/awa-model/src/queue_storage.rs
@@ -3408,6 +3408,28 @@ impl QueueStorage {
             .await
             .map_err(map_sqlx_error)?;
 
+            // #290: queue-leading index so `queue_counts_exact`'s
+            // `WHERE queue = ANY($1)` scan is an index range probe over
+            // the requested queue's rows instead of a full-table scan
+            // across every queue's counters. The PK leads with
+            // `ready_slot`, which is the right shape for the row-level
+            // UPSERT path (one row per group) but the wrong shape for
+            // the read aggregation. Including `priority` as the second
+            // column keeps the index narrow while supporting any future
+            // per-priority drill-down. Notably we do NOT INCLUDE
+            // `live_terminal_count` here — that would block HOT updates
+            // on the very column the increment/decrement path mutates,
+            // re-introducing the v016 bloat shape #290 is trying to
+            // avoid.
+            sqlx::query(&format!(
+                "CREATE INDEX IF NOT EXISTS \
+                 idx_{schema}_queue_terminal_live_counts_queue \
+                 ON {schema}.queue_terminal_live_counts (queue, priority)"
+            ))
+            .execute(install_tx.as_mut())
+            .await
+            .map_err(map_sqlx_error)?;
+
             sqlx::query(&format!(
                 r#"
             ALTER TABLE {schema}.queue_terminal_live_counts SET (

--- a/awa/tests/benchmark_test.rs
+++ b/awa/tests/benchmark_test.rs
@@ -805,7 +805,7 @@ async fn test_throughput_rust_workers_queue_storage() {
                 .expect("Failed to sample queue storage queue counts");
             panic!(
                 "Vacuum-aware timeout after 30s: completed={}/{} available={} running={}",
-                counts.completed, total_jobs, counts.available, counts.running
+                counts.terminal, total_jobs, counts.available, counts.running
             );
         }
 
@@ -815,7 +815,7 @@ async fn test_throughput_rust_workers_queue_storage() {
             .await
             .expect("Failed to sample queue storage queue counts");
 
-        if counts.completed == total_jobs {
+        if counts.terminal == total_jobs {
             let processing_elapsed = processing_start.elapsed();
             let throughput = total_jobs as f64 / processing_elapsed.as_secs_f64();
             let end_to_end_elapsed = benchmark_start.elapsed();
@@ -951,17 +951,17 @@ async fn test_throughput_rust_workers_queue_storage() {
             return;
         }
 
-        if counts.completed == last_completed {
+        if counts.terminal == last_completed {
             stall_checks += 1;
             if stall_checks > 50 {
                 panic!(
                     "Vacuum-aware processing stalled at {}/{} completed jobs",
-                    counts.completed, total_jobs
+                    counts.terminal, total_jobs
                 );
             }
         } else {
             stall_checks = 0;
-            last_completed = counts.completed;
+            last_completed = counts.terminal;
         }
     }
 }
@@ -1117,12 +1117,12 @@ async fn test_queue_storage_runtime_offered_rate() {
             .queue_counts(&pool, queue)
             .await
             .expect("Failed to sample queue storage offered-rate counts");
-        let completed_delta = counts.completed.saturating_sub(previous_completed);
-        previous_completed = counts.completed;
+        let completed_delta = counts.terminal.saturating_sub(previous_completed);
+        previous_completed = counts.terminal;
         println!(
             "[bench-va-offered] second={second:>2} seeded={} completed={} (+{}) available={} running={}",
             seeded.load(Ordering::Relaxed),
-            counts.completed,
+            counts.terminal,
             completed_delta,
             counts.available,
             counts.running,
@@ -1130,7 +1130,7 @@ async fn test_queue_storage_runtime_offered_rate() {
         samples.push(OfferedRateSample {
             second,
             seeded: seeded.load(Ordering::Relaxed),
-            completed: counts.completed,
+            completed: counts.terminal,
             completed_delta,
             available: counts.available,
             running: counts.running,
@@ -1149,7 +1149,7 @@ async fn test_queue_storage_runtime_offered_rate() {
             .queue_counts(&pool, queue)
             .await
             .expect("Failed to sample final offered-rate counts");
-        if counts.completed >= seeded_total
+        if counts.terminal >= seeded_total
             || drain_start.elapsed() >= Duration::from_secs(drain_timeout_secs)
         {
             break counts;
@@ -1170,13 +1170,13 @@ async fn test_queue_storage_runtime_offered_rate() {
         actual_enqueue_per_s,
         completed_per_s,
         seeded_total,
-        final_counts.completed,
+        final_counts.terminal,
         final_backlog,
         elapsed.as_secs_f64(),
     );
 
     let mut outcomes = HashMap::new();
-    outcomes.insert("completed".to_string(), final_counts.completed as u64);
+    outcomes.insert("completed".to_string(), final_counts.terminal as u64);
     outcomes.insert("available".to_string(), final_counts.available as u64);
     outcomes.insert("running".to_string(), final_counts.running as u64);
 
@@ -1203,7 +1203,7 @@ async fn test_queue_storage_runtime_offered_rate() {
     });
     if let Some(start) = db_profile_start.as_ref() {
         if let Some(db_profile) = capture_db_profile_delta(&pool, start).await {
-            let completed = final_counts.completed.max(1);
+            let completed = final_counts.terminal.max(1);
             if let Some(wal_bytes) = db_profile
                 .get("wal_bytes")
                 .and_then(serde_json::Value::as_i64)

--- a/awa/tests/queue_storage_benchmark_test.rs
+++ b/awa/tests/queue_storage_benchmark_test.rs
@@ -350,7 +350,7 @@ async fn sample_snapshot(
     QueueStorageSnapshot {
         available: counts.available,
         running: counts.running,
-        completed: counts.completed,
+        completed: counts.terminal,
         queue_lanes_dead_tup,
         ready_dead_tup,
         done_dead_tup,
@@ -759,7 +759,7 @@ async fn test_queue_storage_round_trip_smoke() {
         .expect("Failed to sample smoke counts");
     assert_eq!(counts.available, 6);
     assert_eq!(counts.running, 4);
-    assert_eq!(counts.completed, 0);
+    assert_eq!(counts.terminal, 0);
 
     let completed = store
         .complete_batch(&pool, &claimed)
@@ -809,7 +809,7 @@ async fn test_queue_storage_round_trip_smoke() {
         .expect("Failed to sample final smoke counts");
     assert_eq!(final_counts.available, 0);
     assert_eq!(final_counts.running, 0);
-    assert_eq!(final_counts.completed, 10);
+    assert_eq!(final_counts.terminal, 10);
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 6)]

--- a/awa/tests/queue_storage_runtime_test.rs
+++ b/awa/tests/queue_storage_runtime_test.rs
@@ -5216,6 +5216,113 @@ async fn test_queue_terminal_live_counts_rebuild_restores_invariant() {
     assert_invariant_holds(&pool, schema, queue, "after rebuild").await;
 }
 
+/// #290 — `queue_counts_exact` honours the
+/// `queue_ring_state.terminal_counter_trusted_at` marker. When the marker
+/// is NULL (e.g. a rolling-upgrade window where a pre-#290 binary may
+/// have written `done_entries` rows without maintaining the counter), the
+/// read path falls back to scanning `done_entries`; otherwise it uses
+/// the counter directly. This keeps the "exact" naming honest.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn test_queue_terminal_counter_trust_marker_gates_read_path() {
+    let _guard = QUEUE_STORAGE_RUNTIME_LOCK.lock().await;
+    let pool = setup_pool(10).await;
+    let queue = "qs_terminal_counter_trust";
+    let schema = "awa_qs_terminal_counter_trust";
+    let store = create_store(&pool, schema).await;
+
+    // Fresh installs auto-mark trusted (empty done_entries at
+    // prepare_schema time).
+    assert!(
+        store
+            .terminal_counter_trusted(&pool)
+            .await
+            .expect("trust check"),
+        "fresh install should auto-mark the trust marker"
+    );
+
+    // Seed 5 terminal rows. The counter and done_entries agree.
+    seed_terminal_rows(&pool, schema, queue, "completed", 5).await;
+    assert_eq!(
+        store
+            .queue_counts(&pool, queue)
+            .await
+            .expect("counts")
+            .terminal,
+        5,
+        "trusted path returns counter sum"
+    );
+
+    // Simulate a pre-#290 binary's drift by:
+    //  1. Inserting an "orphan" done_entries row without a matching
+    //     counter increment.
+    //  2. Manually clearing the trust marker (operator hasn't yet run
+    //     `awa storage rebuild-terminal-counters`).
+    sqlx::query(&format!(
+        "INSERT INTO {schema}.done_entries (
+            ready_slot, ready_generation, job_id, kind, queue, state,
+            priority, attempt, run_lease, lane_seq, enqueue_shard,
+            attempted_at, finalized_at, payload
+        ) VALUES (0, 1, 7000000, 'chaos_job', $1, 'completed'::awa.job_state,
+                  2::smallint, 1::smallint, 1::bigint, 9999::bigint,
+                  0::smallint, now(), now(), '{{}}'::jsonb)"
+    ))
+    .bind(queue)
+    .execute(&pool)
+    .await
+    .expect("seed orphan done row");
+    sqlx::query(&format!(
+        "UPDATE {schema}.queue_ring_state \
+         SET terminal_counter_trusted_at = NULL WHERE singleton = TRUE"
+    ))
+    .execute(&pool)
+    .await
+    .expect("clear trust marker");
+
+    assert!(
+        !store
+            .terminal_counter_trusted(&pool)
+            .await
+            .expect("trust check"),
+        "trust marker cleared"
+    );
+
+    // Untrusted path scans done_entries → reports 6 (the seeded 5 +
+    // the orphan row). If the read still trusted the counter, it
+    // would return 5 and silently mask the drift.
+    assert_eq!(
+        store
+            .queue_counts(&pool, queue)
+            .await
+            .expect("counts")
+            .terminal,
+        6,
+        "untrusted path scans done_entries instead of the counter"
+    );
+
+    // Rebuild restores the invariant AND flips the trust marker back.
+    store
+        .rebuild_terminal_counters(&pool)
+        .await
+        .expect("rebuild");
+    assert!(
+        store
+            .terminal_counter_trusted(&pool)
+            .await
+            .expect("trust check"),
+        "rebuild should set the trust marker"
+    );
+    assert_eq!(
+        store
+            .queue_counts(&pool, queue)
+            .await
+            .expect("counts")
+            .terminal,
+        6,
+        "trusted path post-rebuild returns the rebuilt counter sum"
+    );
+    assert_invariant_holds(&pool, schema, queue, "after rebuild trust flip").await;
+}
+
 async fn live_count_sum(pool: &sqlx::PgPool, schema: &str, queue: &str) -> i64 {
     sqlx::query_scalar::<_, i64>(&format!(
         "SELECT COALESCE(SUM(live_terminal_count), 0)::bigint \

--- a/awa/tests/queue_storage_runtime_test.rs
+++ b/awa/tests/queue_storage_runtime_test.rs
@@ -4113,7 +4113,7 @@ async fn test_queue_storage_prune_skips_live_ready_slot_until_completion() {
         .expect("Failed to sample queue counts after pruning completed slot");
     assert_eq!(counts_after_prune.available, 0);
     assert_eq!(counts_after_prune.running, 0);
-    assert_eq!(counts_after_prune.completed, 1);
+    assert_eq!(counts_after_prune.terminal, 1);
 
     client.shutdown(Duration::from_secs(5)).await;
 }
@@ -4218,7 +4218,7 @@ async fn test_queue_storage_prune_pending_ready_match_is_scoped_by_enqueue_shard
         .expect("Failed to sample queue counts");
     assert_eq!(counts.available, 1);
     assert_eq!(counts.running, 0);
-    assert_eq!(counts.completed, 1);
+    assert_eq!(counts.terminal, 1);
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
@@ -4252,7 +4252,7 @@ async fn test_queue_storage_queue_counts_reads_legacy_lane_rollups_and_backfills
         .queue_counts(&pool, queue)
         .await
         .expect("Failed to read queue counts before backfill");
-    assert_eq!(counts_before_backfill.completed, 7);
+    assert_eq!(counts_before_backfill.terminal, 7);
 
     store
         .prepare_schema(&pool)
@@ -4281,7 +4281,7 @@ async fn test_queue_storage_queue_counts_reads_legacy_lane_rollups_and_backfills
         .queue_counts(&pool, queue)
         .await
         .expect("Failed to read queue counts after backfill");
-    assert_eq!(counts_after_backfill.completed, 7);
+    assert_eq!(counts_after_backfill.terminal, 7);
 }
 
 /// Pin that prepare_schema removes the legacy queue_count_snapshots
@@ -4601,7 +4601,7 @@ async fn test_queue_storage_queue_counts_and_claims_aggregate_across_stripes() {
         .expect("Failed to aggregate queue counts across stripes");
     assert_eq!(counts.available, 8);
     assert_eq!(counts.running, 0);
-    assert_eq!(counts.completed, 0);
+    assert_eq!(counts.terminal, 0);
 
     let claimed = store
         .claim_batch(&pool, queue, 8)
@@ -4660,10 +4660,10 @@ async fn test_queue_storage_queue_counts_fast_matches_exact_on_steady_state() {
         .expect("queue_counts on empty queue");
     assert_eq!(empty_fast.available, 0);
     assert_eq!(empty_fast.running, 0);
-    assert_eq!(empty_fast.completed, 0);
+    assert_eq!(empty_fast.terminal, 0);
     assert_eq!(empty_fast.available, empty_exact.available);
     assert_eq!(empty_fast.running, empty_exact.running);
-    assert_eq!(empty_fast.completed, empty_exact.completed);
+    assert_eq!(empty_fast.terminal, empty_exact.terminal);
 
     // Available rows present: both variants agree.
     store
@@ -4721,9 +4721,9 @@ async fn test_queue_storage_queue_counts_fast_matches_exact_on_steady_state() {
         .queue_counts(&pool, queue)
         .await
         .expect("queue_counts pre-prune");
-    assert_eq!(pre_prune_exact.completed, 5);
+    assert_eq!(pre_prune_exact.terminal, 5);
     assert_eq!(
-        pre_prune_fast.completed, 0,
+        pre_prune_fast.terminal, 0,
         "fast under-counts pre-prune because live done_entries aren't \
          in the rollup yet (documented behaviour)"
     );
@@ -4747,12 +4747,12 @@ async fn test_queue_storage_queue_counts_fast_matches_exact_on_steady_state() {
         .queue_counts(&pool, queue)
         .await
         .expect("queue_counts post-prune");
-    assert_eq!(post_prune_exact.completed, 5);
+    assert_eq!(post_prune_exact.terminal, 5);
     assert_eq!(
-        post_prune_fast.completed, 5,
+        post_prune_fast.terminal, 5,
         "fast must match exact once the segment has rolled up"
     );
-    assert_eq!(post_prune_fast.completed, post_prune_exact.completed);
+    assert_eq!(post_prune_fast.terminal, post_prune_exact.terminal);
 }
 
 /// #290 PR A1 invariant: every terminal-row insert path increments
@@ -6528,7 +6528,7 @@ async fn test_queue_storage_admin_discard_failed_releases_unique_claims_from_don
             .queue_counts(&pool, queue)
             .await
             .expect("Failed to sample queue counts")
-            .completed,
+            .terminal,
         1
     );
 
@@ -6542,7 +6542,7 @@ async fn test_queue_storage_admin_discard_failed_releases_unique_claims_from_don
             .queue_counts(&pool, queue)
             .await
             .expect("Failed to resample queue counts")
-            .completed,
+            .terminal,
         0
     );
 


### PR DESCRIPTION
## Summary

Successor to #305 (auto-closed when its base branch — the now-squashed #304 — was deleted). Carries the same two commits, rebased onto current main:

1. **Read switch + rename**: `queue_counts_exact` now reads live terminal counts from `queue_terminal_live_counts` instead of scanning `done_entries`. `QueueCounts.completed` renamed to `QueueCounts.terminal` — honest name (the count includes failed and cancelled rows, not just completed).
2. **Queue-leading index**: `CREATE INDEX (queue, priority) ON queue_terminal_live_counts`. Without it, the new read path scans every queue's counter rows in multi-queue schemas — undercutting the #290 perf goal.

After this lands, the headline regressor from #169's `long_horizon` evidence — the `O(done_entries)` scan inside `queue_counts_exact` — is gone, and the read path is an indexed range scan over a small denormalised counter.

## What ships

### Read switch in `queue_counts_exact`

The `live_terminal` CTE used to be:

```sql
SELECT count(*)::bigint AS completed
FROM {schema}.done_entries
WHERE queue = ANY($1)
```

…O(done_entries-for-queue). Now reads:

```sql
SELECT COALESCE(SUM(live_terminal_count), 0)::bigint AS terminal
FROM {schema}.queue_terminal_live_counts
WHERE queue = ANY($1)
```

…indexed range scan + heap fetch for the matching counter rows (at most `queue_slot_count × priorities × enqueue_shards` rows per queue).

### Queue-leading index

`CREATE INDEX IF NOT EXISTS idx_..._queue ON queue_terminal_live_counts (queue, priority)`. The PK leads with `ready_slot` (right shape for the row-level UPSERT, wrong shape for the read aggregation), so the new index is what makes the perf claim load-bearing.

Notes on the index choice:
- `(queue, priority)` keeps it narrow while supporting future per-priority drill-down.
- No `INCLUDE (live_terminal_count)` — that would block HOT updates on the column the increment/decrement path mutates on every write, re-introducing the v016 bloat shape #290 set out to avoid. Heap fetch per matching row is fine.

### Rename `QueueCounts.completed` → `QueueCounts.terminal`

The historical name was a misnomer: `queue_counts_exact` has always returned `count(*) FROM done_entries`, which includes `failed` and `cancelled` rows. Field doc spells out the semantic. `queue_counts_fast` got the same rename + a clarifying note.

Internal-only — the struct doesn't derive `Serialize`, so no JSON wire shape changes. Test/bench callers updated; the bench output's local `QueueStorageSnapshot.completed` field is preserved so downstream bench-dashboard scripts that consume the JSON don't break; only the RHS `<queue_counts>.completed` accesses are renamed.

## Refs

- Refs #290. With this PR + #304 (now on main), the #290 implementation is correctness-complete except for the bench + docs PRs.

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo build --workspace --all-targets`
- [x] `cargo test -p awa --test queue_storage_runtime_test test_queue_terminal_live_counts` against Postgres — all 6 #290 invariant tests still pass
- [x] `cargo test -p awa --test queue_storage_runtime_test queue_counts` — 3 pre-existing queue_counts tests pass, proving the counter-backed read returns the same values as the old scan
- [ ] CI for full matrix (running on this push)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Queue metrics now accurately track all terminal job states (completed, failed, and cancelled) instead of completed-only tracking
  * Added automatic counter validation during software upgrades to ensure terminal counts remain accurate without requiring service interruption
  * Implemented fallback verification when terminal counters are being rebuilt to maintain data consistency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->