### PR TITLE
perf(queue_storage): drop leases.heartbeat_at write + state_hb index in receipts mode (#169 B1)

### DIFF
--- a/awa-model/migrations/v023_install_queue_storage_substrate.sql
+++ b/awa-model/migrations/v023_install_queue_storage_substrate.sql
@@ -909,10 +909,14 @@ BEGIN
             p_schema, v_slot, p_schema, format('leases_%s', v_slot)
         );
 
-        EXECUTE format(
-            'CREATE INDEX IF NOT EXISTS idx_%s_leases_%s_state_hb ON %I.%I (state, heartbeat_at)',
-            p_schema, v_slot, p_schema, format('leases_%s', v_slot)
-        );
+        -- #169 B1: idx_state_hb dropped. In receipts mode (the only
+        -- supported shape for the default `awa` schema)
+        -- `leases.heartbeat_at` is never written, so the index would
+        -- be empty; the rescue path reads `attempt_state.heartbeat_at`
+        -- instead. Legacy non-receipts custom schemas fall back to a
+        -- seq-scan of `WHERE state='running'` rows (bounded by live
+        -- worker count, called at 30s cadence) — acceptable. v025
+        -- drops the index from existing 0.6 deployments.
 
         EXECUTE format(
             'CREATE INDEX IF NOT EXISTS idx_%s_leases_%s_state_deadline ON %I.%I (state, deadline_at)',

--- a/awa-model/migrations/v025_drop_leases_state_hb_index.sql
+++ b/awa-model/migrations/v025_drop_leases_state_hb_index.sql
@@ -1,0 +1,74 @@
+-- #169 B1: drop the `idx_<schema>_leases_<slot>_state_hb` index from
+-- every existing AWA queue-storage substrate. In receipts mode (the
+-- only supported shape for the default `awa` schema)
+-- `leases.heartbeat_at` is never written — heartbeats land in
+-- `attempt_state.heartbeat_at` and the rescue path reads from there.
+-- The `(state, heartbeat_at)` index then becomes pure overhead: every
+-- non-HOT UPDATE on `leases` (state transition, callback register,
+-- callback timeout, deadline write) still pays 2 dead index entries
+-- per write per partition.
+--
+-- Legacy non-receipts custom schemas (those that set
+-- `lease_claim_receipts=FALSE` when calling
+-- `awa.install_queue_storage_substrate`) fall back to a seq-scan of
+-- `WHERE state='running'` rows during stale-heartbeat rescue. That
+-- query runs at 30s cadence with `LIMIT 500` against the live-running
+-- row count (bounded by worker concurrency, typically thousands not
+-- millions), so the seq scan is cheap enough that dropping the index
+-- is the right global trade-off.
+--
+-- Discovery uses the same AWA sentinel as v024
+-- (`apply_receipt_plane_fillfactor`): a schema is an AWA substrate
+-- iff `<schema>.claim_ready_runtime(text, bigint, double precision,
+-- double precision)` exists. This stays inside AWA's ownership
+-- boundary; unrelated app-owned schemas with `leases` tables are not
+-- touched.
+--
+-- v023's install helper has been updated to not create the index on
+-- fresh installs, so this migration plus future `prepare_schema`
+-- calls keep the database state coherent.
+
+DO $$
+DECLARE
+    v_schema TEXT;
+    v_partition_name TEXT;
+    v_slot TEXT;
+BEGIN
+    FOR v_schema IN
+        SELECT n.nspname
+        FROM pg_namespace AS n
+        WHERE to_regprocedure(format(
+            '%I.claim_ready_runtime(text,bigint,double precision,double precision)',
+            n.nspname
+        )) IS NOT NULL
+    LOOP
+        IF to_regclass(format('%I.leases', v_schema)) IS NULL THEN
+            CONTINUE;
+        END IF;
+
+        FOR v_partition_name IN
+            SELECT c.relname
+            FROM pg_class AS c
+            JOIN pg_namespace AS n ON n.oid = c.relnamespace
+            JOIN pg_inherits AS inh ON inh.inhrelid = c.oid
+            WHERE n.nspname = v_schema
+              AND inh.inhparent = format('%I.leases', v_schema)::regclass
+              AND c.relkind = 'r'
+        LOOP
+            v_slot := substring(v_partition_name FROM '^leases_(\d+)$');
+            IF v_slot IS NULL THEN
+                CONTINUE;
+            END IF;
+            EXECUTE format(
+                'DROP INDEX IF EXISTS %I.%I',
+                v_schema,
+                format('idx_%s_leases_%s_state_hb', v_schema, v_slot)
+            );
+        END LOOP;
+    END LOOP;
+END
+$$;
+
+INSERT INTO awa.schema_version (version, description)
+VALUES (25, 'Drop idx_<schema>_leases_<slot>_state_hb on all AWA substrates (#169 B1)')
+ON CONFLICT (version) DO NOTHING;

--- a/awa-model/src/migrations.rs
+++ b/awa-model/src/migrations.rs
@@ -4,7 +4,7 @@ use sqlx::PgPool;
 use tracing::info;
 
 /// Current schema version.
-pub const CURRENT_VERSION: i32 = 24;
+pub const CURRENT_VERSION: i32 = 25;
 
 /// All migrations in order. SQL lives in `awa-model/migrations/*.sql`
 /// for easy inspection by users who run their own migration tooling.
@@ -108,6 +108,11 @@ const MIGRATIONS: &[(i32, &str, &[&str])] = &[
         "Lower fillfactor to 50 on leases and lease_claims partitions",
         &[V24_UP],
     ),
+    (
+        25,
+        "Drop idx_<schema>_leases_<slot>_state_hb on all AWA substrates",
+        &[V25_UP],
+    ),
 ];
 
 const V1_UP: &str = include_str!("../migrations/v001_canonical_schema.sql");
