### PR TITLE
perf(maintenance): duration-margin hysteresis + branch cooldown + 250ms lease default (#169)

### DIFF
--- a/awa-worker/src/client.rs
+++ b/awa-worker/src/client.rs
@@ -160,10 +160,19 @@ pub struct ClientBuilder {
 
 impl ClientBuilder {
     pub fn new(pool: PgPool) -> Self {
+        // #169: lease_rotate_interval bumped from 50ms to 250ms. The
+        // 50ms default was over-spec'd — prune backoff (#316) already
+        // throttles the heavy ACCESS-EXCLUSIVE + count(*) work, so
+        // faster rotation just produced loop noise without doing
+        // useful reclamation under pinned MVCC. 250ms keeps rotation
+        // responsive enough that the lease ring still cycles through
+        // its 8 partitions in ~2s, but stops the maintenance loop
+        // flapping at the 50ms boundary that bench evidence on #316
+        // surfaced.
         let (storage, storage_error) = match QueueStorageRuntime::new(
             QueueStorageConfig::default(),
             Duration::from_millis(1_000),
-            Duration::from_millis(50),
+            Duration::from_millis(250),
         ) {
             Ok(runtime) => (RuntimeStorage::QueueStorage(runtime), None),
             Err(err) => (

--- a/awa-worker/src/maintenance.rs
+++ b/awa-worker/src/maintenance.rs
@@ -194,7 +194,15 @@ impl MaintenanceBranchTracker {
         }
 
         // Phase 2: duration-margin + K-consecutive hysteresis.
-        if let Some(last_duration) = state.last_duration {
+        // `take()` consumes the sample so we evaluate each body's
+        // duration exactly once. Without this, when cooldown returns
+        // None (no body runs → no new sample), the next post-cooldown
+        // `try_begin` would re-read the same pre-flip overrun sample,
+        // see `consecutive_overrun >= K` already, and re-arm cooldown
+        // forever. The branch would never run its body again until
+        // the worker restarts. Codex + CodeRabbit both flagged this
+        // on PR #318.
+        if let Some(last_duration) = state.last_duration.take() {
             // Integer-ratio thresholds — avoid f64 in the hot path.
             let upper_threshold = tick_interval * OVERRUN_UPPER_NUM / OVERRUN_UPPER_DEN;
             let lower_threshold = tick_interval * OVERRUN_LOWER_NUM / OVERRUN_LOWER_DEN;
@@ -2519,33 +2527,48 @@ mod tests {
         );
     }
 
-    /// Drive `tracker.try_begin` `n` times against a fixed
-    /// `last_duration` / `tick_interval`. Re-seeds `last_duration`
-    /// before each call so we model `n` consecutive ticks where the
-    /// previous body completed in `last_duration`. Returns the
-    /// observed `try_begin` outcomes (Some = body would have run,
-    /// None = body skipped by cooldown).
+    /// Drive `n` consecutive `try_begin` ticks. When the body would
+    /// have run (try_begin returns Some), call `record_finish` with
+    /// `body_duration` to simulate the body completing in that time.
+    /// When the body is skipped (cooldown returns None), `last_duration`
+    /// is intentionally NOT updated — matching production where a
+    /// skipped tick doesn't produce a new sample. Returns one bool per
+    /// tick: true if the body ran, false if it was skipped.
+    ///
+    /// This helper does NOT seed `last_duration` itself. Tests that need
+    /// an initial sample (e.g., to drive the very first overrun
+    /// observation) must call `seed_last_duration` first.
     fn replay_ticks(
         tracker: &MaintenanceBranchTracker,
         branch: &'static str,
-        last_duration: Duration,
+        body_duration: Duration,
         tick_interval: Duration,
         n: u32,
     ) -> Vec<bool> {
         let metrics = metrics_for_test();
         let mut ran = Vec::with_capacity(n as usize);
         for _ in 0..n {
-            tracker
-                .branches
-                .lock()
-                .unwrap()
-                .entry(branch)
-                .or_default()
-                .last_duration = Some(last_duration);
             let timer_opt = tracker.try_begin(branch, tick_interval, &metrics);
-            ran.push(timer_opt.is_some());
+            let did_run = timer_opt.is_some();
+            ran.push(did_run);
+            if did_run {
+                tracker.record_finish(branch, body_duration);
+            }
         }
         ran
+    }
+
+    /// Explicitly seed `last_duration` as if a prior body completed in
+    /// `dur`. Use to set up the initial state for tests that need
+    /// the first `try_begin` to see a sample.
+    fn seed_last_duration(tracker: &MaintenanceBranchTracker, branch: &'static str, dur: Duration) {
+        tracker
+            .branches
+            .lock()
+            .unwrap()
+            .entry(branch)
+            .or_default()
+            .last_duration = Some(dur);
     }
 
     #[test]
@@ -2553,6 +2576,7 @@ mod tests {
         // A single overrun sample (clearly above the upper threshold)
         // shouldn't flip is_delayed — K-consecutive is required.
         let tracker = MaintenanceBranchTracker::new();
+        seed_last_duration(&tracker, "cleanup", Duration::from_millis(200));
         replay_ticks(
             &tracker,
             "cleanup",
@@ -2569,11 +2593,11 @@ mod tests {
     #[test]
     fn branch_tracker_deadband_sample_does_not_advance_counters() {
         // Samples between LOWER (70ms) and UPPER (150ms) of a 100ms
-        // tick — e.g., 101ms or 51ms — must NOT advance either
-        // counter. This is the fix the bench post-mortem prescribed:
-        // 49ms-vs-51ms flap at the boundary no longer accumulates
-        // toward a flip.
+        // tick — e.g., 101ms — must NOT advance either counter. This
+        // is the fix the bench post-mortem prescribed: 49ms-vs-51ms
+        // flap at the boundary no longer accumulates toward a flip.
         let tracker = MaintenanceBranchTracker::new();
+        seed_last_duration(&tracker, "cleanup", Duration::from_millis(101));
         replay_ticks(
             &tracker,
             "cleanup",
@@ -2590,9 +2614,12 @@ mod tests {
     #[test]
     fn branch_tracker_k_consecutive_overruns_flips_and_arms_cooldown() {
         // After K=3 consecutive samples clearly above UPPER, flip to
-        // delayed AND arm cooldown. The third try_begin returns None
-        // (cooldown gate fires the same tick we flip).
+        // delayed AND arm cooldown. The third try_begin consumes the
+        // K-th sample, crosses the threshold, and returns None (the
+        // flip-tick skips the body so we don't immediately do more
+        // expensive work).
         let tracker = MaintenanceBranchTracker::new();
+        seed_last_duration(&tracker, "cleanup", Duration::from_millis(250));
         let ran = replay_ticks(
             &tracker,
             "cleanup",
@@ -2613,8 +2640,12 @@ mod tests {
     #[test]
     fn branch_tracker_cooldown_skips_body() {
         // Drive past the flip, then assert subsequent ticks return
-        // None until cooldown decrements to zero.
+        // None until cooldown decrements to zero. After the flip,
+        // `last_duration` was consumed by `take()`, so the cooldown
+        // gate is the only thing returning None here — exactly the
+        // production shape we want.
         let tracker = MaintenanceBranchTracker::new();
+        seed_last_duration(&tracker, "cleanup", Duration::from_millis(250));
         replay_ticks(
             &tracker,
             "cleanup",
@@ -2622,9 +2653,9 @@ mod tests {
             Duration::from_millis(100),
             OVERRUN_HYSTERESIS_K,
         );
-        // Next BRANCH_COOLDOWN_TICKS ticks all skip. Replay with
-        // last_duration = 50ms (on-time) so the cooldown is the only
-        // gate that can return None.
+        // Subsequent ticks return None until cooldown drains. We pass
+        // 50ms as the body_duration but it's unused — `record_finish`
+        // is only called when a body actually runs.
         let ran = replay_ticks(
             &tracker,
             "cleanup",
@@ -2642,10 +2673,14 @@ mod tests {
 
     #[test]
     fn branch_tracker_cooldown_expires_then_body_runs() {
-        // Same setup, plus one more on-time tick after cooldown
-        // expires. That tick's body should run; on-time counter
-        // advances.
+        // After cooldown drains, the first post-cooldown try_begin
+        // sees `last_duration = None` (consumed at the flip, no body
+        // ran during cooldown), so no hysteresis check fires; the
+        // body simply runs. The counters do NOT advance on this
+        // first post-cooldown tick — the sample this body produces
+        // is evaluated on the *next* try_begin.
         let tracker = MaintenanceBranchTracker::new();
+        seed_last_duration(&tracker, "cleanup", Duration::from_millis(250));
         replay_ticks(
             &tracker,
             "cleanup",
@@ -2667,20 +2702,31 @@ mod tests {
             Duration::from_millis(100),
             1,
         );
-        assert_eq!(ran, vec![true], "post-cooldown tick runs body");
-        let (_, _, ontime) = tracker.cooldown_snapshot("cleanup").expect("snapshot");
+        assert_eq!(ran, vec![true], "post-cooldown body runs");
+        let (cooldown, overrun, ontime) = tracker.cooldown_snapshot("cleanup").expect("snapshot");
         assert_eq!(
-            ontime, 1,
-            "on-time counter advances on first post-cooldown tick"
+            cooldown, 0,
+            "cooldown stays at zero after a single fast body"
+        );
+        assert_eq!(
+            overrun, OVERRUN_HYSTERESIS_K,
+            "consecutive_overrun preserved across cooldown (no eval on this tick)"
+        );
+        assert_eq!(
+            ontime, 0,
+            "ontime advances on the next tick — this one had no sample to evaluate"
         );
     }
 
     #[test]
     fn branch_tracker_cooldown_rearms_on_continued_overrun() {
-        // After flip + cooldown expiry, if the next body is STILL
-        // slow (above UPPER), cooldown re-arms — without re-emitting
-        // the flip warning (still already delayed).
+        // After cooldown drains, the first post-cooldown body runs
+        // and is slow. That slow body's sample is evaluated on the
+        // *second* post-cooldown try_begin, where it re-arms cooldown
+        // because consecutive_overrun is already at K (preserved
+        // across the cooldown).
         let tracker = MaintenanceBranchTracker::new();
+        seed_last_duration(&tracker, "cleanup", Duration::from_millis(250));
         replay_ticks(
             &tracker,
             "cleanup",
@@ -2688,7 +2734,6 @@ mod tests {
             Duration::from_millis(100),
             OVERRUN_HYSTERESIS_K,
         );
-        // Drain cooldown.
         replay_ticks(
             &tracker,
             "cleanup",
@@ -2697,28 +2742,23 @@ mod tests {
             BRANCH_COOLDOWN_TICKS,
         );
 
-        // First post-cooldown body runs and goes slow again. Need
-        // K more overrun samples to "cross" again because we cleared
-        // consecutive_ontime on each ontime tick. Wait — the on-time
-        // ticks during cooldown were skipped (returned None), so the
-        // consecutive_ontime / consecutive_overrun counters were
-        // frozen during cooldown. After cooldown, consecutive_overrun
-        // is still at OVERRUN_HYSTERESIS_K from before — so the very
-        // first overrun observation post-cooldown re-arms cooldown.
+        // Tick 1 post-cooldown: take None, no eval, body runs slow.
+        // Tick 2: take Some(250), consecutive_overrun saturates past
+        // K, is_delayed && cross → re-arm cooldown.
         let ran = replay_ticks(
             &tracker,
             "cleanup",
             Duration::from_millis(250),
             Duration::from_millis(100),
-            1,
+            2,
         );
         assert_eq!(
             ran,
-            vec![false],
-            "stay-delayed overrun re-arms cooldown without running body"
+            vec![true, false],
+            "first tick runs body; second tick re-arms cooldown"
         );
         let (cooldown, _, _) = tracker.cooldown_snapshot("cleanup").expect("snapshot");
-        assert_eq!(cooldown, BRANCH_COOLDOWN_TICKS);
+        assert_eq!(cooldown, BRANCH_COOLDOWN_TICKS, "cooldown re-armed");
         assert!(
             tracker.snapshot("cleanup").unwrap().1,
             "still delayed across re-arm"
@@ -2731,6 +2771,7 @@ mod tests {
         // clearly-on-time samples. Non-consecutive overruns never
         // accumulate K=3 because each on-time tick resets the counter.
         let tracker = MaintenanceBranchTracker::new();
+        seed_last_duration(&tracker, "cleanup", Duration::from_millis(200));
         for over in [true, false, true, false, true] {
             let dur = if over {
                 Duration::from_millis(200)
@@ -2747,9 +2788,13 @@ mod tests {
 
     #[test]
     fn branch_tracker_recovers_only_after_k_ontime_ticks_post_cooldown() {
-        // After cooldown expires, K consecutive clearly-on-time ticks
-        // are needed before is_delayed clears.
+        // After cooldown drains, K consecutive on-time samples must be
+        // *evaluated* before is_delayed clears. The very first
+        // post-cooldown body has no sample to evaluate (last_duration
+        // was consumed at the flip), so K evaluable samples require
+        // K+1 post-cooldown ticks: one to seed, K to advance ontime.
         let tracker = MaintenanceBranchTracker::new();
+        seed_last_duration(&tracker, "cleanup", Duration::from_millis(250));
         replay_ticks(
             &tracker,
             "cleanup",
@@ -2757,7 +2802,6 @@ mod tests {
             Duration::from_millis(100),
             OVERRUN_HYSTERESIS_K,
         );
-        // Drain cooldown.
         replay_ticks(
             &tracker,
             "cleanup",
@@ -2765,21 +2809,22 @@ mod tests {
             Duration::from_millis(100),
             BRANCH_COOLDOWN_TICKS,
         );
-        // K-1 on-time ticks — not yet recovered. (consecutive_overrun
-        // was OVERRUN_HYSTERESIS_K post-flip; the first on-time tick
-        // that actually runs resets it to 0 and bumps ontime to 1.)
+
+        // K post-cooldown ticks: tick 1 seeds, ticks 2..K evaluate K-1
+        // on-time samples. Still delayed.
         replay_ticks(
             &tracker,
             "cleanup",
             Duration::from_millis(50),
             Duration::from_millis(100),
-            OVERRUN_HYSTERESIS_K - 1,
+            OVERRUN_HYSTERESIS_K,
         );
         assert!(
             tracker.snapshot("cleanup").unwrap().1,
-            "still delayed before K-th on-time tick"
+            "still delayed after only K-1 evaluations"
         );
-        // K-th on-time tick — recovers.
+
+        // (K+1)-th tick evaluates the K-th on-time sample → recovery.
         replay_ticks(
             &tracker,
             "cleanup",
@@ -2789,7 +2834,7 @@ mod tests {
         );
         assert!(
             !tracker.snapshot("cleanup").unwrap().1,
-            "recovered after K consecutive on-time"
+            "recovered after K evaluable on-time samples"
         );
     }
 
@@ -2799,6 +2844,7 @@ mod tests {
         // "promote_scheduled" stays on-time the whole time. Branches
         // must not share state.
         let tracker = MaintenanceBranchTracker::new();
+        seed_last_duration(&tracker, "cleanup", Duration::from_millis(500));
         replay_ticks(
             &tracker,
             "cleanup",
@@ -2806,6 +2852,7 @@ mod tests {
             Duration::from_millis(100),
             OVERRUN_HYSTERESIS_K,
         );
+        seed_last_duration(&tracker, "promote_scheduled", Duration::from_millis(10));
         replay_ticks(
             &tracker,
             "promote_scheduled",

--- a/awa-worker/src/maintenance.rs
+++ b/awa-worker/src/maintenance.rs
@@ -110,7 +110,7 @@ const OVERRUN_LOWER_DEN: u32 = 10;
 const BRANCH_COOLDOWN_TICKS: u32 = 120;
 
 /// Records the start of one branch body and emits observability when the
-/// body returns. Constructed by [`MaintenanceBranchTracker::begin`], which
+/// body returns. Constructed by [`MaintenanceBranchTracker::try_begin`], which
 /// also applies the previous-run overrun check before the body starts so
 /// the warning/counter line up with the fire moment described in #242.
 struct BranchTimer<'a> {
@@ -309,7 +309,7 @@ impl MaintenanceBranchTracker {
 /// <child> IN ACCESS EXCLUSIVE MODE` (with a 50ms timeout) followed by
 /// `SELECT count(*) FROM <child>`. Under a pinned snapshot the child
 /// can't be reclaimed, so the count walks dead tuples and the prune
-/// returns `SkippedActive` — every 50ms by default. This tracker skips
+/// returns `SkippedActive` — every tick. This tracker skips
 /// the next 2^level ticks (capped at 32) after a `SkippedActive` or
 /// `Blocked` outcome, doubling on each repeat. A successful `Pruned`
 /// resets to no backoff. `Noop` (ring empty / nothing to consider)
@@ -331,8 +331,8 @@ struct PruneBackoffState {
     backoff_level: u8,
 }
 
-/// Cap on the backoff exponent. `2^5 = 32` ticks; at the 50ms default
-/// `lease_rotate_interval` that is ~1.6s between prune attempts under
+/// Cap on the backoff exponent. `2^5 = 32` ticks; at the 250ms default
+/// `lease_rotate_interval` that is ~8s between prune attempts under
 /// sustained pin pressure. Long enough to cut the per-tick scan cost
 /// dramatically; short enough that prune resumes promptly once the
 /// snapshot is released.

--- a/awa-worker/src/maintenance.rs
+++ b/awa-worker/src/maintenance.rs
@@ -57,25 +57,57 @@ struct MaintenanceBranchState {
     /// for the current overrun episode. Cleared on the recovery
     /// transition.
     is_delayed: bool,
-    /// Number of consecutive ticks where `last_duration > tick_interval`.
-    /// Used for hysteresis: a single bad tick around the threshold no
-    /// longer flips `is_delayed` and spams the log; we wait for
-    /// `OVERRUN_HYSTERESIS_K` in a row.
+    /// Number of consecutive overrun observations (last_duration above
+    /// the upper threshold). Samples inside the deadband neither
+    /// advance this counter nor reset it.
     consecutive_overrun: u32,
-    /// Mirror of `consecutive_overrun` for on-time ticks; used to gate
-    /// the delayed -> on-time recovery transition with the same K
-    /// hysteresis.
+    /// Mirror of `consecutive_overrun` for clearly-on-time samples
+    /// (last_duration below the lower threshold). Used to gate
+    /// delayed -> on-time recovery with the same K-consecutive
+    /// requirement.
     consecutive_ontime: u32,
+    /// Tick counter that suppresses the branch body while the branch
+    /// is unhealthy. Decremented every tick; while non-zero the
+    /// caller's body is skipped. Re-armed on every flip-to-delayed
+    /// AND every overrun observation while already delayed, so a
+    /// branch that keeps failing keeps quietly waiting instead of
+    /// hammering the database.
+    cooldown_ticks_remaining: u32,
 }
 
 /// How many consecutive observations the branch tracker requires before
-/// flipping `is_delayed` either direction. `K=3` means a single ~tick-
-/// boundary jitter no longer triggers the warning + counter; a real
-/// sustained overrun (or sustained recovery) still does, just one
-/// `tick_interval * (K-1)` later than the previous edge-triggered
-/// shape. The downside of this delay is exactly the upside of the
-/// hysteresis: we stop flapping at the boundary.
+/// flipping `is_delayed` either direction. Combined with the
+/// duration-margin thresholds below: a sample inside the deadband
+/// (between `LOWER_FACTOR_*` and `UPPER_FACTOR_*` of `tick_interval`)
+/// doesn't advance either counter, so the boundary flap from #316's
+/// post-mortem stops at the source. A sample outside the deadband
+/// still needs `OVERRUN_HYSTERESIS_K` peers on the same side before
+/// the state flips.
 const OVERRUN_HYSTERESIS_K: u32 = 3;
+
+/// Duration-margin thresholds. Crossing
+/// `last_duration > tick_interval * UPPER` counts as an overrun
+/// sample; `last_duration < tick_interval * LOWER` counts as an
+/// on-time sample. Everything in between is a deadband that leaves
+/// both counters untouched.
+///
+/// `UPPER = 3/2` and `LOWER = 7/10` give a generous deadband — the
+/// branch has to be at 70% of its tick or below to count as recovered,
+/// and 50% above its tick to count as overrunning. This prevents
+/// 51ms-vs-49ms jitter at the 50ms boundary from advancing either
+/// counter, which is what bench evidence on #316 showed was still
+/// happening with K-only hysteresis. Integer ratios avoid f64 in the
+/// hot path.
+const OVERRUN_UPPER_NUM: u32 = 3;
+const OVERRUN_UPPER_DEN: u32 = 2;
+const OVERRUN_LOWER_NUM: u32 = 7;
+const OVERRUN_LOWER_DEN: u32 = 10;
+
+/// Number of ticks to suppress a delayed branch's body. At the default
+/// `lease_rotate_interval = 250ms`, 120 ticks = 30s wall time of quiet
+/// before the branch tries again. Re-armed on every overrun
+/// observation while still delayed.
+const BRANCH_COOLDOWN_TICKS: u32 = 120;
 
 /// Records the start of one branch body and emits observability when the
 /// body returns. Constructed by [`MaintenanceBranchTracker::begin`], which
@@ -121,37 +153,77 @@ impl MaintenanceBranchTracker {
     }
 
     /// Call at the moment a branch arm fires, before running its body.
-    /// Applies the previous-run overrun check (warn + counter on
-    /// on-time -> delayed; warn on delayed -> on-time), then returns a
-    /// [`BranchTimer`] whose `.finish()` records the body duration.
-    fn begin<'a>(
+    /// Applies cooldown + duration-margin hysteresis, then either:
+    ///   * returns `Some(BranchTimer)` so the caller runs the body
+    ///     and calls `.finish()`, or
+    ///   * returns `None` to signal "skip this tick" — the body
+    ///     must not run, and no duration sample is recorded for this
+    ///     tick (so the K-on-time counter doesn't advance for skipped
+    ///     work).
+    ///
+    /// Two gating phases:
+    ///
+    /// 1. **Cooldown.** If `cooldown_ticks_remaining > 0`, decrement
+    ///    and return `None`. While cooldown is non-zero the branch is
+    ///    quiet; this is set on flip-to-delayed and re-armed on
+    ///    every subsequent overrun observation, so an unhealthy
+    ///    branch backs off instead of beating on the database every
+    ///    tick.
+    /// 2. **Duration-margin hysteresis.** Compare `last_duration` to
+    ///    `tick_interval * UPPER/LOWER`. Outside the deadband, advance
+    ///    the matching K-counter; inside, leave both alone. Crossing
+    ///    K-consecutive on either side flips `is_delayed` and may
+    ///    arm cooldown.
+    fn try_begin<'a>(
         &'a self,
         branch: &'static str,
         tick_interval: Duration,
         metrics: &'a crate::metrics::AwaMetrics,
-    ) -> BranchTimer<'a> {
+    ) -> Option<BranchTimer<'a>> {
         let mut branches = self
             .branches
             .lock()
             .expect("maintenance branch tracker mutex");
         let state = branches.entry(branch).or_default();
+
+        // Phase 1: cooldown gate. Counts down regardless of any
+        // other signal; the branch stays quiet while non-zero.
+        if state.cooldown_ticks_remaining > 0 {
+            state.cooldown_ticks_remaining -= 1;
+            return None;
+        }
+
+        // Phase 2: duration-margin + K-consecutive hysteresis.
         if let Some(last_duration) = state.last_duration {
-            let overdue = last_duration > tick_interval;
-            if overdue {
+            // Integer-ratio thresholds — avoid f64 in the hot path.
+            let upper_threshold = tick_interval * OVERRUN_UPPER_NUM / OVERRUN_UPPER_DEN;
+            let lower_threshold = tick_interval * OVERRUN_LOWER_NUM / OVERRUN_LOWER_DEN;
+
+            if last_duration > upper_threshold {
                 state.consecutive_overrun = state.consecutive_overrun.saturating_add(1);
                 state.consecutive_ontime = 0;
-                if state.consecutive_overrun >= OVERRUN_HYSTERESIS_K && !state.is_delayed {
+                let cross_threshold = state.consecutive_overrun >= OVERRUN_HYSTERESIS_K;
+                if cross_threshold && !state.is_delayed {
                     state.is_delayed = true;
+                    state.cooldown_ticks_remaining = BRANCH_COOLDOWN_TICKS;
                     warn!(
                         branch,
                         last_duration_ms = last_duration.as_millis() as u64,
                         tick_interval_ms = tick_interval.as_millis() as u64,
+                        upper_threshold_ms = upper_threshold.as_millis() as u64,
                         consecutive_overrun = state.consecutive_overrun,
-                        "maintenance branch overran its tick interval",
+                        cooldown_ticks = BRANCH_COOLDOWN_TICKS,
+                        "maintenance branch overran tick interval, entering cooldown",
                     );
                     metrics.record_maintenance_branch_overrun(branch);
+                    return None;
+                } else if cross_threshold && state.is_delayed {
+                    // Already delayed and another overrun arrived —
+                    // re-arm cooldown but stay quiet about it.
+                    state.cooldown_ticks_remaining = BRANCH_COOLDOWN_TICKS;
+                    return None;
                 }
-            } else {
+            } else if last_duration < lower_threshold {
                 state.consecutive_ontime = state.consecutive_ontime.saturating_add(1);
                 state.consecutive_overrun = 0;
                 if state.consecutive_ontime >= OVERRUN_HYSTERESIS_K && state.is_delayed {
@@ -160,19 +232,23 @@ impl MaintenanceBranchTracker {
                         branch,
                         last_duration_ms = last_duration.as_millis() as u64,
                         tick_interval_ms = tick_interval.as_millis() as u64,
+                        lower_threshold_ms = lower_threshold.as_millis() as u64,
                         consecutive_ontime = state.consecutive_ontime,
                         "maintenance branch recovered to on-time",
                     );
                 }
+            } else {
+                // Deadband — neither counter advances. This is the
+                // explicit no-op that kills the 49ms-vs-51ms flap.
             }
         }
         drop(branches);
-        BranchTimer {
+        Some(BranchTimer {
             tracker: self,
             branch,
             metrics,
             started_at: Instant::now(),
-        }
+        })
     }
 
     /// Internal — called by [`BranchTimer::finish`] to stash the body's
@@ -198,6 +274,23 @@ impl MaintenanceBranchTracker {
         branches
             .get(branch)
             .map(|state| (state.last_duration, state.is_delayed))
+    }
+
+    /// Test-only — read the per-branch cooldown counter and consecutive
+    /// counters so tests can assert on the full state machine.
+    #[cfg(test)]
+    fn cooldown_snapshot(&self, branch: &'static str) -> Option<(u32, u32, u32)> {
+        let branches = self
+            .branches
+            .lock()
+            .expect("maintenance branch tracker mutex");
+        branches.get(branch).map(|state| {
+            (
+                state.cooldown_ticks_remaining,
+                state.consecutive_overrun,
+                state.consecutive_ontime,
+            )
+        })
     }
 }
 
@@ -669,57 +762,67 @@ impl MaintenanceService {
                         return;
                     }
                     _ = heartbeat_rescue_timer.tick() => {
-                        let timer = branch_tracker.begin("rescue_stale_heartbeats", self.heartbeat_rescue_interval, &self.metrics);
-                        self.rescue_stale_heartbeats().await;
-                        timer.finish();
+                        if let Some(timer) = branch_tracker.try_begin("rescue_stale_heartbeats", self.heartbeat_rescue_interval, &self.metrics) {
+                            self.rescue_stale_heartbeats().await;
+                            timer.finish();
+                        }
                     }
                     _ = deadline_rescue_timer.tick() => {
-                        let timer = branch_tracker.begin("rescue_expired_deadlines", self.deadline_rescue_interval, &self.metrics);
-                        self.rescue_expired_deadlines().await;
-                        timer.finish();
+                        if let Some(timer) = branch_tracker.try_begin("rescue_expired_deadlines", self.deadline_rescue_interval, &self.metrics) {
+                            self.rescue_expired_deadlines().await;
+                            timer.finish();
+                        }
                     }
                     _ = callback_rescue_timer.tick() => {
-                        let timer = branch_tracker.begin("rescue_expired_callbacks", self.callback_rescue_interval, &self.metrics);
-                        self.rescue_expired_callbacks().await;
-                        timer.finish();
+                        if let Some(timer) = branch_tracker.try_begin("rescue_expired_callbacks", self.callback_rescue_interval, &self.metrics) {
+                            self.rescue_expired_callbacks().await;
+                            timer.finish();
+                        }
                     }
                     _ = promote_timer.tick() => {
-                        let timer = branch_tracker.begin("promote_scheduled", self.promote_interval, &self.metrics);
-                        self.promote_scheduled().await;
-                        timer.finish();
+                        if let Some(timer) = branch_tracker.try_begin("promote_scheduled", self.promote_interval, &self.metrics) {
+                            self.promote_scheduled().await;
+                            timer.finish();
+                        }
                     }
                     _ = cleanup_timer.tick() => {
-                        let timer = branch_tracker.begin("cleanup", self.cleanup_interval, &self.metrics);
-                        self.cleanup_completed().await;
-                        self.cleanup_dlq_rows().await;
-                        self.cleanup_stale_runtime_snapshots().await;
-                        self.cleanup_stale_descriptors().await;
-                        timer.finish();
+                        if let Some(timer) = branch_tracker.try_begin("cleanup", self.cleanup_interval, &self.metrics) {
+                            self.cleanup_completed().await;
+                            self.cleanup_dlq_rows().await;
+                            self.cleanup_stale_runtime_snapshots().await;
+                            self.cleanup_stale_descriptors().await;
+                            timer.finish();
+                        }
                     }
                     _ = cron_sync_timer.tick() => {
-                        let timer = branch_tracker.begin("cron_sync", self.cron_sync_interval, &self.metrics);
-                        self.sync_periodic_jobs_to_db().await;
-                        timer.finish();
+                        if let Some(timer) = branch_tracker.try_begin("cron_sync", self.cron_sync_interval, &self.metrics) {
+                            self.sync_periodic_jobs_to_db().await;
+                            timer.finish();
+                        }
                     }
                     _ = queue_stats_timer.tick() => {
-                        let timer = branch_tracker.begin("queue_stats", self.queue_stats_interval, &self.metrics);
-                        self.publish_queue_health_metrics().await;
-                        timer.finish();
+                        if let Some(timer) = branch_tracker.try_begin("queue_stats", self.queue_stats_interval, &self.metrics) {
+                            self.publish_queue_health_metrics().await;
+                            timer.finish();
+                        }
                     }
                     _ = dirty_key_timer.tick() => {
-                        let timer = branch_tracker.begin("recompute_dirty_admin_metadata", self.dirty_key_recompute_interval, &self.metrics);
-                        self.recompute_dirty_admin_metadata().await;
-                        timer.finish();
+                        if let Some(timer) = branch_tracker.try_begin("recompute_dirty_admin_metadata", self.dirty_key_recompute_interval, &self.metrics) {
+                            self.recompute_dirty_admin_metadata().await;
+                            timer.finish();
+                        }
                     }
                     _ = metadata_reconciliation_timer.tick() => {
-                        let timer = branch_tracker.begin("refresh_admin_metadata", self.metadata_reconciliation_interval, &self.metrics);
-                        self.refresh_admin_metadata().await;
-                        timer.finish();
+                        if let Some(timer) = branch_tracker.try_begin("refresh_admin_metadata", self.metadata_reconciliation_interval, &self.metrics) {
+                            self.refresh_admin_metadata().await;
+                            timer.finish();
+                        }
                     }
                     _ = priority_aging_timer.tick() => {
-                        let timer = branch_tracker.begin("priority_aging", self.priority_aging_interval, &self.metrics);
-                        self.age_waiting_priorities().await;
-                        timer.finish();
+                        if let Some(timer) = branch_tracker.try_begin("priority_aging", self.priority_aging_interval, &self.metrics) {
+                            self.age_waiting_priorities().await;
+                            timer.finish();
+                        }
                     }
                     _ = async {
                         if let Some(timer) = &mut vacuum_queue_timer {
@@ -730,9 +833,10 @@ impl MaintenanceService {
                     }, if vacuum_queue_timer.is_some() => {
                         let interval = vacuum_queue_interval
                             .expect("vacuum_queue_interval Some iff vacuum_queue_timer Some");
-                        let timer = branch_tracker.begin("rotate_queue", interval, &self.metrics);
-                        self.rotate_queue_storage_queue(&prune_tracker).await;
-                        timer.finish();
+                        if let Some(timer) = branch_tracker.try_begin("rotate_queue", interval, &self.metrics) {
+                            self.rotate_queue_storage_queue(&prune_tracker).await;
+                            timer.finish();
+                        }
                     }
                     _ = async {
                         if let Some(timer) = &mut vacuum_lease_timer {
@@ -743,9 +847,10 @@ impl MaintenanceService {
                     }, if vacuum_lease_timer.is_some() => {
                         let interval = vacuum_lease_interval
                             .expect("vacuum_lease_interval Some iff vacuum_lease_timer Some");
-                        let timer = branch_tracker.begin("rotate_lease", interval, &self.metrics);
-                        self.rotate_queue_storage_leases(&prune_tracker).await;
-                        timer.finish();
+                        if let Some(timer) = branch_tracker.try_begin("rotate_lease", interval, &self.metrics) {
+                            self.rotate_queue_storage_leases(&prune_tracker).await;
+                            timer.finish();
+                        }
                     }
                     _ = async {
                         if let Some(timer) = &mut vacuum_claim_timer {
@@ -756,9 +861,10 @@ impl MaintenanceService {
                     }, if vacuum_claim_timer.is_some() => {
                         let interval = vacuum_claim_interval
                             .expect("vacuum_claim_interval Some iff vacuum_claim_timer Some");
-                        let timer = branch_tracker.begin("rotate_claim", interval, &self.metrics);
-                        self.rotate_queue_storage_claims(&prune_tracker).await;
-                        timer.finish();
+                        if let Some(timer) = branch_tracker.try_begin("rotate_claim", interval, &self.metrics) {
+                            self.rotate_queue_storage_claims(&prune_tracker).await;
+                            timer.finish();
+                        }
                     }
                     _ = leader_check_timer.tick() => {
                         // Verify leader connection is still alive.
@@ -2398,36 +2504,37 @@ mod tests {
     fn branch_tracker_finish_records_last_duration() {
         let tracker = MaintenanceBranchTracker::new();
         let metrics = metrics_for_test();
-        let timer = tracker.begin("promote_scheduled", Duration::from_secs(1), &metrics);
+        let timer = tracker
+            .try_begin("promote_scheduled", Duration::from_secs(1), &metrics)
+            .expect("first tick should not be skipped");
         // Body would run here in production; for the test we just finish.
         timer.finish();
         let (last_duration, is_delayed) = tracker
             .snapshot("promote_scheduled")
             .expect("snapshot should exist after one finish");
         assert!(last_duration.is_some());
-        // First tick has no prior duration to compare against, so we
-        // cannot be in the delayed state yet.
-        assert!(!is_delayed);
+        assert!(
+            !is_delayed,
+            "first tick has no prior duration → not delayed"
+        );
     }
 
-    /// Drive `tracker.begin` `n` times against a fixed `last_duration` /
-    /// `tick_interval` so the consecutive-overrun / consecutive-ontime
-    /// counters advance the way real ticks would. Reseting
-    /// `last_duration` after each begin matches the production shape
-    /// where each tick's body finish writes a new value.
+    /// Drive `tracker.try_begin` `n` times against a fixed
+    /// `last_duration` / `tick_interval`. Re-seeds `last_duration`
+    /// before each call so we model `n` consecutive ticks where the
+    /// previous body completed in `last_duration`. Returns the
+    /// observed `try_begin` outcomes (Some = body would have run,
+    /// None = body skipped by cooldown).
     fn replay_ticks(
         tracker: &MaintenanceBranchTracker,
         branch: &'static str,
         last_duration: Duration,
         tick_interval: Duration,
         n: u32,
-    ) {
+    ) -> Vec<bool> {
         let metrics = metrics_for_test();
+        let mut ran = Vec::with_capacity(n as usize);
         for _ in 0..n {
-            // The check in `begin` reads `state.last_duration` set by
-            // the *previous* tick. Re-seed it to the same value on
-            // every iteration so we model `n` consecutive ticks at the
-            // same duration.
             tracker
                 .branches
                 .lock()
@@ -2435,33 +2542,78 @@ mod tests {
                 .entry(branch)
                 .or_default()
                 .last_duration = Some(last_duration);
-            let _timer = tracker.begin(branch, tick_interval, &metrics);
+            let timer_opt = tracker.try_begin(branch, tick_interval, &metrics);
+            ran.push(timer_opt.is_some());
         }
+        ran
     }
 
     #[test]
     fn branch_tracker_single_overrun_does_not_flip() {
-        // Hysteresis: one overrun observation isn't enough to flip
-        // `is_delayed`. A tick that goes 101ms against a 100ms
-        // interval shouldn't spam the log.
+        // A single overrun sample (clearly above the upper threshold)
+        // shouldn't flip is_delayed — K-consecutive is required.
+        let tracker = MaintenanceBranchTracker::new();
+        replay_ticks(
+            &tracker,
+            "cleanup",
+            Duration::from_millis(200), // upper threshold for 100ms tick is 150
+            Duration::from_millis(100),
+            1,
+        );
+        assert!(
+            !tracker.snapshot("cleanup").unwrap().1,
+            "single overrun must not flip is_delayed (K=3 required)"
+        );
+    }
+
+    #[test]
+    fn branch_tracker_deadband_sample_does_not_advance_counters() {
+        // Samples between LOWER (70ms) and UPPER (150ms) of a 100ms
+        // tick — e.g., 101ms or 51ms — must NOT advance either
+        // counter. This is the fix the bench post-mortem prescribed:
+        // 49ms-vs-51ms flap at the boundary no longer accumulates
+        // toward a flip.
         let tracker = MaintenanceBranchTracker::new();
         replay_ticks(
             &tracker,
             "cleanup",
             Duration::from_millis(101),
             Duration::from_millis(100),
-            1,
+            5,
         );
-        let (_, is_delayed) = tracker.snapshot("cleanup").expect("snapshot");
-        assert!(
-            !is_delayed,
-            "single overrun must not flip is_delayed (hysteresis K=3)"
+        let (cooldown, overrun, ontime) = tracker.cooldown_snapshot("cleanup").expect("snapshot");
+        assert_eq!(cooldown, 0, "deadband samples should not arm cooldown");
+        assert_eq!(overrun, 0, "deadband sample 101ms must not advance overrun");
+        assert_eq!(ontime, 0, "deadband sample 101ms must not advance ontime");
+    }
+
+    #[test]
+    fn branch_tracker_k_consecutive_overruns_flips_and_arms_cooldown() {
+        // After K=3 consecutive samples clearly above UPPER, flip to
+        // delayed AND arm cooldown. The third try_begin returns None
+        // (cooldown gate fires the same tick we flip).
+        let tracker = MaintenanceBranchTracker::new();
+        let ran = replay_ticks(
+            &tracker,
+            "cleanup",
+            Duration::from_millis(250),
+            Duration::from_millis(100),
+            OVERRUN_HYSTERESIS_K,
+        );
+        assert_eq!(ran, vec![true, true, false], "flip-tick skips body");
+        let (cooldown, overrun, _) = tracker.cooldown_snapshot("cleanup").expect("snapshot");
+        assert!(tracker.snapshot("cleanup").unwrap().1, "flipped to delayed");
+        assert_eq!(overrun, OVERRUN_HYSTERESIS_K);
+        assert_eq!(
+            cooldown, BRANCH_COOLDOWN_TICKS,
+            "cooldown armed to BRANCH_COOLDOWN_TICKS at flip"
         );
     }
 
     #[test]
-    fn branch_tracker_k_consecutive_overruns_flips() {
-        // After `OVERRUN_HYSTERESIS_K` (3) consecutive overruns, flip.
+    fn branch_tracker_cooldown_skips_body() {
+        // Drive past the flip, then assert subsequent ticks return
+        // None until cooldown decrements to zero.
         let tracker = MaintenanceBranchTracker::new();
         replay_ticks(
             &tracker,
@@ -2470,52 +2622,29 @@ mod tests {
             Duration::from_millis(100),
             OVERRUN_HYSTERESIS_K,
         );
-        let (_, is_delayed) = tracker.snapshot("cleanup").expect("snapshot");
-        assert!(is_delayed, "K consecutive overruns must flip to delayed");
-    }
-
-    #[test]
-    fn branch_tracker_intermittent_overrun_does_not_flip() {
-        // Pattern: overrun, on-time, overrun, on-time, overrun (5
-        // ticks, 3 of them overruns but not consecutive). Must stay
-        // on-time.
-        let tracker = MaintenanceBranchTracker::new();
-        for over in [true, false, true, false, true] {
-            let dur = if over {
-                Duration::from_millis(150)
-            } else {
-                Duration::from_millis(50)
-            };
-            replay_ticks(&tracker, "cleanup", dur, Duration::from_millis(100), 1);
-        }
-        let (_, is_delayed) = tracker.snapshot("cleanup").expect("snapshot");
-        assert!(
-            !is_delayed,
-            "intermittent overruns must not flip is_delayed without K consecutive"
-        );
-    }
-
-    #[test]
-    fn branch_tracker_does_not_re_flag_while_already_delayed() {
-        // While already delayed, further overruns must not re-emit
-        // (state stays delayed). #242's "one event per overrun episode."
-        let tracker = MaintenanceBranchTracker::new();
-        // Push past the K=3 threshold.
-        replay_ticks(
+        // Next BRANCH_COOLDOWN_TICKS ticks all skip. Replay with
+        // last_duration = 50ms (on-time) so the cooldown is the only
+        // gate that can return None.
+        let ran = replay_ticks(
             &tracker,
             "cleanup",
-            Duration::from_millis(250),
+            Duration::from_millis(50),
             Duration::from_millis(100),
-            OVERRUN_HYSTERESIS_K + 5,
+            BRANCH_COOLDOWN_TICKS,
         );
-        let (_, is_delayed) = tracker.snapshot("cleanup").expect("snapshot");
-        assert!(is_delayed, "stays delayed across further overrun ticks");
+        assert!(
+            ran.iter().all(|&r| !r),
+            "every tick during cooldown must skip body"
+        );
+        let (cooldown, _, _) = tracker.cooldown_snapshot("cleanup").expect("snapshot");
+        assert_eq!(cooldown, 0, "cooldown decrements to zero");
     }
 
     #[test]
-    fn branch_tracker_recovers_only_after_k_ontime_ticks() {
-        // Hysteresis on the recovery side too: a single under-interval
-        // tick mid-overrun must not clear is_delayed.
+    fn branch_tracker_cooldown_expires_then_body_runs() {
+        // Same setup, plus one more on-time tick after cooldown
+        // expires. That tick's body should run; on-time counter
+        // advances.
         let tracker = MaintenanceBranchTracker::new();
         replay_ticks(
             &tracker,
@@ -2524,25 +2653,121 @@ mod tests {
             Duration::from_millis(100),
             OVERRUN_HYSTERESIS_K,
         );
-        assert!(
-            tracker.snapshot("cleanup").unwrap().1,
-            "delayed after K overruns"
-        );
-
-        // One on-time tick — still delayed.
         replay_ticks(
+            &tracker,
+            "cleanup",
+            Duration::from_millis(50),
+            Duration::from_millis(100),
+            BRANCH_COOLDOWN_TICKS,
+        );
+        let ran = replay_ticks(
             &tracker,
             "cleanup",
             Duration::from_millis(50),
             Duration::from_millis(100),
             1,
         );
-        assert!(
-            tracker.snapshot("cleanup").unwrap().1,
-            "single on-time tick must not clear delayed (hysteresis K=3)"
+        assert_eq!(ran, vec![true], "post-cooldown tick runs body");
+        let (_, _, ontime) = tracker.cooldown_snapshot("cleanup").expect("snapshot");
+        assert_eq!(
+            ontime, 1,
+            "on-time counter advances on first post-cooldown tick"
+        );
+    }
+
+    #[test]
+    fn branch_tracker_cooldown_rearms_on_continued_overrun() {
+        // After flip + cooldown expiry, if the next body is STILL
+        // slow (above UPPER), cooldown re-arms — without re-emitting
+        // the flip warning (still already delayed).
+        let tracker = MaintenanceBranchTracker::new();
+        replay_ticks(
+            &tracker,
+            "cleanup",
+            Duration::from_millis(250),
+            Duration::from_millis(100),
+            OVERRUN_HYSTERESIS_K,
+        );
+        // Drain cooldown.
+        replay_ticks(
+            &tracker,
+            "cleanup",
+            Duration::from_millis(50),
+            Duration::from_millis(100),
+            BRANCH_COOLDOWN_TICKS,
         );
 
-        // Two more on-time ticks — total K consecutive — recovers.
+        // First post-cooldown body runs and goes slow again. Need
+        // K more overrun samples to "cross" again because we cleared
+        // consecutive_ontime on each ontime tick. Wait — the on-time
+        // ticks during cooldown were skipped (returned None), so the
+        // consecutive_ontime / consecutive_overrun counters were
+        // frozen during cooldown. After cooldown, consecutive_overrun
+        // is still at OVERRUN_HYSTERESIS_K from before — so the very
+        // first overrun observation post-cooldown re-arms cooldown.
+        let ran = replay_ticks(
+            &tracker,
+            "cleanup",
+            Duration::from_millis(250),
+            Duration::from_millis(100),
+            1,
+        );
+        assert_eq!(
+            ran,
+            vec![false],
+            "stay-delayed overrun re-arms cooldown without running body"
+        );
+        let (cooldown, _, _) = tracker.cooldown_snapshot("cleanup").expect("snapshot");
+        assert_eq!(cooldown, BRANCH_COOLDOWN_TICKS);
+        assert!(
+            tracker.snapshot("cleanup").unwrap().1,
+            "still delayed across re-arm"
+        );
+    }
+
+    #[test]
+    fn branch_tracker_intermittent_overrun_does_not_flip() {
+        // Pattern: 3 clearly-overrun samples interleaved with
+        // clearly-on-time samples. Non-consecutive overruns never
+        // accumulate K=3 because each on-time tick resets the counter.
+        let tracker = MaintenanceBranchTracker::new();
+        for over in [true, false, true, false, true] {
+            let dur = if over {
+                Duration::from_millis(200)
+            } else {
+                Duration::from_millis(50)
+            };
+            replay_ticks(&tracker, "cleanup", dur, Duration::from_millis(100), 1);
+        }
+        assert!(
+            !tracker.snapshot("cleanup").unwrap().1,
+            "intermittent overruns must not flip"
+        );
+    }
+
+    #[test]
+    fn branch_tracker_recovers_only_after_k_ontime_ticks_post_cooldown() {
+        // After cooldown expires, K consecutive clearly-on-time ticks
+        // are needed before is_delayed clears.
+        let tracker = MaintenanceBranchTracker::new();
+        replay_ticks(
+            &tracker,
+            "cleanup",
+            Duration::from_millis(250),
+            Duration::from_millis(100),
+            OVERRUN_HYSTERESIS_K,
+        );
+        // Drain cooldown.
+        replay_ticks(
+            &tracker,
+            "cleanup",
+            Duration::from_millis(50),
+            Duration::from_millis(100),
+            BRANCH_COOLDOWN_TICKS,
+        );
+        // K-1 on-time ticks — not yet recovered. (consecutive_overrun
+        // was OVERRUN_HYSTERESIS_K post-flip; the first on-time tick
+        // that actually runs resets it to 0 and bumps ontime to 1.)
         replay_ticks(
             &tracker,
             "cleanup",
@@ -2551,8 +2776,20 @@ mod tests {
             OVERRUN_HYSTERESIS_K - 1,
         );
         assert!(
+            tracker.snapshot("cleanup").unwrap().1,
+            "still delayed before K-th on-time tick"
+        );
+        // K-th on-time tick — recovers.
+        replay_ticks(
+            &tracker,
+            "cleanup",
+            Duration::from_millis(50),
+            Duration::from_millis(100),
+            1,
+        );
+        assert!(
             !tracker.snapshot("cleanup").unwrap().1,
-            "K consecutive on-time ticks recover from delayed"
+            "recovered after K consecutive on-time"
         );
     }
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -271,7 +271,7 @@ maintenance leader:
 | Ring | Partitions | Default cadence | Rotate requires | Prune requires |
 |---|---|---:|---|---|
 | Queue | `ready_entries_*`, `done_entries_*` | `1000ms` | incoming ready/done slot is empty | oldest non-current slot has no active leases and no pending ready rows; terminal rows in that ready segment are reclaimed with their retained ready bodies |
-| Lease | `leases_*` | `50ms` | incoming lease slot is empty | oldest initialized non-current lease slot is empty |
+| Lease | `leases_*` | `250ms` | incoming lease slot is empty | oldest initialized non-current lease slot is empty |
 | Claim | `lease_claims_*`, `lease_claim_closures_*` | matches queue ring | incoming claims/closures slot is empty | every claim in the oldest non-current slot has a matching closure |
 
 The maintenance tick for each ring is deliberately small: attempt one rotate,

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -508,7 +508,7 @@ let client = Client::builder(pool.clone())
             ..Default::default()
         },
         Duration::from_millis(1_000),
-        Duration::from_millis(50),
+        Duration::from_millis(250),
     )
     .claim_rotate_interval(Duration::from_millis(1_000))
     .build()?;
@@ -525,7 +525,7 @@ await client.start(
     queue_storage_claim_slot_count=8,
     queue_storage_queue_stripe_count=1,
     queue_storage_queue_rotate_interval_ms=1000,
-    queue_storage_lease_rotate_interval_ms=50,
+    queue_storage_lease_rotate_interval_ms=250,
     queue_storage_claim_rotate_interval_ms=1000,
 )
 ```
@@ -540,7 +540,7 @@ await client.start(
 | `queue_stripe_count` / `queue_storage_queue_stripe_count` | `1` | Number of physical stripes behind each logical queue. `1` is the normal unstriped path. For a single very hot queue on many small replicas, `2` is the current tuned recommendation; higher values should be benchmarked before use. |
 | `lease_claim_receipts` | `true` | Use the receipt-plane short path (claim writes a row into `lease_claims`; completion writes a closure tombstone into `lease_claim_closures`; both reclaimed by claim-ring prune). Receipts mode supports per-claim deadlines: when `QueueConfig.deadline_duration > 0`, the claim writes `clock_timestamp() + interval` onto `lease_claims.deadline_at` and the maintenance rescue path force-closes expired claims with a `'deadline_expired'` closure. Set to `false` to force every claim through the legacy `leases` materialization path. See ADR-023. |
 | `queue_rotate_interval` | `1000ms` | How often ready/terminal segments rotate |
-| `lease_rotate_interval` | `50ms` | How often lease segments rotate |
+| `lease_rotate_interval` | `250ms` | How often lease segments rotate |
 | `claim_rotate_interval` | matches `queue_rotate_interval` | How often the ADR-023 claim-ring rotates. Set with `ClientBuilder::claim_rotate_interval` (Rust) or `queue_storage_claim_rotate_interval_ms` (Python). Test harnesses sometimes set this to a long interval to pin claim-ring layout for deterministic count assertions. |
 
 The benchmark harness in


### PR DESCRIPTION
## Summary

Follow-up to #316 from the bench post-mortem you ran. K=3 hysteresis alone wasn't enough — bench evidence showed `rotate_lease` still flapping at the 50ms boundary because "delayed" samples hovered at 51ms and "recovered" at 45-49ms. The branch also kept doing real (slow) work between flip and recovery, contributing to dead-tuple growth even with prune backoff.

## Three coordinated changes

### 1. Duration-margin + K-consecutive hysteresis
- Overrun sample: `last_duration > tick_interval * 3/2` (1.5×)
- On-time sample: `last_duration < tick_interval * 7/10` (0.7×)
- Anything in between is a deadband — neither counter advances
- Still requires K=3 consecutive on either side before flipping
- Kills the boundary flap directly: 51ms-vs-49ms can't accumulate K observations because they don't even count
- Integer ratios — no f64 in the hot path

### 2. Per-branch cooldown
- On flip-to-delayed, arm `cooldown_ticks_remaining = 120` (~30s at the new 250ms lease_rotate cadence)
- While non-zero, `try_begin` returns `None` → branch body is skipped: no `ACCESS EXCLUSIVE` attempts, no `count(*)` scans, no contribution to dead-tuple growth
- Cooldown re-arms on every overrun observation while still delayed → chronically-failing branch stays quiet
- Counters are frozen during cooldown (no body = no sample), so recovery requires K real on-time samples *after* cooldown expires

### 3. Default `lease_rotate_interval` 50ms → 250ms
- The 50ms default was over-spec'd given prune backoff already throttles the heavy work
- 250ms still cycles the 8-slot lease ring in ~2s — plenty fast for reclamation
- All other intervals unchanged (`queue_rotate_interval` stays 1000ms; `claim_rotate_interval` defaults to queue)

## API change

`MaintenanceBranchTracker::begin` → `try_begin` returning `Option<BranchTimer>`. None signals "skip this tick's body"; all 13 `select!` arms updated to `if let Some(timer) = ...`. Existing `BranchTimer::finish()` semantics preserved.

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [x] `cargo build --workspace`
- [x] `cargo test -p awa-worker --lib` — 39 passing
- [x] 22 maintenance unit tests passing; 10 new for this PR:
  - `deadband_sample_does_not_advance_counters`
  - `k_consecutive_overruns_flips_and_arms_cooldown`
  - `cooldown_skips_body`
  - `cooldown_expires_then_body_runs`
  - `cooldown_rearms_on_continued_overrun`
  - `recovers_only_after_k_ontime_ticks_post_cooldown`
  - `single_overrun_does_not_flip` (updated for new thresholds)
  - `intermittent_overrun_does_not_flip` (updated)
  - `finish_records_last_duration` (updated for Option return)
  - `per_branch_state_is_independent` (still passes)

## What this is and isn't

This addresses the noise + per-tick work issues the bench surfaced on the maintenance side. It does **not** attempt to close the queue-metadata bloat cliff (`queue_claim_heads` / `queue_enqueue_heads` / `queue_ring_state` / `queue_terminal_live_counts` under sustained pin) — that's the per-row-state-machine model's fundamental limit and is the territory of #295 (rotation+TRUNCATE engine).

The next `long_horizon` re-run will tell us how much of the cliff this closes. If meaningful improvement: ship 0.6.0-beta.2 with the operational-guidance doc shape from the #169 release decision. If not: time to discuss #295 scope formally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Tuned lease rotation timing to reduce churn and improve resource stability.
  * Strengthened maintenance task scheduling with overrun detection, cooldown suppression, and per-branch isolation to avoid repeated work during unhealthy periods.
* **Tests**
  * Updated unit tests to validate the new scheduling, cooldown and recovery behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->