### PR TITLE
refactor(migrations): make runtime_storage_backends migration-owned (#308 PR 2)

### DIFF
--- a/awa-model/migrations/v013_storage_auto_finalize.sql
+++ b/awa-model/migrations/v013_storage_auto_finalize.sql
@@ -22,11 +22,11 @@
 -- liveness window, the function returns FALSE and the caller falls
 -- back to the manual prepare/enter-mixed-transition/finalize path.
 --
--- The schema-install side (prepare_schema in Rust) is the caller's
--- responsibility — auto-finalize assumes the queue-storage tables are
--- already present, mirroring the contract of storage_finalize().
--- Workers should call prepare_schema() before invoking this function;
--- prepare_schema is idempotent so concurrent workers are safe.
+-- The schema-install side is the caller's responsibility — auto-finalize
+-- assumes the queue-storage tables are already present, mirroring the
+-- contract of storage_finalize(). Fresh default `awa` installs get the
+-- substrate from `awa migrate`; custom schemas should be materialized with
+-- prepare_schema() before invoking this function.
 --
 -- The FOR UPDATE on the singleton row serialises with concurrent
 -- callers: first worker's call returns TRUE and flips state to

--- a/awa-model/migrations/v023_install_queue_storage_substrate.sql
+++ b/awa-model/migrations/v023_install_queue_storage_substrate.sql
@@ -24,10 +24,10 @@
 -- serialize concurrent installs (matches the lock pattern previously
 -- held in Rust).
 --
--- Out of scope for this PR:
--- - The `awa.runtime_storage_backends` cross-schema table and its seed —
---   that still lives in `prepare_schema()` and will move to v024 in
---   issue #308 PR 2.
+-- Deliberately not owned by this helper:
+-- - The `awa.runtime_storage_backends` cross-schema table is owned by the
+--   v012 migration. Activation/finalization paths seed or update the
+--   `queue_storage` row.
 -- - The non-additive legacy upgrade edge cases (open_receipt_claims drop,
 --   lease_claims / lease_claim_closures rename-and-rebuild from a
 --   non-partitioned shape, queue_count_snapshots drop) — these are

--- a/awa-model/src/queue_storage.rs
+++ b/awa-model/src/queue_storage.rs
@@ -2139,13 +2139,11 @@ impl QueueStorage {
             //     before the helper creates the partitioned parents, plus the
             //     post-helper copy + drop of the renamed-aside rows.
             //   * `queue_count_snapshots` legacy drop.
-            //   * `awa.runtime_storage_backends` cross-schema CREATE (the
-            //     seed is in `activate_backend`; this CREATE moves to a
-            //     dedicated migration in #308 PR 2).
             //
-            // The helper does NOT touch `awa.runtime_storage_backends` and
-            // does NOT change storage-transition state, so a call to
-            // `prepare_schema` remains activation-neutral.
+            // `awa.runtime_storage_backends` is owned by migrations (v012);
+            // activation paths only seed/update its row. The helper does NOT
+            // touch it and does NOT change storage-transition state, so a call
+            // to `prepare_schema` remains activation-neutral.
 
             sqlx::query(&format!("CREATE SCHEMA IF NOT EXISTS {schema}"))
                 .execute(install_tx.as_mut())
@@ -2392,24 +2390,6 @@ impl QueueStorage {
                 .map_err(map_sqlx_error)?;
             }
 
-            // awa.runtime_storage_backends is a cross-schema table that
-            // tracks which queue-storage schema each storage backend is
-            // currently bound to. Still created here for #308 PR 1; PR 2
-            // moves the CREATE into a dedicated migration so `awa migrate`
-            // owns the row entirely.
-            sqlx::query(
-                r#"
-            CREATE TABLE IF NOT EXISTS awa.runtime_storage_backends (
-                backend     TEXT PRIMARY KEY,
-                schema_name TEXT NOT NULL,
-                updated_at  TIMESTAMPTZ NOT NULL DEFAULT now()
-            )
-            "#,
-            )
-            .execute(install_tx.as_mut())
-            .await
-            .map_err(map_sqlx_error)?;
-
             Ok(())
         }
         .await;
@@ -2425,19 +2405,6 @@ impl QueueStorage {
 
     #[tracing::instrument(skip(self, pool), name = "queue_storage.activate_backend")]
     pub async fn activate_backend(&self, pool: &PgPool) -> Result<(), AwaError> {
-        sqlx::query(
-            r#"
-            CREATE TABLE IF NOT EXISTS awa.runtime_storage_backends (
-                backend     TEXT PRIMARY KEY,
-                schema_name TEXT NOT NULL,
-                updated_at  TIMESTAMPTZ NOT NULL DEFAULT now()
-            )
-            "#,
-        )
-        .execute(pool)
-        .await
-        .map_err(map_sqlx_error)?;
-
         let schema = self.schema();
         let details = serde_json::json!({ "schema": schema });
 
@@ -2446,7 +2413,8 @@ impl QueueStorage {
         // Mark queue storage active only after the full schema, partitions,
         // indexes, and helper functions are in place. The explicit install
         // helper is used by tests and queue-storage-only setups, so it must
-        // flip both the routing registry and the storage transition state.
+        // flip both the migration-owned routing registry row and the storage
+        // transition state.
         sqlx::query(
             r#"
             INSERT INTO awa.runtime_storage_backends (backend, schema_name, updated_at)

--- a/awa-model/src/storage.rs
+++ b/awa-model/src/storage.rs
@@ -127,11 +127,11 @@ fn queue_storage_schema_from_status(status: &StorageStatus) -> Option<String> {
 /// `QueueStorage::prepare_schema`.
 ///
 /// The required objects (tables, the job-id sequence, the claim
-/// function and its exact signature) all originate from
-/// [`QueueStorage::prepare_schema`](crate::QueueStorage::prepare_schema).
-/// If you change a name or the `claim_ready_runtime` signature there,
-/// update this check at the same time — they are intentionally a
-/// single source of truth split across two files for readability.
+/// function and its exact signature) originate from the v023 SQL helper,
+/// called either by `awa migrate` for the default schema or by
+/// [`QueueStorage::prepare_schema`](crate::QueueStorage::prepare_schema)
+/// for custom schemas. If you change a name or the `claim_ready_runtime`
+/// signature there, update this check at the same time.
 pub async fn queue_storage_schema_ready(pool: &PgPool, schema: &str) -> Result<bool, AwaError> {
     sqlx::query_scalar::<_, bool>(
         r#"

--- a/awa/tests/migration_test.rs
+++ b/awa/tests/migration_test.rs
@@ -339,6 +339,10 @@ async fn test_fresh_install_reaches_current_version() {
     migrations::run(&pool).await.unwrap();
     let version = migrations::current_version(&pool).await.unwrap();
     assert_eq!(version, migrations::CURRENT_VERSION);
+    assert!(
+        relation_exists(&pool, "awa.runtime_storage_backends").await,
+        "runtime_storage_backends should be migration-owned"
+    );
 }
 
 // ── Idempotency ──────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- remove duplicate runtime_storage_backends CREATE TABLE calls from QueueStorage::prepare_schema() and activate_backend()
- make v012 the sole owner of the table DDL, with activation paths only upserting the queue_storage marker row
- update migration/readiness comments and add a fresh-install assertion that migrations create awa.runtime_storage_backends

No new v024 migration is needed here: v012_queue_storage_compat.sql already creates awa.runtime_storage_backends, so this PR removes the Rust-side duplicate ownership instead of adding another no-op migration.

Refs #308

## Testing
- cargo fmt --all --check
- cargo test -p awa --test migration_test -- --test-threads=1
- cargo test -p awa --test queue_storage_runtime_test
- cargo test -p awa-worker --lib -- --test-threads=1
- cargo test -p awa-model --lib
- cargo clippy --all-targets --all-features -- -D warnings
- cargo run -q -p awa-cli -- migrate --sql | rg "CREATE TABLE IF NOT EXISTS awa\.runtime_storage_backends|runtime_storage_backends"