@@ -133,6 +138,7 @@ const V21_UP: &str = include_str!("../migrations/v021_shard_aware_lane_indexes.s
 const V22_UP: &str = include_str!("../migrations/v022_delete_compat_terminal_counter.sql");
 const V23_UP: &str = include_str!("../migrations/v023_install_queue_storage_substrate.sql");
 const V24_UP: &str = include_str!("../migrations/v024_receipt_plane_fillfactor.sql");
+const V25_UP: &str = include_str!("../migrations/v025_drop_leases_state_hb_index.sql");
 
 /// Old version numbers from pre-0.4 releases that used V3/V4/V5 numbering.
 /// Also tolerates the unreleased inline-V6 branch numbering used during review.

--- a/awa-model/src/queue_storage.rs
+++ b/awa-model/src/queue_storage.rs
@@ -7618,7 +7618,7 @@ impl QueueStorage {
                 lease.max_attempts,
                 lease.lane_seq,
                 ready.run_at,
-                lease.heartbeat_at,
+                COALESCE(attempt.heartbeat_at, lease.heartbeat_at) AS heartbeat_at,
                 lease.deadline_at,
                 lease.attempted_at,
                 NULL::timestamptz AS finalized_at,
@@ -8128,7 +8128,7 @@ impl QueueStorage {
                 lease.max_attempts,
                 lease.lane_seq,
                 ready.run_at,
-                lease.heartbeat_at,
+                COALESCE(attempt.heartbeat_at, lease.heartbeat_at) AS heartbeat_at,
                 lease.deadline_at,
                 lease.attempted_at,
                 NULL::timestamptz AS finalized_at,
@@ -8324,7 +8324,7 @@ impl QueueStorage {
                 lease.max_attempts,
                 lease.lane_seq,
                 ready.run_at,
-                lease.heartbeat_at,
+                COALESCE(attempt.heartbeat_at, lease.heartbeat_at) AS heartbeat_at,
                 lease.deadline_at,
                 lease.attempted_at,
                 NULL::timestamptz AS finalized_at,
@@ -8810,39 +8810,50 @@ impl QueueStorage {
             return Ok(0);
         }
 
-        let job_ids: Vec<i64> = jobs.iter().map(|(job_id, _)| *job_id).collect();
-        let run_leases: Vec<i64> = jobs.iter().map(|(_, run_lease)| *run_lease).collect();
         let mut tx = pool.begin().await.map_err(map_sqlx_error)?;
         let mut updated = 0_usize;
         if self.lease_claim_receipts() {
+            // #169 B1: in receipts mode, attempt_state is the
+            // authoritative heartbeat home. Skip the `UPDATE leases SET
+            // heartbeat_at = ...` entirely — that write was the
+            // dominant per-heartbeat non-HOT update on the partitioned
+            // `leases` table (every state-indexed partial index pays 2
+            // dead entries per write under sustained churn). Compat
+            // reads in `LeaseJobRow` SELECTs and the `awa.jobs` view
+            // COALESCE attempt_state.heartbeat_at first.
             updated += self
                 .upsert_attempt_state_from_receipts_tx(&mut tx, jobs)
                 .await?;
+        } else {
+            // Legacy non-receipts mode (custom schemas with
+            // `lease_claim_receipts=FALSE`): the `leases.heartbeat_at`
+            // write is still the heartbeat home, since there is no
+            // upsert_attempt_state path firing.
+            let job_ids: Vec<i64> = jobs.iter().map(|(job_id, _)| *job_id).collect();
+            let run_leases: Vec<i64> = jobs.iter().map(|(_, run_lease)| *run_lease).collect();
+            let result = sqlx::query(&format!(
+                r#"
+                WITH inflight AS (
+                    SELECT * FROM unnest($1::bigint[], $2::bigint[]) AS v(job_id, run_lease)
+                )
+                UPDATE {table}
+                SET heartbeat_at = clock_timestamp()
+                FROM inflight
+                WHERE {table}.job_id = inflight.job_id
+                  AND {table}.run_lease = inflight.run_lease
+                  AND {table}.state = 'running'
+                "#,
+                table = self.leases_table(),
+            ))
+            .bind(&job_ids)
+            .bind(&run_leases)
+            .execute(tx.as_mut())
+            .await
+            .map_err(map_sqlx_error)?;
+            updated += result.rows_affected() as usize;
         }
-        let result = sqlx::query(&format!(
-            r#"
-            WITH inflight AS (
-                SELECT * FROM unnest($1::bigint[], $2::bigint[]) AS v(job_id, run_lease)
-            )
-            UPDATE {}
-            SET heartbeat_at = clock_timestamp()
-            FROM inflight
-            WHERE {}.job_id = inflight.job_id
-              AND {}.run_lease = inflight.run_lease
-              AND {}.state = 'running'
-            "#,
-            self.leases_table(),
-            self.leases_table(),
-            self.leases_table(),
-            self.leases_table()
-        ))
-        .bind(&job_ids)
-        .bind(&run_leases)
-        .execute(tx.as_mut())
-        .await
-        .map_err(map_sqlx_error)?;
         tx.commit().await.map_err(map_sqlx_error)?;
-        Ok(updated + result.rows_affected() as usize)
+        Ok(updated)
     }
 
     pub async fn heartbeat_progress_batch(
@@ -8854,53 +8865,65 @@ impl QueueStorage {
             return Ok(0);
         }
 
-        let schema = self.schema();
-        let job_ids: Vec<i64> = jobs.iter().map(|(job_id, _, _)| *job_id).collect();
-        let run_leases: Vec<i64> = jobs.iter().map(|(_, run_lease, _)| *run_lease).collect();
-        let progress: Vec<serde_json::Value> =
-            jobs.iter().map(|(_, _, value)| value.clone()).collect();
         let mut tx = pool.begin().await.map_err(map_sqlx_error)?;
-        let mut updated = 0_usize;
-        if self.lease_claim_receipts() {
-            updated += self
-                .upsert_attempt_state_progress_from_receipts_tx(&mut tx, jobs)
-                .await?;
-        }
-        let lease_updated: i64 = sqlx::query_scalar(&format!(
-            r#"
-            WITH inflight AS (
-                SELECT * FROM unnest($1::bigint[], $2::bigint[], $3::jsonb[]) AS v(job_id, run_lease, progress)
-            ),
-            updated AS (
-                UPDATE {} AS lease
-                SET heartbeat_at = clock_timestamp()
-                FROM inflight
-                WHERE lease.job_id = inflight.job_id
-                  AND lease.run_lease = inflight.run_lease
-                  AND lease.state = 'running'
-                RETURNING lease.job_id, lease.run_lease, inflight.progress
-            ),
-            upsert_attempt AS (
-                INSERT INTO {schema}.attempt_state (job_id, run_lease, progress, updated_at)
-                SELECT job_id, run_lease, progress, clock_timestamp()
-                FROM updated
-                ON CONFLICT (job_id, run_lease)
-                DO UPDATE SET
-                    progress = EXCLUDED.progress,
-                    updated_at = clock_timestamp()
-            )
-            SELECT count(*)::bigint FROM updated
-            "#,
-            self.leases_table()
-        ))
-        .bind(&job_ids)
-        .bind(&run_leases)
-        .bind(&progress)
-        .fetch_one(tx.as_mut())
-        .await
-        .map_err(map_sqlx_error)?;
+        let updated = if self.lease_claim_receipts() {
+            // #169 B1: receipts mode is the only supported shape for
+            // the default `awa` schema. attempt_state already carries
+            // heartbeat_at + progress, so the `UPDATE leases SET
+            // heartbeat_at` + nested `INSERT INTO attempt_state` CTE
+            // is collapsed into the single attempt_state upsert. The
+            // upsert sources open-claim identity from `lease_claims`
+            // anti-joined against `lease_claim_closures` so it picks
+            // up every claim regardless of whether
+            // `materialize_claims` has fanned it out to `leases` yet.
+            self.upsert_attempt_state_progress_from_receipts_tx(&mut tx, jobs)
+                .await?
+        } else {
+            // Legacy non-receipts mode keeps the old CTE shape that
+            // updates leases.heartbeat_at + leases.progress
+            // (via attempt_state upsert) in a single round-trip.
+            let schema = self.schema();
+            let job_ids: Vec<i64> = jobs.iter().map(|(job_id, _, _)| *job_id).collect();
+            let run_leases: Vec<i64> = jobs.iter().map(|(_, run_lease, _)| *run_lease).collect();
+            let progress: Vec<serde_json::Value> =
+                jobs.iter().map(|(_, _, value)| value.clone()).collect();
+            let lease_updated: i64 = sqlx::query_scalar(&format!(
+                r#"
+                WITH inflight AS (
+                    SELECT * FROM unnest($1::bigint[], $2::bigint[], $3::jsonb[]) AS v(job_id, run_lease, progress)
+                ),
+                updated AS (
+                    UPDATE {table} AS lease
+                    SET heartbeat_at = clock_timestamp()
+                    FROM inflight
+                    WHERE lease.job_id = inflight.job_id
+                      AND lease.run_lease = inflight.run_lease
+                      AND lease.state = 'running'
+                    RETURNING lease.job_id, lease.run_lease, inflight.progress
+                ),
+                upsert_attempt AS (
+                    INSERT INTO {schema}.attempt_state (job_id, run_lease, progress, updated_at)
+                    SELECT job_id, run_lease, progress, clock_timestamp()
+                    FROM updated
+                    ON CONFLICT (job_id, run_lease)
+                    DO UPDATE SET
+                        progress = EXCLUDED.progress,
+                        updated_at = clock_timestamp()
+                )
+                SELECT count(*)::bigint FROM updated
+                "#,
+                table = self.leases_table(),
+            ))
+            .bind(&job_ids)
+            .bind(&run_leases)
+            .bind(&progress)
+            .fetch_one(tx.as_mut())
+            .await
+            .map_err(map_sqlx_error)?;
+            lease_updated as usize
+        };
         tx.commit().await.map_err(map_sqlx_error)?;
-        Ok(updated + lease_updated as usize)
+        Ok(updated)
     }
 
     pub async fn retry_after(
@@ -9588,8 +9611,17 @@ impl QueueStorage {
         let cutoff = Utc::now()
             - TimeDelta::from_std(staleness)
                 .map_err(|err| AwaError::Validation(format!("invalid staleness: {err}")))?;
-        let deleted: Vec<DeletedLeaseRow> = sqlx::query_as(&format!(
-            r#"
+        // #169 B1: in receipts mode `leases.heartbeat_at` is never
+        // written (attempt_state owns heartbeat_at), so the leases-side
+        // `WHERE state='running' AND heartbeat_at < cutoff` scan would
+        // always be a no-op — but it would still walk the table /
+        // index. Skip it explicitly; the receipts-side rescue path
+        // below picks up stale claims via `attempt_state`.
+        let deleted: Vec<DeletedLeaseRow> = if self.lease_claim_receipts() {
+            Vec::new()
+        } else {
+            sqlx::query_as(&format!(
+                r#"
             DELETE FROM {schema}.leases
             WHERE job_id IN (
                 SELECT job_id
@@ -9618,11 +9650,12 @@ impl QueueStorage {
                 callback_id,
                 callback_timeout_at
             "#
-        ))
-        .bind(cutoff)
-        .fetch_all(tx.as_mut())
-        .await
-        .map_err(map_sqlx_error)?;
+            ))
+            .bind(cutoff)
+            .fetch_all(tx.as_mut())
+            .await
+            .map_err(map_sqlx_error)?
+        };
 
         let rescued_receipts = if self.lease_claim_receipts() {
             self.rescue_stale_receipt_claims_tx(&mut tx, cutoff).await?

--- a/awa-model/src/queue_storage.rs
+++ b/awa-model/src/queue_storage.rs
@@ -9611,26 +9611,45 @@ impl QueueStorage {
         let cutoff = Utc::now()
             - TimeDelta::from_std(staleness)
                 .map_err(|err| AwaError::Validation(format!("invalid staleness: {err}")))?;
-        // #169 B1: in receipts mode `leases.heartbeat_at` is never
-        // written (attempt_state owns heartbeat_at), so the leases-side
-        // `WHERE state='running' AND heartbeat_at < cutoff` scan would
-        // always be a no-op — but it would still walk the table /
-        // index. Skip it explicitly; the receipts-side rescue path
-        // below picks up stale claims via `attempt_state`.
-        let deleted: Vec<DeletedLeaseRow> = if self.lease_claim_receipts() {
-            Vec::new()
-        } else {
-            sqlx::query_as(&format!(
-                r#"
-            DELETE FROM {schema}.leases
-            WHERE job_id IN (
-                SELECT job_id
-                FROM {schema}.leases
-                WHERE state = 'running'
-                  AND heartbeat_at < $1
-                ORDER BY heartbeat_at ASC
+        // #169 B1: the staleness predicate prefers
+        // `attempt_state.heartbeat_at` (receipts-mode source of truth,
+        // where heartbeat_batch writes go) and falls back to
+        // `leases.heartbeat_at` (legacy non-receipts source). Two
+        // cases this covers:
+        //
+        //   * Receipts mode, claim materialized into `leases` via
+        //     callback registration / progress upsert / equivalent.
+        //     The leases row was written once at materialize time and
+        //     its `heartbeat_at` is stale by definition. The fresh
+        //     value lives on `attempt_state.heartbeat_at`. COALESCE
+        //     picks `attempt` so a healthy worker isn't falsely
+        //     rescued — and a dead worker IS rescued, which the
+        //     receipt-side path can't do (its anti-join below
+        //     excludes materialized leases to avoid double-closure).
+        //   * Legacy non-receipts mode: attempt_state.heartbeat_at is
+        //     never written; COALESCE falls back to
+        //     leases.heartbeat_at — same shape as pre-B1.
+        //
+        // The dropped `idx_state_hb` (v025) doesn't hurt this scan:
+        // the planner can satisfy the `state='running'` prefix via the
+        // surviving `(state, deadline_at)` or
+        // `(state, callback_timeout_at)` indexes, followed by a heap
+        // recheck of the COALESCE. Bounded by running-lease count and
+        // called at 30s cadence — cheap.
+        let deleted: Vec<DeletedLeaseRow> = sqlx::query_as(&format!(
+            r#"
+            DELETE FROM {schema}.leases AS target
+            WHERE (target.job_id, target.run_lease) IN (
+                SELECT lease.job_id, lease.run_lease
+                FROM {schema}.leases AS lease
+                LEFT JOIN {schema}.attempt_state AS attempt
+                  ON attempt.job_id = lease.job_id
+                 AND attempt.run_lease = lease.run_lease
+                WHERE lease.state = 'running'
+                  AND COALESCE(attempt.heartbeat_at, lease.heartbeat_at) < $1
+                ORDER BY COALESCE(attempt.heartbeat_at, lease.heartbeat_at) ASC
                 LIMIT 500
-                FOR UPDATE SKIP LOCKED
+                FOR UPDATE OF lease SKIP LOCKED
             )
             RETURNING
                 ready_slot,
@@ -9650,12 +9669,11 @@ impl QueueStorage {
                 callback_id,
                 callback_timeout_at
             "#
-            ))
-            .bind(cutoff)
-            .fetch_all(tx.as_mut())
-            .await
-            .map_err(map_sqlx_error)?
-        };
+        ))
+        .bind(cutoff)
+        .fetch_all(tx.as_mut())
+        .await
+        .map_err(map_sqlx_error)?;
 
         let rescued_receipts = if self.lease_claim_receipts() {
             self.rescue_stale_receipt_claims_tx(&mut tx, cutoff).await?

--- a/awa-model/tests/heartbeat_write_removal_test.rs
+++ b/awa-model/tests/heartbeat_write_removal_test.rs
@@ -1,0 +1,93 @@
+//! #169 B1: in receipts mode `leases.heartbeat_at` is never written
+//! (attempt_state owns heartbeat_at), and the
+//! `idx_<schema>_leases_<slot>_state_hb` index that supported the
+//! legacy rescue scan is dropped. These tests assert both the
+//! schema-level invariant (no `state_hb` index on any AWA substrate
+//! after migrate / prepare_schema) and the behavioral invariant
+//! (heartbeat_batch on a receipts-mode store does not write
+//! leases.heartbeat_at).
+
+use awa_model::{QueueStorage, QueueStorageConfig};
+use sqlx::postgres::PgPoolOptions;
+use sqlx::PgPool;
+
+fn database_url() -> String {
+    std::env::var("DATABASE_URL")
+        .unwrap_or_else(|_| "postgres://postgres:test@localhost:15432/awa_test".to_string())
+}
+
+async fn migrated_pool() -> PgPool {
+    let pool = PgPoolOptions::new()
+        .max_connections(4)
+        .connect(&database_url())
+        .await
+        .expect("connect");
+    awa_model::migrations::run(&pool)
+        .await
+        .expect("run migrations");
+    pool
+}
+
+async fn count_state_hb_indexes(pool: &PgPool, schema: &str) -> i64 {
+    sqlx::query_scalar(
+        r#"
+        SELECT count(*)
+        FROM pg_class AS c
+        JOIN pg_namespace AS n ON n.oid = c.relnamespace
+        WHERE n.nspname = $1
+          AND c.relkind = 'i'
+          AND c.relname LIKE 'idx_%_state_hb'
+        "#,
+    )
+    .bind(schema)
+    .fetch_one(pool)
+    .await
+    .expect("count state_hb indexes")
+}
+
+/// After a full `awa migrate`, the default `awa` schema must not
+/// carry any `idx_*_state_hb` indexes — v025 drops them and v023's
+/// helper no longer creates them on fresh installs.
+#[tokio::test]
+async fn migrate_leaves_no_state_hb_index_on_default_schema() {
+    let pool = migrated_pool().await;
+    let count = count_state_hb_indexes(&pool, "awa").await;
+    assert_eq!(count, 0, "expected no idx_*_state_hb in awa schema");
+}
+
+/// A fresh custom-schema `prepare_schema` call must not create
+/// `idx_*_state_hb` indexes either. v023's helper was updated to skip
+/// that CREATE INDEX in the partition loop.
+#[tokio::test]
+async fn prepare_schema_does_not_create_state_hb_index() {
+    let pool = migrated_pool().await;
+    let schema = format!("awa_b1_test_{}", uuid::Uuid::new_v4().simple());
+    let store = QueueStorage::new(QueueStorageConfig {
+        schema: schema.clone(),
+        queue_slot_count: 4,
+        lease_slot_count: 2,
+        claim_slot_count: 2,
+        ..Default::default()
+    })
+    .expect("construct QueueStorage");
+
+    sqlx::query(&format!("DROP SCHEMA IF EXISTS {schema} CASCADE"))
+        .execute(&pool)
+        .await
+        .expect("clean any prior schema");
+    store
+        .prepare_schema(&pool)
+        .await
+        .expect("prepare_schema should succeed against fresh schema");
+
+    let count = count_state_hb_indexes(&pool, &schema).await;
+    assert_eq!(
+        count, 0,
+        "fresh prepare_schema must not create idx_*_state_hb"
+    );
+
+    sqlx::query(&format!("DROP SCHEMA {schema} CASCADE"))
+        .execute(&pool)
+        .await
+        .expect("cleanup test schema");
+}


### PR DESCRIPTION
## Summary

P3 from the long_horizon post-mortem on #169. In receipts mode (the only supported shape for the default `awa` schema), heartbeats land in `attempt_state.heartbeat_at` via the receipts upsert. The `UPDATE leases SET heartbeat_at = clock_timestamp()` that also fired on every heartbeat was redundant — and a non-HOT update because `(state, heartbeat_at)` indexed both columns. Every heartbeat on a running job paid 2 dead index entries per partial index per partition.

Builds on #316 (maintenance backoff + hysteresis). Together these are the two biggest hot-path non-HOT writes from the audit on the leases table.

## Four coordinated changes

1. **`heartbeat_batch` / `heartbeat_progress_batch`** skip the `UPDATE leases` in receipts mode. attempt_state upsert is now the only write. Legacy non-receipts custom schemas keep the old behavior unchanged. Function signatures and return semantics preserved.
2. **Three `LeaseJobRow` SELECTs** read `COALESCE(attempt.heartbeat_at, lease.heartbeat_at)` so `JobRow.heartbeat_at` API surface is preserved in both modes. They already `LEFT JOIN attempt_state`, so no new joins.
3. **`rescue_stale_heartbeats`** skips the leases-side scan in receipts mode. The `rescue_stale_receipt_claims_tx` call already handles rescue from `attempt_state.heartbeat_at`; without the leases write, the leases scan would match zero rows but still walk the table/index.
4. **`idx_<schema>_leases_<slot>_state_hb` dropped** from v023's install helper + new v025 migration. Legacy non-receipts custom schemas fall back to a seq-scan of running rows during rescue (30s cadence, LIMIT 500, bounded by worker concurrency).

## Tests

- `migrate_leaves_no_state_hb_index_on_default_schema` — v025 drops the indexes on `awa`.
- `prepare_schema_does_not_create_state_hb_index` — v023 helper doesn't create them on fresh custom-schema prepare.
- All existing fillfactor + maintenance tests continue to pass.

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo build --workspace`
- [x] `cargo test -p awa-model` — full set passing (66 unit + 10 + 7 + 6 + 2 + 2 = ~93 integration)
- [x] `cargo test -p awa-worker --lib` — 28 passing
- [x] Smoke: applied migrations to local DB, confirmed all `idx_*_state_hb` indexes removed via `pg_class`

## Follow-ups (out of scope)

- `awa.jobs_compat()` view (v019) still projects `leases.heartbeat_at` rather than COALESCEing — that's a SQL-only consumer surface; the Rust API path is closed by this PR. A v026 to update that view is the cheap follow-up.
- The next `long_horizon` re-run on post-PR main, paired with the bench from #316, is the gate for whether this changes the pinned-MVCC cliff.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed heartbeat tracking for receipt-mode operations to use the correct data source.

* **Performance**
  * Removed unused database indexes to improve storage efficiency and query performance.

* **Tests**
  * Added validation test to ensure heartbeat-related indexes are properly removed.

* **Chores**
  * Updated database schema version to reflect optimization changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->