### PR TITLE
perf(queue_storage): fillfactor=50 on leases + lease_claims partitions (#169)

### DIFF
--- a/awa-model/migrations/v023_install_queue_storage_substrate.sql
+++ b/awa-model/migrations/v023_install_queue_storage_substrate.sql
@@ -520,24 +520,6 @@ BEGIN
             'CREATE TABLE IF NOT EXISTS %I.%I PARTITION OF %I.lease_claims FOR VALUES IN (%s)',
             p_schema, format('lease_claims_%s', v_slot), p_schema, v_slot
         );
-
-        -- #169: lease_claims gets `SET materialized_at = clock_timestamp()`
-        -- on every receipt materialize. The stale index keys on
-        -- materialized_at, so each UPDATE is non-HOT — leaving fillfactor
-        -- at the default 100 means every UPDATE spills to a fresh page.
-        -- Match the d21e5db / ab99a31 pattern on the other Warm tables.
-        EXECUTE format(
-            $alter$
-            ALTER TABLE %I.%I SET (
-                fillfactor = 50,
-                autovacuum_vacuum_scale_factor = 0.0,
-                autovacuum_vacuum_threshold = 200,
-                autovacuum_vacuum_cost_limit = 2000,
-                autovacuum_vacuum_cost_delay = 2
-            )
-            $alter$,
-            p_schema, format('lease_claims_%s', v_slot)
-        );
     END LOOP;
 
     EXECUTE format(
@@ -905,29 +887,6 @@ BEGIN
         EXECUTE format(
             'CREATE TABLE IF NOT EXISTS %I.%I PARTITION OF %I.leases FOR VALUES IN (%s)',
             p_schema, format('leases_%s', v_slot), p_schema, v_slot
-        );
-
-        -- #169: leases takes heartbeat / state-transition / callback UPDATEs
-        -- (heartbeat_at, state, callback_id, callback_timeout_at,
-        -- deadline_at). Several of those columns are indexed below
-        -- (state_hb / state_deadline / state_callback_timeout / callback),
-        -- so the UPDATEs are non-HOT regardless of fillfactor. fillfactor=50
-        -- still matters: it reserves on-page space so the new tuple version
-        -- lands in the same page, keeping dead-tuple density bounded under
-        -- pinned-MVCC pressure. The companion B1 work-in-progress will
-        -- drop the heartbeat_at write/index entirely in receipts mode; this
-        -- fillfactor change is orthogonal hygiene that benefits both modes.
-        EXECUTE format(
-            $alter$
-            ALTER TABLE %I.%I SET (
-                fillfactor = 50,
-                autovacuum_vacuum_scale_factor = 0.0,
-                autovacuum_vacuum_threshold = 200,
-                autovacuum_vacuum_cost_limit = 2000,
-                autovacuum_vacuum_cost_delay = 2
-            )
-            $alter$,
-            p_schema, format('leases_%s', v_slot)
         );
 
         EXECUTE format(

--- a/awa-model/migrations/v023_install_queue_storage_substrate.sql
+++ b/awa-model/migrations/v023_install_queue_storage_substrate.sql
@@ -520,6 +520,24 @@ BEGIN
             'CREATE TABLE IF NOT EXISTS %I.%I PARTITION OF %I.lease_claims FOR VALUES IN (%s)',
             p_schema, format('lease_claims_%s', v_slot), p_schema, v_slot
         );
+
+        -- #169: lease_claims gets `SET materialized_at = clock_timestamp()`
+        -- on every receipt materialize. The stale index keys on
+        -- materialized_at, so each UPDATE is non-HOT — leaving fillfactor
+        -- at the default 100 means every UPDATE spills to a fresh page.
+        -- Match the d21e5db / ab99a31 pattern on the other Warm tables.
+        EXECUTE format(
+            $alter$
+            ALTER TABLE %I.%I SET (
+                fillfactor = 50,
+                autovacuum_vacuum_scale_factor = 0.0,
+                autovacuum_vacuum_threshold = 200,
+                autovacuum_vacuum_cost_limit = 2000,
+                autovacuum_vacuum_cost_delay = 2
+            )
+            $alter$,
+            p_schema, format('lease_claims_%s', v_slot)
+        );
     END LOOP;
 
     EXECUTE format(
@@ -887,6 +905,29 @@ BEGIN
         EXECUTE format(
             'CREATE TABLE IF NOT EXISTS %I.%I PARTITION OF %I.leases FOR VALUES IN (%s)',
             p_schema, format('leases_%s', v_slot), p_schema, v_slot
+        );
+
+        -- #169: leases takes heartbeat / state-transition / callback UPDATEs
+        -- (heartbeat_at, state, callback_id, callback_timeout_at,
+        -- deadline_at). Several of those columns are indexed below
+        -- (state_hb / state_deadline / state_callback_timeout / callback),
+        -- so the UPDATEs are non-HOT regardless of fillfactor. fillfactor=50
+        -- still matters: it reserves on-page space so the new tuple version
+        -- lands in the same page, keeping dead-tuple density bounded under
+        -- pinned-MVCC pressure. The companion B1 work-in-progress will
+        -- drop the heartbeat_at write/index entirely in receipts mode; this
+        -- fillfactor change is orthogonal hygiene that benefits both modes.
+        EXECUTE format(
+            $alter$
+            ALTER TABLE %I.%I SET (
+                fillfactor = 50,
+                autovacuum_vacuum_scale_factor = 0.0,
+                autovacuum_vacuum_threshold = 200,
+                autovacuum_vacuum_cost_limit = 2000,
+                autovacuum_vacuum_cost_delay = 2
+            )
+            $alter$,
+            p_schema, format('leases_%s', v_slot)
         );
 
         EXECUTE format(

--- a/awa-model/migrations/v024_receipt_plane_fillfactor.sql
+++ b/awa-model/migrations/v024_receipt_plane_fillfactor.sql
@@ -1,0 +1,103 @@
+-- #169: lower fillfactor on the two UPDATE-heavy receipt-plane partitioned
+-- tables to keep dead-tuple density bounded under pinned-MVCC pressure.
+--
+-- Targets (verified UPDATE call sites, see queue_storage.rs):
+--   * leases               — heartbeat, state transition, callback fields
+--   * lease_claims         — SET materialized_at = clock_timestamp()
+--
+-- The other receipt-plane partitioned tables (ready_entries, done_entries,
+-- lease_claim_closures) are INSERT+DELETE only — no UPDATE call sites —
+-- so lowering fillfactor on them would waste pages without restoring
+-- any HOT-update behaviour. They stay at fillfactor=100.
+--
+-- The fillfactor change pattern follows commits d21e5db and ab99a31:
+-- 50% on-page slack restores HOT-update headroom on the sibling
+-- Warm tables (queue_claim_heads / queue_enqueue_heads / queue_ring_state).
+-- Several of the indexes on `leases` still key on UPDATEd columns
+-- (state_hb, state_deadline, state_callback_timeout, callback) so this
+-- fillfactor change alone does not make heartbeat/state updates HOT in
+-- receipts mode — it caps page-spill so the dead-tuple chain stays
+-- bounded. Removing the state_hb index in receipts mode is tracked
+-- separately as the B1 follow-up.
+--
+-- v023's install function was updated in the same change to apply these
+-- settings to fresh installs. This migration applies the ALTERs directly
+-- to existing partitions of `awa.leases` and `awa.lease_claims`, since
+-- the install function already in pg_proc on an existing deployment
+-- still carries the old (pre-edit) body. Direct ALTER avoids having to
+-- reapply the entire helper SQL.
+--
+-- ALTER TABLE SET (fillfactor=N) only changes the hint for future page
+-- allocations; it does not rewrite existing pages, so this is
+-- non-blocking and fast even on populated tables.
+--
+-- Covers the default `awa` schema and any custom queue-storage schemas
+-- currently registered in `awa.runtime_storage_backends`. A custom
+-- schema prepared *after* this migration runs on an existing
+-- deployment will get fillfactor=100 from the install helper still
+-- cached in pg_proc — the operator workaround is `SELECT
+-- awa.apply_receipt_plane_fillfactor('<schema>')` after their
+-- `awa storage prepare-queue-storage-schema` call.
+
+CREATE OR REPLACE FUNCTION awa.apply_receipt_plane_fillfactor(p_schema TEXT)
+RETURNS VOID
+LANGUAGE plpgsql
+SET search_path = pg_catalog, awa
+AS $$
+DECLARE
+    v_partition_relid OID;
+    v_leases_oid      OID;
+    v_claims_oid      OID;
+BEGIN
+    v_leases_oid := to_regclass(format('%I.leases', p_schema));
+    v_claims_oid := to_regclass(format('%I.lease_claims', p_schema));
+
+    IF v_leases_oid IS NULL OR v_claims_oid IS NULL THEN
+        RETURN;
+    END IF;
+
+    FOR v_partition_relid IN
+        SELECT inhrelid
+        FROM pg_inherits
+        WHERE inhparent IN (v_leases_oid, v_claims_oid)
+    LOOP
+        EXECUTE format(
+            $alter$
+            ALTER TABLE %s SET (
+                fillfactor = 50,
+                autovacuum_vacuum_scale_factor = 0.0,
+                autovacuum_vacuum_threshold = 200,
+                autovacuum_vacuum_cost_limit = 2000,
+                autovacuum_vacuum_cost_delay = 2
+            )
+            $alter$,
+            v_partition_relid::regclass::text
+        );
+    END LOOP;
+END
+$$;
+
+GRANT EXECUTE ON FUNCTION awa.apply_receipt_plane_fillfactor(TEXT) TO PUBLIC;
+
+DO $$
+DECLARE
+    v_schema TEXT;
+BEGIN
+    -- Default schema.
+    PERFORM awa.apply_receipt_plane_fillfactor('awa');
+
+    -- Any custom queue-storage schemas registered as active or prepared.
+    FOR v_schema IN
+        SELECT DISTINCT schema_name
+        FROM awa.runtime_storage_backends
+        WHERE schema_name IS NOT NULL
+          AND schema_name <> 'awa'
+    LOOP
+        PERFORM awa.apply_receipt_plane_fillfactor(v_schema);
+    END LOOP;
+END
+$$;
+
+INSERT INTO awa.schema_version (version, description)
+VALUES (24, 'Lower fillfactor to 50 on leases and lease_claims partitions (#169)')
+ON CONFLICT (version) DO NOTHING;

--- a/awa-model/migrations/v024_receipt_plane_fillfactor.sql
+++ b/awa-model/migrations/v024_receipt_plane_fillfactor.sql
@@ -32,12 +32,21 @@
 -- non-blocking and fast even on populated tables.
 --
 -- Covers the default `awa` schema and any custom queue-storage schemas
--- currently registered in `awa.runtime_storage_backends`. A custom
--- schema prepared *after* this migration runs on an existing
--- deployment will get fillfactor=100 from the install helper still
--- cached in pg_proc — the operator workaround is `SELECT
--- awa.apply_receipt_plane_fillfactor('<schema>')` after their
--- `awa storage prepare-queue-storage-schema` call.
+-- whose substrate physically exists in the database. The discovery
+-- query scans pg_class for any schema with both a partitioned `leases`
+-- and `lease_claims` parent — broader than the registration tables
+-- (`runtime_storage_backends` only lists the active backend;
+-- `storage_transition_state.details` only lists the prepared schema
+-- during an in-flight transition), so it picks up custom schemas that
+-- were materialized but never activated.
+--
+-- Rust `QueueStorage::prepare_schema()` also calls
+-- `apply_receipt_plane_fillfactor` after `install_queue_storage_substrate`,
+-- so any schema prepared after this migration (via the CLI or worker
+-- boot path) lands at fillfactor=50 even if the install helper still
+-- cached in pg_proc has the pre-v024 body. External tooling that
+-- bypasses prepare_schema and calls the install helper directly should
+-- also call `apply_receipt_plane_fillfactor` against the same schema.
 
 CREATE OR REPLACE FUNCTION awa.apply_receipt_plane_fillfactor(p_schema TEXT)
 RETURNS VOID
@@ -83,15 +92,28 @@ DO $$
 DECLARE
     v_schema TEXT;
 BEGIN
-    -- Default schema.
-    PERFORM awa.apply_receipt_plane_fillfactor('awa');
-
-    -- Any custom queue-storage schemas registered as active or prepared.
+    -- Discover every schema that has the queue-storage substrate by
+    -- scanning pg_class for a partitioned `leases` table. This is
+    -- broader than reading `awa.runtime_storage_backends` (which only
+    -- carries the active backend's schema) or
+    -- `awa.storage_transition_state.details->>'schema'` (which only
+    -- carries the prepared schema during an in-flight transition):
+    -- both miss custom schemas that were materialized via
+    -- prepare_schema but never activated. pg_class is the authoritative
+    -- source for "this substrate physically exists."
     FOR v_schema IN
-        SELECT DISTINCT schema_name
-        FROM awa.runtime_storage_backends
-        WHERE schema_name IS NOT NULL
-          AND schema_name <> 'awa'
+        SELECT n.nspname
+        FROM pg_class AS c
+        JOIN pg_namespace AS n ON n.oid = c.relnamespace
+        WHERE c.relname = 'leases'
+          AND c.relkind = 'p'  -- partitioned table
+          AND EXISTS (
+              SELECT 1 FROM pg_class AS lc
+              JOIN pg_namespace AS ln ON ln.oid = lc.relnamespace
+              WHERE ln.nspname = n.nspname
+                AND lc.relname = 'lease_claims'
+                AND lc.relkind = 'p'
+          )
     LOOP
         PERFORM awa.apply_receipt_plane_fillfactor(v_schema);
     END LOOP;

--- a/awa-model/migrations/v024_receipt_plane_fillfactor.sql
+++ b/awa-model/migrations/v024_receipt_plane_fillfactor.sql
@@ -57,11 +57,30 @@ DECLARE
     v_partition_relid OID;
     v_leases_oid      OID;
     v_claims_oid      OID;
+    v_is_awa_substrate BOOLEAN;
 BEGIN
     v_leases_oid := to_regclass(format('%I.leases', p_schema));
     v_claims_oid := to_regclass(format('%I.lease_claims', p_schema));
 
     IF v_leases_oid IS NULL OR v_claims_oid IS NULL THEN
+        RETURN;
+    END IF;
+
+    -- Ownership boundary: only touch AWA-owned substrates. Schemas
+    -- that happen to share the `leases` / `lease_claims` table names
+    -- but were not installed by `awa.install_queue_storage_substrate`
+    -- (e.g. unrelated application tables) must be left alone. The
+    -- gating sentinel is the AWA-specific `claim_ready_runtime`
+    -- function with its full signature — the same shape
+    -- `awa_model::storage::queue_storage_schema_ready` uses to
+    -- identify an AWA substrate. The install helper creates that
+    -- function in every substrate; no other code path does.
+    v_is_awa_substrate := to_regprocedure(format(
+        '%I.claim_ready_runtime(text,bigint,double precision,double precision)',
+        p_schema
+    )) IS NOT NULL;
+
+    IF NOT v_is_awa_substrate THEN
         RETURN;
     END IF;
 
@@ -92,29 +111,29 @@ DO $$
 DECLARE
     v_schema TEXT;
 BEGIN
-    -- Discover every schema that has the queue-storage substrate by
-    -- scanning pg_class for a partitioned `leases` table. This is
-    -- broader than reading `awa.runtime_storage_backends` (which only
-    -- carries the active backend's schema) or
-    -- `awa.storage_transition_state.details->>'schema'` (which only
-    -- carries the prepared schema during an in-flight transition):
-    -- both miss custom schemas that were materialized via
-    -- prepare_schema but never activated. pg_class is the authoritative
-    -- source for "this substrate physically exists."
+    -- Discover every schema that holds an AWA queue-storage substrate.
+    -- Matching just "has a partitioned `leases` table" would step on
+    -- unrelated app-owned schemas that happen to share the name, so
+    -- the gating sentinel is `awa.claim_ready_runtime` with the
+    -- AWA-specific signature — the same shape
+    -- `awa_model::storage::queue_storage_schema_ready` uses to identify
+    -- an AWA substrate. The install helper creates that function in
+    -- every substrate; no other code path does. This is broader than
+    -- reading `awa.runtime_storage_backends` (active backend only) or
+    -- `awa.storage_transition_state.details->>'schema'` (prepared
+    -- schema only during an in-flight transition), but stays inside
+    -- AWA's ownership boundary.
     FOR v_schema IN
         SELECT n.nspname
-        FROM pg_class AS c
-        JOIN pg_namespace AS n ON n.oid = c.relnamespace
-        WHERE c.relname = 'leases'
-          AND c.relkind = 'p'  -- partitioned table
-          AND EXISTS (
-              SELECT 1 FROM pg_class AS lc
-              JOIN pg_namespace AS ln ON ln.oid = lc.relnamespace
-              WHERE ln.nspname = n.nspname
-                AND lc.relname = 'lease_claims'
-                AND lc.relkind = 'p'
-          )
+        FROM pg_namespace AS n
+        WHERE to_regprocedure(format(
+            '%I.claim_ready_runtime(text,bigint,double precision,double precision)',
+            n.nspname
+        )) IS NOT NULL
     LOOP
+        -- The helper itself re-checks the sentinel and verifies the
+        -- partitioned `leases` / `lease_claims` exist before doing
+        -- anything, so this loop is safe to be liberal.
         PERFORM awa.apply_receipt_plane_fillfactor(v_schema);
     END LOOP;
 END

--- a/awa-model/src/migrations.rs
+++ b/awa-model/src/migrations.rs
@@ -4,7 +4,7 @@ use sqlx::PgPool;
 use tracing::info;
 
 /// Current schema version.
-pub const CURRENT_VERSION: i32 = 23;
+pub const CURRENT_VERSION: i32 = 24;
 
 /// All migrations in order. SQL lives in `awa-model/migrations/*.sql`
 /// for easy inspection by users who run their own migration tooling.
@@ -103,6 +103,11 @@ const MIGRATIONS: &[(i32, &str, &[&str])] = &[
         "Install default awa queue-storage substrate via SQL helper",
         &[V23_UP],
     ),
+    (
+        24,
+        "Lower fillfactor to 50 on leases and lease_claims partitions",
+        &[V24_UP],
+    ),
 ];
 
 const V1_UP: &str = include_str!("../migrations/v001_canonical_schema.sql");
@@ -127,6 +132,7 @@ const V20_UP: &str = include_str!("../migrations/v020_active_queue_storage_schem
 const V21_UP: &str = include_str!("../migrations/v021_shard_aware_lane_indexes.sql");
 const V22_UP: &str = include_str!("../migrations/v022_delete_compat_terminal_counter.sql");
 const V23_UP: &str = include_str!("../migrations/v023_install_queue_storage_substrate.sql");
+const V24_UP: &str = include_str!("../migrations/v024_receipt_plane_fillfactor.sql");
 
 /// Old version numbers from pre-0.4 releases that used V3/V4/V5 numbering.
 /// Also tolerates the unreleased inline-V6 branch numbering used during review.

--- a/awa-model/src/queue_storage.rs
+++ b/awa-model/src/queue_storage.rs
@@ -2271,6 +2271,19 @@ impl QueueStorage {
                 .await
                 .map_err(map_sqlx_error)?;
 
+            // #169: apply receipt-plane fillfactor tunings. On databases
+            // upgraded across v024, the install helper still in pg_proc
+            // may have the pre-v024 body that doesn't set fillfactor on
+            // leases / lease_claims partitions; this delegated call
+            // closes the gap regardless. Tunings live in their own SQL
+            // function (see v024) so future perf knobs land additively
+            // without touching the bigger install helper.
+            sqlx::query("SELECT awa.apply_receipt_plane_fillfactor($1)")
+                .bind(schema)
+                .execute(install_tx.as_mut())
+                .await
+                .map_err(map_sqlx_error)?;
+
             // Post-helper legacy fixups: copy any renamed-aside rows into the
             // newly partitioned parents created by the helper, then drop the
             // legacy table. ON CONFLICT DO NOTHING so a re-run after a

--- a/awa-model/src/queue_storage.rs
+++ b/awa-model/src/queue_storage.rs
@@ -2271,13 +2271,16 @@ impl QueueStorage {
                 .await
                 .map_err(map_sqlx_error)?;
 
-            // #169: apply receipt-plane fillfactor tunings. On databases
-            // upgraded across v024, the install helper still in pg_proc
-            // may have the pre-v024 body that doesn't set fillfactor on
-            // leases / lease_claims partitions; this delegated call
-            // closes the gap regardless. Tunings live in their own SQL
-            // function (see v024) so future perf knobs land additively
-            // without touching the bigger install helper.
+            // #169: apply receipt-plane fillfactor tunings. The install
+            // helper above creates structure only; tunings live in
+            // their own SQL function (see v024) and the orchestrator
+            // here is the canonical place that composes them. This
+            // means future perf knobs land additively in
+            // `apply_receipt_plane_fillfactor` (or a sibling helper)
+            // without touching the bigger install helper, and every
+            // path that creates substrate — Rust prepare_schema, fresh
+            // `awa migrate` (via v024's sweep), explicit operator call
+            // against a custom schema — composes the same two pieces.
             sqlx::query("SELECT awa.apply_receipt_plane_fillfactor($1)")
                 .bind(schema)
                 .execute(install_tx.as_mut())

--- a/awa-model/tests/receipt_plane_fillfactor_test.rs
+++ b/awa-model/tests/receipt_plane_fillfactor_test.rs
@@ -230,15 +230,28 @@ async fn apply_receipt_plane_fillfactor_helper_restores_reset_partitions() {
         .expect("cleanup test schema");
 }
 
-/// `QueueStorage::prepare_schema` should call
-/// `apply_receipt_plane_fillfactor` automatically so a worker boot or
-/// CLI `prepare-queue-storage-schema` against a new custom schema gets
-/// the fillfactor set even when the install helper still cached in
-/// pg_proc has the pre-v024 body. Mirrors the same RESET-simulate-old-
-/// helper pattern as the test above, but exercises the Rust orchestrator
-/// instead of the SQL helper directly.
+/// Prove that `QueueStorage::prepare_schema`'s call to
+/// `apply_receipt_plane_fillfactor` is what restores tunings on a
+/// re-prepare against an already-installed substrate. This is the
+/// scenario that matters on the upgrade path: the install helper
+/// cached in pg_proc may be the pre-v024 body that doesn't set
+/// fillfactor in its CREATE TABLE loops, but
+/// `install_queue_storage_substrate` is idempotent — on a re-prepare
+/// it skips the CREATE TABLE IF NOT EXISTS branch entirely. So even
+/// if the helper *did* carry the in-loop ALTERs (as on a fresh
+/// install in this checkout), they wouldn't re-fire on re-prepare.
+/// What does fire is the orchestrator's explicit
+/// `apply_receipt_plane_fillfactor` call after install.
+///
+/// Sequence:
+///   1. `prepare_schema` (creates substrate, leaves at fillfactor=50).
+///   2. RESET reloptions on every partition to simulate the
+///      pre-v024 state.
+///   3. `prepare_schema` again. If the orchestrator hook is removed,
+///      this becomes a no-op and the partitions stay reset.
+///   4. Assert fillfactor=50 is back.
 #[tokio::test]
-async fn prepare_schema_applies_receipt_plane_fillfactor() {
+async fn prepare_schema_reapplies_receipt_plane_fillfactor_on_reprepare() {
     use awa_model::{QueueStorage, QueueStorageConfig};
 
     let pool = migrated_pool().await;
@@ -260,7 +273,76 @@ async fn prepare_schema_applies_receipt_plane_fillfactor() {
     store
         .prepare_schema(&pool)
         .await
-        .expect("prepare_schema should succeed against fresh schema");
+        .expect("first prepare_schema should succeed");
+
+    // Simulate the pre-v024 state: strip every reloption the v024 hook
+    // is meant to restore. Discover partitions via pg_inherits so the
+    // simulation works regardless of slot count.
+    let partition_names: Vec<String> = sqlx::query_scalar(
+        r#"
+        SELECT (n.nspname || '.' || c.relname)::text
+        FROM pg_class AS c
+        JOIN pg_namespace AS n ON n.oid = c.relnamespace
+        JOIN pg_inherits AS inh ON inh.inhrelid = c.oid
+        WHERE n.nspname = $1
+          AND (inh.inhparent = ($1 || '.leases')::regclass
+            OR inh.inhparent = ($1 || '.lease_claims')::regclass)
+          AND c.relkind = 'r'
+        "#,
+    )
+    .bind(&schema)
+    .fetch_all(&pool)
+    .await
+    .expect("list partitions");
+    assert!(!partition_names.is_empty(), "expected partitions");
+    for name in &partition_names {
+        sqlx::query(&format!(
+            "ALTER TABLE {name} RESET ( \
+             fillfactor, \
+             autovacuum_vacuum_scale_factor, \
+             autovacuum_vacuum_threshold, \
+             autovacuum_vacuum_cost_limit, \
+             autovacuum_vacuum_cost_delay)"
+        ))
+        .execute(&pool)
+        .await
+        .expect("reset partition reloptions");
+    }
+
+    // Sanity-check the reset took effect — without this the final
+    // assertion could pass vacuously if the RESET didn't actually clear
+    // anything.
+    let after_reset_with_fillfactor: i64 = sqlx::query_scalar(
+        r#"
+        SELECT count(*) FROM pg_class AS c
+        JOIN pg_namespace AS n ON n.oid = c.relnamespace
+        JOIN pg_inherits AS inh ON inh.inhrelid = c.oid
+        WHERE n.nspname = $1
+          AND (inh.inhparent = ($1 || '.leases')::regclass
+            OR inh.inhparent = ($1 || '.lease_claims')::regclass)
+          AND c.relkind = 'r'
+          AND c.reloptions IS NOT NULL
+          AND 'fillfactor=50' = ANY(c.reloptions)
+        "#,
+    )
+    .bind(&schema)
+    .fetch_one(&pool)
+    .await
+    .expect("count partitions still carrying fillfactor=50");
+    assert_eq!(
+        after_reset_with_fillfactor, 0,
+        "RESET must have cleared fillfactor=50 on every partition; \
+         otherwise the orchestrator's contribution can't be observed"
+    );
+
+    // Re-prepare. install_queue_storage_substrate is idempotent and the
+    // CREATE TABLE IF NOT EXISTS branches don't re-fire on existing
+    // partitions, so only the orchestrator's explicit
+    // apply_receipt_plane_fillfactor call can restore the reloptions.
+    store
+        .prepare_schema(&pool)
+        .await
+        .expect("second prepare_schema should succeed");
 
     let partitions: Vec<(String, Option<Vec<String>>)> = sqlx::query_as(
         r#"
@@ -278,17 +360,13 @@ async fn prepare_schema_applies_receipt_plane_fillfactor() {
     .bind(&schema)
     .fetch_all(&pool)
     .await
-    .expect("read partition reloptions");
+    .expect("read partition reloptions after re-prepare");
 
-    assert!(
-        !partitions.is_empty(),
-        "expected leases and lease_claims partitions in {schema}"
-    );
     for (name, opts) in &partitions {
         let opts = opts.clone().unwrap_or_default();
         assert!(
             has_option(&opts, "fillfactor", "50"),
-            "{schema}.{name} reloptions missing fillfactor=50 after prepare_schema: {opts:?}"
+            "{schema}.{name} reloptions missing fillfactor=50 after re-prepare: {opts:?}"
         );
     }
 
@@ -296,6 +374,91 @@ async fn prepare_schema_applies_receipt_plane_fillfactor() {
         .execute(&pool)
         .await
         .expect("cleanup test schema");
+}
+
+/// Ownership boundary: `apply_receipt_plane_fillfactor` and the v024
+/// migration sweep must NOT alter unrelated app-owned schemas that
+/// happen to have a partitioned `leases` / `lease_claims` pair.
+/// Gating on the AWA-specific `claim_ready_runtime` function signature
+/// is what keeps the sweep inside AWA's namespace. This test creates
+/// a lookalike schema, calls the helper, and asserts the lookalike
+/// partitions stay at the default reloptions.
+#[tokio::test]
+async fn apply_receipt_plane_fillfactor_skips_non_awa_schemas() {
+    let pool = migrated_pool().await;
+    let schema = format!("app_owned_test_{}", uuid::Uuid::new_v4().simple());
+
+    sqlx::query(&format!("DROP SCHEMA IF EXISTS {schema} CASCADE"))
+        .execute(&pool)
+        .await
+        .expect("clean any prior schema");
+    sqlx::query(&format!("CREATE SCHEMA {schema}"))
+        .execute(&pool)
+        .await
+        .expect("create app-owned schema");
+    sqlx::query(&format!(
+        "CREATE TABLE {schema}.leases ( \
+         lease_slot INT NOT NULL, id BIGINT NOT NULL, \
+         PRIMARY KEY (lease_slot, id) \
+         ) PARTITION BY LIST (lease_slot)"
+    ))
+    .execute(&pool)
+    .await
+    .expect("create lookalike leases parent");
+    sqlx::query(&format!(
+        "CREATE TABLE {schema}.leases_0 PARTITION OF {schema}.leases FOR VALUES IN (0)"
+    ))
+    .execute(&pool)
+    .await
+    .expect("create lookalike leases partition");
+    sqlx::query(&format!(
+        "CREATE TABLE {schema}.lease_claims ( \
+         claim_slot INT NOT NULL, id BIGINT NOT NULL, \
+         PRIMARY KEY (claim_slot, id) \
+         ) PARTITION BY LIST (claim_slot)"
+    ))
+    .execute(&pool)
+    .await
+    .expect("create lookalike lease_claims parent");
+    sqlx::query(&format!(
+        "CREATE TABLE {schema}.lease_claims_0 PARTITION OF {schema}.lease_claims FOR VALUES IN (0)"
+    ))
+    .execute(&pool)
+    .await
+    .expect("create lookalike lease_claims partition");
+
+    // The helper sees no claim_ready_runtime function in this schema,
+    // so it should return without altering anything.
+    sqlx::query("SELECT awa.apply_receipt_plane_fillfactor($1)")
+        .bind(&schema)
+        .execute(&pool)
+        .await
+        .expect("apply_receipt_plane_fillfactor on unrelated schema");
+
+    let altered: i64 = sqlx::query_scalar(
+        r#"
+        SELECT count(*) FROM pg_class AS c
+        JOIN pg_namespace AS n ON n.oid = c.relnamespace
+        JOIN pg_inherits AS inh ON inh.inhrelid = c.oid
+        WHERE n.nspname = $1
+          AND c.relkind = 'r'
+          AND c.reloptions IS NOT NULL
+        "#,
+    )
+    .bind(&schema)
+    .fetch_one(&pool)
+    .await
+    .expect("count altered partitions in lookalike schema");
+    assert_eq!(
+        altered, 0,
+        "apply_receipt_plane_fillfactor must not touch partitions in a \
+         schema that lacks the AWA claim_ready_runtime sentinel"
+    );
+
+    sqlx::query(&format!("DROP SCHEMA {schema} CASCADE"))
+        .execute(&pool)
+        .await
+        .expect("cleanup lookalike schema");
 }
 
 /// `ready_entries`, `done_entries`, and `lease_claim_closures` are

--- a/awa-model/tests/receipt_plane_fillfactor_test.rs
+++ b/awa-model/tests/receipt_plane_fillfactor_test.rs
@@ -94,14 +94,20 @@ async fn lease_claims_partitions_carry_fillfactor_50() {
     }
 }
 
-/// Custom schemas register themselves in `awa.runtime_storage_backends`
-/// when activated. v024's DO block iterates that table and applies the
-/// fillfactor to every registered schema. This test stamps a fake
-/// registration row, calls `awa.apply_receipt_plane_fillfactor` (the
-/// v024 helper, which is also what operators run for ad-hoc custom
-/// schemas), and asserts the partitions land at fillfactor=50.
+/// Simulates the "upgraded DB, post-v024, operator prepares a new
+/// custom schema" scenario: the install function still cached in
+/// pg_proc may have the pre-v024 body that leaves partitions at the
+/// default fillfactor=100. v024 introduces
+/// `awa.apply_receipt_plane_fillfactor` precisely to close that gap.
+///
+/// To prove the helper is actually what restores the reloptions (and
+/// the test isn't passing vacuously because the install body in *this*
+/// checkout already sets them), we install the substrate, RESET all
+/// the partition reloptions back to the default to simulate the
+/// pre-v024 helper body, then call the helper and assert the settings
+/// come back.
 #[tokio::test]
-async fn apply_receipt_plane_fillfactor_helper_covers_custom_schemas() {
+async fn apply_receipt_plane_fillfactor_helper_restores_reset_partitions() {
     let pool = migrated_pool().await;
     let schema = format!("awa_fillfactor_test_{}", uuid::Uuid::new_v4().simple());
 
@@ -114,16 +120,74 @@ async fn apply_receipt_plane_fillfactor_helper_covers_custom_schemas() {
         .await
         .expect("create test schema");
 
-    // The install function in pg_proc on an existing DB still has the
-    // pre-v024 body (no in-loop fillfactor ALTER), so a fresh
-    // `install_queue_storage_substrate` call leaves partitions at the
-    // default fillfactor=100. v024's apply_... helper is what closes
-    // that gap.
     sqlx::query("SELECT awa.install_queue_storage_substrate($1)")
         .bind(&schema)
         .execute(&pool)
         .await
         .expect("install substrate via helper");
+
+    // Simulate the pre-v024 install body: strip every reloption the
+    // v024 helper is meant to restore. We discover the partitions via
+    // pg_inherits so the simulation works against any slot count.
+    let partition_names: Vec<String> = sqlx::query_scalar(
+        r#"
+        SELECT (n.nspname || '.' || c.relname)::text
+        FROM pg_class AS c
+        JOIN pg_namespace AS n ON n.oid = c.relnamespace
+        JOIN pg_inherits AS inh ON inh.inhrelid = c.oid
+        WHERE n.nspname = $1
+          AND (inh.inhparent = ($1 || '.leases')::regclass
+            OR inh.inhparent = ($1 || '.lease_claims')::regclass)
+          AND c.relkind = 'r'
+        "#,
+    )
+    .bind(&schema)
+    .fetch_all(&pool)
+    .await
+    .expect("list custom-schema partitions");
+    assert!(
+        !partition_names.is_empty(),
+        "expected at least one partition under {schema}"
+    );
+    for name in &partition_names {
+        sqlx::query(&format!(
+            "ALTER TABLE {name} RESET ( \
+             fillfactor, \
+             autovacuum_vacuum_scale_factor, \
+             autovacuum_vacuum_threshold, \
+             autovacuum_vacuum_cost_limit, \
+             autovacuum_vacuum_cost_delay)"
+        ))
+        .execute(&pool)
+        .await
+        .expect("reset partition reloptions");
+    }
+
+    // Confirm the RESET actually stripped the reloptions — otherwise
+    // the subsequent helper call would pass vacuously.
+    let post_reset_with_fillfactor: i64 = sqlx::query_scalar(
+        r#"
+        SELECT count(*) FROM pg_class AS c
+        JOIN pg_namespace AS n ON n.oid = c.relnamespace
+        JOIN pg_inherits AS inh ON inh.inhrelid = c.oid
+        WHERE n.nspname = $1
+          AND (inh.inhparent = ($1 || '.leases')::regclass
+            OR inh.inhparent = ($1 || '.lease_claims')::regclass)
+          AND c.relkind = 'r'
+          AND c.reloptions IS NOT NULL
+          AND 'fillfactor=50' = ANY(c.reloptions)
+        "#,
+    )
+    .bind(&schema)
+    .fetch_one(&pool)
+    .await
+    .expect("count partitions still carrying fillfactor=50");
+    assert_eq!(
+        post_reset_with_fillfactor, 0,
+        "RESET should have cleared fillfactor on all partitions before \
+         the helper call so the assertion below proves the helper works"
+    );
+
     sqlx::query("SELECT awa.apply_receipt_plane_fillfactor($1)")
         .bind(&schema)
         .execute(&pool)
@@ -156,7 +220,75 @@ async fn apply_receipt_plane_fillfactor_helper_covers_custom_schemas() {
         let opts = opts.clone().unwrap_or_default();
         assert!(
             has_option(&opts, "fillfactor", "50"),
-            "{schema}.{name} reloptions missing fillfactor=50: {opts:?}"
+            "{schema}.{name} reloptions missing fillfactor=50 after helper call: {opts:?}"
+        );
+    }
+
+    sqlx::query(&format!("DROP SCHEMA {schema} CASCADE"))
+        .execute(&pool)
+        .await
+        .expect("cleanup test schema");
+}
+
+/// `QueueStorage::prepare_schema` should call
+/// `apply_receipt_plane_fillfactor` automatically so a worker boot or
+/// CLI `prepare-queue-storage-schema` against a new custom schema gets
+/// the fillfactor set even when the install helper still cached in
+/// pg_proc has the pre-v024 body. Mirrors the same RESET-simulate-old-
+/// helper pattern as the test above, but exercises the Rust orchestrator
+/// instead of the SQL helper directly.
+#[tokio::test]
+async fn prepare_schema_applies_receipt_plane_fillfactor() {
+    use awa_model::{QueueStorage, QueueStorageConfig};
+
+    let pool = migrated_pool().await;
+    let schema = format!("awa_prepare_test_{}", uuid::Uuid::new_v4().simple());
+    let store = QueueStorage::new(QueueStorageConfig {
+        schema: schema.clone(),
+        queue_slot_count: 4,
+        lease_slot_count: 2,
+        claim_slot_count: 2,
+        ..Default::default()
+    })
+    .expect("construct QueueStorage");
+
+    sqlx::query(&format!("DROP SCHEMA IF EXISTS {schema} CASCADE"))
+        .execute(&pool)
+        .await
+        .expect("clean any prior schema");
+
+    store
+        .prepare_schema(&pool)
+        .await
+        .expect("prepare_schema should succeed against fresh schema");
+
+    let partitions: Vec<(String, Option<Vec<String>>)> = sqlx::query_as(
+        r#"
+        SELECT c.relname, c.reloptions::text[]
+        FROM pg_class AS c
+        JOIN pg_namespace AS n ON n.oid = c.relnamespace
+        JOIN pg_inherits AS inh ON inh.inhrelid = c.oid
+        WHERE n.nspname = $1
+          AND (inh.inhparent = ($1 || '.leases')::regclass
+            OR inh.inhparent = ($1 || '.lease_claims')::regclass)
+          AND c.relkind = 'r'
+        ORDER BY c.relname
+        "#,
+    )
+    .bind(&schema)
+    .fetch_all(&pool)
+    .await
+    .expect("read partition reloptions");
+
+    assert!(
+        !partitions.is_empty(),
+        "expected leases and lease_claims partitions in {schema}"
+    );
+    for (name, opts) in &partitions {
+        let opts = opts.clone().unwrap_or_default();
+        assert!(
+            has_option(&opts, "fillfactor", "50"),
+            "{schema}.{name} reloptions missing fillfactor=50 after prepare_schema: {opts:?}"
         );
     }
 

--- a/awa-model/tests/receipt_plane_fillfactor_test.rs
+++ b/awa-model/tests/receipt_plane_fillfactor_test.rs
@@ -1,0 +1,190 @@
+//! Regression test for #169: receipt-plane partitions must carry
+//! `fillfactor=50` (and the tightened autovacuum knobs) after a full
+//! `awa migrate`. The two UPDATE-heavy partitioned tables —
+//! `awa.leases` and `awa.lease_claims` — are the only ones that need
+//! the on-page slack; the insert+delete-only siblings (`ready_entries`,
+//! `done_entries`, `lease_claim_closures`) intentionally stay at the
+//! default fillfactor=100.
+
+use sqlx::postgres::PgPoolOptions;
+use sqlx::PgPool;
+
+fn database_url() -> String {
+    std::env::var("DATABASE_URL")
+        .unwrap_or_else(|_| "postgres://postgres:test@localhost:15432/awa_test".to_string())
+}
+
+async fn migrated_pool() -> PgPool {
+    let pool = PgPoolOptions::new()
+        .max_connections(2)
+        .connect(&database_url())
+        .await
+        .expect("connect");
+    awa_model::migrations::run(&pool)
+        .await
+        .expect("run migrations");
+    pool
+}
+
+async fn reloptions_for_partitions(pool: &PgPool, parent: &str) -> Vec<(String, Vec<String>)> {
+    sqlx::query_as::<_, (String, Option<Vec<String>>)>(
+        r#"
+        SELECT c.relname, c.reloptions::text[]
+        FROM pg_class AS c
+        JOIN pg_namespace AS n ON n.oid = c.relnamespace
+        JOIN pg_inherits AS inh ON inh.inhrelid = c.oid
+        WHERE n.nspname = 'awa'
+          AND inh.inhparent = ($1 || '.' || $2)::regclass
+          AND c.relkind = 'r'
+        ORDER BY c.relname
+        "#,
+    )
+    .bind("awa")
+    .bind(parent)
+    .fetch_all(pool)
+    .await
+    .expect("read reloptions")
+    .into_iter()
+    .map(|(name, opts)| (name, opts.unwrap_or_default()))
+    .collect()
+}
+
+fn has_option(opts: &[String], key: &str, expected: &str) -> bool {
+    opts.iter()
+        .any(|o| o.split_once('=') == Some((key, expected)))
+}
+
+#[tokio::test]
+async fn leases_partitions_carry_fillfactor_50() {
+    let pool = migrated_pool().await;
+    let partitions = reloptions_for_partitions(&pool, "leases").await;
+    assert!(
+        !partitions.is_empty(),
+        "expected at least one awa.leases partition after migrate"
+    );
+    for (name, opts) in &partitions {
+        assert!(
+            has_option(opts, "fillfactor", "50"),
+            "{name} reloptions missing fillfactor=50: {opts:?}"
+        );
+        assert!(
+            has_option(opts, "autovacuum_vacuum_scale_factor", "0.0"),
+            "{name} reloptions missing autovacuum_vacuum_scale_factor=0.0: {opts:?}"
+        );
+        assert!(
+            has_option(opts, "autovacuum_vacuum_threshold", "200"),
+            "{name} reloptions missing autovacuum_vacuum_threshold=200: {opts:?}"
+        );
+    }
+}
+
+#[tokio::test]
+async fn lease_claims_partitions_carry_fillfactor_50() {
+    let pool = migrated_pool().await;
+    let partitions = reloptions_for_partitions(&pool, "lease_claims").await;
+    assert!(
+        !partitions.is_empty(),
+        "expected at least one awa.lease_claims partition after migrate"
+    );
+    for (name, opts) in &partitions {
+        assert!(
+            has_option(opts, "fillfactor", "50"),
+            "{name} reloptions missing fillfactor=50: {opts:?}"
+        );
+    }
+}
+
+/// Custom schemas register themselves in `awa.runtime_storage_backends`
+/// when activated. v024's DO block iterates that table and applies the
+/// fillfactor to every registered schema. This test stamps a fake
+/// registration row, calls `awa.apply_receipt_plane_fillfactor` (the
+/// v024 helper, which is also what operators run for ad-hoc custom
+/// schemas), and asserts the partitions land at fillfactor=50.
+#[tokio::test]
+async fn apply_receipt_plane_fillfactor_helper_covers_custom_schemas() {
+    let pool = migrated_pool().await;
+    let schema = format!("awa_fillfactor_test_{}", uuid::Uuid::new_v4().simple());
+
+    sqlx::query(&format!("DROP SCHEMA IF EXISTS {schema} CASCADE"))
+        .execute(&pool)
+        .await
+        .expect("clean any prior schema");
+    sqlx::query(&format!("CREATE SCHEMA {schema}"))
+        .execute(&pool)
+        .await
+        .expect("create test schema");
+
+    // The install function in pg_proc on an existing DB still has the
+    // pre-v024 body (no in-loop fillfactor ALTER), so a fresh
+    // `install_queue_storage_substrate` call leaves partitions at the
+    // default fillfactor=100. v024's apply_... helper is what closes
+    // that gap.
+    sqlx::query("SELECT awa.install_queue_storage_substrate($1)")
+        .bind(&schema)
+        .execute(&pool)
+        .await
+        .expect("install substrate via helper");
+    sqlx::query("SELECT awa.apply_receipt_plane_fillfactor($1)")
+        .bind(&schema)
+        .execute(&pool)
+        .await
+        .expect("apply fillfactor helper");
+
+    let partitions: Vec<(String, Option<Vec<String>>)> = sqlx::query_as(
+        r#"
+        SELECT c.relname, c.reloptions::text[]
+        FROM pg_class AS c
+        JOIN pg_namespace AS n ON n.oid = c.relnamespace
+        JOIN pg_inherits AS inh ON inh.inhrelid = c.oid
+        WHERE n.nspname = $1
+          AND (inh.inhparent = ($1 || '.leases')::regclass
+            OR inh.inhparent = ($1 || '.lease_claims')::regclass)
+          AND c.relkind = 'r'
+        ORDER BY c.relname
+        "#,
+    )
+    .bind(&schema)
+    .fetch_all(&pool)
+    .await
+    .expect("read custom-schema reloptions");
+
+    assert!(
+        !partitions.is_empty(),
+        "expected leases and lease_claims partitions in {schema}"
+    );
+    for (name, opts) in &partitions {
+        let opts = opts.clone().unwrap_or_default();
+        assert!(
+            has_option(&opts, "fillfactor", "50"),
+            "{schema}.{name} reloptions missing fillfactor=50: {opts:?}"
+        );
+    }
+
+    sqlx::query(&format!("DROP SCHEMA {schema} CASCADE"))
+        .execute(&pool)
+        .await
+        .expect("cleanup test schema");
+}
+
+/// `ready_entries`, `done_entries`, and `lease_claim_closures` are
+/// insert+delete only; lowering their fillfactor would waste pages
+/// without restoring any HOT-update behaviour. Assert they stay at the
+/// default (no fillfactor set) so a future change that mass-applies
+/// fillfactor=50 across all partitioned tables gets caught here.
+#[tokio::test]
+async fn insert_only_partitions_keep_default_fillfactor() {
+    let pool = migrated_pool().await;
+    for parent in ["ready_entries", "done_entries", "lease_claim_closures"] {
+        let partitions = reloptions_for_partitions(&pool, parent).await;
+        assert!(
+            !partitions.is_empty(),
+            "expected at least one awa.{parent} partition"
+        );
+        for (name, opts) in &partitions {
+            assert!(
+                !opts.iter().any(|o| o.starts_with("fillfactor=")),
+                "{name} unexpectedly has a fillfactor override (insert-only table): {opts:?}"
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Summary

First HOT-update audit landing for #169 (v0.6 release gate). Two partitioned receipt-plane tables take UPDATEs on the hot path and were left at the default fillfactor=100:

- **`leases`** — heartbeat, state-transition, callback-field UPDATEs
- **`lease_claims`** — `SET materialized_at = clock_timestamp()`

The other receipt-plane partitioned tables (`ready_entries`, `done_entries`, `lease_claim_closures`) have **zero UPDATE call sites** — verified by grep across `queue_storage.rs` and the migration SQL functions — so they stay at fillfactor=100 to avoid wasting pages.

This PR is the orthogonal-hygiene piece. For `leases`, the heartbeat / state-transition UPDATEs still hit indexed columns (`state_hb`, `state_deadline`, `state_callback_timeout`, `callback`) so they remain non-HOT until the companion **B1** work removes the heartbeat write and index in receipts mode. fillfactor=50 still matters here: it caps off-page tuple placement so the dead-tuple chain stays bounded under pinned-MVCC pressure. Mirrors the `d21e5db` / `ab99a31` pattern on `queue_claimer_leases` / `queue_claim_heads` / `queue_enqueue_heads`.

## Mechanics

1. **v023 helper update.** `awa.install_queue_storage_substrate` now applies the ALTERs inside the partition-creation FOR loops, so genuinely fresh installs (new DB, or fresh custom-schema prepare on a deployment whose initial migrate already includes this PR) land at fillfactor=50.
2. **v024 migration.** Defines `awa.apply_receipt_plane_fillfactor(schema TEXT)` which iterates the given schema's `leases` / `lease_claims` partitions and applies the same ALTER. Migration calls it for the default `awa` schema and every schema registered in `awa.runtime_storage_backends`. `ALTER TABLE SET (fillfactor=N)` only changes the hint for future page allocations, so this is non-blocking even on populated tables.

The helper is `GRANT EXECUTE ... TO PUBLIC` so operators can run it ad-hoc against a custom schema they prepare *after* upgrading (the rare case where the install function still cached in `pg_proc` has the pre-v024 body).

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo build --workspace`
- [x] Four regression tests in `awa-model/tests/receipt_plane_fillfactor_test.rs`:
  - `leases_partitions_carry_fillfactor_50` — full reloptions block on every `leases_N`
  - `lease_claims_partitions_carry_fillfactor_50` — same for `lease_claims_N`
  - `insert_only_partitions_keep_default_fillfactor` — `ready_entries`, `done_entries`, `lease_claim_closures` stay at the default (catches future bulk-apply mistakes)
  - `apply_receipt_plane_fillfactor_helper_covers_custom_schemas` — fresh custom schema + helper call lands at fillfactor=50
- [x] Smoke: applied `awa migrate` against local DB, confirmed via `pg_class.reloptions` that all 16 partitions (8 leases + 8 lease_claims) carry the full reloptions block

## Follow-ups (out of scope for this PR)

- **B1.** Stop writing `leases.heartbeat_at` in receipts mode, drop `idx_state_hb`, COALESCE compat-view reads from `attempt_state.heartbeat_at`. Removes heartbeat-driven non-HOT UPDATEs entirely.
- **Bench.** Re-run `long_horizon` against post-PR-A `main` to quantify the fillfactor impact on the leases / lease_claims dead-tuple curve.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Automatic database storage tuning now applied to lease and lease claim tables during schema preparation for improved performance.

* **Tests**
  * Comprehensive test coverage added for storage optimization across various deployment scenarios.

* **Chores**
  * Database migration v24 implements optimized storage configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->