### PR TITLE
feat(cron): per-schedule pause / resume

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ transitions live in [`docs/upgrade-0.5-to-0.6.md`](docs/upgrade-0.5-to-0.6.md).
 
 ## Unreleased
 
+- **Cron schedule pause / resume.** `cron_jobs` carries `paused_at` and
+  `paused_by` columns; `POST /api/cron/{name}/pause` and `/resume` toggle
+  the state. The evaluator skips paused rows and the `atomic_enqueue`
+  CTE re-checks `paused_at IS NULL` so a pause asserted between the
+  leader's read and CAS still takes effect. `last_enqueued_at` is left
+  untouched while paused, so the schedule's `missed_fire_policy` decides
+  catch-up behaviour on resume. Manual `trigger_cron_job` bypasses pause.
+  The `/cron` UI page gains Pause/Resume controls and shows a
+  "queue paused" badge when the target queue is itself paused.
+
 ## [0.6.0-beta.1] — 2026-05-19
 
 First beta of the 0.6 line. Frames the user-facing diff between

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ without Redis or RabbitMQ, Awa is built for you.
 - **Unique jobs** — declare uniqueness by kind/queue/args; cancel by unique key without storing job IDs.
 - **Priorities, retries, snoozes** — exponential backoff with jitter; priority aging for fairness.
 - **Dead Letter Queue** — first-class DLQ with per-queue opt-in, retention, and operator retry/purge.
-- **Periodic/cron jobs** — leader-elected scheduler with timezone support and atomic enqueue.
+- **Periodic/cron jobs** — leader-elected scheduler with timezone support, atomic enqueue, and per-schedule pause/resume.
 - **Sequential callbacks** — `wait_for_callback()` / `resume_external()` for multi-step orchestration within a single handler.
 - **Webhook callbacks** — park jobs for external completion with optional CEL-expression filtering.
 

--- a/awa-model/README.md
+++ b/awa-model/README.md
@@ -30,7 +30,9 @@ against the admin API.
 - **Dead Letter Queue** (`dlq`) — `DlqRow`, `DlqMetadata`,
   `ListDlqFilter`, `RetryFromDlqOpts`, list / retry / move / purge
   helpers backing the `awa dlq` CLI and the DLQ admin UI tab.
-- **Cron** (`cron`) — `PeriodicJob`, `PeriodicJobBuilder`, `CronJobRow`.
+- **Cron** (`cron`) — `PeriodicJob`, `PeriodicJobBuilder`, `CronJobRow`
+  plus `pause_cron_job` / `resume_cron_job` operating on the
+  `paused_at` / `paused_by` columns.
 - **Queue storage** (`queue_storage`) — `QueueStorage`,
   `QueueStorageConfig`, `ClaimedRuntimeJob`, `RotateOutcome`,
   `PruneOutcome`. The vacuum-aware engine introduced in 0.6.

--- a/awa-model/migrations/v026_cron_jobs_pause.sql
+++ b/awa-model/migrations/v026_cron_jobs_pause.sql
@@ -1,0 +1,18 @@
+-- Add pause state to awa.cron_jobs so individual cron schedules can be
+-- paused without deleting them. Column shape mirrors awa.queue_meta
+-- (paused_at / paused_by) so operators see one convention across the
+-- two pause surfaces.
+--
+-- `paused_at IS NULL` means the schedule is active. When non-null, the
+-- evaluator skips it and atomic_enqueue refuses to fire (belt-and-braces).
+-- `last_enqueued_at` is left untouched while paused, so the existing
+-- `missed_fire_policy` (coalesce | catch_up) decides catch-up behaviour
+-- on resume.
+
+ALTER TABLE awa.cron_jobs
+    ADD COLUMN IF NOT EXISTS paused_at TIMESTAMPTZ,
+    ADD COLUMN IF NOT EXISTS paused_by TEXT;
+
+INSERT INTO awa.schema_version (version, description)
+VALUES (26, 'Add paused_at + paused_by to cron_jobs for per-schedule pause')
+ON CONFLICT (version) DO NOTHING;

--- a/awa-model/src/cron.rs
+++ b/awa-model/src/cron.rs
@@ -270,6 +270,19 @@ pub struct CronJobRow {
     pub last_enqueued_at: Option<DateTime<Utc>>,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
+    /// When the schedule was paused, or NULL if active. While paused,
+    /// the evaluator skips this row and `atomic_enqueue` refuses to
+    /// fire. `last_enqueued_at` is preserved across pause, so the
+    /// existing `missed_fire_policy` decides catch-up on resume.
+    pub paused_at: Option<DateTime<Utc>>,
+    pub paused_by: Option<String>,
+}
+
+impl CronJobRow {
+    /// Whether the schedule is currently paused.
+    pub fn is_paused(&self) -> bool {
+        self.paused_at.is_some()
+    }
 }
 
 /// Upsert a periodic job schedule into `awa.cron_jobs`.
@@ -360,6 +373,58 @@ where
     Ok(result.rows_affected() > 0)
 }
 
+/// Pause a cron schedule. The evaluator skips paused schedules and
+/// `atomic_enqueue` refuses to fire while `paused_at IS NOT NULL`.
+///
+/// `last_enqueued_at` is left untouched so the schedule's existing
+/// `missed_fire_policy` decides catch-up behaviour on resume.
+///
+/// Pausing an already-paused schedule refreshes `paused_at` and
+/// `paused_by`. Returns `true` if a row was updated.
+pub async fn pause_cron_job<'e, E>(
+    executor: E,
+    name: &str,
+    paused_by: Option<&str>,
+) -> Result<bool, AwaError>
+where
+    E: PgExecutor<'e>,
+{
+    let result = sqlx::query(
+        r#"
+        UPDATE awa.cron_jobs
+        SET paused_at = now(), paused_by = $2, updated_at = now()
+        WHERE name = $1
+        "#,
+    )
+    .bind(name)
+    .bind(paused_by)
+    .execute(executor)
+    .await?;
+    Ok(result.rows_affected() > 0)
+}
+
+/// Resume a paused cron schedule. Clears `paused_at` and `paused_by`.
+///
+/// Resuming an already-active schedule is a no-op at the row level
+/// (the UPDATE matches but the columns are already NULL). Returns
+/// `true` if a row was updated.
+pub async fn resume_cron_job<'e, E>(executor: E, name: &str) -> Result<bool, AwaError>
+where
+    E: PgExecutor<'e>,
+{
+    let result = sqlx::query(
+        r#"
+        UPDATE awa.cron_jobs
+        SET paused_at = NULL, paused_by = NULL, updated_at = now()
+        WHERE name = $1
+        "#,
+    )
+    .bind(name)
+    .execute(executor)
+    .await?;
+    Ok(result.rows_affected() > 0)
+}
+
 /// Atomically mark a cron job as enqueued AND insert the resulting job.
 ///
 /// Uses a single CTE so that both the UPDATE and INSERT happen in one
@@ -385,6 +450,7 @@ where
             SET last_enqueued_at = $2, updated_at = now()
             WHERE name = $1
               AND (last_enqueued_at IS NOT DISTINCT FROM $3)
+              AND paused_at IS NULL
             RETURNING name, kind, queue, args, priority, max_attempts, tags, metadata
         )
         SELECT inserted.*
@@ -417,7 +483,8 @@ where
 ///
 /// Reads the cron job config from `awa.cron_jobs` and inserts a new job
 /// directly. Does NOT update `last_enqueued_at` so the normal schedule
-/// is unaffected.
+/// is unaffected. Works on paused schedules — pause stops *automatic*
+/// fires; manual trigger is an explicit operator action.
 pub async fn trigger_cron_job<'e, E>(executor: E, name: &str) -> Result<JobRow, AwaError>
 where
     E: PgExecutor<'e>,

--- a/awa-model/src/migrations.rs
+++ b/awa-model/src/migrations.rs
@@ -4,7 +4,7 @@ use sqlx::PgPool;
 use tracing::info;
 
 /// Current schema version.
-pub const CURRENT_VERSION: i32 = 25;
+pub const CURRENT_VERSION: i32 = 26;
 
 /// All migrations in order. SQL lives in `awa-model/migrations/*.sql`
 /// for easy inspection by users who run their own migration tooling.
@@ -113,6 +113,11 @@ const MIGRATIONS: &[(i32, &str, &[&str])] = &[
         "Drop idx_<schema>_leases_<slot>_state_hb on all AWA substrates",
         &[V25_UP],
     ),
+    (
+        26,
+        "Add paused_at + paused_by to cron_jobs for per-schedule pause",
+        &[V26_UP],
+    ),
 ];
 
 const V1_UP: &str = include_str!("../migrations/v001_canonical_schema.sql");
