### PR TITLE
docs+test: SQL-only install/upgrade path for external migration tooling

### DIFF
--- a/awa-model/tests/sql_only_storage_upgrade_test.rs
+++ b/awa-model/tests/sql_only_storage_upgrade_test.rs
@@ -37,6 +37,29 @@ async fn migrated_pool() -> PgPool {
     pool
 }
 
+/// Clear every canonical source the transition gates inspect:
+///
+/// - `awa.jobs_hot` and `awa.scheduled_jobs`, because `awa.jobs` is
+///   `jobs_hot UNION ALL scheduled_jobs` and
+///   `storage_auto_finalize_if_fresh` counts rows from the view.
+/// - `awa.scheduled_jobs` additionally, because
+///   `awa.canonical_live_backlog()` (the finalize gate) sums
+///   non-terminal `jobs_hot` rows + the full count of `scheduled_jobs`.
+///
+/// A leftover scheduled row from another test run can make the
+/// fresh-install test report `auto_finalize = false` or the upgrade
+/// test report a non-zero backlog after the simulated drain.
+async fn clear_canonical_work(pool: &PgPool) {
+    sqlx::query("DELETE FROM awa.jobs_hot")
+        .execute(pool)
+        .await
+        .expect("clear awa.jobs_hot");
+    sqlx::query("DELETE FROM awa.scheduled_jobs")
+        .execute(pool)
+        .await
+        .expect("clear awa.scheduled_jobs");
+}
+
 async fn reset_transition_state(pool: &PgPool) {
     let mut tx = pool.begin().await.expect("begin reset tx");
     sqlx::query(
@@ -133,6 +156,7 @@ async fn external_tooling_can_upgrade_canonical_to_queue_storage_via_sql() {
     let _guard = TRANSITION_LOCK.lock().await;
     let pool = migrated_pool().await;
     reset_transition_state(&pool).await;
+    clear_canonical_work(&pool).await;
 
     // Defeat auto-finalize: ensure there's at least one canonical row
     // so `storage_auto_finalize_if_fresh` would refuse to short-circuit.
@@ -170,14 +194,11 @@ async fn external_tooling_can_upgrade_canonical_to_queue_storage_via_sql() {
 
     // `storage_finalize` refuses to advance while canonical live work
     // remains. In a real upgrade the operator waits in mixed_transition
-    // for workers to drain; for the test we delete the marker to
-    // simulate that drain, then call awa.canonical_live_backlog()
-    // directly to confirm the documented SQL gate is satisfied before
-    // finalize.
-    sqlx::query("DELETE FROM awa.jobs_hot WHERE queue = 'sql_only_upgrade'")
-        .execute(&pool)
-        .await
-        .expect("simulate canonical drain");
+    // for workers to drain; the test clears all canonical sources
+    // (jobs_hot + scheduled_jobs, since `canonical_live_backlog()`
+    // sums both) to simulate that drain, then asserts the two
+    // documented SQL gates explicitly.
+    clear_canonical_work(&pool).await;
 
     let backlog: i64 = sqlx::query_scalar("SELECT awa.canonical_live_backlog()")
         .fetch_one(&pool)
@@ -186,6 +207,26 @@ async fn external_tooling_can_upgrade_canonical_to_queue_storage_via_sql() {
     assert_eq!(
         backlog, 0,
         "documented SQL gate must report empty backlog before finalize"
+    );
+
+    // Second documented gate: no live canonical / canonical_drain_only
+    // runtimes. The only stamped runtime is queue_storage_target, so
+    // this should already be zero; assert it so any future change to
+    // the test setup that introduces a canonical-mode runtime fails
+    // loudly here rather than inside the storage_finalize RAISE.
+    let live_canonical: i64 = sqlx::query_scalar(
+        "SELECT count(*) FROM awa.runtime_instances \
+         WHERE storage_capability IN ('canonical', 'canonical_drain_only') \
+           AND last_seen_at + make_interval( \
+                 secs => GREATEST(((GREATEST(snapshot_interval_ms, 1000) / 1000) * 3)::int, 30) \
+               ) >= now()",
+    )
+    .fetch_one(&pool)
+    .await
+    .expect("count live canonical runtimes");
+    assert_eq!(
+        live_canonical, 0,
+        "documented SQL gate must report no live canonical / drain-only runtimes before finalize"
     );
 
     sqlx::query("SELECT awa.storage_finalize()")
@@ -208,19 +249,19 @@ async fn external_tooling_can_upgrade_canonical_to_queue_storage_via_sql() {
 
 /// Fresh-install path: empty `awa.jobs` and no live runtimes means
 /// `storage_auto_finalize_if_fresh` is allowed to jump straight from
-/// canonical to active. The function is `GRANT EXECUTE ... TO PUBLIC`
-/// (v013) so any caller — including a migration tool running as a
-/// non-owner role — can invoke it. This test calls it via raw SQL with
-/// no Rust runtime involvement.
+/// canonical to active. The function carries `GRANT EXECUTE ... TO
+/// PUBLIC` (v013), so the EXECUTE bit is open to any role; the
+/// function is `SECURITY INVOKER` and still reads/writes
+/// `storage_transition_state`, `jobs`, `runtime_instances`, and
+/// `runtime_storage_backends`, so a non-owner caller also needs the
+/// normal table privileges. This test calls it via raw SQL with no
+/// Rust runtime involvement.
 #[tokio::test]
 async fn external_tooling_can_finalize_fresh_install_via_sql() {
     let _guard = TRANSITION_LOCK.lock().await;
     let pool = migrated_pool().await;
     reset_transition_state(&pool).await;
-    sqlx::query("DELETE FROM awa.jobs_hot")
-        .execute(&pool)
-        .await
-        .expect("clear canonical jobs for fresh-install scenario");
+    clear_canonical_work(&pool).await;
 
     let promoted: bool = sqlx::query_scalar("SELECT awa.storage_auto_finalize_if_fresh($1)")
         .bind("awa")

--- a/awa-model/tests/sql_only_storage_upgrade_test.rs
+++ b/awa-model/tests/sql_only_storage_upgrade_test.rs
@@ -171,11 +171,22 @@ async fn external_tooling_can_upgrade_canonical_to_queue_storage_via_sql() {
     // `storage_finalize` refuses to advance while canonical live work
     // remains. In a real upgrade the operator waits in mixed_transition
     // for workers to drain; for the test we delete the marker to
-    // simulate that drain.
+    // simulate that drain, then call awa.canonical_live_backlog()
+    // directly to confirm the documented SQL gate is satisfied before
+    // finalize.
     sqlx::query("DELETE FROM awa.jobs_hot WHERE queue = 'sql_only_upgrade'")
         .execute(&pool)
         .await
         .expect("simulate canonical drain");
+
+    let backlog: i64 = sqlx::query_scalar("SELECT awa.canonical_live_backlog()")
+        .fetch_one(&pool)
+        .await
+        .expect("canonical_live_backlog");
+    assert_eq!(
+        backlog, 0,
+        "documented SQL gate must report empty backlog before finalize"
+    );
 
     sqlx::query("SELECT awa.storage_finalize()")
         .execute(&pool)

--- a/awa-model/tests/sql_only_storage_upgrade_test.rs
+++ b/awa-model/tests/sql_only_storage_upgrade_test.rs
@@ -1,0 +1,226 @@
+//! Proves an external operator can drive a canonical → queue-storage
+//! transition using only SQL function calls — no Rust code path needs
+//! to run any DDL, and no Rust wrapper needs to be involved beyond
+//! `awa migrate` (which is itself just a SQL applier).
+//!
+//! This is the "external migration tooling" contract that
+//! `docs/queue-storage-substrate.md` describes. The substrate DDL
+//! ships in the migration set (v023 calls
+//! `awa.install_queue_storage_substrate('awa')`), and the staged
+//! transition is driven by the SQL functions defined in v010/v013/v014.
+//! Tests below call those functions directly via raw SQL.
+
+use sqlx::postgres::PgPoolOptions;
+use sqlx::PgPool;
+use std::sync::LazyLock;
+use tokio::sync::Mutex;
+use uuid::Uuid;
+
+// Storage-transition state is a singleton — serialise tests that
+// mutate it so they don't stomp each other when run with `--test-threads`.
+static TRANSITION_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
+
+fn database_url() -> String {
+    std::env::var("DATABASE_URL")
+        .unwrap_or_else(|_| "postgres://postgres:test@localhost:15432/awa_test".to_string())
+}
+
+async fn migrated_pool() -> PgPool {
+    let pool = PgPoolOptions::new()
+        .max_connections(4)
+        .connect(&database_url())
+        .await
+        .expect("connect");
+    awa_model::migrations::run(&pool)
+        .await
+        .expect("run migrations");
+    pool
+}
+
+async fn reset_transition_state(pool: &PgPool) {
+    let mut tx = pool.begin().await.expect("begin reset tx");
+    sqlx::query(
+        r#"
+        UPDATE awa.storage_transition_state
+        SET current_engine = 'canonical',
+            prepared_engine = NULL,
+            state = 'canonical',
+            transition_epoch = transition_epoch + 1,
+            details = '{}'::jsonb,
+            updated_at = now(),
+            finalized_at = NULL
+        WHERE singleton
+        "#,
+    )
+    .execute(&mut *tx)
+    .await
+    .expect("reset transition state");
+    sqlx::query("DELETE FROM awa.runtime_storage_backends WHERE backend = 'queue_storage'")
+        .execute(&mut *tx)
+        .await
+        .expect("clear runtime_storage_backends");
+    sqlx::query("DELETE FROM awa.runtime_instances")
+        .execute(&mut *tx)
+        .await
+        .expect("clear runtime_instances");
+    tx.commit().await.expect("commit reset tx");
+}
+
+async fn read_status(pool: &PgPool) -> (String, String, Option<String>) {
+    let row: (String, String, Option<String>) =
+        sqlx::query_as("SELECT state, current_engine, prepared_engine FROM awa.storage_status()")
+            .fetch_one(pool)
+            .await
+            .expect("read storage_status");
+    row
+}
+
+/// Stamp a synthetic `queue_storage_target` runtime row so the
+/// mixed-transition gate (`storage_enter_mixed_transition`) sees an
+/// executor ready to take queue-storage work after the routing flip.
+/// In a real upgrade the operator brings up a worker with
+/// `transition_role=queue_storage_target`; for an SQL-only test we
+/// synthesise the row directly.
+async fn stamp_queue_storage_target_runtime(pool: &PgPool) -> Uuid {
+    let instance_id = Uuid::new_v4();
+    sqlx::query(
+        r#"
+        INSERT INTO awa.runtime_instances (
+            instance_id,
+            hostname,
+            pid,
+            version,
+            storage_capability,
+            transition_role,
+            started_at,
+            last_seen_at,
+            snapshot_interval_ms,
+            healthy,
+            postgres_connected,
+            poll_loop_alive,
+            heartbeat_alive,
+            maintenance_alive,
+            shutting_down,
+            leader,
+            global_max_workers,
+            queues,
+            queue_descriptor_hashes,
+            job_kind_descriptor_hashes
+        )
+        VALUES (
+            $1, 'sql-only-upgrade-test', 0, '0.0.0-test',
+            'queue_storage', 'queue_storage_target',
+            now(), now(), 5000, TRUE, TRUE, TRUE, TRUE, TRUE,
+            FALSE, FALSE, 1,
+            '[]'::jsonb, '[]'::jsonb, '[]'::jsonb
+        )
+        "#,
+    )
+    .bind(instance_id)
+    .execute(pool)
+    .await
+    .expect("stamp queue_storage_target runtime");
+    instance_id
+}
+
+/// Upgrade-from-canonical path: existing deployment has canonical jobs,
+/// so `storage_auto_finalize_if_fresh` returns FALSE and the operator
+/// must drive the staged transition. This test calls the SQL functions
+/// directly — no Rust wrappers — to prove external migration tooling can
+/// orchestrate the upgrade without any worker DDL.
+#[tokio::test]
+async fn external_tooling_can_upgrade_canonical_to_queue_storage_via_sql() {
+    let _guard = TRANSITION_LOCK.lock().await;
+    let pool = migrated_pool().await;
+    reset_transition_state(&pool).await;
+
+    // Defeat auto-finalize: ensure there's at least one canonical row
+    // so `storage_auto_finalize_if_fresh` would refuse to short-circuit.
+    sqlx::query(
+        "INSERT INTO awa.jobs_hot (kind, queue, args) \
+         VALUES ('sql_only_upgrade_marker', 'sql_only_upgrade', '{}'::jsonb)",
+    )
+    .execute(&pool)
+    .await
+    .expect("insert canonical marker");
+
+    let target_instance = stamp_queue_storage_target_runtime(&pool).await;
+
+    // Drive the staged transition via raw SQL — no awa_model::storage
+    // wrappers, no Rust DDL. This mirrors what an external migration
+    // tool would do as a post-DDL hook.
+    sqlx::query("SELECT awa.storage_prepare($1, $2)")
+        .bind("queue_storage")
+        .bind(serde_json::json!({"schema": "awa"}))
+        .execute(&pool)
+        .await
+        .expect("storage_prepare via raw SQL");
+
+    let (state_after_prepare, _, prepared_after_prepare) = read_status(&pool).await;
+    assert_eq!(state_after_prepare, "prepared");
+    assert_eq!(prepared_after_prepare.as_deref(), Some("queue_storage"));
+
+    sqlx::query("SELECT awa.storage_enter_mixed_transition()")
+        .execute(&pool)
+        .await
+        .expect("storage_enter_mixed_transition via raw SQL");
+
+    let (state_after_enter, _, _) = read_status(&pool).await;
+    assert_eq!(state_after_enter, "mixed_transition");
+
+    // `storage_finalize` refuses to advance while canonical live work
+    // remains. In a real upgrade the operator waits in mixed_transition
+    // for workers to drain; for the test we delete the marker to
+    // simulate that drain.
+    sqlx::query("DELETE FROM awa.jobs_hot WHERE queue = 'sql_only_upgrade'")
+        .execute(&pool)
+        .await
+        .expect("simulate canonical drain");
+
+    sqlx::query("SELECT awa.storage_finalize()")
+        .execute(&pool)
+        .await
+        .expect("storage_finalize via raw SQL");
+
+    let (final_state, final_engine, _) = read_status(&pool).await;
+    assert_eq!(final_state, "active");
+    assert_eq!(final_engine, "queue_storage");
+
+    // Cleanup so other tests aren't poisoned.
+    sqlx::query("DELETE FROM awa.runtime_instances WHERE instance_id = $1")
+        .bind(target_instance)
+        .execute(&pool)
+        .await
+        .expect("cleanup runtime row");
+    reset_transition_state(&pool).await;
+}
+
+/// Fresh-install path: empty `awa.jobs` and no live runtimes means
+/// `storage_auto_finalize_if_fresh` is allowed to jump straight from
+/// canonical to active. The function is `GRANT EXECUTE ... TO PUBLIC`
+/// (v013) so any caller — including a migration tool running as a
+/// non-owner role — can invoke it. This test calls it via raw SQL with
+/// no Rust runtime involvement.
+#[tokio::test]
+async fn external_tooling_can_finalize_fresh_install_via_sql() {
+    let _guard = TRANSITION_LOCK.lock().await;
+    let pool = migrated_pool().await;
+    reset_transition_state(&pool).await;
+    sqlx::query("DELETE FROM awa.jobs_hot")
+        .execute(&pool)
+        .await
+        .expect("clear canonical jobs for fresh-install scenario");
+
+    let promoted: bool = sqlx::query_scalar("SELECT awa.storage_auto_finalize_if_fresh($1)")
+        .bind("awa")
+        .fetch_one(&pool)
+        .await
+        .expect("auto-finalize via raw SQL");
+    assert!(promoted, "fresh install should auto-finalize to active");
+
+    let (state, engine, _) = read_status(&pool).await;
+    assert_eq!(state, "active");
+    assert_eq!(engine, "queue_storage");
+
+    reset_transition_state(&pool).await;
+}

--- a/docs/queue-storage-substrate.md
+++ b/docs/queue-storage-substrate.md
@@ -83,6 +83,64 @@ To rebuild a queue-storage substrate from scratch:
 
 `DROP SCHEMA awa CASCADE` is not a supported operator action.
 
+## Driving installs and upgrades from external migration tooling
+
+Teams that already run their schema changes through a tool like
+Sqitch, Liquibase, or a hand-rolled migration runner do not need to
+invoke `awa migrate` or any other Rust binary. The migration set
+extracted with `awa migrate --sql` (or `--extract-to`) is complete:
+it includes the substrate DDL via the v023 helper, and the staged
+transition is driven by SQL functions.
+
+### Fresh install (no canonical data yet)
+
+After applying the migration files, the first runtime that boots
+calls `awa.storage_auto_finalize_if_fresh('awa')` which atomically
+advances `canonical → active` when `awa.jobs` is empty and no live
+runtimes have heartbeated. External tooling can call the same
+function as a post-migrate step to land in `active` before the first
+worker even starts:
+
+```sql
+SELECT awa.storage_auto_finalize_if_fresh('awa');
+```
+
+`storage_auto_finalize_if_fresh` carries a `GRANT EXECUTE ... TO
+PUBLIC`, so it is callable from any role.
+
+### Upgrade from an existing canonical-only deployment
+
+`storage_auto_finalize_if_fresh` refuses to short-circuit when
+canonical work or live runtimes exist. The operator drives the
+staged transition with three SQL function calls, each of which
+mirrors the equivalent `awa storage` CLI subcommand:
+
+```sql
+-- (1) Mark queue-storage as the prepared target.
+SELECT awa.storage_prepare('queue_storage', '{"schema":"awa"}'::jsonb);
+
+-- (2) Bring up at least one worker with
+--     transition_role=queue_storage_target. Stop any canonical-only
+--     workers. Then flip routing into mixed mode:
+SELECT awa.storage_enter_mixed_transition();
+
+-- (3) Wait for workers to drain the canonical backlog onto
+--     queue-storage. When `awa.queue_counts_exact` shows no
+--     canonical-live work remaining, finalize:
+SELECT awa.storage_finalize();
+```
+
+`storage_enter_mixed_transition` will reject the call until at least
+one live `queue_storage_target` runtime is heartbeating, and
+`storage_finalize` will reject the call until the canonical backlog
+is drained. Both gates are deliberate — they prevent operators from
+flipping routing onto a substrate that has no executor or onto a
+non-empty canonical backlog.
+
+The orchestration (start new-mode workers, stop old-mode workers,
+wait for drain) is unchanged from the CLI flow — only the invocation
+surface is different.
+
 ## Design rationale
 
 The split between migration-owned default substrate and helper-installed

--- a/docs/queue-storage-substrate.md
+++ b/docs/queue-storage-substrate.md
@@ -105,8 +105,12 @@ worker even starts:
 SELECT awa.storage_auto_finalize_if_fresh('awa');
 ```
 
-`storage_auto_finalize_if_fresh` carries a `GRANT EXECUTE ... TO
-PUBLIC`, so it is callable from any role.
+`storage_auto_finalize_if_fresh` has `GRANT EXECUTE ... TO PUBLIC`,
+so the EXECUTE bit is open to any role. The function is
+`SECURITY INVOKER` and reads/writes
+`awa.storage_transition_state`, `awa.jobs`, `awa.runtime_instances`,
+and `awa.runtime_storage_backends`, so callers still need the normal
+runtime/migrator table privileges on those.
 
 ### Upgrade from an existing canonical-only deployment
 
@@ -125,17 +129,32 @@ SELECT awa.storage_prepare('queue_storage', '{"schema":"awa"}'::jsonb);
 SELECT awa.storage_enter_mixed_transition();
 
 -- (3) Wait for workers to drain the canonical backlog onto
---     queue-storage. When `awa.queue_counts_exact` shows no
---     canonical-live work remaining, finalize:
+--     queue-storage. The two SQL gates `storage_finalize` enforces
+--     are observable directly:
+--
+--       SELECT awa.canonical_live_backlog();
+--       -- must return 0 before finalize will advance.
+--
+--       SELECT count(*)
+--       FROM awa.runtime_instances
+--       WHERE storage_capability IN ('canonical', 'canonical_drain_only')
+--         AND last_seen_at + make_interval(
+--               secs => GREATEST(((GREATEST(snapshot_interval_ms, 1000) / 1000) * 3)::int, 30)
+--             ) >= now();
+--       -- must also be 0 (no live canonical or drain-only runtimes).
+--
+--     When both are 0, finalize:
 SELECT awa.storage_finalize();
 ```
 
 `storage_enter_mixed_transition` will reject the call until at least
-one live `queue_storage_target` runtime is heartbeating, and
-`storage_finalize` will reject the call until the canonical backlog
-is drained. Both gates are deliberate — they prevent operators from
-flipping routing onto a substrate that has no executor or onto a
-non-empty canonical backlog.
+one live `queue_storage_target` runtime is heartbeating.
+`storage_finalize` will reject the call while
+`awa.canonical_live_backlog() > 0` or while any canonical /
+canonical-drain-only runtime is still inside its liveness window.
+Both gates are deliberate — they prevent operators from flipping
+routing onto a substrate that has no executor or while canonical
+work or canonical-mode workers are still active.
 
 The orchestration (start new-mode workers, stop old-mode workers,
 wait for drain) is unchanged from the CLI flow — only the invocation


### PR DESCRIPTION
## Summary

External migration tooling (Sqitch, Liquibase, hand-rolled runners) can already drive a fresh install or an existing canonical → queue-storage upgrade without any Rust binary executing DDL — v023 owns the default substrate, and the staged transition is exposed as `awa.storage_prepare` / `storage_enter_mixed_transition` / `storage_finalize` SQL functions. This was substantially complete after the rest of the #308 series; it just lacked documentation and end-to-end test coverage to prove it.

This PR closes that gap:

- **Docs.** `docs/queue-storage-substrate.md` gets a new section showing the fresh-install path (`storage_auto_finalize_if_fresh`, which is `GRANT ... TO PUBLIC` so any role can call it) and the staged-upgrade path (`storage_prepare` → `storage_enter_mixed_transition` → `storage_finalize`), with a note that the orchestration (start new-mode workers, stop canonical-only workers, wait for drain) is unchanged from the CLI flow.
- **Test.** `awa-model/tests/sql_only_storage_upgrade_test.rs` covers both paths end-to-end via raw SQL: the upgrade test inserts a canonical marker to defeat auto-finalize, stamps a `queue_storage_target` runtime so the mixed-transition gate passes, drives the three transition functions directly, simulates canonical drain by deleting the marker, then finalizes; the fresh-install test exercises `storage_auto_finalize_if_fresh` against an empty `awa.jobs`. Neither test invokes any Rust storage wrapper beyond `awa_model::migrations::run`.

Notably, no `GRANT` widening was needed — operators running external migration tooling are using the migration role, which already owns the functions. The `storage_auto_finalize_if_fresh` PUBLIC grant only matters because non-owner worker roles call it on boot.

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo build --workspace`
- [x] `cargo test -p awa-model --test sql_only_storage_upgrade_test` against local Postgres — both tests pass
- [x] First test run caught a real `storage_finalize` gate error (canonical backlog non-zero); fixed the test to drain before finalize, which mirrors the documented operator flow

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guide for external migration tooling to support deployment installations and upgrades

* **Tests**
  * Added integration tests validating SQL-based migration scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->