### PR TITLE
feat(cli): reject `--reset --schema awa` and document substrate ownership

### DIFF
--- a/awa-cli/src/main.rs
+++ b/awa-cli/src/main.rs
@@ -861,6 +861,23 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                         lease_slot_count,
                         reset,
                     } => {
+                        // The default `awa` schema also holds the canonical
+                        // migration tables (schema_version, runtime_instances,
+                        // storage_transition_state, ...). `DROP SCHEMA awa
+                        // CASCADE` would take them with it and leave the
+                        // database unrecoverable. See
+                        // docs/queue-storage-substrate.md.
+                        if reset && schema == "awa" {
+                            return Err(
+                                "Refusing to DROP SCHEMA awa CASCADE — schema 'awa' is the \
+                                 default migration-owned queue-storage substrate and also \
+                                 contains the canonical migration tables (schema_version, \
+                                 runtime_instances, storage_transition_state, etc.). \
+                                 Use --schema <other> for a throwaway substrate, or \
+                                 'awa storage abort' to rewind an in-flight transition."
+                                    .into(),
+                            );
+                        }
                         let store = awa_model::QueueStorage::new(awa_model::QueueStorageConfig {
                             schema: schema.clone(),
                             queue_slot_count: queue_slot_count as usize,

--- a/awa-cli/tests/prepare_schema_reset_guard_test.rs
+++ b/awa-cli/tests/prepare_schema_reset_guard_test.rs
@@ -1,0 +1,86 @@
+//! `awa storage prepare-queue-storage-schema --reset --schema awa` must be
+//! hard-rejected because the `awa` schema is also where the canonical
+//! migration tables live; a `DROP SCHEMA awa CASCADE` would take them with
+//! it and leave the database unrecoverable.
+//!
+//! See `docs/queue-storage-substrate.md` for the contract.
+
+use assert_cmd::Command;
+
+fn database_url() -> String {
+    std::env::var("DATABASE_URL")
+        .unwrap_or_else(|_| "postgres://postgres:test@localhost:15432/awa_test".to_string())
+}
+
+fn run_cli(args: &[&str]) -> Command {
+    let mut command = Command::cargo_bin("awa").expect("awa binary should build");
+    command
+        .env("DATABASE_URL", database_url())
+        .env("RUST_LOG", "warn")
+        .args(args);
+    command
+}
+
+#[test]
+fn reset_on_default_awa_schema_is_rejected() {
+    let assert = run_cli(&[
+        "storage",
+        "prepare-queue-storage-schema",
+        "--schema",
+        "awa",
+        "--reset",
+    ])
+    .assert()
+    .failure();
+    let stderr = String::from_utf8(assert.get_output().stderr.clone()).expect("stderr utf8");
+    assert!(
+        stderr.contains("Refusing to DROP SCHEMA awa CASCADE"),
+        "expected the reset-guard error message, got: {stderr}"
+    );
+    assert!(
+        stderr.contains("--schema <other>"),
+        "guard error must point operators at the custom-schema escape, got: {stderr}"
+    );
+    assert!(
+        stderr.contains("awa storage abort"),
+        "guard error must point operators at the abort flow, got: {stderr}"
+    );
+}
+
+#[tokio::test]
+async fn reset_on_default_awa_schema_does_not_touch_the_database() {
+    // The guard fires before any SQL runs. Confirm by asserting that
+    // `awa.schema_version` is still populated after a rejected reset.
+    let pool = sqlx::postgres::PgPoolOptions::new()
+        .max_connections(1)
+        .connect(&database_url())
+        .await
+        .expect("connect");
+    let version_before: i32 = sqlx::query_scalar("SELECT MAX(version) FROM awa.schema_version")
+        .fetch_one(&pool)
+        .await
+        .expect("schema_version exists pre-call");
+
+    tokio::task::spawn_blocking(|| {
+        run_cli(&[
+            "storage",
+            "prepare-queue-storage-schema",
+            "--schema",
+            "awa",
+            "--reset",
+        ])
+        .assert()
+        .failure();
+    })
+    .await
+    .expect("blocking task");
+
+    let version_after: i32 = sqlx::query_scalar("SELECT MAX(version) FROM awa.schema_version")
+        .fetch_one(&pool)
+        .await
+        .expect("schema_version still exists after rejected reset");
+    assert_eq!(
+        version_before, version_after,
+        "rejected reset must not mutate schema_version"
+    );
+}

--- a/awa-model/migrations/v022_delete_compat_terminal_counter.sql
+++ b/awa-model/migrations/v022_delete_compat_terminal_counter.sql
@@ -160,15 +160,21 @@ BEGIN
     GET DIAGNOSTICS v_rows = ROW_COUNT;
 
     IF v_rows > 0 THEN
-        -- The counter table is created lazily by
-        -- QueueStorage::prepare_schema() on first runtime boot, which
-        -- can happen AFTER migrations have run (migrations don't
-        -- prepare the per-schema queue-storage tables). Guard the
-        -- decrement with `to_regclass` so a DELETE FROM awa.jobs that
-        -- arrives during the boot window degrades to "drift, then
-        -- rebuild" rather than "relation does not exist". Operators
-        -- recover with `awa storage rebuild-terminal-counters` once the
-        -- counter table catches up.
+        -- Guard the counter decrement with `to_regclass`. The default
+        -- `awa.queue_terminal_live_counts` is materialised by `awa
+        -- migrate` (see v023), so this guard is a no-op on the default
+        -- install. It still matters for:
+        --   - Custom queue-storage schemas, where the counter table is
+        --     created by `awa storage prepare-queue-storage-schema`
+        --     (which can run after migrate). A DELETE FROM awa.jobs
+        --     routed to a custom backend before its substrate is
+        --     prepared degrades to "drift, then rebuild" rather than
+        --     "relation does not exist".
+        --   - Partially-prepared schemas during repair.
+        --   - External migration tooling that applies SQL out of order
+        --     or stops mid-flight.
+        -- Operators recover with `awa storage rebuild-terminal-counters`
+        -- once the counter table catches up.
         IF to_regclass(format('%I.queue_terminal_live_counts', v_schema)) IS NOT NULL THEN
             EXECUTE format(
                 'UPDATE %I.queue_terminal_live_counts AS counts

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -96,6 +96,14 @@ receipt plane, and ADR-026 refines terminal history:
 - [ADR-023: Receipt Plane Ring Partitioning](adr/023-receipt-plane-ring-partitioning.md)
 - [ADR-026: Narrow Terminal History](adr/026-narrow-terminal-history.md)
 
+For how the per-schema substrate is installed and who owns which
+objects, see [Queue-storage substrate](queue-storage-substrate.md).
+The default `awa.*` substrate is materialised by `awa migrate`; custom
+queue-storage schemas are installed via the
+`awa.install_queue_storage_substrate()` SQL helper that
+`prepare_schema()` and `awa storage prepare-queue-storage-schema`
+both call into.
+
 ## Job Lifecycle
 
 Core transitions:

--- a/docs/migrations.md
+++ b/docs/migrations.md
@@ -15,11 +15,20 @@ Current guarantees from the migration layer:
 
 Most migrations are additive, but storage-engine migrations can be
 non-additive when they are protected by rollout gates. For example,
-queue-storage migrations reshape internal keys, drop obsolete columns, and
-`prepare_schema()` performs operational DDL for partitions, indexes,
-sequences, and helper functions. Rolling upgrades stay practical because those
-changes are forward-only, idempotent where possible, and gated by the storage
+queue-storage migrations reshape internal keys and drop obsolete
+columns. Rolling upgrades stay practical because those changes are
+forward-only, idempotent where possible, and gated by the storage
 transition state rather than by assuming every DDL step is additive.
+
+The default queue-storage substrate at `awa.*` is owned by
+`awa migrate` via the `v023_install_queue_storage_substrate`
+migration, which calls the `awa.install_queue_storage_substrate(schema, ...)`
+SQL helper. `prepare_schema()` (Rust) and
+`awa storage prepare-queue-storage-schema` (CLI) call the same helper
+for custom queue-storage schemas. See
+[Queue-storage substrate](queue-storage-substrate.md) for the full
+ownership contract, the rejection of `--reset --schema awa`, and how
+to install a custom-shaped substrate.
 
 ## Fresh Install
 

--- a/docs/queue-storage-substrate.md
+++ b/docs/queue-storage-substrate.md
@@ -66,7 +66,7 @@ state.
 
 The CLI rejects this combination:
 
-```
+```text
 Error: "Refusing to DROP SCHEMA awa CASCADE — schema 'awa' is the
 default migration-owned queue-storage substrate and also contains the
 canonical migration tables (schema_version, runtime_instances,

--- a/docs/queue-storage-substrate.md
+++ b/docs/queue-storage-substrate.md
@@ -1,0 +1,117 @@
+# Queue-storage substrate: ownership and customisation
+
+Awa's queue-storage substrate is the set of per-schema tables, indexes,
+sequences, and helper functions the runtime relies on to claim,
+execute, and finalise jobs against the queue-storage engine. This page
+explains who owns those objects, how to customise them, and the
+guardrails that protect the default `awa` schema from accidental
+destructive operations.
+
+## Ownership contract
+
+| Owner | Scope | When it runs |
+|---|---|---|
+| **`awa migrate`** | The canonical schema (`awa.schema_version`, `awa.runtime_instances`, `awa.storage_transition_state`, `awa.runtime_storage_backends`, etc.) **plus** the default queue-storage substrate at `awa.*` (`awa.ready_entries`, `awa.done_entries`, `awa.leases`, `awa.queue_ring_state`, `awa.queue_terminal_live_counts`, the partitions for each, the `awa.claim_ready_runtime` helper, and the `awa.install_queue_storage_substrate` function itself). | Install time and operator-driven upgrades. |
+| **`QueueStorage::prepare_schema()` (Rust) / `awa storage prepare-queue-storage-schema` (CLI)** | Non-default queue-storage schemas (anything other than `awa`), repair flows, test setups. Calls `awa.install_queue_storage_substrate(<schema>, ...)` and performs a small set of legacy upgrade fixups that don't belong in a forward-only DDL function. | Custom-schema deployments; targeted repair; the test suite. |
+| **The `awa.install_queue_storage_substrate(p_schema, ...)` SQL helper** | Per-schema DDL only. Idempotent. Activation-neutral — does NOT touch `awa.runtime_storage_backends` or `awa.storage_transition_state`. | Called by both `awa migrate` (for the default schema) and `prepare_schema()` (for custom schemas). Single source of truth for substrate DDL. |
+
+The helper takes a per-schema advisory transaction lock
+(`awa.queue_storage.install:<schema>`) so concurrent installs from
+Rust workers, the CLI, Python, or externally-extracted migration SQL
+serialise on the same key.
+
+## The default `awa` schema is migration-owned and default-shaped
+
+For `p_schema = 'awa'` the helper rejects non-default configuration
+with `ERRCODE = 22023`:
+
+- `lease_claim_receipts` must be `TRUE`
+- `queue_slot_count` must be `16`
+- `lease_slot_count` must be `8`
+- `claim_slot_count` must be `8`
+
+The default `awa.*` substrate is the single stable shape every fresh
+installation gets. If you need different slot counts or
+`lease_claim_receipts = FALSE`, use a custom queue-storage schema (see
+below). Attempts to tune the default schema get a clear error
+pointing at the custom-schema path.
+
+## Custom queue-storage schemas
+
+For non-default deployments — say a high-throughput tenant that wants
+`queue_slot_count = 32`, or a side-by-side rebuild during an
+incident — install a substrate under a different schema name:
+
+```bash
+awa storage prepare-queue-storage-schema \
+  --schema my_jobs \
+  --queue-slot-count 32 \
+  --lease-slot-count 16
+```
+
+The CLI calls `awa.install_queue_storage_substrate('my_jobs', 32, 16, 8, TRUE)`
+under the per-schema advisory lock. Activate the schema as the
+queue-storage backend via `awa storage prepare`, `awa storage
+enter-mixed-transition`, and `awa storage finalize` once you're ready.
+See [the upgrade guide](upgrade-0.5-to-0.6.md) for the staged flow.
+
+## `--reset` is rejected for `--schema awa`
+
+`awa storage prepare-queue-storage-schema --reset` runs
+`DROP SCHEMA IF EXISTS <schema> CASCADE` before re-preparing. For
+`--schema awa` that would also drop `schema_version`,
+`runtime_instances`, `storage_transition_state`, and every other
+canonical migration table, leaving the database in an unrecoverable
+state.
+
+The CLI rejects this combination:
+
+```
+Error: "Refusing to DROP SCHEMA awa CASCADE — schema 'awa' is the
+default migration-owned queue-storage substrate and also contains the
+canonical migration tables (schema_version, runtime_instances,
+storage_transition_state, etc.). Use --schema <other> for a throwaway
+substrate, or 'awa storage abort' to rewind an in-flight transition."
+```
+
+To rebuild a queue-storage substrate from scratch:
+
+- **Testing or recovery:** target a custom schema name with
+  `--schema <other>` and activate it via the storage transition flow.
+- **Rewind an in-flight transition:** use `awa storage abort`.
+- **Full cluster rebuild:** restore from backup, then run `awa migrate`.
+
+`DROP SCHEMA awa CASCADE` is not a supported operator action.
+
+## Design rationale
+
+The split between migration-owned default substrate and helper-installed
+custom substrate exists for three reasons:
+
+- **`awa migrate --sql` / `--extract-to` must reproduce the full
+  default runtime schema** for external migration tools to be useful.
+  All substrate DDL is reachable from the migration through the SQL
+  helper, so the extracted SQL is complete.
+- **Migrations that depend on queue-storage tables can write
+  unconditional DDL.** Operations like the
+  `queue_terminal_live_counts` decrement inside
+  `awa.delete_job_compat()` need the counter table to exist. Migration
+  ordering guarantees it.
+- **The default schema cannot be accidentally destroyed.** The reset
+  guard above protects operators from a `DROP SCHEMA awa CASCADE` that
+  would take the canonical migration tables with it.
+
+The helper is `SECURITY INVOKER` so callers need their own DDL
+privileges on the target schema; the runtime role does not gain DDL
+through the helper, which keeps the principle-of-least-privilege role
+model intact.
+
+## See also
+
+- [`docs/migrations.md`](migrations.md) — migration policy and the
+  `awa migrate --sql` / `--extract-to` story.
+- [`docs/architecture.md`](architecture.md) — overall storage layering.
+- [`docs/security.md`](security.md) — role boundaries and the
+  `SECURITY INVOKER` posture.
+- [`docs/upgrade-0.5-to-0.6.md`](upgrade-0.5-to-0.6.md) — operator flow
+  for an existing cluster.

--- a/docs/security.md
+++ b/docs/security.md
@@ -156,7 +156,15 @@ does not need this temporary-table grant.
 
 The queue-storage backend defaults to keeping its tables in the same
 `awa` schema, so the grants above cover both control-plane and
-queue-storage tables. If you override the schema name (Rust:
+queue-storage tables. See
+[Queue-storage substrate](queue-storage-substrate.md) for the full
+ownership contract — what `awa migrate` installs by default, how
+custom schemas are materialised via
+`awa.install_queue_storage_substrate()`, and why
+`awa storage prepare-queue-storage-schema --schema awa --reset` is
+rejected.
+
+If you override the schema name (Rust:
 `QueueStorageConfig.schema`; Python: `queue_storage_schema=...`; CLI:
 `awa storage prepare-queue-storage-schema --schema <name>`), repeat
 the grant block against that schema:


### PR DESCRIPTION
## Summary

The default `awa` schema holds both the queue-storage substrate and the canonical migration tables (`schema_version`, `runtime_instances`, `storage_transition_state`, `runtime_storage_backends`, ...). A `DROP SCHEMA awa CASCADE` would take the migration tables with it and leave the database unrecoverable.

This PR is the third of three landing the v0.6 substrate-ownership work:

- **Reset guard.** `awa storage prepare-queue-storage-schema --schema awa --reset` is now hard-rejected with an error pointing operators at the custom-schema escape (`--schema <other>`) or the in-flight transition rewind (`awa storage abort`).
- **Canonical contract doc.** Adds `docs/queue-storage-substrate.md` — who installs what (`awa migrate` for the default schema plus all canonical tables; `prepare_schema()` / the CLI for custom schemas), the default-shape requirements the helper enforces for `p_schema = 'awa'`, and the reset-guard semantics. Cross-linked from `migrations.md`, `architecture.md`, and `security.md`.
- **v022 comment tightening.** Clarifies that the `to_regclass` guard in `delete_job_compat` is a no-op on the default install (v023 materialises the counter table via migrate); it still matters for custom schemas, partially-prepared substrates, and external migration tooling that applies DDL out of order.

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo build --workspace`
- [x] `cargo test -p awa-cli` against local Postgres — new `prepare_schema_reset_guard_test` passes both cases (rejection error message contains all three required hints; rejected reset does not mutate `awa.schema_version`); existing `storage_finalize_cli_test` and other CLI tests still green
- [x] Smoke: `awa storage prepare-queue-storage-schema --schema awa --reset` rejected with the canonical-schema error; `--schema <other> --reset` proceeds normally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Added a safety check that prevents resetting the default schema using the storage prepare command. Clear error messages now guide operators when this operation is attempted.

* **Documentation**
  * Expanded documentation on queue-storage substrate installation and schema preparation, including guidance for custom schemas and related configuration steps.
  * Added detailed security guidance on roles and privileges for custom queue-storage schemas.
  * Enhanced migration docs to clarify queue-storage migration behaviors and substrate ownership.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->