@@ -139,6 +144,7 @@ const V22_UP: &str = include_str!("../migrations/v022_delete_compat_terminal_cou
 const V23_UP: &str = include_str!("../migrations/v023_install_queue_storage_substrate.sql");
 const V24_UP: &str = include_str!("../migrations/v024_receipt_plane_fillfactor.sql");
 const V25_UP: &str = include_str!("../migrations/v025_drop_leases_state_hb_index.sql");
+const V26_UP: &str = include_str!("../migrations/v026_cron_jobs_pause.sql");
 
 /// Old version numbers from pre-0.4 releases that used V3/V4/V5 numbering.
 /// Also tolerates the unreleased inline-V6 branch numbering used during review.

--- a/awa-ui/README.md
+++ b/awa-ui/README.md
@@ -25,7 +25,9 @@ application.
   the **storage-transition card** when the cluster is mid-migration:
   prepared / mixed / finalized state, drain progress, and the gates
   blocking finalization.
-- **Cron** — registered periodic schedules with next-run preview.
+- **Cron** — registered periodic schedules with next-run preview,
+  per-schedule pause / resume / trigger controls, and a target-queue
+  paused indicator.
 - **DLQ** (`/dlq`) — Dead Letter Queue browser with kind / queue /
   tag filters, single and bulk retry, move, and purge actions. The
   DLQ tab is reachable from the Jobs tab via the row links on

--- a/awa-ui/frontend/e2e/cron.spec.ts
+++ b/awa-ui/frontend/e2e/cron.spec.ts
@@ -48,6 +48,66 @@ test.describe("Cron page", () => {
 
     await expect(firstCronSummary(page, cronJobs[0].name)).toBeVisible();
     await expect(page.getByRole("button", { name: "Trigger now" }).first()).toBeVisible();
+    // Every row shows either a Pause or a Resume action.
+    const hasPauseOrResume =
+      (await page.getByRole("button", { name: /Pause|Resume/ }).count()) > 0;
+    expect(hasPauseOrResume).toBe(true);
+  });
+
+  test("pause and resume buttons round-trip a schedule", async ({ page }) => {
+    const cronJobs = await loadCronPage(page);
+    if (cronJobs.length === 0) {
+      test.skip();
+      return;
+    }
+
+    const target = cronJobs[0];
+    const summary = firstCronSummary(page, target.name);
+    const row = summary.locator("xpath=ancestor::div[contains(@class, 'rounded-lg')][1]");
+
+    const pauseBtn = row.getByRole("button", { name: "Pause" });
+    const resumeBtn = row.getByRole("button", { name: "Resume" });
+
+    // Start state may be either paused or active; normalise to active.
+    if ((await resumeBtn.count()) > 0) {
+      const [resumeRes] = await Promise.all([
+        page.waitForResponse(
+          (r) =>
+            r.ok() &&
+            r.request().method() === "POST" &&
+            new URL(r.url()).pathname === `/api/cron/${target.name}/resume`,
+        ),
+        resumeBtn.click(),
+      ]);
+      expect(resumeRes.ok()).toBeTruthy();
+      await expect(pauseBtn).toBeVisible();
+    }
+
+    // Pause.
+    const [pauseRes] = await Promise.all([
+      page.waitForResponse(
+        (r) =>
+          r.ok() &&
+          r.request().method() === "POST" &&
+          new URL(r.url()).pathname === `/api/cron/${target.name}/pause`,
+      ),
+      pauseBtn.click(),
+    ]);
+    expect(pauseRes.ok()).toBeTruthy();
+    await expect(row.getByText(/^paused$/)).toBeVisible();
+    await expect(row.getByRole("button", { name: "Resume" })).toBeVisible();
+
+    // Resume to restore initial state.
+    await Promise.all([
+      page.waitForResponse(
+        (r) =>
+          r.ok() &&
+          r.request().method() === "POST" &&
+          new URL(r.url()).pathname === `/api/cron/${target.name}/resume`,
+      ),
+      row.getByRole("button", { name: "Resume" }).click(),
+    ]);
+    await expect(row.getByRole("button", { name: "Pause" })).toBeVisible();
   });
 
   test("clicking cron row toggles expand/collapse", async ({ page }) => {

--- a/awa-ui/frontend/src/lib/api.ts
+++ b/awa-ui/frontend/src/lib/api.ts
@@ -177,6 +177,8 @@ export interface CronJobRow {
   next_fire_at: string | null;
   created_at: string;
   updated_at: string;
+  paused_at: string | null;
+  paused_by: string | null;
 }
 
 export type StateCounts = Record<string, number>;
@@ -412,6 +414,22 @@ export function fetchCronJobs(): Promise<CronJobRow[]> {
 
 export function triggerCronJob(name: string): Promise<JobRow> {
   return apiFetch(`/cron/${encodeURIComponent(name)}/trigger`, {
+    method: "POST",
+  });
+}
+
+export function pauseCronJob(
+  name: string,
+  pausedBy?: string,
+): Promise<{ ok: boolean }> {
+  return apiFetch(`/cron/${encodeURIComponent(name)}/pause`, {
+    method: "POST",
+    body: JSON.stringify({ paused_by: pausedBy ?? null }),
+  });
+}
+
+export function resumeCronJob(name: string): Promise<{ ok: boolean }> {
+  return apiFetch(`/cron/${encodeURIComponent(name)}/resume`, {
     method: "POST",
   });
 }

--- a/awa-ui/frontend/src/routes/cron.tsx
+++ b/awa-ui/frontend/src/routes/cron.tsx
@@ -1,13 +1,19 @@
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import {
   useQuery,
   useMutation,
   useQueryClient,
 } from "@tanstack/react-query";
-import { fetchCronJobs, triggerCronJob } from "@/lib/api";
+import {
+  fetchCronJobs,
+  fetchQueues,
+  pauseCronJob,
+  resumeCronJob,
+  triggerCronJob,
+} from "@/lib/api";
 import { useReadOnly } from "@/hooks/use-read-only";
 import { toast } from "@/components/ui/toast";
-import type { CronJobRow } from "@/lib/api";
+import type { CronJobRow, QueueOverview } from "@/lib/api";
 import { Heading } from "@/components/ui/heading";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -25,8 +31,27 @@ export function CronPage() {
   const cronQuery = useQuery<CronJobRow[]>({
     queryKey: ["cron"],
     queryFn: fetchCronJobs,
-    refetchInterval: poll.interval, staleTime: poll.staleTime,
+    refetchInterval: poll.interval,
+    staleTime: poll.staleTime,
   });
+
+  const queuesQuery = useQuery<QueueOverview[]>({
+    queryKey: ["queues"],
+    queryFn: fetchQueues,
+    refetchInterval: poll.interval,
+    staleTime: poll.staleTime,
+  });
+
+  const pausedQueues = useMemo(() => {
+    const set = new Set<string>();
+    for (const q of queuesQuery.data ?? []) {
+      if (q.paused) set.add(q.queue);
+    }
+    return set;
+  }, [queuesQuery.data]);
+
+  const invalidateCron = () =>
+    queryClient.invalidateQueries({ queryKey: ["cron"] });
 
   const triggerMutation = useMutation({
     mutationFn: (name: string) => triggerCronJob(name),
@@ -36,6 +61,28 @@ export function CronPage() {
     },
     onError: () => {
       toast.error("Failed to trigger cron job");
+    },
+  });
+
+  const pauseMutation = useMutation({
+    mutationFn: (name: string) => pauseCronJob(name),
+    onSuccess: (_data, name) => {
+      void invalidateCron();
+      toast.success(`Paused "${name}"`);
+    },
+    onError: () => {
+      toast.error("Failed to pause cron job");
+    },
+  });
+
+  const resumeMutation = useMutation({
+    mutationFn: (name: string) => resumeCronJob(name),
+    onSuccess: (_data, name) => {
+      void invalidateCron();
+      toast.success(`Resumed "${name}"`);
+    },
+    onError: () => {
+      toast.error("Failed to resume cron job");
     },
   });
 
@@ -61,6 +108,10 @@ export function CronPage() {
               cj.metadata != null &&
               typeof cj.metadata === "object" &&
               Object.keys(cj.metadata as Record<string, unknown>).length > 0;
+            const isPaused = cj.paused_at != null;
+            const targetQueuePaused = pausedQueues.has(cj.queue);
+            const mutating =
+              pauseMutation.isPending || resumeMutation.isPending;
 
             return (
               <div
@@ -94,6 +145,11 @@ export function CronPage() {
                     </svg>
 
                     <span className="font-medium">{cj.name}</span>
+                    {isPaused && (
+                      <Badge intent="warning" className="text-[10px]">
+                        paused
+                      </Badge>
+                    )}
                     <CronExpr expr={cj.cron_expr} />
                     {cj.timezone !== "UTC" && (
                       <span className="text-xs text-muted-fg">
@@ -102,7 +158,14 @@ export function CronPage() {
                     )}
 
                     <span className="text-sm text-muted-fg">{cj.kind}</span>
-                    <span className="text-sm text-muted-fg">&rarr; {cj.queue}</span>
+                    <span className="text-sm text-muted-fg">
+                      &rarr; {cj.queue}
+                    </span>
+                    {targetQueuePaused && (
+                      <Badge intent="warning" className="text-[10px]">
+                        queue paused
+                      </Badge>
+                    )}
 
                     {cj.priority !== 2 && (
                       <Badge
@@ -114,7 +177,7 @@ export function CronPage() {
                     )}
 
                     <span className="ml-auto flex items-center gap-3 text-sm text-muted-fg">
-                      {cj.next_fire_at && (
+                      {cj.next_fire_at && !isPaused && (
                         <span
                           className="text-success"
                           title={formatInTimezone(cj.next_fire_at, cj.timezone)}
@@ -131,6 +194,30 @@ export function CronPage() {
                       )}
                     </span>
                   </button>
+
+                  {isPaused ? (
+                    <Button
+                      intent="outline"
+                      size="xs"
+                      onPress={() => {
+                        resumeMutation.mutate(cj.name);
+                      }}
+                      isDisabled={readOnly || mutating}
+                    >
+                      Resume
+                    </Button>
+                  ) : (
+                    <Button
+                      intent="outline"
+                      size="xs"
+                      onPress={() => {
+                        pauseMutation.mutate(cj.name);
+                      }}
+                      isDisabled={readOnly || mutating}
+                    >
+                      Pause
+                    </Button>
+                  )}
 
                   <Button
                     intent="outline"
@@ -151,6 +238,39 @@ export function CronPage() {
                     aria-labelledby={summaryId}
                     className="border-t px-4 py-3 space-y-3"
                   >
+                    {isPaused && (
+                      <div className="rounded-md bg-warning/10 border border-warning/30 px-3 py-2 text-sm">
+                        <span className="font-medium">Paused</span>
+                        {cj.paused_at && (
+                          <>
+                            {" "}
+                            <span className="text-muted-fg">
+                              since {new Date(cj.paused_at).toLocaleString()}
+                            </span>
+                          </>
+                        )}
+                        {cj.paused_by && (
+                          <>
+                            {" by "}
+                            <span className="font-mono">{cj.paused_by}</span>
+                          </>
+                        )}
+                        <span className="text-muted-fg">
+                          {" "}— manual triggers still work; resume to restart automatic fires.
+                        </span>
+                      </div>
+                    )}
+                    {targetQueuePaused && (
+                      <div className="rounded-md bg-warning/10 border border-warning/30 px-3 py-2 text-sm">
+                        <span className="font-medium">Target queue paused.</span>
+                        <span className="text-muted-fg">
+                          {" "}Fires continue to enqueue jobs into{" "}
+                          <span className="font-mono">{cj.queue}</span>; they
+                          dispatch when the queue is resumed.
+                        </span>
+                      </div>
+                    )}
+
                     <div className="grid grid-cols-2 gap-x-8 gap-y-2 text-sm sm:grid-cols-4">
                       <div>
                         <dt className="text-muted-fg">Kind</dt>
@@ -199,7 +319,9 @@ export function CronPage() {
 
                     {cj.next_fire_at && (
                       <div>
-                        <dt className="text-sm text-muted-fg">Next fire</dt>
+                        <dt className="text-sm text-muted-fg">
+                          {isPaused ? "Next fire (if resumed)" : "Next fire"}
+                        </dt>
                         <dd className="font-medium">
                           {formatInTimezone(cj.next_fire_at, cj.timezone)}
                           <span className="ml-2 text-muted-fg font-normal">

--- a/awa-ui/src/handlers/cron.rs
+++ b/awa-ui/src/handlers/cron.rs
@@ -1,7 +1,7 @@
 use axum::extract::{Path, State};
 use axum::Json;
 use chrono::{DateTime, Utc};
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 use awa_model::cron;
 use awa_model::job::JobRow;
@@ -11,12 +11,16 @@ use crate::error::ApiError;
 use crate::state::AppState;
 
 /// Enriched cron job response with computed next fire time.
+///
+/// `next_fire_at` is the cron-expression's next tick. It is computed
+/// even for paused schedules so the UI can show "would fire at X if
+/// resumed" — callers should branch on `paused_at` to decide whether
+/// that fire will actually happen.
 #[derive(Serialize)]
 pub struct CronJobResponse {
     #[serde(flatten)]
     #[allow(unused)]
     row: CronJobRow,
-    /// Next scheduled fire time (computed from cron_expr + timezone).
     next_fire_at: Option<DateTime<Utc>>,
 }
 
@@ -42,4 +46,41 @@ pub async fn trigger_cron_job(
     let job = cron::trigger_cron_job(&state.pool, &name).await?;
     state.invalidate_dashboard_caches();
     Ok(Json(job))
+}
+
+#[derive(Debug, Deserialize, Default)]
+pub struct PauseCronPayload {
+    pub paused_by: Option<String>,
+}
+
+pub async fn pause_cron_job(
+    State(state): State<AppState>,
+    Path(name): Path<String>,
+    payload: Option<Json<PauseCronPayload>>,
+) -> Result<Json<serde_json::Value>, ApiError> {
+    state.require_writable()?;
+    let paused_by = payload.as_ref().and_then(|p| p.paused_by.as_deref());
+    let updated = cron::pause_cron_job(&state.pool, &name, paused_by).await?;
+    if !updated {
+        return Err(ApiError::not_found(format!(
+            "cron schedule '{name}' not found"
+        )));
+    }
+    state.invalidate_dashboard_caches();
+    Ok(Json(serde_json::json!({ "ok": true })))
+}
+
+pub async fn resume_cron_job(
+    State(state): State<AppState>,
+    Path(name): Path<String>,
+) -> Result<Json<serde_json::Value>, ApiError> {
+    state.require_writable()?;
+    let updated = cron::resume_cron_job(&state.pool, &name).await?;
+    if !updated {
+        return Err(ApiError::not_found(format!(
+            "cron schedule '{name}' not found"
+        )));
+    }
+    state.invalidate_dashboard_caches();
+    Ok(Json(serde_json::json!({ "ok": true })))
 }

--- a/awa-ui/src/lib.rs
+++ b/awa-ui/src/lib.rs
@@ -90,6 +90,8 @@ pub async fn router_with(
             "/cron/{name}/trigger",
             post(handlers::cron::trigger_cron_job),
         )
+        .route("/cron/{name}/pause", post(handlers::cron::pause_cron_job))
+        .route("/cron/{name}/resume", post(handlers::cron::resume_cron_job))
         // Stats
         .route("/stats", get(handlers::stats::get_stats))
         .route("/stats/timeseries", get(handlers::stats::get_timeseries))

--- a/awa-ui/tests/cron_api_test.rs
+++ b/awa-ui/tests/cron_api_test.rs
@@ -93,3 +93,189 @@ async fn test_cron_api_includes_next_fire_at() {
         .await
         .unwrap();
 }
+
+async fn paused_at(pool: &sqlx::PgPool, name: &str) -> Option<chrono::DateTime<chrono::Utc>> {
+    sqlx::query_scalar::<_, Option<chrono::DateTime<chrono::Utc>>>(
+        "SELECT paused_at FROM awa.cron_jobs WHERE name = $1",
+    )
+    .bind(name)
+    .fetch_one(pool)
+    .await
+    .unwrap()
+}
+
+#[tokio::test]
+async fn test_pause_endpoint_pauses_schedule() {
+    let pool = setup_pool().await;
+    let schedule = "cron_api_pause_ok";
+    seed_cron_schedule(&pool, schedule).await;
+
+    let app = awa_ui::router(pool.clone(), std::time::Duration::ZERO)
+        .await
+        .expect("router should initialize");
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/api/cron/{schedule}/pause"))
+                .header("content-type", "application/json")
+                .body(Body::from(r#"{"paused_by": "ops"}"#))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    assert!(
+        paused_at(&pool, schedule).await.is_some(),
+        "pause endpoint should set paused_at"
+    );
+    let by: Option<String> =
+        sqlx::query_scalar("SELECT paused_by FROM awa.cron_jobs WHERE name=$1")
+            .bind(schedule)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    assert_eq!(by.as_deref(), Some("ops"));
+
+    sqlx::query("DELETE FROM awa.cron_jobs WHERE name = $1")
+        .bind(schedule)
+        .execute(&pool)
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn test_pause_endpoint_no_body_ok() {
+    let pool = setup_pool().await;
+    let schedule = "cron_api_pause_no_body";
+    seed_cron_schedule(&pool, schedule).await;
+
+    let app = awa_ui::router(pool.clone(), std::time::Duration::ZERO)
+        .await
+        .expect("router should initialize");
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/api/cron/{schedule}/pause"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.status(),
+        StatusCode::OK,
+        "pause without a JSON body must succeed (paused_by is optional)"
+    );
+    assert!(paused_at(&pool, schedule).await.is_some());
+
+    sqlx::query("DELETE FROM awa.cron_jobs WHERE name = $1")
+        .bind(schedule)
+        .execute(&pool)
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn test_resume_endpoint_clears_pause() {
+    let pool = setup_pool().await;
+    let schedule = "cron_api_resume_ok";
+    seed_cron_schedule(&pool, schedule).await;
+
+    sqlx::query("UPDATE awa.cron_jobs SET paused_at = now(), paused_by = 'seed' WHERE name = $1")
+        .bind(schedule)
+        .execute(&pool)
+        .await
+        .unwrap();
+    assert!(paused_at(&pool, schedule).await.is_some());
+
+    let app = awa_ui::router(pool.clone(), std::time::Duration::ZERO)
+        .await
+        .expect("router should initialize");
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/api/cron/{schedule}/resume"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    assert!(
+        paused_at(&pool, schedule).await.is_none(),
+        "resume endpoint should clear paused_at"
+    );
+
+    sqlx::query("DELETE FROM awa.cron_jobs WHERE name = $1")
+        .bind(schedule)
+        .execute(&pool)
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn test_pause_unknown_schedule_returns_404() {
+    let pool = setup_pool().await;
+    let app = awa_ui::router(pool.clone(), std::time::Duration::ZERO)
+        .await
+        .expect("router should initialize");
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/cron/cron_api_pause_unknown_xyz/pause")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn test_list_response_includes_paused_state() {
+    let pool = setup_pool().await;
+    let schedule = "cron_api_list_paused";
+    seed_cron_schedule(&pool, schedule).await;
+    sqlx::query("UPDATE awa.cron_jobs SET paused_at = now(), paused_by = 'seed' WHERE name = $1")
+        .bind(schedule)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+    let app = awa_ui::router(pool.clone(), std::time::Duration::ZERO)
+        .await
+        .expect("router should initialize");
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri("/api/cron")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+    let rows: Vec<Value> = serde_json::from_slice(&body).unwrap();
+
+    let row = rows
+        .iter()
+        .find(|r| r["name"] == schedule)
+        .expect("test schedule should appear in list");
+    assert!(
+        row.get("paused_at").map(|v| !v.is_null()).unwrap_or(false),
+        "list response must surface paused_at: {row}"
+    );
+    assert_eq!(row.get("paused_by").and_then(|v| v.as_str()), Some("seed"));
+
+    sqlx::query("DELETE FROM awa.cron_jobs WHERE name = $1")
+        .bind(schedule)
+        .execute(&pool)
+        .await
+        .unwrap();
+}

--- a/awa-worker/src/maintenance.rs
+++ b/awa-worker/src/maintenance.rs
@@ -872,6 +872,10 @@ impl MaintenanceService {
         let now = Utc::now();
 
         for row in &cron_rows {
+            if row.is_paused() {
+                debug!(cron_name = %row.name, "Skipping paused cron schedule");
+                continue;
+            }
             let fire_times = compute_fire_times(row, now, CRON_CATCH_UP_LIMIT);
             if fire_times.is_empty() {
                 continue;
@@ -2295,6 +2299,8 @@ mod tests {
             last_enqueued_at,
             created_at,
             updated_at: created_at,
+            paused_at: None,
+            paused_by: None,
         }
     }
 

--- a/awa/tests/cron_test.rs
+++ b/awa/tests/cron_test.rs
@@ -3,7 +3,10 @@
 //! Set DATABASE_URL=postgres://postgres:test@localhost:15432/awa_test
 
 use awa::model::{
-    cron::{atomic_enqueue, delete_cron_job, list_cron_jobs, upsert_cron_job},
+    cron::{
+        atomic_enqueue, delete_cron_job, list_cron_jobs, pause_cron_job, resume_cron_job,
+        trigger_cron_job, upsert_cron_job,
+    },
     migrations,
 };
 use awa::{
@@ -493,4 +496,279 @@ async fn test_cron_job_with_tags_and_metadata() {
         job_row.metadata.get("cron_name").and_then(|v| v.as_str()),
         Some("tagged_job")
     );
+}
+
+// -- Pause / resume --
+
+#[tokio::test]
+async fn test_pause_sets_paused_at_and_paused_by() {
+    let pool = setup().await;
+    clean_cron_names(&pool, &["pause_sets_fields"]).await;
+
+    let job = PeriodicJob::builder("pause_sets_fields", "* * * * *")
+        .build_raw("pause_test".to_string(), serde_json::json!({}))
+        .unwrap();
+    upsert_cron_job(&pool, &job).await.unwrap();
+
+    let updated = pause_cron_job(&pool, "pause_sets_fields", Some("alice"))
+        .await
+        .unwrap();
+    assert!(updated, "pause should report row updated");
+
+    let row = list_cron_jobs(&pool)
+        .await
+        .unwrap()
+        .into_iter()
+        .find(|r| r.name == "pause_sets_fields")
+        .unwrap();
+    assert!(row.is_paused(), "row should report paused");
+    assert_eq!(row.paused_by.as_deref(), Some("alice"));
+    assert!(row.paused_at.is_some());
+}
+
+#[tokio::test]
+async fn test_pause_unknown_returns_false() {
+    let pool = setup().await;
+    clean_cron_names(&pool, &["pause_unknown"]).await;
+
+    let updated = pause_cron_job(&pool, "pause_unknown", None).await.unwrap();
+    assert!(
+        !updated,
+        "pause on a non-existent schedule should report no row updated"
+    );
+}
+
+#[tokio::test]
+async fn test_atomic_enqueue_refuses_while_paused() {
+    let pool = setup().await;
+    clean_cron_names(&pool, &["pause_blocks_enqueue"]).await;
+    let queue = "cron_pause_blocks";
+    clean_queue(&pool, queue).await;
+
+    let job = PeriodicJob::builder("pause_blocks_enqueue", "* * * * *")
+        .queue(queue)
+        .build_raw("pause_test".to_string(), serde_json::json!({}))
+        .unwrap();
+    upsert_cron_job(&pool, &job).await.unwrap();
+
+    pause_cron_job(&pool, "pause_blocks_enqueue", Some("bob"))
+        .await
+        .unwrap();
+
+    let fire_time = Utc::now();
+    let result = atomic_enqueue(&pool, "pause_blocks_enqueue", fire_time, None)
+        .await
+        .unwrap();
+    assert!(
+        result.is_none(),
+        "atomic_enqueue must return None while the schedule is paused"
+    );
+
+    // last_enqueued_at must stay NULL — the paused row was not marked.
+    let row = list_cron_jobs(&pool)
+        .await
+        .unwrap()
+        .into_iter()
+        .find(|r| r.name == "pause_blocks_enqueue")
+        .unwrap();
+    assert!(
+        row.last_enqueued_at.is_none(),
+        "last_enqueued_at must not advance while paused"
+    );
+}
+
+#[tokio::test]
+async fn test_resume_re_enables_enqueue() {
+    let pool = setup().await;
+    clean_cron_names(&pool, &["resume_enables"]).await;
+    let queue = "cron_resume_enables";
+    clean_queue(&pool, queue).await;
+
+    let job = PeriodicJob::builder("resume_enables", "* * * * *")
+        .queue(queue)
+        .build_raw("pause_test".to_string(), serde_json::json!({}))
+        .unwrap();
+    upsert_cron_job(&pool, &job).await.unwrap();
+
+    pause_cron_job(&pool, "resume_enables", None).await.unwrap();
+    let updated = resume_cron_job(&pool, "resume_enables").await.unwrap();
+    assert!(updated, "resume should report row updated");
+
+    let fire_time = Utc::now();
+    let result = atomic_enqueue(&pool, "resume_enables", fire_time, None)
+        .await
+        .unwrap();
+    assert!(
+        result.is_some(),
+        "atomic_enqueue should succeed after resume"
+    );
+
+    let row = list_cron_jobs(&pool)
+        .await
+        .unwrap()
+        .into_iter()
+        .find(|r| r.name == "resume_enables")
+        .unwrap();
+    assert!(!row.is_paused());
+    assert!(row.paused_at.is_none());
+    assert!(row.paused_by.is_none());
+}
+
+#[tokio::test]
+async fn test_pause_preserves_last_enqueued_at() {
+    let pool = setup().await;
+    clean_cron_names(&pool, &["pause_preserves"]).await;
+    let queue = "cron_pause_preserves";
+    clean_queue(&pool, queue).await;
+
+    let job = PeriodicJob::builder("pause_preserves", "* * * * *")
+        .queue(queue)
+        .build_raw("pause_test".to_string(), serde_json::json!({}))
+        .unwrap();
+    upsert_cron_job(&pool, &job).await.unwrap();
+
+    // First fire sets last_enqueued_at
+    let fire_time = Utc::now();
+    atomic_enqueue(&pool, "pause_preserves", fire_time, None)
+        .await
+        .unwrap()
+        .expect("first enqueue should succeed");
+
+    let before = list_cron_jobs(&pool)
+        .await
+        .unwrap()
+        .into_iter()
+        .find(|r| r.name == "pause_preserves")
+        .unwrap();
+    let last_before = before.last_enqueued_at.expect("should be set after fire");
+
+    pause_cron_job(&pool, "pause_preserves", None)
+        .await
+        .unwrap();
+    resume_cron_job(&pool, "pause_preserves").await.unwrap();
+
+    let after = list_cron_jobs(&pool)
+        .await
+        .unwrap()
+        .into_iter()
+        .find(|r| r.name == "pause_preserves")
+        .unwrap();
+    assert_eq!(
+        after.last_enqueued_at,
+        Some(last_before),
+        "last_enqueued_at must survive a pause/resume cycle so missed_fire_policy decides catch-up"
+    );
+}
+
+#[tokio::test]
+async fn test_upsert_preserves_pause_state() {
+    let pool = setup().await;
+    clean_cron_names(&pool, &["upsert_preserves_pause"]).await;
+
+    let job = PeriodicJob::builder("upsert_preserves_pause", "0 9 * * *")
+        .build_raw("pause_test".to_string(), serde_json::json!({}))
+        .unwrap();
+    upsert_cron_job(&pool, &job).await.unwrap();
+
+    pause_cron_job(&pool, "upsert_preserves_pause", Some("ops"))
+        .await
+        .unwrap();
+
+    // Simulate a deploy re-registering the schedule
+    let job_v2 = PeriodicJob::builder("upsert_preserves_pause", "30 8 * * *")
+        .build_raw(
+            "pause_test".to_string(),
+            serde_json::json!({"version": "v2"}),
+        )
+        .unwrap();
+    upsert_cron_job(&pool, &job_v2).await.unwrap();
+
+    let row = list_cron_jobs(&pool)
+        .await
+        .unwrap()
+        .into_iter()
+        .find(|r| r.name == "upsert_preserves_pause")
+        .unwrap();
+    assert!(
+        row.is_paused(),
+        "upsert must not clear paused state — operators expect pause to survive deploys"
+    );
+    assert_eq!(row.paused_by.as_deref(), Some("ops"));
+    assert_eq!(row.cron_expr, "30 8 * * *");
+    assert_eq!(row.args, serde_json::json!({"version": "v2"}));
+}
+
+#[tokio::test]
+async fn test_trigger_works_on_paused_schedule() {
+    let pool = setup().await;
+    clean_cron_names(&pool, &["trigger_on_paused"]).await;
+    let queue = "cron_trigger_paused";
+    clean_queue(&pool, queue).await;
+
+    let job = PeriodicJob::builder("trigger_on_paused", "0 9 * * *")
+        .queue(queue)
+        .build_raw("pause_test".to_string(), serde_json::json!({}))
+        .unwrap();
+    upsert_cron_job(&pool, &job).await.unwrap();
+
+    pause_cron_job(&pool, "trigger_on_paused", None)
+        .await
+        .unwrap();
+
+    // Manual trigger is an explicit operator action; pause only blocks
+    // *automatic* fires.
+    let job_row = trigger_cron_job(&pool, "trigger_on_paused").await.unwrap();
+    assert_eq!(job_row.queue, queue);
+    assert_eq!(
+        job_row
+            .metadata
+            .get("triggered_manually")
+            .and_then(|v| v.as_bool()),
+        Some(true)
+    );
+
+    // Pause state must be unchanged.
+    let row = list_cron_jobs(&pool)
+        .await
+        .unwrap()
+        .into_iter()
+        .find(|r| r.name == "trigger_on_paused")
+        .unwrap();
+    assert!(row.is_paused());
+}
+
+#[tokio::test]
+async fn test_resume_unknown_returns_false() {
+    let pool = setup().await;
+    clean_cron_names(&pool, &["resume_unknown"]).await;
+
+    let updated = resume_cron_job(&pool, "resume_unknown").await.unwrap();
+    assert!(
+        !updated,
+        "resume on a non-existent schedule should report no row updated"
+    );
+}
+
+#[tokio::test]
+async fn test_delete_clears_paused_row() {
+    // Pause then delete must work — delete_cron_job is name-keyed and
+    // doesn't care about pause state.
+    let pool = setup().await;
+    clean_cron_names(&pool, &["delete_paused"]).await;
+
+    let job = PeriodicJob::builder("delete_paused", "0 9 * * *")
+        .build_raw("pause_test".to_string(), serde_json::json!({}))
+        .unwrap();
+    upsert_cron_job(&pool, &job).await.unwrap();
+    pause_cron_job(&pool, "delete_paused", None).await.unwrap();
+
+    let deleted = delete_cron_job(&pool, "delete_paused").await.unwrap();
+    assert!(deleted);
+
+    let still_there = list_cron_jobs(&pool)
+        .await
+        .unwrap()
+        .into_iter()
+        .any(|r| r.name == "delete_paused");
+    assert!(!still_there);
 }

--- a/correctness/races/AwaCron.cfg
+++ b/correctness/races/AwaCron.cfg
@@ -1,5 +1,5 @@
-\* Safety checking: full spec with crashes.
-\* Verifies NoDuplicateFire even under leader failover and instance crashes.
+\* Safety checking: full spec with crashes, pause / resume, and leader
+\* failover. Verifies NoDuplicateFire and the pause guarantee.
 SPECIFICATION Spec
 
 INVARIANTS
@@ -8,3 +8,6 @@ INVARIANTS
   SnapshotNeverAheadOfDB
   SnapshotRequiresAlive
   LeaderAlive
+
+PROPERTIES
+  PausedBlocksEnqueue

--- a/correctness/races/AwaCron.tla
+++ b/correctness/races/AwaCron.tla
@@ -260,13 +260,19 @@ PausedBlocksEnqueue ==
 
 \* ─── Liveness (under fairness) ────────────────────────────
 \*
-\* Liveness requires an external availability assumption: at least one
-\* instance stays alive and eventually becomes leader. In a finite model
-\* where TLC can crash the entire cluster, this cannot be checked without
-\* restricting the spec. We check liveness under a "stable cluster" Next
-\* that omits Crash/Recover (all instances stay alive). Pause and Resume
-\* remain in scope; weak fairness on Resume ensures that any pause is
-\* eventually undone, so liveness holds.
+\* Liveness requires external assumptions:
+\*   - at least one instance stays alive and eventually becomes leader, and
+\*   - the operator stops adversarially pausing: a paused schedule will
+\*     eventually be resumed, after which it stays active.
+\*
+\* In a finite model where TLC can crash the entire cluster or storm
+\* Pause / Resume, neither liveness claim can be checked without
+\* restricting the spec. StableNext omits Crash, Recover, and Pause but
+\* keeps Resume so an initially-paused schedule can become active. Weak
+\* fairness on Resume ensures that any pause eventually clears. Safety
+\* (Spec, PausedBlocksEnqueue) is still checked across the full Next
+\* that includes the omitted actions — the restriction only narrows
+\* what liveness means, not what safety must hold under.
 
 StableNext ==
     \/ AdvanceClock
@@ -275,7 +281,6 @@ StableNext ==
     \/ \E i \in Instances : ReadCronState(i)
     \/ \E i \in Instances : AtomicEnqueue(i)
     \/ \E i \in Instances : CASFail(i)
-    \/ Pause
     \/ Resume
 
 StableSpec == Init /\ [][StableNext]_vars
@@ -290,14 +295,12 @@ FairSpec ==
     /\ WF_vars(Resume)
 
 \* Coalesced schedules eventually enqueue the latest due fire.
-\* Checked under FairSpec (stable cluster with no crashes; Resume eventually
-\* fires if Pause is asserted).
+\* Checked under FairSpec (stable cluster, no adversarial pause/resume).
 CoalescedLatestFireEventuallyEnqueued ==
     (policy = "coalesce" /\ clock = MaxFire) ~> (jobCount[MaxFire] = 1)
 
 \* Catch-up schedules eventually enqueue every missed fire in order.
-\* Checked under FairSpec (stable cluster with no crashes; Resume eventually
-\* fires if Pause is asserted).
+\* Checked under FairSpec (stable cluster, no adversarial pause/resume).
 CatchUpFiresEventuallyEnqueued ==
     (policy = "catch_up" /\ clock = MaxFire) ~> (\A f \in FireTimes : jobCount[f] = 1)
 

--- a/correctness/races/AwaCron.tla
+++ b/correctness/races/AwaCron.tla
@@ -2,28 +2,41 @@
 EXTENDS FiniteSets, Naturals
 
 (*
-  Cron double-fire prevention model.
+  Cron double-fire prevention and pause-gated firing model.
 
   Models the interaction between the maintenance leader's cron evaluation
-  loop and the atomic_enqueue CTE. The key safety property: each fire time
-  produces at most one enqueued job, even under leader failover where
-  multiple instances may concurrently attempt the CAS.
+  loop and the atomic_enqueue CTE. Key safety properties:
+
+    1. Each fire time produces at most one enqueued job, even under leader
+       failover where multiple instances may concurrently attempt the CAS.
+    2. While a schedule is paused, no fire time ever produces a job. The
+       atomic_enqueue CTE's `paused_at IS NULL` guard means a stale snapshot
+       carried across a pause still cannot enqueue.
 
   The cron evaluator can run either coalesced (enqueue only the latest
   missed fire) or catch-up (enqueue every missed fire in timestamp order).
   The safety argument is the same for both: every enqueue advances
-  last_enqueued_at with a compare-and-swap against the evaluator's snapshot.
+  last_enqueued_at with a compare-and-swap against the evaluator's snapshot,
+  and the same UPDATE also re-checks paused_at.
 
   Maps to code:
-    ReadCronState  -> maintenance.rs: evaluate_cron_schedules calls list_cron_jobs
+    ReadCronState  -> maintenance.rs: evaluate_cron_schedules calls
+                      list_cron_jobs (paused rows are skipped up front in
+                      Rust; the model exercises the harder case where the
+                      paused flag flips between read and CAS)
     ChosenFire     -> maintenance.rs: compute_fire_times
-    AtomicEnqueue  -> cron.rs: atomic_enqueue CTE (UPDATE...WHERE last_enqueued_at
-                     IS NOT DISTINCT FROM $3, then INSERT...FROM mark)
-    CASFail        -> CTE UPDATE matches 0 rows, INSERT produces nothing
+    AtomicEnqueue  -> cron.rs: atomic_enqueue CTE
+                      (UPDATE...WHERE last_enqueued_at IS NOT DISTINCT FROM $3
+                       AND paused_at IS NULL, then INSERT...FROM mark)
+    CASFail        -> CTE UPDATE matches 0 rows: either last_enqueued_at
+                      moved (another leader won) OR paused_at became NOT NULL
+                      (operator paused the schedule)
+    Pause / Resume -> cron.rs: pause_cron_job / resume_cron_job
 
   The read (list_cron_jobs) and write (atomic_enqueue) are separate DB
-  operations. Between them, leadership can change and another instance
-  can claim the same fire. The CAS prevents duplicate enqueues.
+  operations. Between them, leadership can change, another instance can
+  claim the same fire, or an operator can pause the schedule. The CAS plus
+  the paused-row guard make all three safe.
 *)
 
 Instances == {"A", "B"}
@@ -39,6 +52,7 @@ Policies == {"coalesce", "catch_up"}
 VARIABLES
     leader,         \* Advisory lock holder: Instances \cup {NoLeader}
     policy,         \* Cron missed-fire policy for this schedule
+    paused,         \* Schedule pause flag (cron_jobs.paused_at IS NOT NULL)
     lastEnqueued,   \* DB column cron_jobs.last_enqueued_at (0 = never)
     snapshot,       \* Per-instance: cached lastEnqueued from list_cron_jobs read
     hasSnapshot,    \* Per-instance: whether a valid snapshot exists
@@ -46,13 +60,14 @@ VARIABLES
     jobCount,       \* Per fire: count of jobs created (safety target)
     alive           \* Per-instance: whether the instance process is running
 
-vars == <<leader, policy, lastEnqueued, snapshot, hasSnapshot, clock, jobCount, alive>>
+vars == <<leader, policy, paused, lastEnqueued, snapshot, hasSnapshot, clock, jobCount, alive>>
 
 \* ─── Initial state ────────────────────────────────────────
 
 Init ==
     /\ leader = NoLeader
     /\ policy \in Policies
+    /\ paused \in BOOLEAN
     /\ lastEnqueued = 0
     /\ snapshot = [i \in Instances |-> 0]
     /\ hasSnapshot = [i \in Instances |-> FALSE]
@@ -66,21 +81,21 @@ Init ==
 AdvanceClock ==
     /\ clock < MaxFire
     /\ clock' = clock + 1
-    /\ UNCHANGED <<leader, policy, lastEnqueued, snapshot, hasSnapshot, jobCount, alive>>
+    /\ UNCHANGED <<leader, policy, paused, lastEnqueued, snapshot, hasSnapshot, jobCount, alive>>
 
 \* Acquire advisory lock (pg_try_advisory_lock succeeds).
 AcquireLeader(i) ==
     /\ alive[i]
     /\ leader = NoLeader
     /\ leader' = i
-    /\ UNCHANGED <<policy, lastEnqueued, snapshot, hasSnapshot, clock, jobCount, alive>>
+    /\ UNCHANGED <<policy, paused, lastEnqueued, snapshot, hasSnapshot, clock, jobCount, alive>>
 
 \* Lose advisory lock: connection dies, explicit release, or shutdown.
 \* The instance may still have a cached snapshot from a prior read.
 LoseLeader(i) ==
     /\ leader = i
     /\ leader' = NoLeader
-    /\ UNCHANGED <<policy, lastEnqueued, snapshot, hasSnapshot, clock, jobCount, alive>>
+    /\ UNCHANGED <<policy, paused, lastEnqueued, snapshot, hasSnapshot, clock, jobCount, alive>>
 
 \* Instance crashes: loses leadership, loses snapshot (stack unwound).
 Crash(i) ==
@@ -88,22 +103,40 @@ Crash(i) ==
     /\ alive' = [alive EXCEPT ![i] = FALSE]
     /\ hasSnapshot' = [hasSnapshot EXCEPT ![i] = FALSE]
     /\ leader' = IF leader = i THEN NoLeader ELSE leader
-    /\ UNCHANGED <<policy, lastEnqueued, snapshot, clock, jobCount>>
+    /\ UNCHANGED <<policy, paused, lastEnqueued, snapshot, clock, jobCount>>
 
 \* Instance recovers (restarts).
 Recover(i) ==
     /\ ~alive[i]
     /\ alive' = [alive EXCEPT ![i] = TRUE]
-    /\ UNCHANGED <<leader, policy, lastEnqueued, snapshot, hasSnapshot, clock, jobCount>>
+    /\ UNCHANGED <<leader, policy, paused, lastEnqueued, snapshot, hasSnapshot, clock, jobCount>>
+
+\* Operator pauses the schedule (pause_cron_job). Global DB state — does
+\* not require leadership. May race with a leader holding a snapshot.
+Pause ==
+    /\ ~paused
+    /\ paused' = TRUE
+    /\ UNCHANGED <<leader, policy, lastEnqueued, snapshot, hasSnapshot, clock, jobCount, alive>>
+
+\* Operator resumes the schedule (resume_cron_job). Snapshots that
+\* survived through a pause/resume cycle are still valid: lastEnqueued
+\* does not change while paused, so the CAS will still match.
+Resume ==
+    /\ paused
+    /\ paused' = FALSE
+    /\ UNCHANGED <<leader, policy, lastEnqueued, snapshot, hasSnapshot, clock, jobCount, alive>>
 
 \* Leader reads cron state from DB (list_cron_jobs).
-\* Only the leader enters evaluate_cron_schedules.
+\* Only the leader enters evaluate_cron_schedules. The Rust code skips
+\* paused rows before calling atomic_enqueue, but the model allows the
+\* read to happen regardless of pause state to exercise the harder case
+\* where pause flips between read and CAS.
 ReadCronState(i) ==
     /\ alive[i]
     /\ leader = i
     /\ snapshot' = [snapshot EXCEPT ![i] = lastEnqueued]
     /\ hasSnapshot' = [hasSnapshot EXCEPT ![i] = TRUE]
-    /\ UNCHANGED <<leader, policy, lastEnqueued, clock, jobCount, alive>>
+    /\ UNCHANGED <<leader, policy, paused, lastEnqueued, clock, jobCount, alive>>
 
 \* Due fires from this instance's perspective.
 DueFires(i) == {f \in FireTimes : f <= clock /\ f > snapshot[i]}
@@ -129,18 +162,20 @@ MoreDueAfter(i, fire) ==
     \E f \in FireTimes : f <= clock /\ f > fire
 
 \* Atomic CAS + insert (the atomic_enqueue CTE).
-\* CAS succeeds: DB lastEnqueued matches our snapshot.
+\* Both predicates must hold for the UPDATE to match a row:
+\*   lastEnqueued = snapshot[i]    (CAS against the read)
+\*   ~paused                        (paused_at IS NULL guard)
+\* If either fails the UPDATE matches 0 rows and the INSERT produces
+\* nothing — modeled by CASFail.
 \* Precondition does NOT require current leadership — models the window
 \* where leadership was lost between ReadCronState and this action.
-\* Coalesced mode attempts the latest due fire. Catch-up mode attempts
-\* one due fire at a time and advances the in-memory snapshot after each
-\* successful enqueue, matching evaluate_cron_schedules' previous_enqueued_at.
 AtomicEnqueue(i) ==
     LET fire == ChosenFire(i) IN
     /\ alive[i]
     /\ hasSnapshot[i]
     /\ fire > 0                          \* a fire is due
     /\ lastEnqueued = snapshot[i]        \* CAS: DB matches what we read
+    /\ ~paused                           \* paused_at IS NULL guard
     /\ lastEnqueued' = fire
     /\ jobCount' = [jobCount EXCEPT ![fire] = @ + 1]
     /\ IF policy = "catch_up" /\ MoreDueAfter(i, fire)
@@ -150,18 +185,21 @@ AtomicEnqueue(i) ==
        ELSE
            /\ snapshot' = snapshot
            /\ hasSnapshot' = [hasSnapshot EXCEPT ![i] = FALSE]
-    /\ UNCHANGED <<leader, policy, clock, alive>>
+    /\ UNCHANGED <<leader, policy, paused, clock, alive>>
 
-\* CAS fails: another instance already updated last_enqueued_at.
-\* The CTE UPDATE matches 0 rows, INSERT produces nothing.
+\* The CTE UPDATE matches 0 rows. Two physical causes:
+\*   - another instance already updated last_enqueued_at (CAS mismatch)
+\*   - the row was paused between read and CAS (paused_at IS NOT NULL)
+\* In either case the INSERT produces nothing and the instance discards
+\* its snapshot.
 CASFail(i) ==
     LET fire == ChosenFire(i) IN
     /\ alive[i]
     /\ hasSnapshot[i]
     /\ fire > 0
-    /\ lastEnqueued # snapshot[i]        \* CAS fails — DB moved
+    /\ (lastEnqueued # snapshot[i] \/ paused)
     /\ hasSnapshot' = [hasSnapshot EXCEPT ![i] = FALSE]
-    /\ UNCHANGED <<leader, policy, lastEnqueued, snapshot, clock, jobCount, alive>>
+    /\ UNCHANGED <<leader, policy, paused, lastEnqueued, snapshot, clock, jobCount, alive>>
 
 \* ─── Specification ────────────────────────────────────────
 
@@ -174,6 +212,8 @@ Next ==
     \/ \E i \in Instances : ReadCronState(i)
     \/ \E i \in Instances : AtomicEnqueue(i)
     \/ \E i \in Instances : CASFail(i)
+    \/ Pause
+    \/ Resume
 
 Spec == Init /\ [][Next]_vars
 
@@ -182,6 +222,7 @@ Spec == Init /\ [][Next]_vars
 TypeOK ==
     /\ leader \in Instances \cup {NoLeader}
     /\ policy \in Policies
+    /\ paused \in BOOLEAN
     /\ lastEnqueued \in 0..MaxFire
     /\ snapshot \in [Instances -> 0..MaxFire]
     /\ hasSnapshot \in [Instances -> BOOLEAN]
@@ -196,6 +237,7 @@ NoDuplicateFire ==
 \* A cached snapshot is never ahead of the current DB value.
 \* Holds because: snapshots are read from lastEnqueued, and lastEnqueued
 \* only increases (AtomicEnqueue: fire > snapshot[i] = lastEnqueued).
+\* Pause / Resume do not modify lastEnqueued so they cannot break this.
 SnapshotNeverAheadOfDB ==
     \A i \in Instances :
         hasSnapshot[i] => snapshot[i] <= lastEnqueued
@@ -208,15 +250,23 @@ SnapshotRequiresAlive ==
 LeaderAlive ==
     leader # NoLeader => alive[leader]
 
-\* ─── Liveness (under fairness) ────────────────────────────
+\* While paused, no new fires are enqueued. This is a temporal property
+\* (action formula) rather than a state invariant — it asserts that any
+\* step taken from a paused state leaves jobCount unchanged. Enforced by
+\* AtomicEnqueue's ~paused precondition; checking it here means a future
+\* refactor that drops that precondition fails the model loudly.
+PausedBlocksEnqueue ==
+    [][paused => UNCHANGED jobCount]_vars
 
-\* ─── Liveness (stable cluster — no crashes) ────────────────
+\* ─── Liveness (under fairness) ────────────────────────────
 \*
 \* Liveness requires an external availability assumption: at least one
 \* instance stays alive and eventually becomes leader. In a finite model
 \* where TLC can crash the entire cluster, this cannot be checked without
 \* restricting the spec. We check liveness under a "stable cluster" Next
-\* that omits Crash/Recover (all instances stay alive).
+\* that omits Crash/Recover (all instances stay alive). Pause and Resume
+\* remain in scope; weak fairness on Resume ensures that any pause is
+\* eventually undone, so liveness holds.
 
 StableNext ==
     \/ AdvanceClock
@@ -225,6 +275,8 @@ StableNext ==
     \/ \E i \in Instances : ReadCronState(i)
     \/ \E i \in Instances : AtomicEnqueue(i)
     \/ \E i \in Instances : CASFail(i)
+    \/ Pause
+    \/ Resume
 
 StableSpec == Init /\ [][StableNext]_vars
 
@@ -235,14 +287,17 @@ FairSpec ==
     /\ SF_vars(\E i \in Instances : ReadCronState(i))
     /\ SF_vars(\E i \in Instances : AtomicEnqueue(i))
     /\ SF_vars(\E i \in Instances : CASFail(i))
+    /\ WF_vars(Resume)
 
 \* Coalesced schedules eventually enqueue the latest due fire.
-\* Checked under FairSpec (stable cluster with no crashes).
+\* Checked under FairSpec (stable cluster with no crashes; Resume eventually
+\* fires if Pause is asserted).
 CoalescedLatestFireEventuallyEnqueued ==
     (policy = "coalesce" /\ clock = MaxFire) ~> (jobCount[MaxFire] = 1)
 
 \* Catch-up schedules eventually enqueue every missed fire in order.
-\* Checked under FairSpec (stable cluster with no crashes).
+\* Checked under FairSpec (stable cluster with no crashes; Resume eventually
+\* fires if Pause is asserted).
 CatchUpFiresEventuallyEnqueued ==
     (policy = "catch_up" /\ clock = MaxFire) ~> (\A f \in FireTimes : jobCount[f] = 1)
 

--- a/docs/adr/007-periodic-cron-jobs.md
+++ b/docs/adr/007-periodic-cron-jobs.md
@@ -56,6 +56,33 @@ By default, when evaluation is delayed or a worker starts after being down, the 
 
 Schedules that represent reconciliation or polling work can opt into `catch_up`, which enqueues each missed fire in timestamp order subject to the worker's bounded per-pass catch-up limit. Catch-up schedules should use idempotent handlers and expect several jobs to appear in quick succession after downtime.
 
+### Pause and resume
+
+Schedules can be paused without deleting them. `cron_jobs.paused_at` (a nullable timestamp) records when the schedule was paused; `paused_by` records the operator label. The column shape mirrors `queue_meta` so operators see one convention for both pause surfaces.
+
+The evaluator skips paused rows up front to avoid wasted CAS work, and the `atomic_enqueue` CTE re-checks `paused_at IS NULL` inside the same UPDATE that performs the compare-and-swap on `last_enqueued_at`. The CTE guard is load-bearing: it closes the window where a leader read the schedule, the operator paused it, and the leader then attempted to enqueue.
+
+`last_enqueued_at` is not touched while paused. On resume, the existing `missed_fire_policy` decides catch-up behaviour — a coalesced schedule fires once on resume; a catch-up schedule replays missed fires in order, bounded by the per-pass limit. Operators choose the catch-up shape when they register the schedule; pausing does not change it.
+
+Manual triggers (`trigger_cron_job`) bypass pause. Pause stops *automatic* fires; an explicit operator action is always allowed. Operators who want the schedule to be entirely inert should delete the row.
+
+#### In-flight jobs and queue pause
+
+Once `atomic_enqueue` commits, the job is a normal row in the queue with no back-reference to its cron source other than `metadata.cron_name` as a label. Pausing a schedule does not affect:
+
+- jobs already sitting `available` in the queue (a worker will pick them up),
+- jobs currently `running` (heartbeats, deadlines, and callbacks continue),
+- subsequent retries of those jobs (the per-job `max_attempts` budget governs, not the schedule),
+- DLQ entries derived from those jobs.
+
+An operator who wants to also purge in-flight cron-fired work pauses the schedule and then bulk-cancels jobs filtered by `metadata.cron_name = <name>`. The two operations are intentionally separate because there is no canonical answer to "should already-running jobs be killed too?".
+
+Cron pause and queue pause are also independent. Queue pause is enforced at dispatch, not enqueue: the atomic CTE inserts into a paused queue without complaint, and `last_enqueued_at` advances normally. With cron active + queue paused, fires accumulate as available jobs and dispatch on queue resume. With cron paused + queue active, no new fires arrive but in-flight work continues. Each surface is resumed independently. The `/cron` UI surfaces a "queue paused" badge so an operator looking at a quiet schedule sees the cause even when it is the consumer side that is stopped.
+
+#### Model
+
+The pause guarantee is verified in TLA+. `AwaCron` includes `Pause` and `Resume` actions; the `PausedBlocksEnqueue` property asserts that no step taken from a paused state increments `jobCount`. Liveness is checked under weak fairness on `Resume`, so a paused schedule still satisfies the "due fires eventually enqueue" property once Resume is taken.
+
 ### Leader liveness verification
 
 The advisory lock is session-scoped: as long as the connection is alive, the lock is held. But if the connection drops silently, Postgres releases the lock and another node becomes leader -- while the old node may still think it's leader. Awa verifies liveness by pinging the leader connection every 30 seconds (`SELECT 1`). If the ping fails, the node re-enters the election loop.
@@ -69,6 +96,7 @@ The advisory lock is session-scoped: as long as the connection is alive, the loc
 - **Multi-deployment safe.** Additive-only sync prevents accidental deletion of other deployments' schedules.
 - **Timezone-aware.** Schedules support IANA timezones via `chrono-tz`, handling DST transitions correctly.
 - **Eager validation.** Invalid cron expressions or timezones fail at builder time, not at fire time.
+- **Pause without delete.** Operators can pause a noisy or misbehaving schedule and resume it later; `last_enqueued_at` and the schedule definition survive a pause/resume cycle. Re-deploying the schedule does not clear pause.
 
 ### Negative
 

--- a/docs/adr/007-periodic-cron-jobs.md
+++ b/docs/adr/007-periodic-cron-jobs.md
@@ -81,7 +81,7 @@ Cron pause and queue pause are also independent. Queue pause is enforced at disp
 
 #### Model
 
-The pause guarantee is verified in TLA+. `AwaCron` includes `Pause` and `Resume` actions; the `PausedBlocksEnqueue` property asserts that no step taken from a paused state increments `jobCount`. Liveness is checked under weak fairness on `Resume`, so a paused schedule still satisfies the "due fires eventually enqueue" property once Resume is taken.
+The pause guarantee is verified in TLA+. `AwaCron` includes `Pause` and `Resume` actions; the `PausedBlocksEnqueue` property asserts that no step taken from a paused state increments `jobCount` and is checked across the full safety spec, including Pause / Resume storms. Liveness (`CoalescedLatestFireEventuallyEnqueued`, `CatchUpFiresEventuallyEnqueued`) is checked under a restricted "stable cluster, no adversarial pause" spec that includes `Resume` (with weak fairness) but omits `Pause` — TLC otherwise finds a Pause / Resume storm that starves `AtomicEnqueue` by toggling `paused` between the leader's read and CAS. This matches how the model already omits `Crash` / `Recover` from the liveness spec: progress claims hold only when the environment is not adversarial.
 
 ### Leader liveness verification
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -355,6 +355,9 @@ table for failed snapshots that need operator action.
 Periodic jobs are declared by worker code and synchronized to `cron_jobs`.
 Only the maintenance leader evaluates due schedules. Enqueue is atomic, so a
 crash between evaluation and insert cannot create half-visible work.
+Schedules carry a `paused_at` flag; the evaluator skips paused rows and the
+atomic enqueue CTE re-checks the flag inside the same UPDATE, so a pause
+asserted between the leader's read and its enqueue still takes effect.
 
 ## Observability And Correctness
 

--- a/docs/test-plan.md
+++ b/docs/test-plan.md
@@ -165,6 +165,7 @@ Rust worker.
 |---|------|------|----|
 | T34-T46 | Cron: migration, upsert, atomic CTE, dedup, backfill, DST | ✓ | |
 | T40-T41 | End-to-end periodic + metadata propagation | ✓ | |
+| CRP1-CRP9 | Cron pause / resume: state transitions, CTE guard, upsert preserves pause, manual trigger bypass, queue interaction | ✓ | |
 
 ### COPY Batch Ingestion
 
@@ -237,7 +238,7 @@ Concurrent lifecycle benchmark (1 queue × 128 workers, 20K jobs):
 | TLA1 | AwaCore | Lease-guarded finalization, stale completion rejected |
 | TLA2 | AwaExtended | Shutdown/rescue/permit/fairness protocol |
 | TLA3 | AwaCbk | At-most-once callback resolution, sequential resume |
-| TLA4 | AwaCron | No duplicate fire under leader failover |
+| TLA4 | AwaCron | No duplicate fire under leader failover; paused schedules block enqueue across a snapshot-pause-CAS race; liveness preserved under fair Resume |
 | TLA5 | AwaBatcher | At-most-once completion, DirectCompleteFail recovery |
 | TLA6 | AwaDispatchClaim with NewClaim config | Dispatch claim safety |
 | TLA7 | AwaSegmentedStorage | Segmented storage safety, waiting flow, optional attempt-state, prune safety |

--- a/docs/ui-design.md
+++ b/docs/ui-design.md
@@ -67,6 +67,8 @@ GET  /api/stats/queues                  Distinct queues
 
 GET  /api/cron
 POST /api/cron/:name/trigger
+POST /api/cron/:name/pause              { paused_by? }
+POST /api/cron/:name/resume
 
 GET  /api/dlq?kind=&queue=&tag=&limit=&before_id=&before_dlq_at=
 GET  /api/dlq/:id
@@ -121,6 +123,10 @@ Cluster overview: instance count, liveness, leader status, and an attention pane
 ### Cron (`/cron`)
 
 Accordion list of registered periodic job schedules. Each entry shows the cron expression, job kind, target queue, priority, next fire time (countdown), and last run. Expandable to see full details including arguments and tags. "Trigger now" fires the job immediately without affecting the next scheduled run.
+
+Paused schedules render with a "paused" badge and the `paused_by` label. Pause/Resume controls sit next to "Trigger now"; a manual trigger is allowed on a paused schedule, which is called out in the expanded detail so operators understand pause stops automatic fires only. Pausing leaves `last_enqueued_at` untouched, so resume respects the schedule's existing missed-fire policy.
+
+When the target queue is itself paused, the row shows a "queue paused" badge alongside the queue name and the expanded detail explains that fires continue to enqueue jobs into the paused queue but those jobs dispatch only after the queue is resumed. Cron pause and queue pause are independent — one is "stop scheduling," the other is "stop dispatching."
 
 ### Dead Letter Queue (`/dlq`, `/dlq/:id`)
 


### PR DESCRIPTION
## Summary

- Adds `paused_at` + `paused_by` to `awa.cron_jobs` (mirrors the `queue_meta` shape). The evaluator skips paused rows and `atomic_enqueue`'s CTE re-checks `paused_at IS NULL` inside the same UPDATE — a pause asserted between the leader's read and the CAS still takes effect.
- `last_enqueued_at` is left untouched while paused, so the schedule's existing `missed_fire_policy` decides catch-up behaviour on resume. Manual `trigger_cron_job` bypasses pause (pause stops *automatic* fires only).
- HTTP: `POST /api/cron/{name}/pause` (optional `{paused_by}` body) and `/resume`. List response carries `paused_at` / `paused_by`.
- UI: per-row Pause / Resume controls; "paused" badge; "queue paused" badge inline next to the target queue when the queue is itself paused. Expanded panel calls out both states.
- TLA+: `AwaCron` gains `paused`, `Pause`, `Resume`. `AtomicEnqueue` requires `~paused`; `CASFail` extended to model the paused-row UPDATE-zero-rows case. New `PausedBlocksEnqueue` temporal property asserts no step from a paused state increments `jobCount`. Liveness `StableNext` includes `Resume` (with WF) but omits `Pause`.
- Cron pause and queue pause are intentionally independent — one stops scheduling, the other stops dispatch. The UI surfaces both so an operator looking at a quiet schedule can see which side is stopped. ADR-007 documents the matrix and the in-flight-job semantics (pause does not affect already-enqueued jobs).

## TLA+ model checking

Run locally via `./correctness/run-tlc.sh` against `correctness/Dockerfile` (TLA 1.8.0, Eclipse Temurin 21).

**`AwaCron.cfg` (safety)** — 9,248 states, 1,658 distinct, depth 17. `TypeOK`, `NoDuplicateFire`, `SnapshotNeverAheadOfDB`, `SnapshotRequiresAlive`, `LeaderAlive`, and the new `PausedBlocksEnqueue` temporal property all hold across the full `Next` (including `Pause`/`Resume`/`Crash`/`Recover`).

**`AwaCronLiveness.cfg`** — initially failed. TLC found a Pause/Resume storm that starves `AtomicEnqueue`:

```
AcquireLeader → ReadCronState → CASFail(paused) → Resume → Pause → ...
```

The leader's snapshot is dropped on `CASFail` and `Pause` re-fires before `ReadCronState` can refresh it, so `(hasSnapshot ∧ ~paused)` is never simultaneously enabled. Weak fairness on `Resume` didn't help — the fairness antecedent was satisfied by the loop but `AtomicEnqueue`'s preconditions weren't.

Fix in `de3fb84`: `StableNext` (the liveness Next) keeps `Resume` (with WF, so any initial paused state still clears) but omits `Pause`. `Pause`/`Resume` remain in the full safety `Next`, so `PausedBlocksEnqueue` is still verified against storms. This matches the existing convention of omitting `Crash`/`Recover` from liveness — progress claims hold only when the environment is not adversarial.

After the fix: liveness passes — 1,180 states, 360 distinct, depth 14. Both `CoalescedLatestFireEventuallyEnqueued` and `CatchUpFiresEventuallyEnqueued` hold.

## Test plan

- [x] `cargo fmt --all --check`
- [x] `SQLX_OFFLINE=true cargo clippy --all-targets --all-features -- -D warnings`
- [x] `SQLX_OFFLINE=true cargo build --workspace`
- [x] `cargo test -p awa --test cron_test` — 21 passing (9 new pause/resume tests + existing)
- [x] `cargo test -p awa-ui --test cron_api_test` — 6 passing (5 new pause endpoint tests + existing)
- [x] `cargo test -p awa --test migration_test` — 37 passing (v026 migration applies cleanly on existing DB)
- [x] `npm run lint` (`tsc --noEmit`) in `awa-ui/frontend/` — clean
- [x] TLC model check `correctness/races/AwaCron.tla` — safety + liveness pass (see above)
- [ ] Manual smoke in browser: pause a schedule, confirm badge + Resume button appear, confirm no fires; resume, confirm fires resume; pause a target queue, confirm "queue paused" badge appears on the cron page.