### PR TITLE
Move queue storage cursors off hot rows

### DIFF
--- a/awa-model/migrations/v022_delete_compat_terminal_counter.sql
+++ b/awa-model/migrations/v022_delete_compat_terminal_counter.sql
@@ -182,10 +182,11 @@ BEGIN
                  WHERE counts.ready_slot     = $1
                    AND counts.queue          = $2
                    AND counts.priority       = $3
-                   AND counts.enqueue_shard  = $4',
+                   AND counts.enqueue_shard  = $4
+                   AND counts.counter_bucket = mod(mod($5, 256::bigint) + 256::bigint, 256::bigint)::smallint',
                 v_schema
             )
-            USING v_ready_slot, v_queue, v_priority, v_enqueue_shard;
+            USING v_ready_slot, v_queue, v_priority, v_enqueue_shard, p_id;
         END IF;
         PERFORM awa.release_queue_storage_unique_claim(
             p_id,

--- a/awa-model/migrations/v023_install_queue_storage_substrate.sql
+++ b/awa-model/migrations/v023_install_queue_storage_substrate.sql
@@ -51,7 +51,6 @@ DECLARE
     v_slot           INT;
     v_initial_gen    BIGINT;
     v_claimed_cte    TEXT;
-    v_advance_claim_condition TEXT;
 BEGIN
     IF p_schema IS NULL OR p_schema !~ '^[a-z_][a-z0-9_]*$' THEN
         RAISE EXCEPTION 'install_queue_storage_substrate: schema name must match ^[a-z_][a-z0-9_]*$; got %',
@@ -448,27 +447,6 @@ BEGIN
                     format('%%I.%%I', %1$L, p_seq_name),
                     p_next - 1
                 );
-            END IF;
-        END;
-        $func$
-        $ddl$,
-        p_schema
-    );
-
-    EXECUTE format(
-        $ddl$
-        CREATE OR REPLACE FUNCTION %1$I.set_sequence_next_if(
-            p_seq_name TEXT,
-            p_next BIGINT,
-            p_enabled BOOLEAN
-        )
-        RETURNS VOID
-        LANGUAGE plpgsql
-        SET search_path = pg_catalog
-        AS $func$
-        BEGIN
-            IF p_enabled THEN
-                PERFORM %1$I.set_sequence_next(p_seq_name, p_next);
             END IF;
         END;
         $func$
@@ -1411,8 +1389,6 @@ BEGIN
     -- receipts=FALSE writes directly into the partitioned leases table.
     --------------------------------------------------------------------
 
-    v_advance_claim_condition := 'FALSE';
-
     IF p_lease_claim_receipts THEN
         v_claimed_cte := format(
             $cte$
@@ -1449,8 +1425,9 @@ BEGIN
                     selected.lane_seq,
                     v_lane_shard,
                     v_deadline_at
-                FROM selected
+                FROM selected_with_spent AS selected
                 CROSS JOIN claim_ring
+                WHERE NOT selected.attempt_spent
                 RETURNING
                     claim_rows.claim_slot,
                     claim_rows.ready_slot,
@@ -1505,8 +1482,9 @@ BEGIN
                     v_claimed_at,
                     v_deadline_at,
                     v_claimed_at
-                FROM selected
+                FROM selected_with_spent AS selected
                 CROSS JOIN lease_ring
+                WHERE NOT selected.attempt_spent
                 RETURNING
                     0::int AS claim_slot,
                     lease_rows.ready_slot,
@@ -1577,6 +1555,7 @@ BEGIN
             v_target_generation BIGINT;
             v_claimed_at TIMESTAMPTZ;
             v_deadline_at TIMESTAMPTZ;
+            v_spent_next_seq BIGINT;
         BEGIN
             SELECT
                 claims.priority,
@@ -1669,6 +1648,76 @@ BEGIN
                 v_deadline_at := NULL::timestamptz;
             END IF;
 
+            WITH selected AS (
+                SELECT
+                    ready.job_id,
+                    ready.run_lease,
+                    ready.lane_seq
+                FROM %1$I.ready_entries AS ready
+                WHERE ready.queue = p_queue
+                  AND ready.priority = v_lane_priority
+                  AND ready.enqueue_shard = v_lane_shard
+                  AND ready.ready_slot = v_target_slot
+                  AND ready.ready_generation = v_target_generation
+                  AND ready.lane_seq >= v_lane_claim_seq
+                ORDER BY ready.lane_seq ASC
+                LIMIT v_claim_limit
+            ),
+            selected_with_spent AS (
+                SELECT
+                    selected.*,
+                    (
+                        EXISTS (
+                            SELECT 1
+                            FROM %1$I.lease_claims AS existing_claims
+                            WHERE existing_claims.job_id = selected.job_id
+                              AND existing_claims.run_lease = selected.run_lease + 1
+                        )
+                        OR EXISTS (
+                            SELECT 1
+                            FROM %1$I.leases AS existing_leases
+                            WHERE existing_leases.job_id = selected.job_id
+                              AND existing_leases.run_lease = selected.run_lease + 1
+                        )
+                        OR EXISTS (
+                            SELECT 1
+                            FROM %1$I.done_entries AS existing_done
+                            WHERE existing_done.job_id = selected.job_id
+                              AND existing_done.run_lease = selected.run_lease + 1
+                        )
+                        OR EXISTS (
+                            SELECT 1
+                            FROM %1$I.deferred_jobs AS existing_deferred
+                            WHERE existing_deferred.job_id = selected.job_id
+                              AND existing_deferred.run_lease = selected.run_lease + 1
+                        )
+                        OR EXISTS (
+                            SELECT 1
+                            FROM %1$I.dlq_entries AS existing_dlq
+                            WHERE existing_dlq.job_id = selected.job_id
+                              AND existing_dlq.run_lease = selected.run_lease + 1
+                        )
+                        OR EXISTS (
+                            SELECT 1
+                            FROM %1$I.ready_entries AS existing_ready
+                            WHERE existing_ready.job_id = selected.job_id
+                              AND existing_ready.run_lease = selected.run_lease + 1
+                        )
+                    ) AS attempt_spent
+                FROM selected
+            )
+            SELECT max(selected_with_spent.lane_seq) + 1
+            INTO v_spent_next_seq
+            FROM selected_with_spent
+            WHERE attempt_spent;
+
+            IF v_spent_next_seq IS NOT NULL THEN
+                -- Safe in-transaction sequence movement: this only skips
+                -- attempts with already-committed evidence. Newly emitted
+                -- claims still advance post-commit.
+                PERFORM %1$I.set_sequence_next(v_claim_seq_name, v_spent_next_seq);
+            END IF;
+
             RETURN QUERY
             WITH lease_ring AS (
                 SELECT current_slot AS lease_slot, generation AS lease_generation
@@ -1712,15 +1761,63 @@ BEGIN
                 ORDER BY ready.lane_seq ASC
                 LIMIT v_claim_limit
             ),
-            advanced AS (
-                SELECT %1$I.set_sequence_next_if(
-                    v_claim_seq_name,
-                    COALESCE(
-                        (SELECT max(selected.lane_seq) + 1 FROM selected),
-                        v_lane_claim_seq
-                    ),
-                    %3$s
-                )
+            selected_with_spent AS (
+                SELECT
+                    selected.*,
+                    (
+                        -- Claim cursor advancement is deliberately
+                        -- post-commit for newly emitted attempts: PostgreSQL
+                        -- sequence movement is non-transactional, so advancing
+                        -- inside the claim transaction could skip committed
+                        -- work if that transaction later aborts. If the
+                        -- post-commit advance is lost, the cursor may lag and
+                        -- this ready row can be selected again after ring
+                        -- rotation.
+                        --
+                        -- Treat the next run_lease as an idempotency key.
+                        -- Once committed evidence exists for (job_id,
+                        -- run_lease), the attempt has already been emitted.
+                        -- Legitimate retries re-enter ready/deferred state
+                        -- with selected.run_lease advanced, so they target a
+                        -- new idempotency key.
+                        EXISTS (
+                            SELECT 1
+                            FROM %1$I.lease_claims AS existing_claims
+                            WHERE existing_claims.job_id = selected.job_id
+                              AND existing_claims.run_lease = selected.run_lease + 1
+                        )
+                        OR EXISTS (
+                            SELECT 1
+                            FROM %1$I.leases AS existing_leases
+                            WHERE existing_leases.job_id = selected.job_id
+                              AND existing_leases.run_lease = selected.run_lease + 1
+                        )
+                        OR EXISTS (
+                            SELECT 1
+                            FROM %1$I.done_entries AS existing_done
+                            WHERE existing_done.job_id = selected.job_id
+                              AND existing_done.run_lease = selected.run_lease + 1
+                        )
+                        OR EXISTS (
+                            SELECT 1
+                            FROM %1$I.deferred_jobs AS existing_deferred
+                            WHERE existing_deferred.job_id = selected.job_id
+                              AND existing_deferred.run_lease = selected.run_lease + 1
+                        )
+                        OR EXISTS (
+                            SELECT 1
+                            FROM %1$I.dlq_entries AS existing_dlq
+                            WHERE existing_dlq.job_id = selected.job_id
+                              AND existing_dlq.run_lease = selected.run_lease + 1
+                        )
+                        OR EXISTS (
+                            SELECT 1
+                            FROM %1$I.ready_entries AS existing_ready
+                            WHERE existing_ready.job_id = selected.job_id
+                              AND existing_ready.run_lease = selected.run_lease + 1
+                        )
+                    ) AS attempt_spent
+                FROM selected
             ),
             %2$s
             SELECT
@@ -1756,7 +1853,6 @@ BEGIN
                 selected.payload
             FROM claimed
             CROSS JOIN lease_ring
-            CROSS JOIN advanced
             JOIN selected
              ON selected.ready_slot = claimed.ready_slot
              AND selected.ready_generation = claimed.ready_generation
@@ -1768,17 +1864,19 @@ BEGIN
             GET DIAGNOSTICS v_claimed_count = ROW_COUNT;
 
             -- If a target ready row existed but the claim CTE produced no
-            -- rows, leave the sequence cursor untouched. The earlier
-            -- NOT FOUND branch handles true gaps. Advancing here can skip a
-            -- live retry/rescue row because sequence movement is
-            -- non-transactional and cannot be recovered by rollback.
+            -- rows, the spent-attempt pre-pass may still have moved the
+            -- sequence cursor over committed spent attempts. It deliberately
+            -- does not advance over unspent rows: newly emitted claims still
+            -- move the sequence only after the surrounding transaction
+            -- commits, because sequence movement is non-transactional and
+            -- cannot be recovered by rollback.
             IF v_claimed_count = 0 THEN
                 RETURN;
             END IF;
         END;
         $func$
         $create_runtime$,
-        p_schema, v_claimed_cte, v_advance_claim_condition
+        p_schema, v_claimed_cte
     );
 
     --------------------------------------------------------------------

--- a/awa-model/migrations/v023_install_queue_storage_substrate.sql
+++ b/awa-model/migrations/v023_install_queue_storage_substrate.sql
@@ -1298,6 +1298,24 @@ BEGIN
         p_schema
     );
 
+    -- If an upgraded schema already had live-counter rows before
+    -- counter_bucket existed, every aggregate row received DEFAULT 0.
+    -- The aggregate table has no job_id, so the installer cannot rebucket
+    -- those rows in place. Mark the counter untrusted here; v027's schema
+    -- rewalker rebuilds it from done_entries immediately after calling this
+    -- helper, and operator-initiated prepare_schema() remains honest even if
+    -- run outside the migration path.
+    EXECUTE format(
+        $ddl$
+        UPDATE %1$I.queue_ring_state
+        SET terminal_counter_trusted_at = NULL
+        WHERE singleton = TRUE
+          AND EXISTS (SELECT 1 FROM %1$I.queue_terminal_live_counts LIMIT 1)
+          AND EXISTS (SELECT 1 FROM %1$I.done_entries LIMIT 1)
+        $ddl$,
+        p_schema
+    );
+
     -- Backfill from existing done_entries (no-op on fresh installs).
     EXECUTE format(
         $ddl$

--- a/awa-model/migrations/v023_install_queue_storage_substrate.sql
+++ b/awa-model/migrations/v023_install_queue_storage_substrate.sql
@@ -51,6 +51,7 @@ DECLARE
     v_slot           INT;
     v_initial_gen    BIGINT;
     v_claimed_cte    TEXT;
+    v_advance_claim_condition TEXT;
 BEGIN
     IF p_schema IS NULL OR p_schema !~ '^[a-z_][a-z0-9_]*$' THEN
         RAISE EXCEPTION 'install_queue_storage_substrate: schema name must match ^[a-z_][a-z0-9_]*$; got %',
@@ -305,6 +306,7 @@ BEGIN
             priority      SMALLINT NOT NULL,
             enqueue_shard SMALLINT NOT NULL DEFAULT 0,
             next_seq      BIGINT NOT NULL DEFAULT 1,
+            seq_name      TEXT,
             PRIMARY KEY (queue, priority, enqueue_shard)
         )
         $ddl$,
@@ -331,6 +333,7 @@ BEGIN
             priority      SMALLINT NOT NULL,
             enqueue_shard SMALLINT NOT NULL DEFAULT 0,
             claim_seq     BIGINT NOT NULL DEFAULT 1,
+            seq_name      TEXT,
             PRIMARY KEY (queue, priority, enqueue_shard)
         )
         $ddl$,
@@ -347,6 +350,342 @@ BEGIN
             autovacuum_vacuum_cost_delay = 2
         )
         $ddl$,
+        p_schema
+    );
+
+    EXECUTE format(
+        'ALTER TABLE %I.queue_enqueue_heads ADD COLUMN IF NOT EXISTS seq_name TEXT',
+        p_schema
+    );
+
+    EXECUTE format(
+        'ALTER TABLE %I.queue_claim_heads ADD COLUMN IF NOT EXISTS seq_name TEXT',
+        p_schema
+    );
+
+    --------------------------------------------------------------------
+    -- Sequence-backed lane cursors (#295 pulled into v0.6).
+    --
+    -- queue_enqueue_heads / queue_claim_heads remain as cold lane
+    -- registries and lock targets. The hot cursor movement happens via
+    -- PostgreSQL sequences, which are not MVCC heap tuples. This removes
+    -- the per-claim/per-enqueue UPDATE dead-tuple stream while preserving
+    -- the existing lane identity and SKIP LOCKED fairness shape.
+    --------------------------------------------------------------------
+
+    EXECUTE format(
+        $ddl$
+        CREATE OR REPLACE FUNCTION %1$I.queue_lane_sequence_name(
+            p_prefix TEXT,
+            p_queue TEXT,
+            p_priority SMALLINT,
+            p_enqueue_shard SMALLINT
+        )
+        RETURNS TEXT
+        LANGUAGE sql
+        IMMUTABLE
+        SET search_path = pg_catalog
+        AS $func$
+            SELECT p_prefix || '_' ||
+                   substr(md5(p_queue || ':' || p_priority::text || ':' || p_enqueue_shard::text), 1, 32)
+        $func$
+        $ddl$,
+        p_schema
+    );
+
+    EXECUTE format(
+        $ddl$
+        CREATE OR REPLACE FUNCTION %1$I.sequence_next_value(p_seq_name TEXT)
+        RETURNS BIGINT
+        LANGUAGE plpgsql
+        SET search_path = pg_catalog
+        AS $func$
+        DECLARE
+            v_last BIGINT;
+            v_is_called BOOLEAN;
+        BEGIN
+            IF p_seq_name IS NULL THEN
+                RAISE EXCEPTION 'lane sequence name is NULL'
+                    USING ERRCODE = '55000';
+            END IF;
+
+            EXECUTE format('SELECT last_value, is_called FROM %%I.%%I', %1$L, p_seq_name)
+            INTO v_last, v_is_called;
+
+            IF v_is_called THEN
+                RETURN v_last + 1;
+            END IF;
+            RETURN v_last;
+        END;
+        $func$
+        $ddl$,
+        p_schema
+    );
+
+    EXECUTE format(
+        $ddl$
+        CREATE OR REPLACE FUNCTION %1$I.set_sequence_next(p_seq_name TEXT, p_next BIGINT)
+        RETURNS VOID
+        LANGUAGE plpgsql
+        SET search_path = pg_catalog
+        AS $func$
+        BEGIN
+            IF p_seq_name IS NULL THEN
+                RAISE EXCEPTION 'lane sequence name is NULL'
+                    USING ERRCODE = '55000';
+            END IF;
+
+            p_next := GREATEST(p_next, %1$I.sequence_next_value(p_seq_name));
+
+            IF p_next <= 1 THEN
+                EXECUTE format(
+                    'SELECT setval(%%L::regclass, 1, false)',
+                    format('%%I.%%I', %1$L, p_seq_name)
+                );
+            ELSE
+                EXECUTE format(
+                    'SELECT setval(%%L::regclass, %%s, true)',
+                    format('%%I.%%I', %1$L, p_seq_name),
+                    p_next - 1
+                );
+            END IF;
+        END;
+        $func$
+        $ddl$,
+        p_schema
+    );
+
+    EXECUTE format(
+        $ddl$
+        CREATE OR REPLACE FUNCTION %1$I.set_sequence_next_if(
+            p_seq_name TEXT,
+            p_next BIGINT,
+            p_enabled BOOLEAN
+        )
+        RETURNS VOID
+        LANGUAGE plpgsql
+        SET search_path = pg_catalog
+        AS $func$
+        BEGIN
+            IF p_enabled THEN
+                PERFORM %1$I.set_sequence_next(p_seq_name, p_next);
+            END IF;
+        END;
+        $func$
+        $ddl$,
+        p_schema
+    );
+
+    EXECUTE format(
+        $ddl$
+        CREATE OR REPLACE FUNCTION %1$I.ensure_lane_sequences(
+            p_queue TEXT,
+            p_priority SMALLINT,
+            p_enqueue_shard SMALLINT
+        )
+        RETURNS VOID
+        LANGUAGE plpgsql
+        SET search_path = pg_catalog
+        AS $func$
+        DECLARE
+            v_enqueue_seq TEXT := %1$I.queue_lane_sequence_name(
+                'queue_enqueue_seq',
+                p_queue,
+                p_priority,
+                p_enqueue_shard
+            );
+            v_claim_seq TEXT := %1$I.queue_lane_sequence_name(
+                'queue_claim_seq',
+                p_queue,
+                p_priority,
+                p_enqueue_shard
+            );
+        BEGIN
+            EXECUTE format(
+                'CREATE SEQUENCE IF NOT EXISTS %%I.%%I AS bigint START WITH 1 MINVALUE 1 CACHE 1',
+                %1$L,
+                v_enqueue_seq
+            );
+            EXECUTE format(
+                'CREATE SEQUENCE IF NOT EXISTS %%I.%%I AS bigint START WITH 1 MINVALUE 1 CACHE 1',
+                %1$L,
+                v_claim_seq
+            );
+
+            UPDATE %1$I.queue_enqueue_heads
+            SET seq_name = v_enqueue_seq
+            WHERE queue = p_queue
+              AND priority = p_priority
+              AND enqueue_shard = p_enqueue_shard
+              AND seq_name IS DISTINCT FROM v_enqueue_seq;
+
+            UPDATE %1$I.queue_claim_heads
+            SET seq_name = v_claim_seq
+            WHERE queue = p_queue
+              AND priority = p_priority
+              AND enqueue_shard = p_enqueue_shard
+              AND seq_name IS DISTINCT FROM v_claim_seq;
+        END;
+        $func$
+        $ddl$,
+        p_schema
+    );
+
+    EXECUTE format(
+        $ddl$
+        CREATE OR REPLACE FUNCTION %1$I.reserve_enqueue_seq(
+            p_queue TEXT,
+            p_priority SMALLINT,
+            p_enqueue_shard SMALLINT,
+            p_count BIGINT
+        )
+        RETURNS BIGINT
+        LANGUAGE plpgsql
+        SET search_path = pg_catalog
+        AS $func$
+        DECLARE
+            v_seq_name TEXT;
+            v_start BIGINT;
+        BEGIN
+            IF p_count <= 0 THEN
+                RETURN %1$I.sequence_next_value((
+                    SELECT seq_name
+                    FROM %1$I.queue_enqueue_heads
+                    WHERE queue = p_queue
+                      AND priority = p_priority
+                      AND enqueue_shard = p_enqueue_shard
+                ));
+            END IF;
+
+            PERFORM %1$I.ensure_lane_sequences(p_queue, p_priority, p_enqueue_shard);
+
+            SELECT seq_name
+            INTO v_seq_name
+            FROM %1$I.queue_enqueue_heads
+            WHERE queue = p_queue
+              AND priority = p_priority
+              AND enqueue_shard = p_enqueue_shard;
+
+            IF v_seq_name IS NULL THEN
+                RAISE EXCEPTION 'missing enqueue lane sequence for queue %%, priority %%, shard %%',
+                    p_queue, p_priority, p_enqueue_shard
+                    USING ERRCODE = '55000';
+            END IF;
+
+            EXECUTE format(
+                'SELECT min(nextval(%%L::regclass))::bigint FROM generate_series(1::bigint, $1)',
+                format('%%I.%%I', %1$L, v_seq_name)
+            )
+            INTO v_start
+            USING p_count;
+
+            RETURN v_start;
+        END;
+        $func$
+        $ddl$,
+        p_schema
+    );
+
+    EXECUTE format(
+        $ddl$
+        CREATE OR REPLACE FUNCTION %1$I.queue_enqueue_head_sequence_sync()
+        RETURNS TRIGGER
+        LANGUAGE plpgsql
+        SET search_path = pg_catalog
+        AS $func$
+        DECLARE
+            v_seq_name TEXT := %1$I.queue_lane_sequence_name(
+                'queue_enqueue_seq',
+                NEW.queue,
+                NEW.priority,
+                NEW.enqueue_shard
+            );
+            v_qualified_seq TEXT := format('%%I.%%I', %1$L, v_seq_name);
+            v_count BIGINT;
+            v_start BIGINT;
+        BEGIN
+            EXECUTE format(
+                'CREATE SEQUENCE IF NOT EXISTS %%I.%%I AS bigint START WITH 1 MINVALUE 1 CACHE 1',
+                %1$L,
+                v_seq_name
+            );
+            NEW.seq_name := v_seq_name;
+
+            IF TG_OP = 'UPDATE'
+               AND NEW.next_seq IS DISTINCT FROM OLD.next_seq
+               AND NEW.next_seq > OLD.next_seq
+            THEN
+                v_count := NEW.next_seq - OLD.next_seq;
+                EXECUTE format(
+                    'SELECT min(nextval(%%L::regclass))::bigint FROM generate_series(1::bigint, $1)',
+                    v_qualified_seq
+                )
+                INTO v_start
+                USING v_count;
+                NEW.next_seq := v_start + v_count;
+            ELSE
+                PERFORM %1$I.set_sequence_next(v_seq_name, NEW.next_seq);
+            END IF;
+
+            RETURN NEW;
+        END;
+        $func$
+        $ddl$,
+        p_schema
+    );
+
+    EXECUTE format(
+        $ddl$
+        CREATE OR REPLACE FUNCTION %1$I.queue_claim_head_sequence_sync()
+        RETURNS TRIGGER
+        LANGUAGE plpgsql
+        SET search_path = pg_catalog
+        AS $func$
+        DECLARE
+            v_seq_name TEXT := %1$I.queue_lane_sequence_name(
+                'queue_claim_seq',
+                NEW.queue,
+                NEW.priority,
+                NEW.enqueue_shard
+            );
+        BEGIN
+            EXECUTE format(
+                'CREATE SEQUENCE IF NOT EXISTS %%I.%%I AS bigint START WITH 1 MINVALUE 1 CACHE 1',
+                %1$L,
+                v_seq_name
+            );
+            NEW.seq_name := v_seq_name;
+
+            IF TG_OP = 'INSERT' THEN
+                PERFORM %1$I.set_sequence_next(v_seq_name, NEW.claim_seq);
+            END IF;
+
+            RETURN NEW;
+        END;
+        $func$
+        $ddl$,
+        p_schema
+    );
+
+    EXECUTE format(
+        'DROP TRIGGER IF EXISTS queue_enqueue_heads_sequence_sync ON %I.queue_enqueue_heads',
+        p_schema
+    );
+
+    EXECUTE format(
+        'CREATE TRIGGER queue_enqueue_heads_sequence_sync BEFORE INSERT OR UPDATE OF next_seq ON %I.queue_enqueue_heads FOR EACH ROW EXECUTE FUNCTION %I.queue_enqueue_head_sequence_sync()',
+        p_schema,
+        p_schema
+    );
+
+    EXECUTE format(
+        'DROP TRIGGER IF EXISTS queue_claim_heads_sequence_sync ON %I.queue_claim_heads',
+        p_schema
+    );
+
+    EXECUTE format(
+        'CREATE TRIGGER queue_claim_heads_sequence_sync BEFORE INSERT OR UPDATE OF claim_seq ON %I.queue_claim_heads FOR EACH ROW EXECUTE FUNCTION %I.queue_claim_head_sequence_sync()',
+        p_schema,
         p_schema
     );
 
@@ -440,6 +779,36 @@ BEGIN
 
     EXECUTE format(
         $ddl$
+        SELECT %1$I.ensure_lane_sequences(lanes.queue, lanes.priority, lanes.enqueue_shard)
+        FROM (
+            SELECT queue, priority, enqueue_shard FROM %1$I.queue_enqueue_heads
+            UNION
+            SELECT queue, priority, enqueue_shard FROM %1$I.queue_claim_heads
+        ) AS lanes
+        $ddl$,
+        p_schema
+    );
+
+    EXECUTE format(
+        $ddl$
+        SELECT %1$I.set_sequence_next(seq_name, next_seq)
+        FROM %1$I.queue_enqueue_heads
+        WHERE seq_name IS NOT NULL
+        $ddl$,
+        p_schema
+    );
+
+    EXECUTE format(
+        $ddl$
+        SELECT %1$I.set_sequence_next(seq_name, claim_seq)
+        FROM %1$I.queue_claim_heads
+        WHERE seq_name IS NOT NULL
+        $ddl$,
+        p_schema
+    );
+
+    EXECUTE format(
+        $ddl$
         INSERT INTO %1$I.queue_terminal_rollups AS rollups (queue, priority, pruned_completed_count)
         SELECT queue, priority, pruned_completed_count
         FROM %1$I.queue_lanes
@@ -488,6 +857,20 @@ BEGIN
 
     EXECUTE format(
         $ddl$
+        ALTER TABLE %I.leases
+            ADD COLUMN IF NOT EXISTS state awa.job_state NOT NULL DEFAULT 'running',
+            ADD COLUMN IF NOT EXISTS enqueue_shard SMALLINT NOT NULL DEFAULT 0,
+            ADD COLUMN IF NOT EXISTS heartbeat_at TIMESTAMPTZ,
+            ADD COLUMN IF NOT EXISTS deadline_at TIMESTAMPTZ,
+            ADD COLUMN IF NOT EXISTS attempted_at TIMESTAMPTZ,
+            ADD COLUMN IF NOT EXISTS callback_id UUID,
+            ADD COLUMN IF NOT EXISTS callback_timeout_at TIMESTAMPTZ
+        $ddl$,
+        p_schema
+    );
+
+    EXECUTE format(
+        $ddl$
         CREATE TABLE IF NOT EXISTS %I.lease_claims (
             claim_slot       INT NOT NULL,
             job_id           BIGINT NOT NULL,
@@ -509,9 +892,14 @@ BEGIN
         p_schema
     );
 
-    -- Idempotent column-add for upgrades from before deadline_at existed.
+    -- Idempotent column-add for upgrades from before receipts carried
+    -- shard/deadline metadata.
     EXECUTE format(
-        'ALTER TABLE %I.lease_claims ADD COLUMN IF NOT EXISTS deadline_at TIMESTAMPTZ',
+        $ddl$
+        ALTER TABLE %I.lease_claims
+            ADD COLUMN IF NOT EXISTS enqueue_shard SMALLINT NOT NULL DEFAULT 0,
+            ADD COLUMN IF NOT EXISTS deadline_at TIMESTAMPTZ
+        $ddl$,
         p_schema
     );
 
@@ -660,6 +1048,23 @@ BEGIN
         p_schema
     );
 
+    EXECUTE format(
+        $ddl$
+        ALTER TABLE %I.done_entries
+            ADD COLUMN IF NOT EXISTS args JSONB,
+            ADD COLUMN IF NOT EXISTS state awa.job_state NOT NULL DEFAULT 'completed',
+            ADD COLUMN IF NOT EXISTS max_attempts SMALLINT,
+            ADD COLUMN IF NOT EXISTS enqueue_shard SMALLINT NOT NULL DEFAULT 0,
+            ADD COLUMN IF NOT EXISTS run_at TIMESTAMPTZ,
+            ADD COLUMN IF NOT EXISTS attempted_at TIMESTAMPTZ,
+            ADD COLUMN IF NOT EXISTS created_at TIMESTAMPTZ,
+            ADD COLUMN IF NOT EXISTS unique_key BYTEA,
+            ADD COLUMN IF NOT EXISTS unique_states TEXT,
+            ADD COLUMN IF NOT EXISTS payload JSONB
+        $ddl$,
+        p_schema
+    );
+
     -- Narrow terminal history: see queue_storage.rs comment.
     EXECUTE format(
         $ddl$
@@ -733,6 +1138,24 @@ BEGIN
             payload       JSONB,
             CONSTRAINT deferred_jobs_state_check CHECK (state IN ('scheduled', 'retryable'))
         )
+        $ddl$,
+        p_schema
+    );
+
+    EXECUTE format(
+        $ddl$
+        ALTER TABLE %I.deferred_jobs
+            ADD COLUMN IF NOT EXISTS args JSONB NOT NULL DEFAULT '{}'::jsonb,
+            ADD COLUMN IF NOT EXISTS state awa.job_state NOT NULL DEFAULT 'scheduled',
+            ADD COLUMN IF NOT EXISTS attempt SMALLINT NOT NULL DEFAULT 0,
+            ADD COLUMN IF NOT EXISTS run_lease BIGINT NOT NULL DEFAULT 0,
+            ADD COLUMN IF NOT EXISTS max_attempts SMALLINT NOT NULL DEFAULT 25,
+            ADD COLUMN IF NOT EXISTS attempted_at TIMESTAMPTZ,
+            ADD COLUMN IF NOT EXISTS finalized_at TIMESTAMPTZ,
+            ADD COLUMN IF NOT EXISTS created_at TIMESTAMPTZ NOT NULL DEFAULT clock_timestamp(),
+            ADD COLUMN IF NOT EXISTS unique_key BYTEA,
+            ADD COLUMN IF NOT EXISTS unique_states TEXT,
+            ADD COLUMN IF NOT EXISTS payload JSONB
         $ddl$,
         p_schema
     );
@@ -828,9 +1251,53 @@ BEGIN
             queue               TEXT NOT NULL,
             priority            SMALLINT NOT NULL,
             enqueue_shard       SMALLINT NOT NULL,
+            counter_bucket      SMALLINT NOT NULL DEFAULT 0,
             live_terminal_count BIGINT NOT NULL DEFAULT 0,
-            PRIMARY KEY (ready_slot, queue, priority, enqueue_shard)
+            PRIMARY KEY (ready_slot, queue, priority, enqueue_shard, counter_bucket)
         )
+        $ddl$,
+        p_schema
+    );
+
+    EXECUTE format(
+        'ALTER TABLE %I.queue_terminal_live_counts ADD COLUMN IF NOT EXISTS counter_bucket SMALLINT NOT NULL DEFAULT 0',
+        p_schema
+    );
+
+    EXECUTE format(
+        $ddl$
+        DO $inner$
+        DECLARE
+            v_has_bucket_key BOOLEAN;
+        BEGIN
+            SELECT EXISTS (
+                SELECT 1
+                FROM pg_constraint AS c
+                JOIN pg_class AS t ON t.oid = c.conrelid
+                JOIN pg_namespace AS n ON n.oid = t.relnamespace
+                WHERE n.nspname = %1$L
+                  AND t.relname = 'queue_terminal_live_counts'
+                  AND c.contype = 'p'
+                  AND EXISTS (
+                      SELECT 1
+                      FROM unnest(c.conkey) AS key(attnum)
+                      JOIN pg_attribute AS a
+                        ON a.attrelid = t.oid
+                       AND a.attnum = key.attnum
+                      WHERE a.attname = 'counter_bucket'
+                  )
+            )
+            INTO v_has_bucket_key;
+
+            IF NOT v_has_bucket_key THEN
+                ALTER TABLE %1$I.queue_terminal_live_counts
+                    DROP CONSTRAINT IF EXISTS queue_terminal_live_counts_pkey;
+                ALTER TABLE %1$I.queue_terminal_live_counts
+                    ADD CONSTRAINT queue_terminal_live_counts_pkey
+                    PRIMARY KEY (ready_slot, queue, priority, enqueue_shard, counter_bucket);
+            END IF;
+        END
+        $inner$
         $ddl$,
         p_schema
     );
@@ -857,12 +1324,21 @@ BEGIN
     EXECUTE format(
         $ddl$
         INSERT INTO %1$I.queue_terminal_live_counts AS counts (
-            ready_slot, queue, priority, enqueue_shard, live_terminal_count
+            ready_slot, queue, priority, enqueue_shard, counter_bucket, live_terminal_count
         )
-        SELECT ready_slot, queue, priority, enqueue_shard, count(*)::bigint
+        SELECT
+            ready_slot,
+            queue,
+            priority,
+            enqueue_shard,
+            mod(mod(job_id, 256::bigint) + 256::bigint, 256::bigint)::smallint AS counter_bucket,
+            count(*)::bigint
         FROM %1$I.done_entries
-        GROUP BY ready_slot, queue, priority, enqueue_shard
-        ON CONFLICT (ready_slot, queue, priority, enqueue_shard) DO NOTHING
+        WHERE NOT EXISTS (
+            SELECT 1 FROM %1$I.queue_terminal_live_counts LIMIT 1
+        )
+        GROUP BY ready_slot, queue, priority, enqueue_shard, counter_bucket
+        ON CONFLICT (ready_slot, queue, priority, enqueue_shard, counter_bucket) DO NOTHING
         $ddl$,
         p_schema
     );
@@ -934,6 +1410,8 @@ BEGIN
     -- receipts mode: receipts=TRUE writes into lease_claims (ADR-023),
     -- receipts=FALSE writes directly into the partitioned leases table.
     --------------------------------------------------------------------
+
+    v_advance_claim_condition := 'FALSE';
 
     IF p_lease_claim_receipts THEN
         v_claimed_cte := format(
@@ -1090,6 +1568,7 @@ BEGIN
         DECLARE
             v_lane_priority SMALLINT;
             v_lane_shard SMALLINT;
+            v_claim_seq_name TEXT;
             v_lane_claim_seq BIGINT;
             v_lane_next_seq BIGINT;
             v_claim_limit BIGINT;
@@ -1102,15 +1581,21 @@ BEGIN
             SELECT
                 claims.priority,
                 claims.enqueue_shard,
-                claims.claim_seq,
-                enqueues.next_seq
-            INTO v_lane_priority, v_lane_shard, v_lane_claim_seq, v_lane_next_seq
+                claims.seq_name,
+                cursors.claim_seq,
+                cursors.next_seq
+            INTO v_lane_priority, v_lane_shard, v_claim_seq_name, v_lane_claim_seq, v_lane_next_seq
             FROM %1$I.queue_claim_heads AS claims
             JOIN %1$I.queue_enqueue_heads AS enqueues
               ON enqueues.queue = claims.queue
              AND enqueues.priority = claims.priority
              AND enqueues.enqueue_shard = claims.enqueue_shard
-            JOIN LATERAL (
+            CROSS JOIN LATERAL (
+                SELECT
+                    %1$I.sequence_next_value(claims.seq_name) AS claim_seq,
+                    %1$I.sequence_next_value(enqueues.seq_name) AS next_seq
+            ) AS cursors
+            LEFT JOIN LATERAL (
                 SELECT
                     ready.ready_slot,
                     ready.ready_generation,
@@ -1128,7 +1613,7 @@ BEGIN
                 WHERE ready.queue = p_queue
                   AND ready.priority = claims.priority
                   AND ready.enqueue_shard = claims.enqueue_shard
-                  AND ready.lane_seq >= claims.claim_seq
+                  AND ready.lane_seq >= cursors.claim_seq
                 ORDER BY ready.lane_seq ASC
                 LIMIT 1
             ) AS candidate ON TRUE
@@ -1139,8 +1624,11 @@ BEGIN
                   WHERE meta.queue = p_queue
                     AND meta.paused = TRUE
               )
-              AND claims.claim_seq < enqueues.next_seq
-            ORDER BY candidate.effective_priority ASC, candidate.run_at ASC, claims.priority ASC
+              AND cursors.claim_seq < cursors.next_seq
+            ORDER BY
+                candidate.effective_priority ASC NULLS LAST,
+                candidate.run_at ASC NULLS LAST,
+                claims.priority ASC
             LIMIT 1
             FOR UPDATE OF claims SKIP LOCKED;
 
@@ -1159,11 +1647,13 @@ BEGIN
             LIMIT 1;
 
             IF NOT FOUND THEN
-                UPDATE %1$I.queue_claim_heads AS claims
-                SET claim_seq = GREATEST(claims.claim_seq, v_lane_next_seq)
-                WHERE claims.queue = p_queue
-                  AND claims.priority = v_lane_priority
-                  AND claims.enqueue_shard = v_lane_shard;
+                -- The enqueue cursor is sequence-backed and can include
+                -- uncommitted reservations. If no committed ready row is
+                -- visible yet, do not advance the claim cursor to the enqueue
+                -- cursor: that can skip a ready row when the enqueue
+                -- transaction commits moments later. True gaps from admin
+                -- deletes are harmless over-count drift and close naturally
+                -- when a later committed row on the lane is claimed.
                 RETURN;
             END IF;
 
@@ -1223,15 +1713,14 @@ BEGIN
                 LIMIT v_claim_limit
             ),
             advanced AS (
-                UPDATE %1$I.queue_claim_heads AS claims
-                SET claim_seq = COALESCE(
+                SELECT %1$I.set_sequence_next_if(
+                    v_claim_seq_name,
+                    COALESCE(
                         (SELECT max(selected.lane_seq) + 1 FROM selected),
-                        claims.claim_seq
-                    )
-                WHERE claims.queue = p_queue
-                  AND claims.priority = v_lane_priority
-                  AND claims.enqueue_shard = v_lane_shard
-                RETURNING claims.priority
+                        v_lane_claim_seq
+                    ),
+                    %3$s
+                )
             ),
             %2$s
             SELECT
@@ -1267,6 +1756,7 @@ BEGIN
                 selected.payload
             FROM claimed
             CROSS JOIN lease_ring
+            CROSS JOIN advanced
             JOIN selected
              ON selected.ready_slot = claimed.ready_slot
              AND selected.ready_generation = claimed.ready_generation
@@ -1277,17 +1767,18 @@ BEGIN
 
             GET DIAGNOSTICS v_claimed_count = ROW_COUNT;
 
+            -- If a target ready row existed but the claim CTE produced no
+            -- rows, leave the sequence cursor untouched. The earlier
+            -- NOT FOUND branch handles true gaps. Advancing here can skip a
+            -- live retry/rescue row because sequence movement is
+            -- non-transactional and cannot be recovered by rollback.
             IF v_claimed_count = 0 THEN
-                UPDATE %1$I.queue_claim_heads AS claims
-                SET claim_seq = GREATEST(claims.claim_seq, v_lane_next_seq)
-                WHERE claims.queue = p_queue
-                  AND claims.priority = v_lane_priority
-                  AND claims.enqueue_shard = v_lane_shard;
+                RETURN;
             END IF;
         END;
         $func$
         $create_runtime$,
-        p_schema, v_claimed_cte
+        p_schema, v_claimed_cte, v_advance_claim_condition
     );
 
     --------------------------------------------------------------------

--- a/awa-model/migrations/v027_sequence_lane_cursors.sql
+++ b/awa-model/migrations/v027_sequence_lane_cursors.sql
@@ -77,6 +77,38 @@ BEGIN
             v_claim_slots,
             v_lease_claim_receipts
         );
+
+        -- Existing #290 deployments may already have
+        -- queue_terminal_live_counts rows from the pre-striped shape. Adding
+        -- counter_bucket gives those rows DEFAULT 0, while v27 delete/retry
+        -- paths decrement by job_id % 256. Rebuild the counter once during
+        -- the v27 rewalk so upgraded schemas do not keep an inflated bucket-0
+        -- aggregate.
+        EXECUTE format('TRUNCATE TABLE %I.queue_terminal_live_counts', v_schema);
+        EXECUTE format(
+            $sql$
+            INSERT INTO %1$I.queue_terminal_live_counts AS counts (
+                ready_slot, queue, priority, enqueue_shard, counter_bucket, live_terminal_count
+            )
+            SELECT
+                ready_slot,
+                queue,
+                priority,
+                enqueue_shard,
+                mod(mod(job_id, 256::bigint) + 256::bigint, 256::bigint)::smallint AS counter_bucket,
+                count(*)::bigint
+            FROM %1$I.done_entries
+            GROUP BY ready_slot, queue, priority, enqueue_shard, counter_bucket
+            ON CONFLICT (ready_slot, queue, priority, enqueue_shard, counter_bucket) DO UPDATE
+            SET live_terminal_count = EXCLUDED.live_terminal_count
+            $sql$,
+            v_schema
+        );
+
+        EXECUTE format(
+            'UPDATE %I.queue_ring_state SET terminal_counter_trusted_at = now() WHERE singleton = TRUE',
+            v_schema
+        );
     END LOOP;
 END
 $$;

--- a/awa-model/migrations/v027_sequence_lane_cursors.sql
+++ b/awa-model/migrations/v027_sequence_lane_cursors.sql
@@ -1,0 +1,86 @@
+-- #295 pulled into v0.6: move the hot queue-storage lane cursors from
+-- MVCC-updated heap rows to PostgreSQL sequences, and stripe the #290
+-- terminal live counter so completion-heavy queues do not hammer one
+-- counter row under pinned MVCC.
+--
+-- v023's install helper is part of this migration's step list before this
+-- file, so `awa.install_queue_storage_substrate` has already been replaced
+-- with the sequence-cursor substrate definition. This file applies that
+-- refreshed helper to every existing AWA-owned queue-storage substrate and
+-- records schema version 27.
+--
+-- The old `queue_enqueue_heads.next_seq` and `queue_claim_heads.claim_seq`
+-- columns are retained as rolling-upgrade compatibility columns. The enqueue
+-- trigger translates legacy row UPDATEs into sequence reservations. Claim
+-- cursor movement is intentionally sequence-owned and post-commit: a legacy
+-- `claim_seq` row UPDATE may differ from the hot cursor, but it cannot
+-- advance a non-transactional sequence past work that later rolls back.
+
+DO $$
+DECLARE
+    v_schema TEXT;
+    v_queue_slots INT;
+    v_lease_slots INT;
+    v_claim_slots INT;
+    v_claim_runtime REGPROCEDURE;
+    v_claim_runtime_def TEXT;
+    v_lease_claim_receipts BOOLEAN;
+BEGIN
+    FOR v_schema IN
+        SELECT n.nspname
+        FROM pg_namespace AS n
+        WHERE to_regprocedure(format(
+            '%I.claim_ready_runtime(text,bigint,double precision,double precision)',
+            n.nspname
+        )) IS NOT NULL
+    LOOP
+        IF to_regclass(format('%I.queue_ring_state', v_schema)) IS NULL
+           OR to_regclass(format('%I.lease_ring_state', v_schema)) IS NULL
+           OR to_regclass(format('%I.claim_ring_state', v_schema)) IS NULL THEN
+            CONTINUE;
+        END IF;
+
+        EXECUTE format(
+            'SELECT slot_count FROM %I.queue_ring_state WHERE singleton = TRUE',
+            v_schema
+        )
+        INTO v_queue_slots;
+
+        EXECUTE format(
+            'SELECT slot_count FROM %I.lease_ring_state WHERE singleton = TRUE',
+            v_schema
+        )
+        INTO v_lease_slots;
+
+        EXECUTE format(
+            'SELECT slot_count FROM %I.claim_ring_state WHERE singleton = TRUE',
+            v_schema
+        )
+        INTO v_claim_slots;
+
+        IF v_queue_slots IS NULL OR v_lease_slots IS NULL OR v_claim_slots IS NULL THEN
+            CONTINUE;
+        END IF;
+
+        v_claim_runtime := to_regprocedure(format(
+            '%I.claim_ready_runtime(text,bigint,double precision,double precision)',
+            v_schema
+        ));
+        v_claim_runtime_def := pg_get_functiondef(v_claim_runtime::oid);
+        v_lease_claim_receipts := v_schema = 'awa'
+            OR position(format('INSERT INTO %I.lease_claims', v_schema) IN v_claim_runtime_def) > 0;
+
+        PERFORM awa.install_queue_storage_substrate(
+            v_schema,
+            v_queue_slots,
+            v_lease_slots,
+            v_claim_slots,
+            v_lease_claim_receipts
+        );
+    END LOOP;
+END
+$$;
+
+INSERT INTO awa.schema_version (version, description)
+VALUES (27, 'Move lane cursors to sequences and stripe terminal counters (#295/#290)')
+ON CONFLICT (version) DO NOTHING;

--- a/awa-model/src/admin.rs
+++ b/awa-model/src/admin.rs
@@ -285,7 +285,7 @@ fn queue_storage_current_jobs_cte(schema: &str) -> String {
               ON claims.queue = ready.queue
              AND claims.priority = ready.priority
              AND claims.enqueue_shard = ready.enqueue_shard
-            WHERE ready.lane_seq >= claims.claim_seq
+            WHERE ready.lane_seq >= {schema}.sequence_next_value(claims.seq_name)
         ),
         current_jobs AS (
             SELECT job_id, kind, queue, state, created_at, run_at, finalized_at
@@ -560,7 +560,7 @@ pub async fn cancel_by_unique_key(
                   ON claims.queue = ready.queue
                  AND claims.priority = ready.priority
                  AND claims.enqueue_shard = ready.enqueue_shard
-                WHERE ready.lane_seq >= claims.claim_seq
+                WHERE ready.lane_seq >= {schema}.sequence_next_value(claims.seq_name)
             ),
             candidates AS (
                 SELECT job_id
@@ -2299,7 +2299,7 @@ pub async fn state_counts(pool: &PgPool) -> Result<HashMap<JobState, i64>, AwaEr
                       ON claims.queue = ready.queue
                      AND claims.priority = ready.priority
                      AND claims.enqueue_shard = ready.enqueue_shard
-                    WHERE ready.lane_seq >= claims.claim_seq
+                    WHERE ready.lane_seq >= {schema}.sequence_next_value(claims.seq_name)
                 ), 0) AS available,
                 COALESCE((SELECT count(*)::bigint FROM {schema}.leases WHERE state = 'running'), 0) AS running,
                 COALESCE((SELECT count(*)::bigint FROM {schema}.done_entries WHERE state = 'completed'), 0) AS completed,

--- a/awa-model/src/migrations.rs
+++ b/awa-model/src/migrations.rs
@@ -4,7 +4,7 @@ use sqlx::PgPool;
 use tracing::info;
 
 /// Current schema version.
-pub const CURRENT_VERSION: i32 = 26;
+pub const CURRENT_VERSION: i32 = 27;
 
 /// All migrations in order. SQL lives in `awa-model/migrations/*.sql`
 /// for easy inspection by users who run their own migration tooling.
@@ -118,6 +118,11 @@ const MIGRATIONS: &[(i32, &str, &[&str])] = &[
         "Add paused_at + paused_by to cron_jobs for per-schedule pause",
         &[V26_UP],
     ),
+    (
+        27,
+        "Move lane cursors to sequences and stripe terminal counters",
+        &[V23_UP, V22_UP, V27_UP],
+    ),
 ];
 
 const V1_UP: &str = include_str!("../migrations/v001_canonical_schema.sql");
@@ -145,6 +150,7 @@ const V23_UP: &str = include_str!("../migrations/v023_install_queue_storage_subs
 const V24_UP: &str = include_str!("../migrations/v024_receipt_plane_fillfactor.sql");
 const V25_UP: &str = include_str!("../migrations/v025_drop_leases_state_hb_index.sql");
 const V26_UP: &str = include_str!("../migrations/v026_cron_jobs_pause.sql");
+const V27_UP: &str = include_str!("../migrations/v027_sequence_lane_cursors.sql");
 
 /// Old version numbers from pre-0.4 releases that used V3/V4/V5 numbering.
 /// Also tolerates the unreleased inline-V6 branch numbering used during review.

--- a/awa-model/src/queue_storage.rs
+++ b/awa-model/src/queue_storage.rs
@@ -2732,13 +2732,34 @@ impl QueueStorage {
     ) -> Result<(), AwaError> {
         // Fast path: this store has previously written the three lane
         // rows for this `(queue, priority, shard)` triple. The cache is
-        // optimistic — if that earlier transaction rolled back, the head
-        // row is missing even though the cache says it exists.
-        // `advance_enqueue_head` detects that case via the empty reserve
-        // result, invalidates the cache entry, and re-runs
-        // `ensure_lane_inserts` directly (bypassing this fast path).
+        // optimistic: another transaction may have marked the lane before
+        // commit, or the marking transaction may later roll back. Verify the
+        // head row is visible in this transaction before trusting the cache.
         if self.lane_is_cached(queue, priority, enqueue_shard) {
-            return Ok(());
+            let schema = self.schema();
+            let visible: bool = sqlx::query_scalar(&format!(
+                r#"
+                SELECT EXISTS (
+                    SELECT 1
+                    FROM {schema}.queue_enqueue_heads
+                    WHERE queue = $1
+                      AND priority = $2
+                      AND enqueue_shard = $3
+                )
+                "#
+            ))
+            .bind(queue)
+            .bind(priority)
+            .bind(enqueue_shard)
+            .fetch_one(tx.as_mut())
+            .await
+            .map_err(map_sqlx_error)?;
+
+            if visible {
+                return Ok(());
+            }
+
+            self.invalidate_cached_lane(queue, priority, enqueue_shard);
         }
 
         self.ensure_lane_inserts(tx, queue, priority, enqueue_shard)
@@ -2758,6 +2779,13 @@ impl QueueStorage {
         enqueue_shard: i16,
     ) -> Result<(), AwaError> {
         let schema = self.schema();
+        let lane_lock_key = format!("{schema}:{queue}:{priority}:{enqueue_shard}");
+        sqlx::query("SELECT pg_advisory_xact_lock(hashtextextended($1, 0))")
+            .bind(lane_lock_key)
+            .execute(tx.as_mut())
+            .await
+            .map_err(map_sqlx_error)?;
+
         sqlx::query(&format!(
             r#"
             INSERT INTO {schema}.queue_lanes (queue, priority)
@@ -3312,17 +3340,12 @@ impl QueueStorage {
         let mut job_id_iter = job_ids.into_iter();
 
         let mut ready_rows = Vec::with_capacity(total_rows);
+        let mut lane_ranges = Vec::with_capacity(grouped.len());
 
         for ((queue, priority, enqueue_shard), lane_rows) in grouped {
-            self.ensure_lane(tx, &queue, priority, enqueue_shard)
-                .await?;
+            let range_start = ready_rows.len();
 
-            let count = lane_rows.len() as i64;
-            let start_seq = self
-                .advance_enqueue_head(tx, &queue, priority, enqueue_shard, count)
-                .await?;
-
-            for (offset, row) in lane_rows.into_iter().enumerate() {
+            for row in lane_rows {
                 let job_id = job_id_iter.next().ok_or_else(|| {
                     AwaError::Validation("queue storage job id allocation underflow".to_string())
                 })?;
@@ -3337,7 +3360,7 @@ impl QueueStorage {
                     max_attempts: row.max_attempts,
                     run_at: row.run_at,
                     attempted_at: row.attempted_at,
-                    lane_seq: start_seq + offset as i64,
+                    lane_seq: 0,
                     enqueue_shard,
                     created_at: row.created_at,
                     unique_key: row.unique_key,
@@ -3345,10 +3368,30 @@ impl QueueStorage {
                     payload: row.payload,
                 });
             }
+            lane_ranges.push((
+                queue,
+                priority,
+                enqueue_shard,
+                range_start,
+                ready_rows.len(),
+            ));
         }
 
         self.sync_ready_enqueue_unique_claims(tx, &ready_rows)
             .await?;
+        for (queue, priority, enqueue_shard, range_start, range_end) in lane_ranges {
+            self.ensure_lane(tx, &queue, priority, enqueue_shard)
+                .await?;
+
+            let count = (range_end - range_start) as i64;
+            let start_seq = self
+                .advance_enqueue_head(tx, &queue, priority, enqueue_shard, count)
+                .await?;
+
+            for (offset, row) in ready_rows[range_start..range_end].iter_mut().enumerate() {
+                row.lane_seq = start_seq + offset as i64;
+            }
+        }
         self.execute_ready_inserts_tx(tx, &ready_rows).await?;
         Ok(total_rows)
     }
@@ -3437,17 +3480,12 @@ impl QueueStorage {
         let mut job_id_iter = job_ids.into_iter();
 
         let mut ready_rows = Vec::with_capacity(total_rows);
+        let mut lane_ranges = Vec::with_capacity(grouped.len());
 
         for ((queue, priority, enqueue_shard), lane_rows) in grouped {
-            self.ensure_lane(tx, &queue, priority, enqueue_shard)
-                .await?;
+            let range_start = ready_rows.len();
 
-            let count = lane_rows.len() as i64;
-            let start_seq = self
-                .advance_enqueue_head(tx, &queue, priority, enqueue_shard, count)
-                .await?;
-
-            for (offset, row) in lane_rows.into_iter().enumerate() {
+            for row in lane_rows {
                 let job_id = job_id_iter.next().ok_or_else(|| {
                     AwaError::Validation("queue storage job id allocation underflow".to_string())
                 })?;
@@ -3462,7 +3500,7 @@ impl QueueStorage {
                     max_attempts: row.max_attempts,
                     run_at: row.run_at,
                     attempted_at: row.attempted_at,
-                    lane_seq: start_seq + offset as i64,
+                    lane_seq: 0,
                     enqueue_shard,
                     created_at: row.created_at,
                     unique_key: row.unique_key,
@@ -3470,10 +3508,30 @@ impl QueueStorage {
                     payload: row.payload,
                 });
             }
+            lane_ranges.push((
+                queue,
+                priority,
+                enqueue_shard,
+                range_start,
+                ready_rows.len(),
+            ));
         }
 
         self.sync_ready_enqueue_unique_claims(tx, &ready_rows)
             .await?;
+        for (queue, priority, enqueue_shard, range_start, range_end) in lane_ranges {
+            self.ensure_lane(tx, &queue, priority, enqueue_shard)
+                .await?;
+
+            let count = (range_end - range_start) as i64;
+            let start_seq = self
+                .advance_enqueue_head(tx, &queue, priority, enqueue_shard, count)
+                .await?;
+
+            for (offset, row) in ready_rows[range_start..range_end].iter_mut().enumerate() {
+                row.lane_seq = start_seq + offset as i64;
+            }
+        }
         self.execute_ready_copy_tx(tx, &ready_rows).await?;
         Ok(total_rows)
     }

--- a/awa-model/src/queue_storage.rs
+++ b/awa-model/src/queue_storage.rs
@@ -1396,7 +1396,7 @@ impl DlqJobRow {
             args: self.args,
             priority,
             attempt: 0,
-            run_lease: 0,
+            run_lease: self.run_lease,
             max_attempts: self.max_attempts,
             run_at,
             attempted_at: None,
@@ -1422,7 +1422,7 @@ impl DlqJobRow {
             state: JobState::Scheduled,
             priority,
             attempt: 0,
-            run_lease: 0,
+            run_lease: self.run_lease,
             max_attempts: self.max_attempts,
             run_at,
             attempted_at: None,
@@ -6145,7 +6145,6 @@ impl QueueStorage {
             )?;
             let ready_row = ExistingReadyRow {
                 attempt: 0,
-                run_lease: 0,
                 run_at: Utc::now(),
                 attempted_at: None,
                 ..waiting.clone().into_ready_row(Utc::now(), ready_payload)
@@ -6218,7 +6217,7 @@ impl QueueStorage {
                 args: terminal.args,
                 priority: terminal.priority,
                 attempt: 0,
-                run_lease: 0,
+                run_lease: terminal.run_lease,
                 max_attempts: terminal.max_attempts,
                 run_at: Utc::now(),
                 attempted_at: None,

--- a/awa-model/src/queue_storage.rs
+++ b/awa-model/src/queue_storage.rs
@@ -22,6 +22,7 @@ const DEFAULT_QUEUE_STRIPE_COUNT: usize = 1;
 const QUEUE_STRIPE_DELIMITER: &str = "#";
 const COPY_NULL_SENTINEL: &str = "__AWA_NULL__";
 const COPY_CHUNK_TARGET_BYTES: usize = 256 * 1024;
+const TERMINAL_COUNTER_BUCKETS: i16 = 256;
 
 /// Deterministically map an ordering key to a shard in `[0, shards)`.
 ///
@@ -44,6 +45,10 @@ pub fn shard_for_ordering_key(ordering_key: &[u8], shards: i16) -> i16 {
         hash = hash.wrapping_mul(PRIME).wrapping_add(*byte as u128) & MASK;
     }
     (hash % (shards as u128)) as i16
+}
+
+fn terminal_counter_bucket(job_id: i64) -> i16 {
+    job_id.rem_euclid(TERMINAL_COUNTER_BUCKETS as i64) as i16
 }
 
 #[derive(Debug, Clone)]
@@ -204,10 +209,9 @@ pub struct QueueCounts {
 }
 
 /// Cheap available-only signal used by the dispatcher's claimer-sizing
-/// control loop. Derives the count from
-/// `queue_enqueue_heads.next_seq − queue_claim_heads.claim_seq`
-/// summed over the queue's physical stripes — two PK reads per lane,
-/// O(few rows) regardless of backlog size.
+/// control loop. Derives the count from enqueue and claim sequence cursors
+/// summed over the queue's physical stripes — two PK reads per lane, O(few
+/// rows) regardless of backlog size.
 ///
 /// This is intentionally a separate type from [`QueueCounts`]: the
 /// dispatcher claim hot path only consumes the available count, and
@@ -990,6 +994,20 @@ struct ReadyTransitionRow {
     unique_key: Option<Vec<u8>>,
     unique_states: Option<String>,
     payload: serde_json::Value,
+}
+
+#[derive(Debug, Clone)]
+struct ClaimCursorAdvance {
+    queue: String,
+    priority: i16,
+    enqueue_shard: i16,
+    next_seq: i64,
+    only_if_current: Option<i64>,
+}
+
+struct CancelJobTxResult {
+    row: JobRow,
+    claim_cursor_advance: Option<ClaimCursorAdvance>,
 }
 
 impl ReadyTransitionRow {
@@ -2668,7 +2686,7 @@ impl QueueStorage {
         // rows for this `(queue, priority, shard)` triple. The cache is
         // optimistic — if that earlier transaction rolled back, the head
         // row is missing even though the cache says it exists.
-        // `advance_enqueue_head` detects that case via the empty UPDATE
+        // `advance_enqueue_head` detects that case via the empty reserve
         // result, invalidates the cache entry, and re-runs
         // `ensure_lane_inserts` directly (bypassing this fast path).
         if self.lane_is_cached(queue, priority, enqueue_shard) {
@@ -2724,6 +2742,18 @@ impl QueueStorage {
             INSERT INTO {schema}.queue_claim_heads (queue, priority, enqueue_shard)
             VALUES ($1, $2, $3)
             ON CONFLICT (queue, priority, enqueue_shard) DO NOTHING
+            "#
+        ))
+        .bind(queue)
+        .bind(priority)
+        .bind(enqueue_shard)
+        .execute(tx.as_mut())
+        .await
+        .map_err(map_sqlx_error)?;
+
+        sqlx::query(&format!(
+            r#"
+            SELECT {schema}.ensure_lane_sequences($1, $2, $3)
             "#
         ))
         .bind(queue)
@@ -2835,13 +2865,13 @@ impl QueueStorage {
             .clear();
     }
 
-    // Advance `queue_enqueue_heads.next_seq` for a specific
+    // Reserve lane sequence numbers for a specific
     // `(queue, priority, shard)` triple and return the lane sequence at
     // which the caller's range starts. If the head row is missing —
     // typically because a previous ensure_lane ran inside a transaction
     // that ultimately rolled back, leaving a stale cache entry behind —
-    // the cache entry is invalidated, ensure_lane is re-run, and the
-    // UPDATE is retried exactly once. A second miss surfaces as
+    // the cache entry is invalidated, ensure_lane is re-run, and the reserve
+    // is retried exactly once. A second miss surfaces as
     // RowNotFound.
     async fn advance_enqueue_head<'a>(
         &self,
@@ -2854,10 +2884,9 @@ impl QueueStorage {
         let schema = self.schema();
         let sql = format!(
             r#"
-            UPDATE {schema}.queue_enqueue_heads
-            SET next_seq = next_seq + $4
+            SELECT {schema}.reserve_enqueue_seq($1, $2, $3, $4)
+            FROM {schema}.queue_enqueue_heads
             WHERE queue = $1 AND priority = $2 AND enqueue_shard = $3
-            RETURNING next_seq - $4
             "#
         );
 
@@ -2989,6 +3018,86 @@ impl QueueStorage {
         .fetch_all(tx.as_mut())
         .await
         .map_err(map_sqlx_error)
+    }
+
+    fn claim_cursor_advances(rows: &[ReadyJobLeaseRow]) -> Vec<ClaimCursorAdvance> {
+        let mut next_by_lane: BTreeMap<(String, i16, i16), i64> = BTreeMap::new();
+        for row in rows {
+            let key = (row.queue.clone(), row.lane_priority, row.enqueue_shard);
+            let next = row.lane_seq + 1;
+            next_by_lane
+                .entry(key)
+                .and_modify(|current| *current = (*current).max(next))
+                .or_insert(next);
+        }
+
+        next_by_lane
+            .into_iter()
+            .map(
+                |((queue, priority, enqueue_shard), next_seq)| ClaimCursorAdvance {
+                    queue,
+                    priority,
+                    enqueue_shard,
+                    next_seq,
+                    only_if_current: None,
+                },
+            )
+            .collect()
+    }
+
+    async fn advance_claim_cursors(&self, pool: &PgPool, advances: &[ClaimCursorAdvance]) {
+        // PostgreSQL sequence state is not rolled back with the surrounding
+        // transaction. Keep claim cursors lagging rather than risking a cursor
+        // that gets ahead of ready rows whose claim/cancel transaction aborts.
+        if let Err(err) = self.advance_claim_cursors_strict(pool, advances).await {
+            tracing::warn!(
+                error = ?err,
+                lanes = advances.len(),
+                "failed to advance queue-storage claim cursors after committed state change"
+            );
+        }
+    }
+
+    async fn advance_claim_cursors_strict(
+        &self,
+        pool: &PgPool,
+        advances: &[ClaimCursorAdvance],
+    ) -> Result<(), AwaError> {
+        if advances.is_empty() {
+            return Ok(());
+        }
+
+        let schema = self.schema();
+        let mut tx = pool.begin().await.map_err(map_sqlx_error)?;
+        for advance in advances {
+            sqlx::query(&format!(
+                r#"
+                WITH head AS MATERIALIZED (
+                    SELECT seq_name
+                    FROM {schema}.queue_claim_heads
+                    WHERE queue = $1
+                      AND priority = $2
+                      AND enqueue_shard = $3
+                    FOR UPDATE
+                )
+                SELECT {schema}.set_sequence_next(seq_name, $4)
+                FROM head
+                WHERE $5::bigint IS NULL
+                   OR {schema}.sequence_next_value(seq_name) = $5
+                "#
+            ))
+            .bind(&advance.queue)
+            .bind(advance.priority)
+            .bind(advance.enqueue_shard)
+            .bind(advance.next_seq)
+            .bind(advance.only_if_current)
+            .execute(tx.as_mut())
+            .await
+            .map_err(map_sqlx_error)?;
+        }
+
+        tx.commit().await.map_err(map_sqlx_error)?;
+        Ok(())
     }
 
     async fn execute_ready_inserts_tx<'a>(
@@ -3586,13 +3695,14 @@ impl QueueStorage {
         // or they can deadlock on the ON CONFLICT DO UPDATE. Sorted key
         // iteration removes that race entirely. See also the matching
         // ORDER BY in the fused CTE upsert.
-        let mut by_group: BTreeMap<(i32, String, i16, i16), i64> = BTreeMap::new();
+        let mut by_group: BTreeMap<(i32, String, i16, i16, i16), i64> = BTreeMap::new();
         for row in rows {
             let key = (
                 row.ready_slot,
                 row.queue.clone(),
                 row.priority,
                 row.enqueue_shard,
+                terminal_counter_bucket(row.job_id),
             );
             *by_group.entry(key).or_insert(0) += 1;
         }
@@ -3600,12 +3710,14 @@ impl QueueStorage {
         let mut queues: Vec<String> = Vec::with_capacity(by_group.len());
         let mut priorities: Vec<i16> = Vec::with_capacity(by_group.len());
         let mut enqueue_shards: Vec<i16> = Vec::with_capacity(by_group.len());
+        let mut counter_buckets: Vec<i16> = Vec::with_capacity(by_group.len());
         let mut deltas: Vec<i64> = Vec::with_capacity(by_group.len());
-        for ((slot, queue, prio, shard), delta) in by_group {
+        for ((slot, queue, prio, shard, bucket), delta) in by_group {
             ready_slots.push(slot);
             queues.push(queue);
             priorities.push(prio);
             enqueue_shards.push(shard);
+            counter_buckets.push(bucket);
             deltas.push(delta);
         }
         let schema = self.schema();
@@ -3614,14 +3726,14 @@ impl QueueStorage {
         sqlx::query(&format!(
             r#"
             INSERT INTO {schema}.queue_terminal_live_counts AS counts (
-                ready_slot, queue, priority, enqueue_shard, live_terminal_count
+                ready_slot, queue, priority, enqueue_shard, counter_bucket, live_terminal_count
             )
-            SELECT ready_slot, queue, priority, enqueue_shard, delta
+            SELECT ready_slot, queue, priority, enqueue_shard, counter_bucket, delta
             FROM unnest(
-                $1::int[], $2::text[], $3::smallint[], $4::smallint[], $5::bigint[]
-            ) AS d(ready_slot, queue, priority, enqueue_shard, delta)
-            ORDER BY ready_slot, queue, priority, enqueue_shard
-            ON CONFLICT (ready_slot, queue, priority, enqueue_shard) DO UPDATE
+                $1::int[], $2::text[], $3::smallint[], $4::smallint[], $5::smallint[], $6::bigint[]
+            ) AS d(ready_slot, queue, priority, enqueue_shard, counter_bucket, delta)
+            ORDER BY ready_slot, queue, priority, enqueue_shard, counter_bucket
+            ON CONFLICT (ready_slot, queue, priority, enqueue_shard, counter_bucket) DO UPDATE
             SET live_terminal_count = counts.live_terminal_count + EXCLUDED.live_terminal_count
             "#
         ))
@@ -3629,6 +3741,7 @@ impl QueueStorage {
         .bind(&queues)
         .bind(&priorities)
         .bind(&enqueue_shards)
+        .bind(&counter_buckets)
         .bind(&deltas)
         .execute(tx.as_mut())
         .await
@@ -3644,7 +3757,7 @@ impl QueueStorage {
     async fn decrement_live_terminal_counters_tx<'a>(
         &self,
         tx: &mut sqlx::Transaction<'a, sqlx::Postgres>,
-        rows: &[(i32, String, i16, i16)],
+        rows: &[(i32, String, i16, i16, i16)],
     ) -> Result<(), AwaError> {
         if rows.is_empty() {
             return Ok(());
@@ -3654,7 +3767,7 @@ impl QueueStorage {
         // its driving subquery; sorting the unnest input gives a stable
         // (slot, queue, priority, shard) lock-acquisition order across
         // concurrent transactions.
-        let mut by_group: BTreeMap<(i32, String, i16, i16), i64> = BTreeMap::new();
+        let mut by_group: BTreeMap<(i32, String, i16, i16, i16), i64> = BTreeMap::new();
         for key in rows {
             *by_group.entry(key.clone()).or_insert(0) += 1;
         }
@@ -3662,12 +3775,14 @@ impl QueueStorage {
         let mut queues: Vec<String> = Vec::with_capacity(by_group.len());
         let mut priorities: Vec<i16> = Vec::with_capacity(by_group.len());
         let mut enqueue_shards: Vec<i16> = Vec::with_capacity(by_group.len());
+        let mut counter_buckets: Vec<i16> = Vec::with_capacity(by_group.len());
         let mut deltas: Vec<i64> = Vec::with_capacity(by_group.len());
-        for ((slot, queue, prio, shard), delta) in by_group {
+        for ((slot, queue, prio, shard, bucket), delta) in by_group {
             ready_slots.push(slot);
             queues.push(queue);
             priorities.push(prio);
             enqueue_shards.push(shard);
+            counter_buckets.push(bucket);
             deltas.push(delta);
         }
         let schema = self.schema();
@@ -3676,22 +3791,24 @@ impl QueueStorage {
             UPDATE {schema}.queue_terminal_live_counts AS counts
             SET live_terminal_count = GREATEST(0, counts.live_terminal_count - sorted.delta)
             FROM (
-                SELECT ready_slot, queue, priority, enqueue_shard, delta
+                SELECT ready_slot, queue, priority, enqueue_shard, counter_bucket, delta
                 FROM unnest(
-                    $1::int[], $2::text[], $3::smallint[], $4::smallint[], $5::bigint[]
-                ) AS d(ready_slot, queue, priority, enqueue_shard, delta)
-                ORDER BY ready_slot, queue, priority, enqueue_shard
+                    $1::int[], $2::text[], $3::smallint[], $4::smallint[], $5::smallint[], $6::bigint[]
+                ) AS d(ready_slot, queue, priority, enqueue_shard, counter_bucket, delta)
+                ORDER BY ready_slot, queue, priority, enqueue_shard, counter_bucket
             ) AS sorted
             WHERE counts.ready_slot     = sorted.ready_slot
               AND counts.queue          = sorted.queue
               AND counts.priority       = sorted.priority
               AND counts.enqueue_shard  = sorted.enqueue_shard
+              AND counts.counter_bucket = sorted.counter_bucket
             "#
         ))
         .bind(&ready_slots)
         .bind(&queues)
         .bind(&priorities)
         .bind(&enqueue_shards)
+        .bind(&counter_buckets)
         .bind(&deltas)
         .execute(tx.as_mut())
         .await
@@ -3703,7 +3820,7 @@ impl QueueStorage {
     /// from a slice of `DoneJobRow` (used by retry-from-terminal,
     /// DLQ move, and discard, all of which DELETE FROM done_entries
     /// with `RETURNING *` materialised into `DoneJobRow`).
-    fn done_rows_to_counter_keys(rows: &[DoneJobRow]) -> Vec<(i32, String, i16, i16)> {
+    fn done_rows_to_counter_keys(rows: &[DoneJobRow]) -> Vec<(i32, String, i16, i16, i16)> {
         rows.iter()
             .map(|row| {
                 (
@@ -3711,6 +3828,7 @@ impl QueueStorage {
                     row.queue.clone(),
                     row.priority,
                     row.enqueue_shard,
+                    terminal_counter_bucket(row.job_id),
                 )
             })
             .collect()
@@ -4265,12 +4383,15 @@ impl QueueStorage {
                 .await?,
             );
         }
+        let claim_cursor_advances = Self::claim_cursor_advances(&claimed_rows);
         let claimed = claimed_rows
             .into_iter()
             .map(|row| row.claim_ref(self.lease_claim_receipts()))
             .collect();
 
         tx.commit().await.map_err(map_sqlx_error)?;
+        self.advance_claim_cursors(pool, &claim_cursor_advances)
+            .await;
         Ok(claimed)
     }
 
@@ -4389,17 +4510,25 @@ impl QueueStorage {
             // timestamp, so a post-commit conversion error would strand the
             // materialized lease indefinitely. Keep the old rollback semantics
             // for that path.
-            let claimed = claimed
-                .into_iter()
+            let converted = claimed
+                .iter()
+                .cloned()
                 .map(|row| row.into_claimed_runtime_job(use_lease_claim_receipts))
                 .collect::<Result<Vec<_>, _>>()?;
+            let claim_cursor_advances = Self::claim_cursor_advances(&claimed);
             tx.commit().await.map_err(map_sqlx_error)?;
-            return Ok(claimed);
+            self.advance_claim_cursors(pool, &claim_cursor_advances)
+                .await;
+            return Ok(converted);
         }
+
+        let claim_cursor_advances = Self::claim_cursor_advances(&claimed);
 
         // Release claim locks before doing Rust-side payload conversion; this
         // keeps the hot claim transaction focused on database state changes.
         tx.commit().await.map_err(map_sqlx_error)?;
+        self.advance_claim_cursors(pool, &claim_cursor_advances)
+            .await;
 
         claimed
             .into_iter()
@@ -4593,10 +4722,10 @@ impl QueueStorage {
         signal: &AvailableSignal,
         max_claimers: i16,
     ) -> i16 {
-        // The signal source `queue_enqueue_heads.next_seq -
-        // queue_claim_heads.claim_seq` counts lane positions enqueued
-        // but not yet claimed, so we don't subtract a running count —
-        // already-claimed rows are excluded by the claim_seq advance.
+        // The signal source counts sequence positions reserved for enqueue
+        // but not yet claimed. It can over-count deleted or uncommitted
+        // positions, but already-claimed rows are excluded by the claim cursor
+        // advance.
         // `backlog` is retained as a separate name in the threshold
         // table to keep room for shape tweaks that diverge from
         // `available` later.
@@ -4712,14 +4841,14 @@ impl QueueStorage {
 
     /// Cheap, dispatcher-grade available-count signal.
     ///
-    /// Sums `next_seq - claim_seq` across the queue's (queue, priority)
-    /// lanes — one PK read into each of the two head tables per lane
+    /// Sums `enqueue_cursor - claim_cursor` across the queue's
+    /// (queue, priority) lanes — one PK read into each of the two head tables per lane
     /// (typically ≤ 4 lanes per logical queue). The difference is an
     /// upper bound on the count of unclaimed ready rows: admin DELETEs
-    /// of unclaimed jobs leave a gap between `claim_seq` and `next_seq`
-    /// until the next claim attempt's gap-recovery branch closes it.
-    /// The dispatcher tolerates this drift because the worst case is
-    /// one wasted claim attempt that finds no rows.
+    /// of unclaimed jobs and in-flight enqueue reservations can leave a
+    /// gap between `claim_cursor` and `enqueue_cursor`. The dispatcher
+    /// tolerates this drift because the worst case is a wasted claim
+    /// attempt that finds no committed rows.
     ///
     /// For an exact count, use [`Self::queue_counts_exact`], which
     /// scans `ready_entries`.
@@ -4732,7 +4861,14 @@ impl QueueStorage {
         let queues = self.physical_queues_for_logical(queue);
         let available: i64 = sqlx::query_scalar(&format!(
             r#"
-            SELECT COALESCE(sum(GREATEST(qe.next_seq - qc.claim_seq, 0)), 0)::bigint
+            SELECT COALESCE(
+                sum(GREATEST(
+                    {schema}.sequence_next_value(qe.seq_name)
+                        - {schema}.sequence_next_value(qc.seq_name),
+                    0
+                )),
+                0
+            )::bigint
             FROM {schema}.queue_enqueue_heads AS qe
             JOIN {schema}.queue_claim_heads AS qc
               ON qc.queue = qe.queue
@@ -5072,22 +5208,27 @@ impl QueueStorage {
             -- differed.
             counter_upsert AS (
                 INSERT INTO {schema}.queue_terminal_live_counts AS counts (
-                    ready_slot, queue, priority, enqueue_shard, live_terminal_count
+                    ready_slot, queue, priority, enqueue_shard, counter_bucket, live_terminal_count
                 )
                 SELECT
-                    ready_slot, queue, priority, enqueue_shard, delta
+                    ready_slot, queue, priority, enqueue_shard, counter_bucket, delta
                 FROM (
                     SELECT
                         terminal.ready_slot,
                         terminal.queue,
                         terminal.priority,
                         terminal.enqueue_shard,
+                        mod(
+                            mod(terminal.job_id, {TERMINAL_COUNTER_BUCKETS}::bigint)
+                                + {TERMINAL_COUNTER_BUCKETS}::bigint,
+                            {TERMINAL_COUNTER_BUCKETS}::bigint
+                        )::smallint AS counter_bucket,
                         count(*)::bigint AS delta
                     FROM terminal
-                    GROUP BY terminal.ready_slot, terminal.queue, terminal.priority, terminal.enqueue_shard
+                    GROUP BY terminal.ready_slot, terminal.queue, terminal.priority, terminal.enqueue_shard, counter_bucket
                 ) AS grouped
-                ORDER BY ready_slot, queue, priority, enqueue_shard
-                ON CONFLICT (ready_slot, queue, priority, enqueue_shard) DO UPDATE
+                ORDER BY ready_slot, queue, priority, enqueue_shard, counter_bucket
+                ON CONFLICT (ready_slot, queue, priority, enqueue_shard, counter_bucket) DO UPDATE
                 SET live_terminal_count = counts.live_terminal_count + EXCLUDED.live_terminal_count
                 RETURNING 1
             )
@@ -5607,9 +5748,9 @@ impl QueueStorage {
 
     /// Exact admin/UI-grade queue counts. Scans `ready_entries` rather
     /// than reading the head tables — slower, but unaffected by the
-    /// transient gap between admin DELETE of an unclaimed row and the
-    /// dispatcher's next gap-recovery pass. Use [`Self::queue_claimer_signal`]
-    /// for the dispatcher hot path.
+    /// transient gap between sequence reservations and committed,
+    /// still-claimable ready rows. Use [`Self::queue_claimer_signal`] for the
+    /// dispatcher hot path.
     ///
     /// The live-terminal portion reads from `queue_terminal_live_counts`
     /// (the #290 denormaliser) when [`Self::terminal_counter_trusted`]
@@ -5657,11 +5798,11 @@ impl QueueStorage {
             WITH lane_counts AS (
                 -- Exact count: a ready row is available iff its
                 -- lane_seq has not yet been passed by the lane's
-                -- claim_seq cursor. Each shard within a (queue,
+                -- claim sequence cursor. Each shard within a (queue,
                 -- priority) lane carries its own sequence, so the
                 -- join matches on shard too — otherwise a ready row
                 -- in shard A could be incorrectly compared against
-                -- shard B's claim_seq.
+                -- shard B's claim cursor.
                 SELECT COALESCE(count(*)::bigint, 0) AS available
                 FROM {schema}.ready_entries AS ready
                 JOIN {schema}.queue_claim_heads AS claims
@@ -5669,7 +5810,7 @@ impl QueueStorage {
                  AND claims.priority = ready.priority
                  AND claims.enqueue_shard = ready.enqueue_shard
                 WHERE ready.queue = ANY($1)
-                  AND ready.lane_seq >= claims.claim_seq
+                  AND ready.lane_seq >= {schema}.sequence_next_value(claims.seq_name)
             ),
             pruned_terminal AS (
                 SELECT COALESCE(
@@ -5755,11 +5896,10 @@ impl QueueStorage {
     /// - **available** is the same as the dispatcher's claim signal:
     ///   `sum(GREATEST(enqueue_seq - claim_seq, 0))` over the shard
     ///   head tables. No scan of `ready_entries`. This is an upper
-    ///   bound — the dispatcher closes the gap on its next claim
-    ///   attempt, but an admin DELETE of an unclaimed row leaves the
-    ///   head sequence ahead of the actual ready row count until that
-    ///   recovery branch runs. Acceptable for depth-target throttling
-    ///   and dashboards; not suitable for exact billing-style counts.
+    ///   bound: admin DELETEs, committed gaps, and uncommitted enqueue
+    ///   reservations can leave the enqueue sequence ahead of the actual
+    ///   ready row count. Acceptable for depth-target throttling and
+    ///   dashboards; not suitable for exact billing-style counts.
     /// - **running** matches [`Self::queue_counts`]'s strict definition:
     ///   `leases.state = 'running'` only. Receipt-plane claims that
     ///   have not yet materialised a lease row are omitted (the
@@ -6095,7 +6235,7 @@ impl QueueStorage {
         &self,
         tx: &mut sqlx::Transaction<'a, sqlx::Postgres>,
         job_id: i64,
-    ) -> Result<Option<JobRow>, AwaError> {
+    ) -> Result<Option<CancelJobTxResult>, AwaError> {
         let schema = self.schema();
         let ready: Option<ReadyTransitionRow> = sqlx::query_as(&format!(
             r#"
@@ -6113,7 +6253,7 @@ impl QueueStorage {
                  AND claims.priority = ready.priority
                  AND claims.enqueue_shard = ready.enqueue_shard
                 WHERE ready.job_id = $1
-                  AND ready.lane_seq >= claims.claim_seq
+                  AND ready.lane_seq >= {schema}.sequence_next_value(claims.seq_name)
                 ORDER BY ready.lane_seq DESC
                 LIMIT 1
                 FOR UPDATE SKIP LOCKED
@@ -6152,31 +6292,24 @@ impl QueueStorage {
             self.insert_done_rows_tx(tx, std::slice::from_ref(&done), Some(JobState::Available))
                 .await?;
             // If the cancelled lane was *exactly* at the claim head,
-            // advance the head past it so the derived
-            // `next_seq - claim_seq` count drops by 1 immediately.
+            // advance the head past it so the derived cursor-difference count
+            // drops by 1 immediately.
             // When other unclaimed lanes still sit between claim_seq
             // and the cancelled lane_seq, leave claim_seq alone —
             // advancing would skip past those still-claimable rows.
-            // The dispatcher's gap-recovery branch absorbs the
-            // transient over-count when claim_seq later catches up.
-            sqlx::query(&format!(
-                r#"
-                UPDATE {schema}.queue_claim_heads
-                SET claim_seq = claim_seq + 1
-                WHERE queue = $1
-                  AND priority = $2
-                  AND enqueue_shard = $3
-                  AND claim_seq = $4
-                "#
-            ))
-            .bind(&ready.queue)
-            .bind(ready.priority)
-            .bind(ready.enqueue_shard)
-            .bind(ready.lane_seq)
-            .execute(tx.as_mut())
-            .await
-            .map_err(map_sqlx_error)?;
-            return Ok(Some(done.into_job_row()?));
+            // Non-head deletes can leave a bounded dispatcher over-count until
+            // later committed rows on the lane are claimed.
+            let claim_cursor_advance = ClaimCursorAdvance {
+                queue: ready.queue.clone(),
+                priority: ready.priority,
+                enqueue_shard: ready.enqueue_shard,
+                next_seq: ready.lane_seq + 1,
+                only_if_current: Some(ready.lane_seq),
+            };
+            return Ok(Some(CancelJobTxResult {
+                row: done.into_job_row()?,
+                claim_cursor_advance: Some(claim_cursor_advance),
+            }));
         }
 
         let deleted_lease: Vec<DeletedLeaseRow> = sqlx::query_as(&format!(
@@ -6230,7 +6363,10 @@ impl QueueStorage {
             // Wake any worker currently executing this attempt.
             self.notify_cancellation_tx(tx, lease.job_id, lease.run_lease)
                 .await?;
-            return Ok(Some(done.into_job_row()?));
+            return Ok(Some(CancelJobTxResult {
+                row: done.into_job_row()?,
+                claim_cursor_advance: None,
+            }));
         }
 
         // ADR-023 receipt-only cancel: the job may be running on a
@@ -6401,7 +6537,10 @@ impl QueueStorage {
                 .await
                 .map_err(map_sqlx_error)?;
                 self.notify_cancellation_tx(tx, job_id, run_lease).await?;
-                return Ok(Some(done.into_job_row()?));
+                return Ok(Some(CancelJobTxResult {
+                    row: done.into_job_row()?,
+                    claim_cursor_advance: None,
+                }));
             }
         }
 
@@ -6469,7 +6608,10 @@ impl QueueStorage {
             };
             self.insert_done_rows_tx(tx, std::slice::from_ref(&done), Some(deferred.state))
                 .await?;
-            return Ok(Some(done.into_job_row()?));
+            return Ok(Some(CancelJobTxResult {
+                row: done.into_job_row()?,
+                claim_cursor_advance: None,
+            }));
         }
 
         Ok(None)
@@ -6477,9 +6619,17 @@ impl QueueStorage {
 
     pub async fn cancel_job(&self, pool: &PgPool, job_id: i64) -> Result<Option<JobRow>, AwaError> {
         let mut tx = pool.begin().await.map_err(map_sqlx_error)?;
-        let row = self.cancel_job_tx(&mut tx, job_id).await?;
+        let result = self.cancel_job_tx(&mut tx, job_id).await?;
         tx.commit().await.map_err(map_sqlx_error)?;
-        Ok(row)
+        if let Some(result) = result {
+            if let Some(advance) = result.claim_cursor_advance.as_ref() {
+                self.advance_claim_cursors(pool, std::slice::from_ref(advance))
+                    .await;
+            }
+            Ok(Some(result.row))
+        } else {
+            Ok(None)
+        }
     }
 
     pub async fn cancel_jobs_by_ids(
@@ -6493,12 +6643,18 @@ impl QueueStorage {
 
         let mut tx = pool.begin().await.map_err(map_sqlx_error)?;
         let mut rows = Vec::with_capacity(ids.len());
+        let mut claim_cursor_advances = Vec::new();
         for job_id in ids {
-            if let Some(row) = self.cancel_job_tx(&mut tx, *job_id).await? {
-                rows.push(row);
+            if let Some(result) = self.cancel_job_tx(&mut tx, *job_id).await? {
+                if let Some(advance) = result.claim_cursor_advance {
+                    claim_cursor_advances.push(advance);
+                }
+                rows.push(result.row);
             }
         }
         tx.commit().await.map_err(map_sqlx_error)?;
+        self.advance_claim_cursors(pool, &claim_cursor_advances)
+            .await;
         Ok(rows)
     }
 
@@ -6533,7 +6689,7 @@ impl QueueStorage {
                   ON claims.queue = ready.queue
                  AND claims.priority = ready.priority
                  AND claims.enqueue_shard = ready.enqueue_shard
-                WHERE ready.lane_seq >= claims.claim_seq
+                WHERE ready.lane_seq >= {schema}.sequence_next_value(claims.seq_name)
                   AND ready.priority > 1
                   AND ready.run_at <= $1
                 ORDER BY ready.run_at ASC, ready.lane_seq ASC
@@ -6608,14 +6764,11 @@ impl QueueStorage {
             });
         }
 
-        // Aging deletes ready rows from the source lane without
-        // moving the source's claim_seq, then re-inserts on the
-        // target lane (which bumps target's next_seq). The source's
-        // derived `next_seq - claim_seq` over-counts by `moved` until
-        // the dispatcher's next claim attempt on that lane hits the
-        // gap-recovery branch in `claim_ready_runtime` and catches
-        // claim_seq up. The drift is bounded by aging rate × poll
-        // interval and self-corrects.
+        // Aging deletes ready rows from the source lane without moving the
+        // source's claim cursor, then re-inserts on the target lane. The
+        // source lane can temporarily over-count by `moved`; later successful
+        // claims on that lane advance the cursor again. The drift is bounded
+        // by aging rate × poll interval.
         self.insert_existing_ready_rows_tx(&mut tx, ready_rows, Some(JobState::Available))
             .await?;
         self.notify_queues_tx(&mut tx, queues).await?;
@@ -10207,16 +10360,21 @@ impl QueueStorage {
             r#"
             WITH inserted AS (
                 INSERT INTO {schema}.queue_terminal_live_counts AS counts (
-                    ready_slot, queue, priority, enqueue_shard, live_terminal_count
+                    ready_slot, queue, priority, enqueue_shard, counter_bucket, live_terminal_count
                 )
                 SELECT
                     ready_slot,
                     queue,
                     priority,
                     enqueue_shard,
+                    mod(
+                        mod(job_id, {TERMINAL_COUNTER_BUCKETS}::bigint)
+                            + {TERMINAL_COUNTER_BUCKETS}::bigint,
+                        {TERMINAL_COUNTER_BUCKETS}::bigint
+                    )::smallint AS counter_bucket,
                     count(*)::bigint
                 FROM {schema}.done_entries
-                GROUP BY ready_slot, queue, priority, enqueue_shard
+                GROUP BY ready_slot, queue, priority, enqueue_shard, counter_bucket
                 RETURNING 1
             )
             SELECT COALESCE(count(*), 0)::bigint FROM inserted

--- a/awa-model/src/queue_storage.rs
+++ b/awa-model/src/queue_storage.rs
@@ -552,6 +552,49 @@ mod ring_slot_tests {
     }
 }
 
+#[cfg(test)]
+mod claim_cursor_advance_tests {
+    use super::{ClaimCursorAdvance, QueueStorage};
+
+    fn advance(next_seq: i64, only_if_current: Option<i64>) -> ClaimCursorAdvance {
+        ClaimCursorAdvance {
+            queue: "queue".to_string(),
+            priority: 2,
+            enqueue_shard: 0,
+            next_seq,
+            only_if_current,
+        }
+    }
+
+    #[test]
+    fn normalize_claim_cursor_advances_sorts_conditional_lane_updates() {
+        let normalized = QueueStorage::normalize_claim_cursor_advances(&[
+            advance(7, Some(6)),
+            advance(6, Some(5)),
+            advance(8, Some(7)),
+        ]);
+
+        let ordered: Vec<(i64, i64)> = normalized
+            .iter()
+            .map(|advance| (advance.only_if_current.unwrap(), advance.next_seq))
+            .collect();
+        assert_eq!(ordered, vec![(5, 6), (6, 7), (7, 8)]);
+    }
+
+    #[test]
+    fn normalize_claim_cursor_advances_coalesces_unconditional_lane_updates() {
+        let normalized = QueueStorage::normalize_claim_cursor_advances(&[
+            advance(3, None),
+            advance(5, None),
+            advance(4, Some(3)),
+        ]);
+
+        assert_eq!(normalized.len(), 1);
+        assert_eq!(normalized[0].next_seq, 5);
+        assert_eq!(normalized[0].only_if_current, None);
+    }
+}
+
 fn default_payload_metadata() -> serde_json::Value {
     serde_json::json!({})
 }
@@ -3045,16 +3088,85 @@ impl QueueStorage {
             .collect()
     }
 
+    fn normalize_claim_cursor_advances(advances: &[ClaimCursorAdvance]) -> Vec<ClaimCursorAdvance> {
+        let mut grouped: BTreeMap<(String, i16, i16), (Option<i64>, BTreeMap<i64, i64>)> =
+            BTreeMap::new();
+
+        for advance in advances {
+            let key = (
+                advance.queue.clone(),
+                advance.priority,
+                advance.enqueue_shard,
+            );
+            let (unconditional, conditional) = grouped.entry(key).or_default();
+            if let Some(only_if_current) = advance.only_if_current {
+                conditional
+                    .entry(only_if_current)
+                    .and_modify(|next| *next = (*next).max(advance.next_seq))
+                    .or_insert(advance.next_seq);
+            } else {
+                *unconditional = Some(
+                    unconditional
+                        .map(|next| next.max(advance.next_seq))
+                        .unwrap_or(advance.next_seq),
+                );
+            }
+        }
+
+        let mut normalized = Vec::with_capacity(advances.len());
+        for ((queue, priority, enqueue_shard), (unconditional, conditional)) in grouped {
+            if let Some(next_seq) = unconditional {
+                normalized.push(ClaimCursorAdvance {
+                    queue,
+                    priority,
+                    enqueue_shard,
+                    next_seq,
+                    only_if_current: None,
+                });
+                continue;
+            }
+
+            for (only_if_current, next_seq) in conditional {
+                normalized.push(ClaimCursorAdvance {
+                    queue: queue.clone(),
+                    priority,
+                    enqueue_shard,
+                    next_seq,
+                    only_if_current: Some(only_if_current),
+                });
+            }
+        }
+
+        normalized
+    }
+
     async fn advance_claim_cursors(&self, pool: &PgPool, advances: &[ClaimCursorAdvance]) {
+        let advances = Self::normalize_claim_cursor_advances(advances);
         // PostgreSQL sequence state is not rolled back with the surrounding
         // transaction. Keep claim cursors lagging rather than risking a cursor
         // that gets ahead of ready rows whose claim/cancel transaction aborts.
-        if let Err(err) = self.advance_claim_cursors_strict(pool, advances).await {
-            tracing::warn!(
-                error = ?err,
-                lanes = advances.len(),
-                "failed to advance queue-storage claim cursors after committed state change"
-            );
+        for attempt in 1..=3 {
+            match self.advance_claim_cursors_strict(pool, &advances).await {
+                Ok(()) => return,
+                Err(err) if attempt < 3 => {
+                    tracing::warn!(
+                        error = ?err,
+                        lanes = advances.len(),
+                        attempt,
+                        "failed to advance queue-storage claim cursors after committed state change; retrying"
+                    );
+                    tokio::time::sleep(Duration::from_millis(25 * attempt as u64)).await;
+                }
+                Err(err) => {
+                    tracing::warn!(
+                        error = ?err,
+                        lanes = advances.len(),
+                        attempts = attempt,
+                        "failed to advance queue-storage claim cursors after committed state change"
+                    );
+                    return;
+                }
+            }
         }
     }
 

--- a/awa-model/src/queue_storage.rs
+++ b/awa-model/src/queue_storage.rs
@@ -1048,6 +1048,11 @@ struct ClaimCursorAdvance {
     only_if_current: Option<i64>,
 }
 
+type ClaimCursorLaneKey = (String, i16, i16);
+type ConditionalClaimCursorAdvances = BTreeMap<i64, i64>;
+type GroupedClaimCursorAdvances =
+    BTreeMap<ClaimCursorLaneKey, (Option<i64>, ConditionalClaimCursorAdvances)>;
+
 struct CancelJobTxResult {
     row: JobRow,
     claim_cursor_advance: Option<ClaimCursorAdvance>,
@@ -3064,7 +3069,7 @@ impl QueueStorage {
     }
 
     fn claim_cursor_advances(rows: &[ReadyJobLeaseRow]) -> Vec<ClaimCursorAdvance> {
-        let mut next_by_lane: BTreeMap<(String, i16, i16), i64> = BTreeMap::new();
+        let mut next_by_lane: BTreeMap<ClaimCursorLaneKey, i64> = BTreeMap::new();
         for row in rows {
             let key = (row.queue.clone(), row.lane_priority, row.enqueue_shard);
             let next = row.lane_seq + 1;
@@ -3089,8 +3094,7 @@ impl QueueStorage {
     }
 
     fn normalize_claim_cursor_advances(advances: &[ClaimCursorAdvance]) -> Vec<ClaimCursorAdvance> {
-        let mut grouped: BTreeMap<(String, i16, i16), (Option<i64>, BTreeMap<i64, i64>)> =
-            BTreeMap::new();
+        let mut grouped: GroupedClaimCursorAdvances = BTreeMap::new();
 
         for advance in advances {
             let key = (

--- a/awa-model/tests/queue_storage_copy_test.rs
+++ b/awa-model/tests/queue_storage_copy_test.rs
@@ -105,6 +105,31 @@ fn bench_env_usize(name: &str, default: usize) -> usize {
         .unwrap_or(default)
 }
 
+async fn lane_available_count(pool: &PgPool, schema: &str, queues: Vec<String>) -> i64 {
+    sqlx::query_scalar(&format!(
+        r#"
+        SELECT COALESCE(
+            sum(GREATEST(
+                {schema}.sequence_next_value(qe.seq_name)
+                  - {schema}.sequence_next_value(qc.seq_name),
+                0
+            )),
+            0
+        )::bigint
+        FROM {schema}.queue_enqueue_heads AS qe
+        JOIN {schema}.queue_claim_heads AS qc
+          ON qc.queue = qe.queue
+         AND qc.priority = qe.priority
+         AND qc.enqueue_shard = qe.enqueue_shard
+        WHERE qe.queue = ANY($1)
+        "#
+    ))
+    .bind(queues)
+    .fetch_one(pool)
+    .await
+    .expect("count lane availability")
+}
+
 #[tokio::test]
 async fn queue_storage_copy_enqueues_ready_and_deferred_rows() {
     let _guard = QUEUE_STORAGE_COPY_LOCK.lock().await;
@@ -206,22 +231,8 @@ async fn queue_storage_copy_enqueues_ready_and_deferred_rows() {
     .expect("count deferred rows");
     assert_eq!(deferred_count, 1);
 
-    // Available count is derived from queue_enqueue_heads.next_seq -
-    // queue_claim_heads.claim_seq.
-    let available_count: i64 = sqlx::query_scalar(&format!(
-        "SELECT GREATEST(qe.next_seq - qc.claim_seq, 0)
-         FROM {schema}.queue_enqueue_heads AS qe
-         JOIN {schema}.queue_claim_heads AS qc
-           ON qc.queue = qe.queue
-          AND qc.priority = qe.priority
-          AND qc.enqueue_shard = qe.enqueue_shard
-         WHERE qe.queue = $1 AND qe.priority = 1",
-        schema = store.schema()
-    ))
-    .bind(queue)
-    .fetch_one(&pool)
-    .await
-    .expect("read lane count");
+    let available_count =
+        lane_available_count(&pool, store.schema(), vec![queue.to_string()]).await;
     assert_eq!(available_count, 2);
 }
 
@@ -268,14 +279,7 @@ async fn queue_storage_copy_rolls_back_on_unique_conflict() {
     .expect("count ready rows");
     assert_eq!(ready_count, 0);
 
-    let lane_available: i64 = sqlx::query_scalar(&format!(
-        "SELECT COALESCE(sum(GREATEST(qe.next_seq - qc.claim_seq, 0)), 0)::bigint FROM {0}.queue_enqueue_heads qe JOIN {0}.queue_claim_heads qc ON qc.queue = qe.queue AND qc.priority = qe.priority AND qc.enqueue_shard = qe.enqueue_shard WHERE qe.queue = $1",
-        store.schema()
-    ))
-    .bind(queue)
-    .fetch_one(&pool)
-    .await
-    .expect("count lane availability");
+    let lane_available = lane_available_count(&pool, store.schema(), vec![queue.to_string()]).await;
     assert_eq!(lane_available, 0);
 }
 
@@ -322,14 +326,7 @@ async fn queue_storage_batch_rolls_back_on_batched_unique_conflict() {
     .expect("count ready rows");
     assert_eq!(ready_count, 0);
 
-    let lane_available: i64 = sqlx::query_scalar(&format!(
-        "SELECT COALESCE(sum(GREATEST(qe.next_seq - qc.claim_seq, 0)), 0)::bigint FROM {0}.queue_enqueue_heads qe JOIN {0}.queue_claim_heads qc ON qc.queue = qe.queue AND qc.priority = qe.priority AND qc.enqueue_shard = qe.enqueue_shard WHERE qe.queue = $1",
-        store.schema()
-    ))
-    .bind(queue)
-    .fetch_one(&pool)
-    .await
-    .expect("count lane availability");
+    let lane_available = lane_available_count(&pool, store.schema(), vec![queue.to_string()]).await;
     assert_eq!(lane_available, 0);
 }
 
@@ -376,14 +373,7 @@ async fn queue_storage_copy_rolls_back_on_existing_unique_conflict() {
     .expect("count ready rows");
     assert_eq!(ready_count, 1);
 
-    let lane_available: i64 = sqlx::query_scalar(&format!(
-        "SELECT COALESCE(sum(GREATEST(qe.next_seq - qc.claim_seq, 0)), 0)::bigint FROM {0}.queue_enqueue_heads qe JOIN {0}.queue_claim_heads qc ON qc.queue = qe.queue AND qc.priority = qe.priority AND qc.enqueue_shard = qe.enqueue_shard WHERE qe.queue = $1",
-        store.schema()
-    ))
-    .bind(queue)
-    .fetch_one(&pool)
-    .await
-    .expect("count lane availability");
+    let lane_available = lane_available_count(&pool, store.schema(), vec![queue.to_string()]).await;
     assert_eq!(lane_available, 1);
 }
 
@@ -440,14 +430,8 @@ async fn queue_storage_copy_concurrent_lane_seq_is_dense() {
         assert_eq!(actual_seq, first_seq + offset as i64);
     }
 
-    let available_count: i64 = sqlx::query_scalar(&format!(
-        "SELECT COALESCE(sum(GREATEST(qe.next_seq - qc.claim_seq, 0)), 0)::bigint FROM {0}.queue_enqueue_heads qe JOIN {0}.queue_claim_heads qc ON qc.queue = qe.queue AND qc.priority = qe.priority AND qc.enqueue_shard = qe.enqueue_shard WHERE qe.queue = $1",
-        store.schema()
-    ))
-    .bind(queue)
-    .fetch_one(&pool)
-    .await
-    .expect("read available count");
+    let available_count =
+        lane_available_count(&pool, store.schema(), vec![queue.to_string()]).await;
     assert_eq!(available_count, expected);
 }
 
@@ -485,14 +469,12 @@ async fn queue_storage_copy_distributes_across_stripes() {
         assert_eq!(seqs[1], seqs[0] + 1, "unexpected lane seqs for {physical}");
     }
 
-    let available_count: i64 = sqlx::query_scalar(&format!(
-        "SELECT COALESCE(sum(GREATEST(qe.next_seq - qc.claim_seq, 0)), 0)::bigint FROM {0}.queue_enqueue_heads qe JOIN {0}.queue_claim_heads qc ON qc.queue = qe.queue AND qc.priority = qe.priority AND qc.enqueue_shard = qe.enqueue_shard WHERE qe.queue = ANY($1)",
-        store.schema()
-    ))
-    .bind((0..4).map(|stripe| format!("{queue}#{stripe}")).collect::<Vec<_>>())
-    .fetch_one(&pool)
-    .await
-    .expect("read striped available count");
+    let available_count = lane_available_count(
+        &pool,
+        store.schema(),
+        (0..4).map(|stripe| format!("{queue}#{stripe}")).collect(),
+    )
+    .await;
     assert_eq!(available_count, 8);
 }
 

--- a/awa-python/python/awa/_awa.pyi
+++ b/awa-python/python/awa/_awa.pyi
@@ -496,7 +496,7 @@ class Client:
         queue_storage_claim_slot_count: int = 8,
         queue_storage_queue_stripe_count: int = 1,
         queue_storage_queue_rotate_interval_ms: int = 1000,
-        queue_storage_lease_rotate_interval_ms: int = 50,
+        queue_storage_lease_rotate_interval_ms: int = 250,
         queue_storage_claim_rotate_interval_ms: int | None = None,
         storage_transition_role: str | None = None,
     ) -> None: ...

--- a/awa-python/python/awa/client.py
+++ b/awa-python/python/awa/client.py
@@ -671,7 +671,7 @@ class AsyncClient:
         queue_storage_claim_slot_count: int = DEFAULT_QUEUE_STORAGE_CLAIM_SLOT_COUNT,
         queue_storage_queue_stripe_count: int = DEFAULT_QUEUE_STORAGE_QUEUE_STRIPE_COUNT,
         queue_storage_queue_rotate_interval_ms: int = 1000,
-        queue_storage_lease_rotate_interval_ms: int = 50,
+        queue_storage_lease_rotate_interval_ms: int = 250,
         queue_storage_claim_rotate_interval_ms: int | None = None,
         storage_transition_role: Literal[
             "auto", "canonical_drain", "queue_storage_target"

--- a/awa-python/src/client.rs
+++ b/awa-python/src/client.rs
@@ -1501,7 +1501,7 @@ impl PyClient {
         })
     }
 
-    #[pyo3(signature = (queues=None, *, poll_interval_ms=200, global_max_workers=None, completed_retention_hours=None, failed_retention_hours=None, descriptor_retention_days=None, cleanup_batch_size=None, leader_election_interval_ms=None, heartbeat_interval_ms=None, promote_interval_ms=None, heartbeat_rescue_interval_ms=None, heartbeat_staleness_ms=None, deadline_rescue_interval_ms=None, callback_rescue_interval_ms=None, queue_storage_schema=None, queue_storage_queue_slot_count=16, queue_storage_lease_slot_count=8, queue_storage_claim_slot_count=8, queue_storage_queue_stripe_count=1, queue_storage_queue_rotate_interval_ms=1000, queue_storage_lease_rotate_interval_ms=50, queue_storage_claim_rotate_interval_ms=None, storage_transition_role=None))]
+    #[pyo3(signature = (queues=None, *, poll_interval_ms=200, global_max_workers=None, completed_retention_hours=None, failed_retention_hours=None, descriptor_retention_days=None, cleanup_batch_size=None, leader_election_interval_ms=None, heartbeat_interval_ms=None, promote_interval_ms=None, heartbeat_rescue_interval_ms=None, heartbeat_staleness_ms=None, deadline_rescue_interval_ms=None, callback_rescue_interval_ms=None, queue_storage_schema=None, queue_storage_queue_slot_count=16, queue_storage_lease_slot_count=8, queue_storage_claim_slot_count=8, queue_storage_queue_stripe_count=1, queue_storage_queue_rotate_interval_ms=1000, queue_storage_lease_rotate_interval_ms=250, queue_storage_claim_rotate_interval_ms=None, storage_transition_role=None))]
     #[allow(clippy::too_many_arguments)]
     fn start<'py>(
         &self,

--- a/awa-python/tests/test_awa.py
+++ b/awa-python/tests/test_awa.py
@@ -327,16 +327,20 @@ async def test_enqueue_many_copy_queue_storage(client):
         """,
         queue,
     )
-    # Available count derives from queue_enqueue_heads.next_seq -
-    # queue_claim_heads.claim_seq; aliased to keep the historical
-    # `available_count` field name on the returned row.
+    # Available count derives from sequence-backed lane cursors; aliased to
+    # keep the historical `available_count` field name on the returned row.
     counts = await tx.fetch_one(
         f"""
-        SELECT GREATEST(qe.next_seq - qc.claim_seq, 0) AS available_count
+        SELECT GREATEST(
+            {schema}.sequence_next_value(qe.seq_name)
+              - {schema}.sequence_next_value(qc.seq_name),
+            0
+        ) AS available_count
         FROM {schema}.queue_enqueue_heads AS qe
         JOIN {schema}.queue_claim_heads AS qc
           ON qc.queue = qe.queue
          AND qc.priority = qe.priority
+         AND qc.enqueue_shard = qe.enqueue_shard
         WHERE qe.queue = $1 AND qe.priority = 1
         """,
         queue,

--- a/awa-python/tests/test_sync.py
+++ b/awa-python/tests/test_sync.py
@@ -292,16 +292,20 @@ def test_enqueue_many_copy_sync_queue_storage(client):
         """,
         queue,
     )
-    # Available count derives from queue_enqueue_heads.next_seq -
-    # queue_claim_heads.claim_seq; aliased to keep the historical
-    # `available_count` field name on the returned row.
+    # Available count derives from sequence-backed lane cursors; aliased to
+    # keep the historical `available_count` field name on the returned row.
     counts = tx.fetch_one(
         f"""
-        SELECT GREATEST(qe.next_seq - qc.claim_seq, 0) AS available_count
+        SELECT GREATEST(
+            {schema}.sequence_next_value(qe.seq_name)
+              - {schema}.sequence_next_value(qc.seq_name),
+            0
+        ) AS available_count
         FROM {schema}.queue_enqueue_heads AS qe
         JOIN {schema}.queue_claim_heads AS qc
           ON qc.queue = qe.queue
          AND qc.priority = qe.priority
+         AND qc.enqueue_shard = qe.enqueue_shard
         WHERE qe.queue = $1 AND qe.priority = 1
         """,
         queue,

--- a/awa-worker/src/client.rs
+++ b/awa-worker/src/client.rs
@@ -160,10 +160,19 @@ pub struct ClientBuilder {
 
 impl ClientBuilder {
     pub fn new(pool: PgPool) -> Self {
+        // #169: lease_rotate_interval bumped from 50ms to 250ms. The
+        // 50ms default was over-spec'd — prune backoff (#316) already
+        // throttles the heavy ACCESS-EXCLUSIVE + count(*) work, so
+        // faster rotation just produced loop noise without doing
+        // useful reclamation under pinned MVCC. 250ms keeps rotation
+        // responsive enough that the lease ring still cycles through
+        // its 8 partitions in ~2s, but stops the maintenance loop
+        // flapping at the 50ms boundary that bench evidence on #316
+        // surfaced.
         let (storage, storage_error) = match QueueStorageRuntime::new(
             QueueStorageConfig::default(),
             Duration::from_millis(1_000),
-            Duration::from_millis(50),
+            Duration::from_millis(250),
         ) {
             Ok(runtime) => (RuntimeStorage::QueueStorage(runtime), None),
             Err(err) => (

--- a/awa-worker/src/maintenance.rs
+++ b/awa-worker/src/maintenance.rs
@@ -194,7 +194,15 @@ impl MaintenanceBranchTracker {
         }
 
         // Phase 2: duration-margin + K-consecutive hysteresis.
-        if let Some(last_duration) = state.last_duration {
+        // `take()` consumes the sample so we evaluate each body's
+        // duration exactly once. Without this, when cooldown returns
+        // None (no body runs → no new sample), the next post-cooldown
+        // `try_begin` would re-read the same pre-flip overrun sample,
+        // see `consecutive_overrun >= K` already, and re-arm cooldown
+        // forever. The branch would never run its body again until
+        // the worker restarts. Codex + CodeRabbit both flagged this
+        // on PR #318.
+        if let Some(last_duration) = state.last_duration.take() {
             // Integer-ratio thresholds — avoid f64 in the hot path.
             let upper_threshold = tick_interval * OVERRUN_UPPER_NUM / OVERRUN_UPPER_DEN;
             let lower_threshold = tick_interval * OVERRUN_LOWER_NUM / OVERRUN_LOWER_DEN;
@@ -2525,33 +2533,48 @@ mod tests {
         );
     }
 
-    /// Drive `tracker.try_begin` `n` times against a fixed
-    /// `last_duration` / `tick_interval`. Re-seeds `last_duration`
-    /// before each call so we model `n` consecutive ticks where the
-    /// previous body completed in `last_duration`. Returns the
-    /// observed `try_begin` outcomes (Some = body would have run,
-    /// None = body skipped by cooldown).
+    /// Drive `n` consecutive `try_begin` ticks. When the body would
+    /// have run (try_begin returns Some), call `record_finish` with
+    /// `body_duration` to simulate the body completing in that time.
+    /// When the body is skipped (cooldown returns None), `last_duration`
+    /// is intentionally NOT updated — matching production where a
+    /// skipped tick doesn't produce a new sample. Returns one bool per
+    /// tick: true if the body ran, false if it was skipped.
+    ///
+    /// This helper does NOT seed `last_duration` itself. Tests that need
+    /// an initial sample (e.g., to drive the very first overrun
+    /// observation) must call `seed_last_duration` first.
     fn replay_ticks(
         tracker: &MaintenanceBranchTracker,
         branch: &'static str,
-        last_duration: Duration,
+        body_duration: Duration,
         tick_interval: Duration,
         n: u32,
     ) -> Vec<bool> {
         let metrics = metrics_for_test();
         let mut ran = Vec::with_capacity(n as usize);
         for _ in 0..n {
-            tracker
-                .branches
-                .lock()
-                .unwrap()
-                .entry(branch)
-                .or_default()
-                .last_duration = Some(last_duration);
             let timer_opt = tracker.try_begin(branch, tick_interval, &metrics);
-            ran.push(timer_opt.is_some());
+            let did_run = timer_opt.is_some();
+            ran.push(did_run);
+            if did_run {
+                tracker.record_finish(branch, body_duration);
+            }
         }
         ran
+    }
+
+    /// Explicitly seed `last_duration` as if a prior body completed in
+    /// `dur`. Use to set up the initial state for tests that need
+    /// the first `try_begin` to see a sample.
+    fn seed_last_duration(tracker: &MaintenanceBranchTracker, branch: &'static str, dur: Duration) {
+        tracker
+            .branches
+            .lock()
+            .unwrap()
+            .entry(branch)
+            .or_default()
+            .last_duration = Some(dur);
     }
 
     #[test]
@@ -2559,6 +2582,7 @@ mod tests {
         // A single overrun sample (clearly above the upper threshold)
         // shouldn't flip is_delayed — K-consecutive is required.
         let tracker = MaintenanceBranchTracker::new();
+        seed_last_duration(&tracker, "cleanup", Duration::from_millis(200));
         replay_ticks(
             &tracker,
             "cleanup",
@@ -2575,11 +2599,11 @@ mod tests {
     #[test]
     fn branch_tracker_deadband_sample_does_not_advance_counters() {
         // Samples between LOWER (70ms) and UPPER (150ms) of a 100ms
-        // tick — e.g., 101ms or 51ms — must NOT advance either
-        // counter. This is the fix the bench post-mortem prescribed:
-        // 49ms-vs-51ms flap at the boundary no longer accumulates
-        // toward a flip.
+        // tick — e.g., 101ms — must NOT advance either counter. This
+        // is the fix the bench post-mortem prescribed: 49ms-vs-51ms
+        // flap at the boundary no longer accumulates toward a flip.
         let tracker = MaintenanceBranchTracker::new();
+        seed_last_duration(&tracker, "cleanup", Duration::from_millis(101));
         replay_ticks(
             &tracker,
             "cleanup",
@@ -2596,9 +2620,12 @@ mod tests {
     #[test]
     fn branch_tracker_k_consecutive_overruns_flips_and_arms_cooldown() {
         // After K=3 consecutive samples clearly above UPPER, flip to
-        // delayed AND arm cooldown. The third try_begin returns None
-        // (cooldown gate fires the same tick we flip).
+        // delayed AND arm cooldown. The third try_begin consumes the
+        // K-th sample, crosses the threshold, and returns None (the
+        // flip-tick skips the body so we don't immediately do more
+        // expensive work).
         let tracker = MaintenanceBranchTracker::new();
+        seed_last_duration(&tracker, "cleanup", Duration::from_millis(250));
         let ran = replay_ticks(
             &tracker,
             "cleanup",
@@ -2619,8 +2646,12 @@ mod tests {
     #[test]
     fn branch_tracker_cooldown_skips_body() {
         // Drive past the flip, then assert subsequent ticks return
-        // None until cooldown decrements to zero.
+        // None until cooldown decrements to zero. After the flip,
+        // `last_duration` was consumed by `take()`, so the cooldown
+        // gate is the only thing returning None here — exactly the
+        // production shape we want.
         let tracker = MaintenanceBranchTracker::new();
+        seed_last_duration(&tracker, "cleanup", Duration::from_millis(250));
         replay_ticks(
             &tracker,
             "cleanup",
@@ -2628,9 +2659,9 @@ mod tests {
             Duration::from_millis(100),
             OVERRUN_HYSTERESIS_K,
         );
-        // Next BRANCH_COOLDOWN_TICKS ticks all skip. Replay with
-        // last_duration = 50ms (on-time) so the cooldown is the only
-        // gate that can return None.
+        // Subsequent ticks return None until cooldown drains. We pass
+        // 50ms as the body_duration but it's unused — `record_finish`
+        // is only called when a body actually runs.
         let ran = replay_ticks(
             &tracker,
             "cleanup",
@@ -2648,10 +2679,14 @@ mod tests {
 
     #[test]
     fn branch_tracker_cooldown_expires_then_body_runs() {
-        // Same setup, plus one more on-time tick after cooldown
-        // expires. That tick's body should run; on-time counter
-        // advances.
+        // After cooldown drains, the first post-cooldown try_begin
+        // sees `last_duration = None` (consumed at the flip, no body
+        // ran during cooldown), so no hysteresis check fires; the
+        // body simply runs. The counters do NOT advance on this
+        // first post-cooldown tick — the sample this body produces
+        // is evaluated on the *next* try_begin.
         let tracker = MaintenanceBranchTracker::new();
+        seed_last_duration(&tracker, "cleanup", Duration::from_millis(250));
         replay_ticks(
             &tracker,
             "cleanup",
@@ -2673,20 +2708,31 @@ mod tests {
             Duration::from_millis(100),
             1,
         );
-        assert_eq!(ran, vec![true], "post-cooldown tick runs body");
-        let (_, _, ontime) = tracker.cooldown_snapshot("cleanup").expect("snapshot");
+        assert_eq!(ran, vec![true], "post-cooldown body runs");
+        let (cooldown, overrun, ontime) = tracker.cooldown_snapshot("cleanup").expect("snapshot");
         assert_eq!(
-            ontime, 1,
-            "on-time counter advances on first post-cooldown tick"
+            cooldown, 0,
+            "cooldown stays at zero after a single fast body"
+        );
+        assert_eq!(
+            overrun, OVERRUN_HYSTERESIS_K,
+            "consecutive_overrun preserved across cooldown (no eval on this tick)"
+        );
+        assert_eq!(
+            ontime, 0,
+            "ontime advances on the next tick — this one had no sample to evaluate"
         );
     }
 
     #[test]
     fn branch_tracker_cooldown_rearms_on_continued_overrun() {
-        // After flip + cooldown expiry, if the next body is STILL
-        // slow (above UPPER), cooldown re-arms — without re-emitting
-        // the flip warning (still already delayed).
+        // After cooldown drains, the first post-cooldown body runs
+        // and is slow. That slow body's sample is evaluated on the
+        // *second* post-cooldown try_begin, where it re-arms cooldown
+        // because consecutive_overrun is already at K (preserved
+        // across the cooldown).
         let tracker = MaintenanceBranchTracker::new();
+        seed_last_duration(&tracker, "cleanup", Duration::from_millis(250));
         replay_ticks(
             &tracker,
             "cleanup",
@@ -2694,7 +2740,6 @@ mod tests {
             Duration::from_millis(100),
             OVERRUN_HYSTERESIS_K,
         );
-        // Drain cooldown.
         replay_ticks(
             &tracker,
             "cleanup",
@@ -2703,28 +2748,23 @@ mod tests {
             BRANCH_COOLDOWN_TICKS,
         );
 
-        // First post-cooldown body runs and goes slow again. Need
-        // K more overrun samples to "cross" again because we cleared
-        // consecutive_ontime on each ontime tick. Wait — the on-time
-        // ticks during cooldown were skipped (returned None), so the
-        // consecutive_ontime / consecutive_overrun counters were
-        // frozen during cooldown. After cooldown, consecutive_overrun
-        // is still at OVERRUN_HYSTERESIS_K from before — so the very
-        // first overrun observation post-cooldown re-arms cooldown.
+        // Tick 1 post-cooldown: take None, no eval, body runs slow.
+        // Tick 2: take Some(250), consecutive_overrun saturates past
+        // K, is_delayed && cross → re-arm cooldown.
         let ran = replay_ticks(
             &tracker,
             "cleanup",
             Duration::from_millis(250),
             Duration::from_millis(100),
-            1,
+            2,
         );
         assert_eq!(
             ran,
-            vec![false],
-            "stay-delayed overrun re-arms cooldown without running body"
+            vec![true, false],
+            "first tick runs body; second tick re-arms cooldown"
         );
         let (cooldown, _, _) = tracker.cooldown_snapshot("cleanup").expect("snapshot");
-        assert_eq!(cooldown, BRANCH_COOLDOWN_TICKS);
+        assert_eq!(cooldown, BRANCH_COOLDOWN_TICKS, "cooldown re-armed");
         assert!(
             tracker.snapshot("cleanup").unwrap().1,
             "still delayed across re-arm"
@@ -2737,6 +2777,7 @@ mod tests {
         // clearly-on-time samples. Non-consecutive overruns never
         // accumulate K=3 because each on-time tick resets the counter.
         let tracker = MaintenanceBranchTracker::new();
+        seed_last_duration(&tracker, "cleanup", Duration::from_millis(200));
         for over in [true, false, true, false, true] {
             let dur = if over {
                 Duration::from_millis(200)
@@ -2753,9 +2794,13 @@ mod tests {
 
     #[test]
     fn branch_tracker_recovers_only_after_k_ontime_ticks_post_cooldown() {
-        // After cooldown expires, K consecutive clearly-on-time ticks
-        // are needed before is_delayed clears.
+        // After cooldown drains, K consecutive on-time samples must be
+        // *evaluated* before is_delayed clears. The very first
+        // post-cooldown body has no sample to evaluate (last_duration
+        // was consumed at the flip), so K evaluable samples require
+        // K+1 post-cooldown ticks: one to seed, K to advance ontime.
         let tracker = MaintenanceBranchTracker::new();
+        seed_last_duration(&tracker, "cleanup", Duration::from_millis(250));
         replay_ticks(
             &tracker,
             "cleanup",
@@ -2763,7 +2808,6 @@ mod tests {
             Duration::from_millis(100),
             OVERRUN_HYSTERESIS_K,
         );
-        // Drain cooldown.
         replay_ticks(
             &tracker,
             "cleanup",
@@ -2771,21 +2815,22 @@ mod tests {
             Duration::from_millis(100),
             BRANCH_COOLDOWN_TICKS,
         );
-        // K-1 on-time ticks — not yet recovered. (consecutive_overrun
-        // was OVERRUN_HYSTERESIS_K post-flip; the first on-time tick
-        // that actually runs resets it to 0 and bumps ontime to 1.)
+
+        // K post-cooldown ticks: tick 1 seeds, ticks 2..K evaluate K-1
+        // on-time samples. Still delayed.
         replay_ticks(
             &tracker,
             "cleanup",
             Duration::from_millis(50),
             Duration::from_millis(100),
-            OVERRUN_HYSTERESIS_K - 1,
+            OVERRUN_HYSTERESIS_K,
         );
         assert!(
             tracker.snapshot("cleanup").unwrap().1,
-            "still delayed before K-th on-time tick"
+            "still delayed after only K-1 evaluations"
         );
-        // K-th on-time tick — recovers.
+
+        // (K+1)-th tick evaluates the K-th on-time sample → recovery.
         replay_ticks(
             &tracker,
             "cleanup",
@@ -2795,7 +2840,7 @@ mod tests {
         );
         assert!(
             !tracker.snapshot("cleanup").unwrap().1,
-            "recovered after K consecutive on-time"
+            "recovered after K evaluable on-time samples"
         );
     }
 
@@ -2805,6 +2850,7 @@ mod tests {
         // "promote_scheduled" stays on-time the whole time. Branches
         // must not share state.
         let tracker = MaintenanceBranchTracker::new();
+        seed_last_duration(&tracker, "cleanup", Duration::from_millis(500));
         replay_ticks(
             &tracker,
             "cleanup",
@@ -2812,6 +2858,7 @@ mod tests {
             Duration::from_millis(100),
             OVERRUN_HYSTERESIS_K,
         );
+        seed_last_duration(&tracker, "promote_scheduled", Duration::from_millis(10));
         replay_ticks(
             &tracker,
             "promote_scheduled",

--- a/awa-worker/src/maintenance.rs
+++ b/awa-worker/src/maintenance.rs
@@ -110,7 +110,7 @@ const OVERRUN_LOWER_DEN: u32 = 10;
 const BRANCH_COOLDOWN_TICKS: u32 = 120;
 
 /// Records the start of one branch body and emits observability when the
-/// body returns. Constructed by [`MaintenanceBranchTracker::begin`], which
+/// body returns. Constructed by [`MaintenanceBranchTracker::try_begin`], which
 /// also applies the previous-run overrun check before the body starts so
 /// the warning/counter line up with the fire moment described in #242.
 struct BranchTimer<'a> {
@@ -309,7 +309,7 @@ impl MaintenanceBranchTracker {
 /// <child> IN ACCESS EXCLUSIVE MODE` (with a 50ms timeout) followed by
 /// `SELECT count(*) FROM <child>`. Under a pinned snapshot the child
 /// can't be reclaimed, so the count walks dead tuples and the prune
-/// returns `SkippedActive` — every 50ms by default. This tracker skips
+/// returns `SkippedActive` — every tick. This tracker skips
 /// the next 2^level ticks (capped at 32) after a `SkippedActive` or
 /// `Blocked` outcome, doubling on each repeat. A successful `Pruned`
 /// resets to no backoff. `Noop` (ring empty / nothing to consider)
@@ -331,8 +331,8 @@ struct PruneBackoffState {
     backoff_level: u8,
 }
 
-/// Cap on the backoff exponent. `2^5 = 32` ticks; at the 50ms default
-/// `lease_rotate_interval` that is ~1.6s between prune attempts under
+/// Cap on the backoff exponent. `2^5 = 32` ticks; at the 250ms default
+/// `lease_rotate_interval` that is ~8s between prune attempts under
 /// sustained pin pressure. Long enough to cut the per-tick scan cost
 /// dramatically; short enough that prune resumes promptly once the
 /// snapshot is released.

--- a/awa-worker/src/maintenance.rs
+++ b/awa-worker/src/maintenance.rs
@@ -57,25 +57,57 @@ struct MaintenanceBranchState {
     /// for the current overrun episode. Cleared on the recovery
     /// transition.
     is_delayed: bool,
-    /// Number of consecutive ticks where `last_duration > tick_interval`.
-    /// Used for hysteresis: a single bad tick around the threshold no
-    /// longer flips `is_delayed` and spams the log; we wait for
-    /// `OVERRUN_HYSTERESIS_K` in a row.
+    /// Number of consecutive overrun observations (last_duration above
+    /// the upper threshold). Samples inside the deadband neither
+    /// advance this counter nor reset it.
     consecutive_overrun: u32,
-    /// Mirror of `consecutive_overrun` for on-time ticks; used to gate
-    /// the delayed -> on-time recovery transition with the same K
-    /// hysteresis.
+    /// Mirror of `consecutive_overrun` for clearly-on-time samples
+    /// (last_duration below the lower threshold). Used to gate
+    /// delayed -> on-time recovery with the same K-consecutive
+    /// requirement.
     consecutive_ontime: u32,
+    /// Tick counter that suppresses the branch body while the branch
+    /// is unhealthy. Decremented every tick; while non-zero the
+    /// caller's body is skipped. Re-armed on every flip-to-delayed
+    /// AND every overrun observation while already delayed, so a
+    /// branch that keeps failing keeps quietly waiting instead of
+    /// hammering the database.
+    cooldown_ticks_remaining: u32,
 }
 
 /// How many consecutive observations the branch tracker requires before
-/// flipping `is_delayed` either direction. `K=3` means a single ~tick-
-/// boundary jitter no longer triggers the warning + counter; a real
-/// sustained overrun (or sustained recovery) still does, just one
-/// `tick_interval * (K-1)` later than the previous edge-triggered
-/// shape. The downside of this delay is exactly the upside of the
-/// hysteresis: we stop flapping at the boundary.
+/// flipping `is_delayed` either direction. Combined with the
+/// duration-margin thresholds below: a sample inside the deadband
+/// (between `LOWER_FACTOR_*` and `UPPER_FACTOR_*` of `tick_interval`)
+/// doesn't advance either counter, so the boundary flap from #316's
+/// post-mortem stops at the source. A sample outside the deadband
+/// still needs `OVERRUN_HYSTERESIS_K` peers on the same side before
+/// the state flips.
 const OVERRUN_HYSTERESIS_K: u32 = 3;
+
+/// Duration-margin thresholds. Crossing
+/// `last_duration > tick_interval * UPPER` counts as an overrun
+/// sample; `last_duration < tick_interval * LOWER` counts as an
+/// on-time sample. Everything in between is a deadband that leaves
+/// both counters untouched.
+///
+/// `UPPER = 3/2` and `LOWER = 7/10` give a generous deadband — the
+/// branch has to be at 70% of its tick or below to count as recovered,
+/// and 50% above its tick to count as overrunning. This prevents
+/// 51ms-vs-49ms jitter at the 50ms boundary from advancing either
+/// counter, which is what bench evidence on #316 showed was still
+/// happening with K-only hysteresis. Integer ratios avoid f64 in the
+/// hot path.
+const OVERRUN_UPPER_NUM: u32 = 3;
+const OVERRUN_UPPER_DEN: u32 = 2;
+const OVERRUN_LOWER_NUM: u32 = 7;
+const OVERRUN_LOWER_DEN: u32 = 10;
+
+/// Number of ticks to suppress a delayed branch's body. At the default
+/// `lease_rotate_interval = 250ms`, 120 ticks = 30s wall time of quiet
+/// before the branch tries again. Re-armed on every overrun
+/// observation while still delayed.
+const BRANCH_COOLDOWN_TICKS: u32 = 120;
 
 /// Records the start of one branch body and emits observability when the
 /// body returns. Constructed by [`MaintenanceBranchTracker::begin`], which
@@ -121,37 +153,77 @@ impl MaintenanceBranchTracker {
     }
 
     /// Call at the moment a branch arm fires, before running its body.
-    /// Applies the previous-run overrun check (warn + counter on
-    /// on-time -> delayed; warn on delayed -> on-time), then returns a
-    /// [`BranchTimer`] whose `.finish()` records the body duration.
-    fn begin<'a>(
+    /// Applies cooldown + duration-margin hysteresis, then either:
+    ///   * returns `Some(BranchTimer)` so the caller runs the body
+    ///     and calls `.finish()`, or
+    ///   * returns `None` to signal "skip this tick" — the body
+    ///     must not run, and no duration sample is recorded for this
+    ///     tick (so the K-on-time counter doesn't advance for skipped
+    ///     work).
+    ///
+    /// Two gating phases:
+    ///
+    /// 1. **Cooldown.** If `cooldown_ticks_remaining > 0`, decrement
+    ///    and return `None`. While cooldown is non-zero the branch is
+    ///    quiet; this is set on flip-to-delayed and re-armed on
+    ///    every subsequent overrun observation, so an unhealthy
+    ///    branch backs off instead of beating on the database every
+    ///    tick.
+    /// 2. **Duration-margin hysteresis.** Compare `last_duration` to
+    ///    `tick_interval * UPPER/LOWER`. Outside the deadband, advance
+    ///    the matching K-counter; inside, leave both alone. Crossing
+    ///    K-consecutive on either side flips `is_delayed` and may
+    ///    arm cooldown.
+    fn try_begin<'a>(
         &'a self,
         branch: &'static str,
         tick_interval: Duration,
         metrics: &'a crate::metrics::AwaMetrics,
-    ) -> BranchTimer<'a> {
+    ) -> Option<BranchTimer<'a>> {
         let mut branches = self
             .branches
             .lock()
             .expect("maintenance branch tracker mutex");
         let state = branches.entry(branch).or_default();
+
+        // Phase 1: cooldown gate. Counts down regardless of any
+        // other signal; the branch stays quiet while non-zero.
+        if state.cooldown_ticks_remaining > 0 {
+            state.cooldown_ticks_remaining -= 1;
+            return None;
+        }
+
+        // Phase 2: duration-margin + K-consecutive hysteresis.
         if let Some(last_duration) = state.last_duration {
-            let overdue = last_duration > tick_interval;
-            if overdue {
+            // Integer-ratio thresholds — avoid f64 in the hot path.
+            let upper_threshold = tick_interval * OVERRUN_UPPER_NUM / OVERRUN_UPPER_DEN;
+            let lower_threshold = tick_interval * OVERRUN_LOWER_NUM / OVERRUN_LOWER_DEN;
+
+            if last_duration > upper_threshold {
                 state.consecutive_overrun = state.consecutive_overrun.saturating_add(1);
                 state.consecutive_ontime = 0;
-                if state.consecutive_overrun >= OVERRUN_HYSTERESIS_K && !state.is_delayed {
+                let cross_threshold = state.consecutive_overrun >= OVERRUN_HYSTERESIS_K;
+                if cross_threshold && !state.is_delayed {
                     state.is_delayed = true;
+                    state.cooldown_ticks_remaining = BRANCH_COOLDOWN_TICKS;
                     warn!(
                         branch,
                         last_duration_ms = last_duration.as_millis() as u64,
                         tick_interval_ms = tick_interval.as_millis() as u64,
+                        upper_threshold_ms = upper_threshold.as_millis() as u64,
                         consecutive_overrun = state.consecutive_overrun,
-                        "maintenance branch overran its tick interval",
+                        cooldown_ticks = BRANCH_COOLDOWN_TICKS,
+                        "maintenance branch overran tick interval, entering cooldown",
                     );
                     metrics.record_maintenance_branch_overrun(branch);
+                    return None;
+                } else if cross_threshold && state.is_delayed {
+                    // Already delayed and another overrun arrived —
+                    // re-arm cooldown but stay quiet about it.
+                    state.cooldown_ticks_remaining = BRANCH_COOLDOWN_TICKS;
+                    return None;
                 }
-            } else {
+            } else if last_duration < lower_threshold {
                 state.consecutive_ontime = state.consecutive_ontime.saturating_add(1);
                 state.consecutive_overrun = 0;
                 if state.consecutive_ontime >= OVERRUN_HYSTERESIS_K && state.is_delayed {
@@ -160,19 +232,23 @@ impl MaintenanceBranchTracker {
                         branch,
                         last_duration_ms = last_duration.as_millis() as u64,
                         tick_interval_ms = tick_interval.as_millis() as u64,
+                        lower_threshold_ms = lower_threshold.as_millis() as u64,
                         consecutive_ontime = state.consecutive_ontime,
                         "maintenance branch recovered to on-time",
                     );
                 }
+            } else {
+                // Deadband — neither counter advances. This is the
+                // explicit no-op that kills the 49ms-vs-51ms flap.
             }
         }
         drop(branches);
-        BranchTimer {
+        Some(BranchTimer {
             tracker: self,
             branch,
             metrics,
             started_at: Instant::now(),
-        }
+        })
     }
 
     /// Internal — called by [`BranchTimer::finish`] to stash the body's
@@ -198,6 +274,23 @@ impl MaintenanceBranchTracker {
         branches
             .get(branch)
             .map(|state| (state.last_duration, state.is_delayed))
+    }
+
+    /// Test-only — read the per-branch cooldown counter and consecutive
+    /// counters so tests can assert on the full state machine.
+    #[cfg(test)]
+    fn cooldown_snapshot(&self, branch: &'static str) -> Option<(u32, u32, u32)> {
+        let branches = self
+            .branches
+            .lock()
+            .expect("maintenance branch tracker mutex");
+        branches.get(branch).map(|state| {
+            (
+                state.cooldown_ticks_remaining,
+                state.consecutive_overrun,
+                state.consecutive_ontime,
+            )
+        })
     }
 }
 
@@ -669,57 +762,67 @@ impl MaintenanceService {
                         return;
                     }
                     _ = heartbeat_rescue_timer.tick() => {
-                        let timer = branch_tracker.begin("rescue_stale_heartbeats", self.heartbeat_rescue_interval, &self.metrics);
-                        self.rescue_stale_heartbeats().await;
-                        timer.finish();
+                        if let Some(timer) = branch_tracker.try_begin("rescue_stale_heartbeats", self.heartbeat_rescue_interval, &self.metrics) {
+                            self.rescue_stale_heartbeats().await;
+                            timer.finish();
+                        }
                     }
                     _ = deadline_rescue_timer.tick() => {
-                        let timer = branch_tracker.begin("rescue_expired_deadlines", self.deadline_rescue_interval, &self.metrics);
-                        self.rescue_expired_deadlines().await;
-                        timer.finish();
+                        if let Some(timer) = branch_tracker.try_begin("rescue_expired_deadlines", self.deadline_rescue_interval, &self.metrics) {
+                            self.rescue_expired_deadlines().await;
+                            timer.finish();
+                        }
                     }
                     _ = callback_rescue_timer.tick() => {
-                        let timer = branch_tracker.begin("rescue_expired_callbacks", self.callback_rescue_interval, &self.metrics);
-                        self.rescue_expired_callbacks().await;
-                        timer.finish();
+                        if let Some(timer) = branch_tracker.try_begin("rescue_expired_callbacks", self.callback_rescue_interval, &self.metrics) {
+                            self.rescue_expired_callbacks().await;
+                            timer.finish();
+                        }
                     }
                     _ = promote_timer.tick() => {
-                        let timer = branch_tracker.begin("promote_scheduled", self.promote_interval, &self.metrics);
-                        self.promote_scheduled().await;
-                        timer.finish();
+                        if let Some(timer) = branch_tracker.try_begin("promote_scheduled", self.promote_interval, &self.metrics) {
+                            self.promote_scheduled().await;
+                            timer.finish();
+                        }
                     }
                     _ = cleanup_timer.tick() => {
-                        let timer = branch_tracker.begin("cleanup", self.cleanup_interval, &self.metrics);
-                        self.cleanup_completed().await;
-                        self.cleanup_dlq_rows().await;
-                        self.cleanup_stale_runtime_snapshots().await;
-                        self.cleanup_stale_descriptors().await;
-                        timer.finish();
+                        if let Some(timer) = branch_tracker.try_begin("cleanup", self.cleanup_interval, &self.metrics) {
+                            self.cleanup_completed().await;
+                            self.cleanup_dlq_rows().await;
+                            self.cleanup_stale_runtime_snapshots().await;
+                            self.cleanup_stale_descriptors().await;
+                            timer.finish();
+                        }
                     }
                     _ = cron_sync_timer.tick() => {
-                        let timer = branch_tracker.begin("cron_sync", self.cron_sync_interval, &self.metrics);
-                        self.sync_periodic_jobs_to_db().await;
-                        timer.finish();
+                        if let Some(timer) = branch_tracker.try_begin("cron_sync", self.cron_sync_interval, &self.metrics) {
+                            self.sync_periodic_jobs_to_db().await;
+                            timer.finish();
+                        }
                     }
                     _ = queue_stats_timer.tick() => {
-                        let timer = branch_tracker.begin("queue_stats", self.queue_stats_interval, &self.metrics);
-                        self.publish_queue_health_metrics().await;
-                        timer.finish();
+                        if let Some(timer) = branch_tracker.try_begin("queue_stats", self.queue_stats_interval, &self.metrics) {
+                            self.publish_queue_health_metrics().await;
+                            timer.finish();
+                        }
                     }
                     _ = dirty_key_timer.tick() => {
-                        let timer = branch_tracker.begin("recompute_dirty_admin_metadata", self.dirty_key_recompute_interval, &self.metrics);
-                        self.recompute_dirty_admin_metadata().await;
-                        timer.finish();
+                        if let Some(timer) = branch_tracker.try_begin("recompute_dirty_admin_metadata", self.dirty_key_recompute_interval, &self.metrics) {
+                            self.recompute_dirty_admin_metadata().await;
+                            timer.finish();
+                        }
                     }
                     _ = metadata_reconciliation_timer.tick() => {
-                        let timer = branch_tracker.begin("refresh_admin_metadata", self.metadata_reconciliation_interval, &self.metrics);
-                        self.refresh_admin_metadata().await;
-                        timer.finish();
+                        if let Some(timer) = branch_tracker.try_begin("refresh_admin_metadata", self.metadata_reconciliation_interval, &self.metrics) {
+                            self.refresh_admin_metadata().await;
+                            timer.finish();
+                        }
                     }
                     _ = priority_aging_timer.tick() => {
-                        let timer = branch_tracker.begin("priority_aging", self.priority_aging_interval, &self.metrics);
-                        self.age_waiting_priorities().await;
-                        timer.finish();
+                        if let Some(timer) = branch_tracker.try_begin("priority_aging", self.priority_aging_interval, &self.metrics) {
+                            self.age_waiting_priorities().await;
+                            timer.finish();
+                        }
                     }
                     _ = async {
                         if let Some(timer) = &mut vacuum_queue_timer {
@@ -730,9 +833,10 @@ impl MaintenanceService {
                     }, if vacuum_queue_timer.is_some() => {
                         let interval = vacuum_queue_interval
                             .expect("vacuum_queue_interval Some iff vacuum_queue_timer Some");
-                        let timer = branch_tracker.begin("rotate_queue", interval, &self.metrics);
-                        self.rotate_queue_storage_queue(&prune_tracker).await;
-                        timer.finish();
+                        if let Some(timer) = branch_tracker.try_begin("rotate_queue", interval, &self.metrics) {
+                            self.rotate_queue_storage_queue(&prune_tracker).await;
+                            timer.finish();
+                        }
                     }
                     _ = async {
                         if let Some(timer) = &mut vacuum_lease_timer {
@@ -743,9 +847,10 @@ impl MaintenanceService {
                     }, if vacuum_lease_timer.is_some() => {
                         let interval = vacuum_lease_interval
                             .expect("vacuum_lease_interval Some iff vacuum_lease_timer Some");
-                        let timer = branch_tracker.begin("rotate_lease", interval, &self.metrics);
-                        self.rotate_queue_storage_leases(&prune_tracker).await;
-                        timer.finish();
+                        if let Some(timer) = branch_tracker.try_begin("rotate_lease", interval, &self.metrics) {
+                            self.rotate_queue_storage_leases(&prune_tracker).await;
+                            timer.finish();
+                        }
                     }
                     _ = async {
                         if let Some(timer) = &mut vacuum_claim_timer {
@@ -756,9 +861,10 @@ impl MaintenanceService {
                     }, if vacuum_claim_timer.is_some() => {
                         let interval = vacuum_claim_interval
                             .expect("vacuum_claim_interval Some iff vacuum_claim_timer Some");
-                        let timer = branch_tracker.begin("rotate_claim", interval, &self.metrics);
-                        self.rotate_queue_storage_claims(&prune_tracker).await;
-                        timer.finish();
+                        if let Some(timer) = branch_tracker.try_begin("rotate_claim", interval, &self.metrics) {
+                            self.rotate_queue_storage_claims(&prune_tracker).await;
+                            timer.finish();
+                        }
                     }
                     _ = leader_check_timer.tick() => {
                         // Verify leader connection is still alive.
@@ -2404,36 +2510,37 @@ mod tests {
     fn branch_tracker_finish_records_last_duration() {
         let tracker = MaintenanceBranchTracker::new();
         let metrics = metrics_for_test();
-        let timer = tracker.begin("promote_scheduled", Duration::from_secs(1), &metrics);
+        let timer = tracker
+            .try_begin("promote_scheduled", Duration::from_secs(1), &metrics)
+            .expect("first tick should not be skipped");
         // Body would run here in production; for the test we just finish.
         timer.finish();
         let (last_duration, is_delayed) = tracker
             .snapshot("promote_scheduled")
             .expect("snapshot should exist after one finish");
         assert!(last_duration.is_some());
-        // First tick has no prior duration to compare against, so we
-        // cannot be in the delayed state yet.
-        assert!(!is_delayed);
+        assert!(
+            !is_delayed,
+            "first tick has no prior duration → not delayed"
+        );
     }
 
-    /// Drive `tracker.begin` `n` times against a fixed `last_duration` /
-    /// `tick_interval` so the consecutive-overrun / consecutive-ontime
-    /// counters advance the way real ticks would. Reseting
-    /// `last_duration` after each begin matches the production shape
-    /// where each tick's body finish writes a new value.
+    /// Drive `tracker.try_begin` `n` times against a fixed
+    /// `last_duration` / `tick_interval`. Re-seeds `last_duration`
+    /// before each call so we model `n` consecutive ticks where the
+    /// previous body completed in `last_duration`. Returns the
+    /// observed `try_begin` outcomes (Some = body would have run,
+    /// None = body skipped by cooldown).
     fn replay_ticks(
         tracker: &MaintenanceBranchTracker,
         branch: &'static str,
         last_duration: Duration,
         tick_interval: Duration,
         n: u32,
-    ) {
+    ) -> Vec<bool> {
         let metrics = metrics_for_test();
+        let mut ran = Vec::with_capacity(n as usize);
         for _ in 0..n {
-            // The check in `begin` reads `state.last_duration` set by
-            // the *previous* tick. Re-seed it to the same value on
-            // every iteration so we model `n` consecutive ticks at the
-            // same duration.
             tracker
                 .branches
                 .lock()
@@ -2441,33 +2548,78 @@ mod tests {
                 .entry(branch)
                 .or_default()
                 .last_duration = Some(last_duration);
-            let _timer = tracker.begin(branch, tick_interval, &metrics);
+            let timer_opt = tracker.try_begin(branch, tick_interval, &metrics);
+            ran.push(timer_opt.is_some());
         }
+        ran
     }
 
     #[test]
     fn branch_tracker_single_overrun_does_not_flip() {
-        // Hysteresis: one overrun observation isn't enough to flip
-        // `is_delayed`. A tick that goes 101ms against a 100ms
-        // interval shouldn't spam the log.
+        // A single overrun sample (clearly above the upper threshold)
+        // shouldn't flip is_delayed — K-consecutive is required.
+        let tracker = MaintenanceBranchTracker::new();
+        replay_ticks(
+            &tracker,
+            "cleanup",
+            Duration::from_millis(200), // upper threshold for 100ms tick is 150
+            Duration::from_millis(100),
+            1,
+        );
+        assert!(
+            !tracker.snapshot("cleanup").unwrap().1,
+            "single overrun must not flip is_delayed (K=3 required)"
+        );
+    }
+
+    #[test]
+    fn branch_tracker_deadband_sample_does_not_advance_counters() {
+        // Samples between LOWER (70ms) and UPPER (150ms) of a 100ms
+        // tick — e.g., 101ms or 51ms — must NOT advance either
+        // counter. This is the fix the bench post-mortem prescribed:
+        // 49ms-vs-51ms flap at the boundary no longer accumulates
+        // toward a flip.
         let tracker = MaintenanceBranchTracker::new();
         replay_ticks(
             &tracker,
             "cleanup",
             Duration::from_millis(101),
             Duration::from_millis(100),
-            1,
+            5,
         );
-        let (_, is_delayed) = tracker.snapshot("cleanup").expect("snapshot");
-        assert!(
-            !is_delayed,
-            "single overrun must not flip is_delayed (hysteresis K=3)"
+        let (cooldown, overrun, ontime) = tracker.cooldown_snapshot("cleanup").expect("snapshot");
+        assert_eq!(cooldown, 0, "deadband samples should not arm cooldown");
+        assert_eq!(overrun, 0, "deadband sample 101ms must not advance overrun");
+        assert_eq!(ontime, 0, "deadband sample 101ms must not advance ontime");
+    }
+
+    #[test]
+    fn branch_tracker_k_consecutive_overruns_flips_and_arms_cooldown() {
+        // After K=3 consecutive samples clearly above UPPER, flip to
+        // delayed AND arm cooldown. The third try_begin returns None
+        // (cooldown gate fires the same tick we flip).
+        let tracker = MaintenanceBranchTracker::new();
+        let ran = replay_ticks(
+            &tracker,
+            "cleanup",
+            Duration::from_millis(250),
+            Duration::from_millis(100),
+            OVERRUN_HYSTERESIS_K,
+        );
+        assert_eq!(ran, vec![true, true, false], "flip-tick skips body");
+        let (cooldown, overrun, _) = tracker.cooldown_snapshot("cleanup").expect("snapshot");
+        assert!(tracker.snapshot("cleanup").unwrap().1, "flipped to delayed");
+        assert_eq!(overrun, OVERRUN_HYSTERESIS_K);
+        assert_eq!(
+            cooldown, BRANCH_COOLDOWN_TICKS,
+            "cooldown armed to BRANCH_COOLDOWN_TICKS at flip"
         );
     }
 
     #[test]
-    fn branch_tracker_k_consecutive_overruns_flips() {
-        // After `OVERRUN_HYSTERESIS_K` (3) consecutive overruns, flip.
+    fn branch_tracker_cooldown_skips_body() {
+        // Drive past the flip, then assert subsequent ticks return
+        // None until cooldown decrements to zero.
         let tracker = MaintenanceBranchTracker::new();
         replay_ticks(
             &tracker,
@@ -2476,52 +2628,29 @@ mod tests {
             Duration::from_millis(100),
             OVERRUN_HYSTERESIS_K,
         );
-        let (_, is_delayed) = tracker.snapshot("cleanup").expect("snapshot");
-        assert!(is_delayed, "K consecutive overruns must flip to delayed");
-    }
-
-    #[test]
-    fn branch_tracker_intermittent_overrun_does_not_flip() {
-        // Pattern: overrun, on-time, overrun, on-time, overrun (5
-        // ticks, 3 of them overruns but not consecutive). Must stay
-        // on-time.
-        let tracker = MaintenanceBranchTracker::new();
-        for over in [true, false, true, false, true] {
-            let dur = if over {
-                Duration::from_millis(150)
-            } else {
-                Duration::from_millis(50)
-            };
-            replay_ticks(&tracker, "cleanup", dur, Duration::from_millis(100), 1);
-        }
-        let (_, is_delayed) = tracker.snapshot("cleanup").expect("snapshot");
-        assert!(
-            !is_delayed,
-            "intermittent overruns must not flip is_delayed without K consecutive"
-        );
-    }
-
-    #[test]
-    fn branch_tracker_does_not_re_flag_while_already_delayed() {
-        // While already delayed, further overruns must not re-emit
-        // (state stays delayed). #242's "one event per overrun episode."
-        let tracker = MaintenanceBranchTracker::new();
-        // Push past the K=3 threshold.
-        replay_ticks(
+        // Next BRANCH_COOLDOWN_TICKS ticks all skip. Replay with
+        // last_duration = 50ms (on-time) so the cooldown is the only
+        // gate that can return None.
+        let ran = replay_ticks(
             &tracker,
             "cleanup",
-            Duration::from_millis(250),
+            Duration::from_millis(50),
             Duration::from_millis(100),
-            OVERRUN_HYSTERESIS_K + 5,
+            BRANCH_COOLDOWN_TICKS,
         );
-        let (_, is_delayed) = tracker.snapshot("cleanup").expect("snapshot");
-        assert!(is_delayed, "stays delayed across further overrun ticks");
+        assert!(
+            ran.iter().all(|&r| !r),
+            "every tick during cooldown must skip body"
+        );
+        let (cooldown, _, _) = tracker.cooldown_snapshot("cleanup").expect("snapshot");
+        assert_eq!(cooldown, 0, "cooldown decrements to zero");
     }
 
     #[test]
-    fn branch_tracker_recovers_only_after_k_ontime_ticks() {
-        // Hysteresis on the recovery side too: a single under-interval
-        // tick mid-overrun must not clear is_delayed.
+    fn branch_tracker_cooldown_expires_then_body_runs() {
+        // Same setup, plus one more on-time tick after cooldown
+        // expires. That tick's body should run; on-time counter
+        // advances.
         let tracker = MaintenanceBranchTracker::new();
         replay_ticks(
             &tracker,
@@ -2530,25 +2659,121 @@ mod tests {
             Duration::from_millis(100),
             OVERRUN_HYSTERESIS_K,
         );
-        assert!(
-            tracker.snapshot("cleanup").unwrap().1,
-            "delayed after K overruns"
-        );
-
-        // One on-time tick — still delayed.
         replay_ticks(
+            &tracker,
+            "cleanup",
+            Duration::from_millis(50),
+            Duration::from_millis(100),
+            BRANCH_COOLDOWN_TICKS,
+        );
+        let ran = replay_ticks(
             &tracker,
             "cleanup",
             Duration::from_millis(50),
             Duration::from_millis(100),
             1,
         );
-        assert!(
-            tracker.snapshot("cleanup").unwrap().1,
-            "single on-time tick must not clear delayed (hysteresis K=3)"
+        assert_eq!(ran, vec![true], "post-cooldown tick runs body");
+        let (_, _, ontime) = tracker.cooldown_snapshot("cleanup").expect("snapshot");
+        assert_eq!(
+            ontime, 1,
+            "on-time counter advances on first post-cooldown tick"
+        );
+    }
+
+    #[test]
+    fn branch_tracker_cooldown_rearms_on_continued_overrun() {
+        // After flip + cooldown expiry, if the next body is STILL
+        // slow (above UPPER), cooldown re-arms — without re-emitting
+        // the flip warning (still already delayed).
+        let tracker = MaintenanceBranchTracker::new();
+        replay_ticks(
+            &tracker,
+            "cleanup",
+            Duration::from_millis(250),
+            Duration::from_millis(100),
+            OVERRUN_HYSTERESIS_K,
+        );
+        // Drain cooldown.
+        replay_ticks(
+            &tracker,
+            "cleanup",
+            Duration::from_millis(50),
+            Duration::from_millis(100),
+            BRANCH_COOLDOWN_TICKS,
         );
 
-        // Two more on-time ticks — total K consecutive — recovers.
+        // First post-cooldown body runs and goes slow again. Need
+        // K more overrun samples to "cross" again because we cleared
+        // consecutive_ontime on each ontime tick. Wait — the on-time
+        // ticks during cooldown were skipped (returned None), so the
+        // consecutive_ontime / consecutive_overrun counters were
+        // frozen during cooldown. After cooldown, consecutive_overrun
+        // is still at OVERRUN_HYSTERESIS_K from before — so the very
+        // first overrun observation post-cooldown re-arms cooldown.
+        let ran = replay_ticks(
+            &tracker,
+            "cleanup",
+            Duration::from_millis(250),
+            Duration::from_millis(100),
+            1,
+        );
+        assert_eq!(
+            ran,
+            vec![false],
+            "stay-delayed overrun re-arms cooldown without running body"
+        );
+        let (cooldown, _, _) = tracker.cooldown_snapshot("cleanup").expect("snapshot");
+        assert_eq!(cooldown, BRANCH_COOLDOWN_TICKS);
+        assert!(
+            tracker.snapshot("cleanup").unwrap().1,
+            "still delayed across re-arm"
+        );
+    }
+
+    #[test]
+    fn branch_tracker_intermittent_overrun_does_not_flip() {
+        // Pattern: 3 clearly-overrun samples interleaved with
+        // clearly-on-time samples. Non-consecutive overruns never
+        // accumulate K=3 because each on-time tick resets the counter.
+        let tracker = MaintenanceBranchTracker::new();
+        for over in [true, false, true, false, true] {
+            let dur = if over {
+                Duration::from_millis(200)
+            } else {
+                Duration::from_millis(50)
+            };
+            replay_ticks(&tracker, "cleanup", dur, Duration::from_millis(100), 1);
+        }
+        assert!(
+            !tracker.snapshot("cleanup").unwrap().1,
+            "intermittent overruns must not flip"
+        );
+    }
+
+    #[test]
+    fn branch_tracker_recovers_only_after_k_ontime_ticks_post_cooldown() {
+        // After cooldown expires, K consecutive clearly-on-time ticks
+        // are needed before is_delayed clears.
+        let tracker = MaintenanceBranchTracker::new();
+        replay_ticks(
+            &tracker,
+            "cleanup",
+            Duration::from_millis(250),
+            Duration::from_millis(100),
+            OVERRUN_HYSTERESIS_K,
+        );
+        // Drain cooldown.
+        replay_ticks(
+            &tracker,
+            "cleanup",
+            Duration::from_millis(50),
+            Duration::from_millis(100),
+            BRANCH_COOLDOWN_TICKS,
+        );
+        // K-1 on-time ticks — not yet recovered. (consecutive_overrun
+        // was OVERRUN_HYSTERESIS_K post-flip; the first on-time tick
+        // that actually runs resets it to 0 and bumps ontime to 1.)
         replay_ticks(
             &tracker,
             "cleanup",
@@ -2557,8 +2782,20 @@ mod tests {
             OVERRUN_HYSTERESIS_K - 1,
         );
         assert!(
+            tracker.snapshot("cleanup").unwrap().1,
+            "still delayed before K-th on-time tick"
+        );
+        // K-th on-time tick — recovers.
+        replay_ticks(
+            &tracker,
+            "cleanup",
+            Duration::from_millis(50),
+            Duration::from_millis(100),
+            1,
+        );
+        assert!(
             !tracker.snapshot("cleanup").unwrap().1,
-            "K consecutive on-time ticks recover from delayed"
+            "recovered after K consecutive on-time"
         );
     }
 

--- a/awa/tests/chaos_suite_test.rs
+++ b/awa/tests/chaos_suite_test.rs
@@ -84,7 +84,7 @@ async fn queue_state_counts(pool: &sqlx::PgPool, queue: &str) -> HashMap<String,
                   AND claims.priority = ready.priority \
                   AND claims.enqueue_shard = ready.enqueue_shard \
                  WHERE ready.queue = $1 \
-                   AND ready.lane_seq >= claims.claim_seq \
+                   AND ready.lane_seq >= {schema}.sequence_next_value(claims.seq_name) \
                  UNION ALL \
                  SELECT state FROM {schema}.deferred_jobs WHERE queue = $1 \
                  UNION ALL \

--- a/awa/tests/migration_test.rs
+++ b/awa/tests/migration_test.rs
@@ -697,6 +697,78 @@ async fn test_v023_migrates_legacy_default_queue_storage_tables() {
     }
 }
 
+#[tokio::test]
+async fn test_v027_rebuckets_existing_terminal_live_counts() {
+    let _guard = acquire_migration_guard().await;
+    let pool = pool().await;
+    reset_schema(&pool).await;
+
+    for (_version, _desc, sql) in migrations::migration_sql_range(0, 26) {
+        sqlx::raw_sql(&sql).execute(&pool).await.unwrap();
+    }
+
+    sqlx::raw_sql(
+        r#"
+        INSERT INTO awa.done_entries (
+            ready_slot, ready_generation, job_id, kind, queue, state,
+            priority, attempt, run_lease, lane_seq, enqueue_shard,
+            attempted_at, finalized_at, payload
+        ) VALUES
+            (0, 0, 1001, 'migration_job', 'v27_rebucket', 'completed'::awa.job_state,
+             2::smallint, 1::smallint, 1::bigint, 1::bigint, 0::smallint,
+             now(), now(), '{}'::jsonb),
+            (0, 0, 1002, 'migration_job', 'v27_rebucket', 'completed'::awa.job_state,
+             2::smallint, 1::smallint, 1::bigint, 2::bigint, 0::smallint,
+             now(), now(), '{}'::jsonb);
+
+        TRUNCATE TABLE awa.queue_terminal_live_counts;
+        INSERT INTO awa.queue_terminal_live_counts (
+            ready_slot, queue, priority, enqueue_shard, counter_bucket, live_terminal_count
+        ) VALUES (
+            0, 'v27_rebucket', 2::smallint, 0::smallint, 0::smallint, 2::bigint
+        );
+
+        UPDATE awa.queue_ring_state
+        SET terminal_counter_trusted_at = now()
+        WHERE singleton = TRUE;
+        "#,
+    )
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    migrations::run(&pool).await.unwrap();
+
+    let buckets: Vec<(i16, i64)> = sqlx::query_as(
+        r#"
+        SELECT counter_bucket, live_terminal_count
+        FROM awa.queue_terminal_live_counts
+        WHERE queue = 'v27_rebucket'
+        ORDER BY counter_bucket
+        "#,
+    )
+    .fetch_all(&pool)
+    .await
+    .unwrap();
+
+    assert_eq!(
+        buckets,
+        vec![(233_i16, 1), (234_i16, 1)],
+        "v27 should rebuild existing terminal live counters into job_id buckets"
+    );
+
+    let trusted: bool = sqlx::query_scalar(
+        "SELECT terminal_counter_trusted_at IS NOT NULL FROM awa.queue_ring_state WHERE singleton = TRUE",
+    )
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert!(
+        trusted,
+        "v27 rebuild should leave the rebuilt counter trusted"
+    );
+}
+
 // ── Legacy version upgrade (0.3.x → 0.4.x) ─────────────────────
 
 #[tokio::test]

--- a/awa/tests/poll_until_deadline_test.rs
+++ b/awa/tests/poll_until_deadline_test.rs
@@ -152,6 +152,26 @@ async fn setup_pool() -> sqlx::PgPool {
     migrations::run(&pool)
         .await
         .expect("Failed to run migrations");
+    sqlx::query(
+        r#"
+        UPDATE awa.storage_transition_state
+        SET current_engine = 'canonical',
+            prepared_engine = NULL,
+            state = 'canonical',
+            transition_epoch = transition_epoch + 1,
+            details = '{}'::jsonb,
+            updated_at = now(),
+            finalized_at = NULL
+        WHERE singleton
+        "#,
+    )
+    .execute(&pool)
+    .await
+    .expect("Failed to reset storage transition state");
+    sqlx::query("DELETE FROM awa.runtime_storage_backends WHERE backend = 'queue_storage'")
+        .execute(&pool)
+        .await
+        .expect("Failed to reset active runtime backend");
     pool
 }
 

--- a/awa/tests/postgres_failover_smoke_test.rs
+++ b/awa/tests/postgres_failover_smoke_test.rs
@@ -268,7 +268,7 @@ async fn queue_state_counts(pool: &sqlx::PgPool, queue: &str) -> HashMap<String,
                       AND claims.priority = ready.priority \
                       AND claims.enqueue_shard = ready.enqueue_shard \
                      WHERE ready.queue = $1 \
-                       AND ready.lane_seq >= claims.claim_seq \
+                       AND ready.lane_seq >= {schema}.sequence_next_value(claims.seq_name) \
                      UNION ALL \
                      SELECT state FROM {schema}.deferred_jobs WHERE queue = $1 \
                      UNION ALL \

--- a/awa/tests/queue_storage_benchmark_test.rs
+++ b/awa/tests/queue_storage_benchmark_test.rs
@@ -670,7 +670,7 @@ async fn overlap_reader(
                           AND claims.priority = ready.priority \
                           AND claims.enqueue_shard = ready.enqueue_shard \
                          WHERE ready.queue = $1 \
-                           AND ready.lane_seq >= claims.claim_seq\
+                           AND ready.lane_seq >= {schema}.sequence_next_value(claims.seq_name)\
                      ), pruned AS (\
                          SELECT COALESCE(sum(pruned_completed_count), 0)::bigint AS terminal_rollup \
                          FROM {schema}.queue_terminal_rollups \

--- a/awa/tests/queue_storage_runtime_test.rs
+++ b/awa/tests/queue_storage_runtime_test.rs
@@ -26,6 +26,18 @@ use uuid::Uuid;
 
 static QUEUE_STORAGE_RUNTIME_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
 
+#[derive(Debug, PartialEq, sqlx::FromRow)]
+struct RawReceiptClaimRow {
+    ready_slot: i32,
+    ready_generation: i64,
+    job_id: i64,
+    priority: i16,
+    attempt: i16,
+    run_lease: i64,
+    lane_seq: i64,
+    claim_slot: i32,
+}
+
 fn install_in_memory_metrics() -> (InMemoryMetricExporter, SdkMeterProvider) {
     let exporter = InMemoryMetricExporter::default();
     let meter_provider = SdkMeterProvider::builder()
@@ -3821,7 +3833,7 @@ async fn test_queue_storage_receipt_claim_dedupes_when_post_commit_cursor_advanc
     .await
     .expect("claim sequence name");
 
-    let first: Vec<(i32, i64, i64, i16, i16, i64, i64, i32)> = sqlx::query_as(&format!(
+    let first: Vec<RawReceiptClaimRow> = sqlx::query_as(&format!(
         "SELECT ready_slot, ready_generation, job_id, priority, attempt, run_lease, lane_seq, claim_slot
          FROM {schema}.claim_ready_runtime($1, $2, $3, $4)"
     ))
@@ -3833,7 +3845,19 @@ async fn test_queue_storage_receipt_claim_dedupes_when_post_commit_cursor_advanc
     .await
     .expect("first raw receipt claim");
 
-    assert_eq!(first, vec![(0, 0, job_id, 2, 1, 1, 1, 0)]);
+    assert_eq!(
+        first,
+        vec![RawReceiptClaimRow {
+            ready_slot: 0,
+            ready_generation: 0,
+            job_id,
+            priority: 2,
+            attempt: 1,
+            run_lease: 1,
+            lane_seq: 1,
+            claim_slot: 0,
+        }]
+    );
     assert_eq!(
         claim_cursor().await,
         1,

--- a/awa/tests/queue_storage_runtime_test.rs
+++ b/awa/tests/queue_storage_runtime_test.rs
@@ -3685,6 +3685,89 @@ async fn test_queue_storage_attempt_state_only_receipts_rescue_after_stale_heart
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn test_queue_storage_claim_gap_does_not_skip_uncommitted_enqueue_sequence() {
+    let _guard = QUEUE_STORAGE_RUNTIME_LOCK.lock().await;
+    let pool = setup_pool(10).await;
+    let queue = "qs_sequence_gap_uncommitted_enqueue";
+    let schema = "awa_qs_sequence_gap_uncommitted_enqueue";
+    let store = create_store_with_config(
+        &pool,
+        QueueStorageConfig {
+            schema: schema.to_string(),
+            queue_slot_count: 4,
+            lease_slot_count: 2,
+            queue_stripe_count: 1,
+            lease_claim_receipts: true,
+            claim_slot_count: 2,
+        },
+    )
+    .await;
+
+    let _job_id = enqueue_job(
+        &pool,
+        &store,
+        &HeartbeatRescueJob { id: 7 },
+        InsertOpts {
+            queue: queue.to_string(),
+            ..Default::default()
+        },
+    )
+    .await;
+
+    let claimed = store
+        .claim_runtime_batch(&pool, queue, 1, Duration::ZERO)
+        .await
+        .expect("initial claim should succeed");
+    assert_eq!(claimed.len(), 1);
+    assert_eq!(claimed[0].claim.lane_seq, 1);
+
+    let claim_cursor = || async {
+        sqlx::query_scalar::<_, i64>(&format!(
+            "SELECT {schema}.sequence_next_value(seq_name)
+             FROM {schema}.queue_claim_heads
+             WHERE queue = $1 AND priority = $2 AND enqueue_shard = $3"
+        ))
+        .bind(queue)
+        .bind(2_i16)
+        .bind(0_i16)
+        .fetch_one(&pool)
+        .await
+        .expect("claim cursor")
+    };
+
+    assert_eq!(claim_cursor().await, 2);
+
+    let mut tx = pool.begin().await.expect("begin enqueue reservation");
+    let reserved: i64 = sqlx::query_scalar(&format!(
+        "SELECT {schema}.reserve_enqueue_seq($1, $2, $3, $4)"
+    ))
+    .bind(queue)
+    .bind(2_i16)
+    .bind(0_i16)
+    .bind(1_i64)
+    .fetch_one(tx.as_mut())
+    .await
+    .expect("reserve enqueue sequence");
+    assert_eq!(reserved, 2);
+
+    let missed = store
+        .claim_runtime_batch(&pool, queue, 1, Duration::ZERO)
+        .await
+        .expect("claim against uncommitted enqueue reservation should not fail");
+    assert!(
+        missed.is_empty(),
+        "uncommitted enqueue reservation must not be claimable"
+    );
+    assert_eq!(
+        claim_cursor().await,
+        2,
+        "claim cursor must not advance to an enqueue sequence reservation whose ready row is not committed"
+    );
+
+    tx.rollback().await.expect("rollback reservation holder");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn test_queue_storage_receipt_claims_rescue_after_grace_window() {
     let _guard = QUEUE_STORAGE_RUNTIME_LOCK.lock().await;
     let pool = setup_pool(10).await;
@@ -4385,16 +4468,17 @@ async fn test_queue_storage_prepare_schema_drops_legacy_count_snapshots_table() 
 /// Drift-detection guard for the head-table-derived available count.
 ///
 /// `queue_counts_exact` (admin API) scans `ready_entries` with
-/// `lane_seq >= claim_seq`; the dispatcher hot path reads the cheaper
-/// `sum(next_seq - claim_seq)` from the two head tables. The two are
+/// `lane_seq >= claim_cursor`; the dispatcher hot path reads the cheaper
+/// `sum(enqueue_cursor - claim_cursor)` from the two head tables. The two are
 /// only equivalent when every lifecycle path that adds or removes a
 /// live ready row keeps the head tables honest:
 ///
-///   * enqueue → bumps queue_enqueue_heads.next_seq
-///   * claim   → bumps queue_claim_heads.claim_seq past the lane_seq
-///   * cancel / delete of an unclaimed head-lane → bumps claim_seq
-///   * cancel / delete of a non-head lane → leaves a gap that the
-///     dispatcher's gap-recovery branch in claim_ready_runtime closes
+///   * enqueue → bumps the lane's enqueue sequence
+///   * claim   → bumps the lane's claim sequence past the lane_seq
+///   * Rust cancel of an unclaimed head-lane → bumps the claim sequence after
+///     commit
+///   * SQL-compat deletes and non-head deletes → may leave a hot-path
+///     over-count until later committed rows on that lane are claimed
 ///
 /// A missed bump would persistently over-count and burn dispatcher
 /// claim attempts on phantom availability. This test pins the
@@ -4405,8 +4489,8 @@ async fn test_queue_storage_prepare_schema_drops_legacy_count_snapshots_table() 
 ///
 /// At every checkpoint:
 ///   - `store.queue_counts(...).available` (public API) ==
-///     `count(*) FROM ready_entries WHERE lane_seq >= claim_seq`
-///   - `sum(next_seq - claim_seq)` (hot-path approximation)
+///     `count(*) FROM ready_entries WHERE lane_seq >= claim_cursor`
+///   - `sum(enqueue_cursor - claim_cursor)` (hot-path approximation)
 ///     `>= scan` (never under-counts)
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn test_available_count_matches_ready_entries_scan() {
@@ -4432,7 +4516,7 @@ async fn test_available_count_matches_ready_entries_scan() {
               AND claims.priority = ready.priority
               AND claims.enqueue_shard = ready.enqueue_shard
              WHERE ready.queue = $1
-               AND ready.lane_seq >= claims.claim_seq"
+               AND ready.lane_seq >= {schema}.sequence_next_value(claims.seq_name)"
         ))
         .bind(queue)
         .fetch_one(pool)
@@ -4441,15 +4525,14 @@ async fn test_available_count_matches_ready_entries_scan() {
 
         // There are two available-count formulations and they only
         // agree when no admin DELETE has punched a gap between
-        // claim_seq and next_seq:
+        // claim_cursor and enqueue_cursor:
         //
         // - Hot-path signal (queue_claimer_signal): cheap derived
-        //   `sum(next_seq - claim_seq)`. Two PK reads per lane.
+        //   `sum(enqueue_cursor - claim_cursor)`. Two PK reads per lane.
         //   Tolerates transient over-counts after admin DELETEs of
-        //   non-head lanes — the dispatcher's gap-recovery branch
-        //   absorbs the drift on the next claim attempt.
+        //   non-head lanes and in-flight sequence reservations.
         // - Admin API (queue_counts): exact, via a scan over
-        //   ready_entries with `lane_seq >= claim_seq`. Same
+        //   ready_entries with `lane_seq >= claim_cursor`. Same
         //   predicate as the ground-truth scan below.
         //
         // The test pins API == scan (the admin contract) and only
@@ -4458,7 +4541,11 @@ async fn test_available_count_matches_ready_entries_scan() {
         // of mid-ring deletes since the last claim on that lane.
         let derived_approx: i64 = sqlx::query_scalar(&format!(
             "SELECT COALESCE(
-                sum(GREATEST(qe.next_seq - qc.claim_seq, 0)),
+                sum(GREATEST(
+                    {schema}.sequence_next_value(qe.seq_name)
+                        - {schema}.sequence_next_value(qc.seq_name),
+                    0
+                )),
                 0
             )::bigint
              FROM {schema}.queue_enqueue_heads AS qe
@@ -4535,7 +4622,7 @@ async fn test_available_count_matches_ready_entries_scan() {
           AND claims.enqueue_shard = ready.enqueue_shard
          WHERE ready.queue = $1
            AND ready.priority = 2
-           AND ready.lane_seq >= claims.claim_seq
+           AND ready.lane_seq >= {schema}.sequence_next_value(claims.seq_name)
          ORDER BY ready.lane_seq ASC
          LIMIT 1"
     ))
@@ -4594,9 +4681,9 @@ async fn test_available_count_matches_ready_entries_scan() {
     assert_all_three_agree(&pool, &store, queue, "after canonical insert_job_compat").await;
 
     // ── checkpoint 8: canonical-side delete_job_compat ───────────────
-    // Same compat route in reverse — verifies delete_job_compat decrements
-    // the counter only for rows still satisfying lane_seq >= claim_seq
-    // (the same predicate the legacy scan used).
+    // Same compat route in reverse. The SQL function cannot safely move the
+    // non-transactional claim sequence before its caller's transaction commits,
+    // so this pins the exact API count and never-undercount hot-path contract.
     let compat_id: i64 = sqlx::query_scalar(&format!(
         "SELECT job_id
          FROM {schema}.ready_entries
@@ -5159,15 +5246,27 @@ async fn seed_terminal_rows_with_kind(
     sqlx::query(&format!(
         r#"
         INSERT INTO {schema}.queue_terminal_live_counts AS counts (
-            ready_slot, queue, priority, enqueue_shard, live_terminal_count
+            ready_slot, queue, priority, enqueue_shard, counter_bucket, live_terminal_count
         )
-        VALUES (0, $1, 2::smallint, 0::smallint, $2::bigint)
-        ON CONFLICT (ready_slot, queue, priority, enqueue_shard) DO UPDATE
+        SELECT
+            0,
+            $1,
+            2::smallint,
+            0::smallint,
+            bucket.counter_bucket,
+            count(*)::bigint
+        FROM (
+            SELECT mod(mod($2::bigint + g - 1, 256::bigint) + 256::bigint, 256::bigint)::smallint AS counter_bucket
+            FROM generate_series(1, $3::int) AS g
+        ) AS bucket
+        GROUP BY bucket.counter_bucket
+        ON CONFLICT (ready_slot, queue, priority, enqueue_shard, counter_bucket) DO UPDATE
         SET live_terminal_count = counts.live_terminal_count + EXCLUDED.live_terminal_count
         "#
     ))
     .bind(queue)
-    .bind(n)
+    .bind(next_job_id)
+    .bind(n as i32)
     .execute(pool)
     .await
     .expect("seed live counter");
@@ -5270,8 +5369,10 @@ async fn test_queue_terminal_live_counts_rebuild_restores_invariant() {
     .await
     .expect("poison counter");
 
-    // Sanity-check the drift is present.
-    assert_eq!(live_count_sum(&pool, schema, queue).await, 999);
+    // Sanity-check the drift is present. With bucketed counters this
+    // poisons every bucket row for the queue, so the exact poisoned sum
+    // depends on how many buckets the seeded job_ids touched.
+    assert_ne!(live_count_sum(&pool, schema, queue).await, 7);
     assert_eq!(done_entries_count(&pool, schema, queue).await, 7);
 
     let rebuilt = store
@@ -7099,8 +7200,18 @@ async fn test_queue_storage_ensure_lane_cache_recovers_after_rollback() {
         .await
         .expect("post-rollback enqueue should self-heal via cache invalidation");
 
-    let next_seq: i64 = sqlx::query_scalar(&format!(
-        "SELECT next_seq FROM {schema}.queue_enqueue_heads WHERE queue = $1 AND priority = $2"
+    let (next_seq, ready_count, max_lane_seq): (i64, i64, Option<i64>) = sqlx::query_as(&format!(
+        "SELECT
+             {schema}.sequence_next_value(heads.seq_name),
+             count(ready.*)::bigint,
+             max(ready.lane_seq)
+         FROM {schema}.queue_enqueue_heads AS heads
+         LEFT JOIN {schema}.ready_entries AS ready
+           ON ready.queue = heads.queue
+          AND ready.priority = heads.priority
+          AND ready.enqueue_shard = heads.enqueue_shard
+         WHERE heads.queue = $1 AND heads.priority = $2
+         GROUP BY heads.seq_name"
     ))
     .bind(queue)
     .bind(4_i16)
@@ -7109,8 +7220,13 @@ async fn test_queue_storage_ensure_lane_cache_recovers_after_rollback() {
     .expect("queue_enqueue_heads row should exist after recovery");
 
     assert_eq!(
-        next_seq, 4,
-        "next_seq should reflect the three recovery jobs starting from a re-initialised head"
+        ready_count, 3,
+        "recovery enqueue should write all three replacement ready rows"
+    );
+    assert_eq!(
+        Some(next_seq - 1),
+        max_lane_seq,
+        "enqueue sequence should sit immediately after the recovered ready rows"
     );
 }
 
@@ -7541,8 +7657,8 @@ async fn test_queue_storage_multi_shard_claim_path_does_not_starve_shards() {
 
     let heads: Vec<(i16, i64, i64)> = sqlx::query_as(&format!(
         "SELECT claims.enqueue_shard,
-                claims.claim_seq,
-                enqueues.next_seq
+                {schema}.sequence_next_value(claims.seq_name) AS claim_seq,
+                {schema}.sequence_next_value(enqueues.seq_name) AS next_seq
          FROM {schema}.queue_claim_heads AS claims
          JOIN {schema}.queue_enqueue_heads AS enqueues
            ON enqueues.queue = claims.queue

--- a/awa/tests/queue_storage_runtime_test.rs
+++ b/awa/tests/queue_storage_runtime_test.rs
@@ -3734,7 +3734,6 @@ async fn test_queue_storage_claim_gap_does_not_skip_uncommitted_enqueue_sequence
         .await
         .expect("claim cursor")
     };
-
     assert_eq!(claim_cursor().await, 2);
 
     let mut tx = pool.begin().await.expect("begin enqueue reservation");
@@ -3765,6 +3764,236 @@ async fn test_queue_storage_claim_gap_does_not_skip_uncommitted_enqueue_sequence
     );
 
     tx.rollback().await.expect("rollback reservation holder");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn test_queue_storage_receipt_claim_dedupes_when_post_commit_cursor_advance_is_lost() {
+    let _guard = QUEUE_STORAGE_RUNTIME_LOCK.lock().await;
+    let pool = setup_pool(10).await;
+    let queue = "qs_receipt_claim_lost_cursor_advance";
+    let schema = "awa_qs_receipt_claim_lost_cursor_advance";
+    let store = create_store_with_config(
+        &pool,
+        QueueStorageConfig {
+            schema: schema.to_string(),
+            queue_slot_count: 4,
+            lease_slot_count: 2,
+            queue_stripe_count: 1,
+            lease_claim_receipts: true,
+            claim_slot_count: 2,
+        },
+    )
+    .await;
+
+    let job_id = enqueue_job(
+        &pool,
+        &store,
+        &HeartbeatRescueJob { id: 8 },
+        InsertOpts {
+            queue: queue.to_string(),
+            ..Default::default()
+        },
+    )
+    .await;
+
+    let claim_cursor = || async {
+        sqlx::query_scalar::<_, i64>(&format!(
+            "SELECT {schema}.sequence_next_value(seq_name)
+             FROM {schema}.queue_claim_heads
+             WHERE queue = $1 AND priority = $2 AND enqueue_shard = $3"
+        ))
+        .bind(queue)
+        .bind(2_i16)
+        .bind(0_i16)
+        .fetch_one(&pool)
+        .await
+        .expect("claim cursor")
+    };
+    let claim_seq_name: String = sqlx::query_scalar(&format!(
+        "SELECT seq_name
+         FROM {schema}.queue_claim_heads
+         WHERE queue = $1 AND priority = $2 AND enqueue_shard = $3"
+    ))
+    .bind(queue)
+    .bind(2_i16)
+    .bind(0_i16)
+    .fetch_one(&pool)
+    .await
+    .expect("claim sequence name");
+
+    let first: Vec<(i32, i64, i64, i16, i16, i64, i64, i32)> = sqlx::query_as(&format!(
+        "SELECT ready_slot, ready_generation, job_id, priority, attempt, run_lease, lane_seq, claim_slot
+         FROM {schema}.claim_ready_runtime($1, $2, $3, $4)"
+    ))
+    .bind(queue)
+    .bind(1_i64)
+    .bind(0.0_f64)
+    .bind(0.0_f64)
+    .fetch_all(&pool)
+    .await
+    .expect("first raw receipt claim");
+
+    assert_eq!(first, vec![(0, 0, job_id, 2, 1, 1, 1, 0)]);
+    assert_eq!(
+        claim_cursor().await,
+        1,
+        "raw claim intentionally leaves the post-commit claim cursor advance unsent"
+    );
+
+    match store.rotate_claims(&pool).await.expect("rotate claims") {
+        RotateOutcome::Rotated { slot, .. } => assert_eq!(slot, 1),
+        other => panic!("expected claim ring to rotate to slot 1, got {other:?}"),
+    }
+
+    let second: Vec<(i64, i64, i64, i32)> = sqlx::query_as(&format!(
+        "SELECT job_id, run_lease, lane_seq, claim_slot
+         FROM {schema}.claim_ready_runtime($1, $2, $3, $4)"
+    ))
+    .bind(queue)
+    .bind(1_i64)
+    .bind(0.0_f64)
+    .bind(0.0_f64)
+    .fetch_all(&pool)
+    .await
+    .expect("second raw receipt claim with stale cursor");
+
+    assert!(
+        second.is_empty(),
+        "stale claim cursor plus claim-ring rotation must not emit a second open receipt"
+    );
+    assert_eq!(
+        claim_cursor().await,
+        2,
+        "spent receipt evidence should advance the stale claim cursor over the emitted attempt"
+    );
+
+    let receipt_rows: i64 = sqlx::query_scalar(&format!(
+        "SELECT count(*)::bigint
+         FROM {schema}.lease_claims
+         WHERE job_id = $1 AND run_lease = $2"
+    ))
+    .bind(job_id)
+    .bind(1_i64)
+    .fetch_one(&pool)
+    .await
+    .expect("count receipt rows");
+    assert_eq!(
+        receipt_rows, 1,
+        "there must be only one receipt row for the claimed attempt across claim partitions"
+    );
+
+    assert_eq!(
+        open_receipt_claim_count(&pool, &store).await,
+        1,
+        "the original receipt remains open for completion or rescue"
+    );
+
+    sqlx::query("SELECT setval(format('%I.%I', $1, $2)::regclass, $3, $4)")
+        .bind(schema)
+        .bind(&claim_seq_name)
+        .bind(1_i64)
+        .bind(false)
+        .execute(&pool)
+        .await
+        .expect("reset claim cursor for closed-receipt phase");
+
+    sqlx::query(&format!(
+        "INSERT INTO {schema}.lease_claim_closures (claim_slot, job_id, run_lease, outcome)
+         VALUES ($1, $2, $3, 'completed')"
+    ))
+    .bind(0_i32)
+    .bind(job_id)
+    .bind(1_i64)
+    .execute(&pool)
+    .await
+    .expect("close first receipt");
+
+    let after_closure: Vec<(i64, i64, i64, i32)> = sqlx::query_as(&format!(
+        "SELECT job_id, run_lease, lane_seq, claim_slot
+         FROM {schema}.claim_ready_runtime($1, $2, $3, $4)"
+    ))
+    .bind(queue)
+    .bind(1_i64)
+    .bind(0.0_f64)
+    .bind(0.0_f64)
+    .fetch_all(&pool)
+    .await
+    .expect("raw receipt claim after closure with stale cursor");
+
+    assert!(
+        after_closure.is_empty(),
+        "a closed receipt still marks the attempt as spent while the claim cursor is stale"
+    );
+    assert_eq!(
+        claim_cursor().await,
+        2,
+        "closed receipt evidence should also advance the stale claim cursor"
+    );
+
+    sqlx::query("SELECT setval(format('%I.%I', $1, $2)::regclass, $3, $4)")
+        .bind(schema)
+        .bind(&claim_seq_name)
+        .bind(1_i64)
+        .bind(false)
+        .execute(&pool)
+        .await
+        .expect("reset claim cursor for terminal-evidence phase");
+
+    sqlx::query(&format!(
+        "INSERT INTO {schema}.done_entries (
+            ready_slot, ready_generation, job_id, kind, queue, state,
+            priority, attempt, run_lease, lane_seq, enqueue_shard,
+            attempted_at, finalized_at, payload
+        ) VALUES (
+            0, 0, $1, 'heartbeat_rescue_job', $2, 'completed'::awa.job_state,
+            2::smallint, 1::smallint, 1::bigint, 1::bigint, 0::smallint,
+            now(), now(), '{{}}'::jsonb
+        )"
+    ))
+    .bind(job_id)
+    .bind(queue)
+    .execute(&pool)
+    .await
+    .expect("seed terminal evidence");
+
+    sqlx::query(&format!(
+        "DELETE FROM {schema}.lease_claim_closures WHERE job_id = $1 AND run_lease = $2"
+    ))
+    .bind(job_id)
+    .bind(1_i64)
+    .execute(&pool)
+    .await
+    .expect("remove closure evidence");
+    sqlx::query(&format!(
+        "DELETE FROM {schema}.lease_claims WHERE job_id = $1 AND run_lease = $2"
+    ))
+    .bind(job_id)
+    .bind(1_i64)
+    .execute(&pool)
+    .await
+    .expect("remove claim evidence");
+
+    let after_receipt_prune: Vec<(i64, i64, i64, i32)> = sqlx::query_as(&format!(
+        "SELECT job_id, run_lease, lane_seq, claim_slot
+         FROM {schema}.claim_ready_runtime($1, $2, $3, $4)"
+    ))
+    .bind(queue)
+    .bind(1_i64)
+    .bind(0.0_f64)
+    .bind(0.0_f64)
+    .fetch_all(&pool)
+    .await
+    .expect("raw receipt claim after receipt evidence is gone");
+
+    assert!(
+        after_receipt_prune.is_empty(),
+        "terminal evidence must also prevent re-emitting a spent attempt after receipt partitions are pruned"
+    );
+    assert_eq!(
+        claim_cursor().await,
+        2,
+        "terminal evidence should advance the stale claim cursor after receipt evidence is gone"
+    );
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]

--- a/awa/tests/telemetry_test.rs
+++ b/awa/tests/telemetry_test.rs
@@ -160,7 +160,7 @@ async fn queue_job_count(pool: &sqlx::PgPool, queue: &str, state: &str) -> i64 {
                   AND claims.priority = ready.priority \
                   AND claims.enqueue_shard = ready.enqueue_shard \
                  WHERE ready.queue = $1 \
-                   AND ready.lane_seq >= claims.claim_seq \
+                   AND ready.lane_seq >= {schema}.sequence_next_value(claims.seq_name) \
                  UNION ALL \
                  SELECT state FROM {schema}.deferred_jobs WHERE queue = $1 \
                  UNION ALL \
@@ -234,7 +234,7 @@ async fn queue_state_breakdown(pool: &sqlx::PgPool, queue: &str) -> Vec<(String,
                   AND claims.priority = ready.priority \
                   AND claims.enqueue_shard = ready.enqueue_shard \
                  WHERE ready.queue = $1 \
-                   AND ready.lane_seq >= claims.claim_seq \
+                   AND ready.lane_seq >= {schema}.sequence_next_value(claims.seq_name) \
                  UNION ALL \
                  SELECT state FROM {schema}.deferred_jobs WHERE queue = $1 \
                  UNION ALL \

--- a/correctness/README.md
+++ b/correctness/README.md
@@ -112,6 +112,7 @@ What is intentionally not modeled:
 - `storage/AwaSegmentedStorageTrace.tla` /
   `storage/AwaSegmentedStorageTrace.cfg` /
   `storage/AwaSegmentedStorageTraceReceiptRescue.cfg` /
+  `storage/AwaSegmentedStorageTraceLostClaimAdvance.cfg` /
   `storage/AwaSegmentedStorageTraceRunningCancel.cfg` /
   `storage/AwaSegmentedStorageTraceReceiptOnlyCancel.cfg` /
   `storage/AwaSegmentedStorageTraceCallbackWait.cfg` /
@@ -192,6 +193,7 @@ Expected counterexample or positive-witness configs:
 ./correctness/run-tlc.sh storage/AwaSegmentedStorageRaces.tla storage/AwaSegmentedStorageRaces.cfg
 ./correctness/run-tlc.sh storage/AwaSegmentedStorageTrace.tla
 ./correctness/run-tlc.sh storage/AwaSegmentedStorageTrace.tla storage/AwaSegmentedStorageTraceReceiptRescue.cfg
+./correctness/run-tlc.sh storage/AwaSegmentedStorageTrace.tla storage/AwaSegmentedStorageTraceLostClaimAdvance.cfg
 ./correctness/run-tlc.sh storage/AwaSegmentedStorageTrace.tla storage/AwaSegmentedStorageTraceRunningCancel.cfg
 ./correctness/run-tlc.sh storage/AwaSegmentedStorageTrace.tla storage/AwaSegmentedStorageTraceReceiptOnlyCancel.cfg
 ./correctness/run-tlc.sh storage/AwaSegmentedStorageTrace.tla storage/AwaSegmentedStorageTraceCallbackWait.cfg

--- a/correctness/storage/AwaSegmentedStorageTrace.tla
+++ b/correctness/storage/AwaSegmentedStorageTrace.tla
@@ -52,6 +52,17 @@ ReceiptRescueTrace == <<
     [action |-> "RescueStaleReceipt",       job |-> "j1", run_lease |-> 1]
 >>
 
+\* Post-commit claim-cursor advance loss trace. This models the v0.6
+\* sequence-cursor shape where the receipt claim commits but the separate
+\* sequence advance does not run. The committed receipt makes the ready head
+\* a spent attempt, so AdvanceClaimCursor may move over it without opening a
+\* second receipt.
+LostClaimAdvanceTrace == <<
+    [action |-> "EnqueueReady",                        job |-> "j1"],
+    [action |-> "SeedOpenReceiptOnlyClaimLostAdvance", worker |-> "w1", job |-> "j1"],
+    [action |-> "AdvanceClaimCursor"]
+>>
+
 \* Running admin-cancel trace: enqueue, claim a lease-backed running job,
 \* admin-cancel it into terminal_entries, and close the matching receipt.
 RunningCancelTrace == <<
@@ -164,6 +175,41 @@ SeedOpenReceiptOnlyClaim(w, j) ==
                    terminalSegmentOf>>
     /\ UnchangedSegmentState
 
+\* Same receipt-only seed, but deliberately leaves laneState.claimSeq at the
+\* old head to model a process dying between claim commit and the
+\* post-commit sequence advance. CurrentReady excludes the open receipt, so
+\* the base AdvanceClaimCursor action can self-heal by moving over the spent
+\* committed attempt.
+SeedOpenReceiptOnlyClaimLostAdvance(w, j) ==
+    LET newKey == <<j, runLease[j] + 1>>
+    IN
+    /\ w \in Workers
+    /\ j \in CurrentReady
+    /\ laneSeq[j] = laneState.claimSeq
+    /\ runLease[j] < MaxRunLease
+    /\ claimSegments[claimSegmentCursor] = "open"
+    /\ runLease' = [runLease EXCEPT ![j] = runLease[j] + 1]
+    /\ claimSegmentOf' = [claimSegmentOf EXCEPT ![newKey] = claimSegmentCursor]
+    /\ claimOpen' = claimOpen \cup {newKey}
+    /\ UNCHANGED claimClosed
+    /\ laneState' = [laneState EXCEPT !.readyCount = laneState.readyCount - 1]
+    /\ UNCHANGED <<deferredEntries,
+                   waitingLeases,
+                   terminalEntries,
+                   dlqEntries,
+                   activeLeases,
+                   leaseOwner,
+                   taskLease,
+                   attemptState,
+                   heartbeatFresh,
+                   progressTouched,
+                   readyEntries,
+                   laneSeq,
+                   readySegmentOf,
+                   leaseSegmentOf,
+                   terminalSegmentOf>>
+    /\ UnchangedSegmentState
+
 \* Fire the base spec action matching trace[n]. Events that take a
 \* (worker, job) pair read both ev.worker and ev.job. Events that take
 \* only a job read ev.job.
@@ -173,6 +219,9 @@ TraceStep(trace, n) ==
     /\ \/ (ev.action = "EnqueueReady" /\ EnqueueReady(ev.job))
        \/ (ev.action = "SeedOpenReceiptOnlyClaim" /\
               SeedOpenReceiptOnlyClaim(ev.worker, ev.job))
+       \/ (ev.action = "SeedOpenReceiptOnlyClaimLostAdvance" /\
+              SeedOpenReceiptOnlyClaimLostAdvance(ev.worker, ev.job))
+       \/ (ev.action = "AdvanceClaimCursor" /\ AdvanceClaimCursor)
        \/ (ev.action = "Claim" /\ Claim(ev.worker, ev.job))
        \/ (ev.action = "RetryToDeferred" /\ RetryToDeferred(ev.worker, ev.job))
        \/ (ev.action = "PromoteDeferred" /\ PromoteDeferred(ev.job))
@@ -212,6 +261,7 @@ TraceNextFor(trace) ==
 \* `SPECIFICATION SpecSnooze`, etc.
 SpecSnooze == TraceInit /\ [][TraceNextFor(SnoozeTrace)]_<<vars, traceIdx>>
 SpecReceiptRescue == TraceInit /\ [][TraceNextFor(ReceiptRescueTrace)]_<<vars, traceIdx>>
+SpecLostClaimAdvance == TraceInit /\ [][TraceNextFor(LostClaimAdvanceTrace)]_<<vars, traceIdx>>
 SpecRunningCancel == TraceInit /\ [][TraceNextFor(RunningCancelTrace)]_<<vars, traceIdx>>
 SpecDlqRetry == TraceInit /\ [][TraceNextFor(DlqRetryTrace)]_<<vars, traceIdx>>
 SpecReceiptOnlyCancel == TraceInit /\ [][TraceNextFor(ReceiptOnlyCancelTrace)]_<<vars, traceIdx>>
@@ -227,6 +277,7 @@ SpecBroken == TraceInit /\ [][TraceNextFor(BrokenTrace)]_<<vars, traceIdx>>
 \* end — the deadlock at traceIdx < Len proves the rejection.
 SnoozeTraceIncomplete == traceIdx < Len(SnoozeTrace)
 ReceiptRescueTraceIncomplete == traceIdx < Len(ReceiptRescueTrace)
+LostClaimAdvanceTraceIncomplete == traceIdx < Len(LostClaimAdvanceTrace)
 RunningCancelTraceIncomplete == traceIdx < Len(RunningCancelTrace)
 DlqRetryTraceIncomplete == traceIdx < Len(DlqRetryTrace)
 ReceiptOnlyCancelTraceIncomplete == traceIdx < Len(ReceiptOnlyCancelTrace)

--- a/correctness/storage/AwaSegmentedStorageTraceLostClaimAdvance.cfg
+++ b/correctness/storage/AwaSegmentedStorageTraceLostClaimAdvance.cfg
@@ -1,0 +1,36 @@
+\* Lost post-commit claim-cursor advance trace validation. TLC should report
+\* "Invariant LostClaimAdvanceTraceIncomplete is violated" when the trace
+\* reaches Len(LostClaimAdvanceTrace) = 3.
+CONSTANTS
+  Jobs = {"j1"}
+  Workers = {"w1"}
+  ReadySegmentCount = 2
+  LeaseSegmentCount = 2
+  TerminalSegmentCount = 2
+  ClaimSegmentCount = 2
+  MaxRunLease = 2
+  MaxAppendSeq = 2
+
+SPECIFICATION SpecLostClaimAdvance
+
+INVARIANTS
+  TypeOK
+  ActiveLeasesSubsetReadyEntries
+  AttemptStateRequiresLiveLease
+  FreshHeartbeatRequiresLease
+  ProgressRequiresAttemptState
+  TerminalHasNoLiveRuntime
+  TerminalHasRetainedReadyBody
+  DlqHasNoLiveRuntime
+  DlqAndTerminalDisjoint
+  DeferredHasNoLiveRuntime
+  WaitingIsLeaseState
+  ReadyEntriesHaveLaneSeq
+  DeferredEntriesClearLaneSeq
+  ReadyLaneSeqUnique
+  ClaimCursorBounded
+  NoLostClaim
+  ClaimOpenAndClosedDisjoint
+  LaneStateConsistent
+  TaskLeaseBounded
+  LostClaimAdvanceTraceIncomplete

--- a/correctness/storage/README.md
+++ b/correctness/storage/README.md
@@ -390,6 +390,7 @@ Run:
 ```bash
 ./correctness/run-tlc.sh storage/AwaSegmentedStorageTrace.tla
 ./correctness/run-tlc.sh storage/AwaSegmentedStorageTrace.tla storage/AwaSegmentedStorageTraceReceiptRescue.cfg
+./correctness/run-tlc.sh storage/AwaSegmentedStorageTrace.tla storage/AwaSegmentedStorageTraceLostClaimAdvance.cfg
 ./correctness/run-tlc.sh storage/AwaSegmentedStorageTrace.tla storage/AwaSegmentedStorageTraceRunningCancel.cfg
 ./correctness/run-tlc.sh storage/AwaSegmentedStorageTrace.tla storage/AwaSegmentedStorageTraceDlqRetry.cfg
 ./correctness/run-tlc.sh storage/AwaSegmentedStorageTrace.tla storage/AwaSegmentedStorageTraceBroken.cfg

--- a/docs/adr/008-copy-batch-ingestion.md
+++ b/docs/adr/008-copy-batch-ingestion.md
@@ -133,14 +133,14 @@ and dispatchers handle duplicates gracefully.
 - **Staging overhead remains:** COPY still pays for staging and a final insert
   into the real Awa tables, so it is not automatically faster than chunked
   multi-row `INSERT` in every workload.
-- **Lane cursors remain online:** queue-storage enqueue still bumps
-  `queue_enqueue_heads.next_seq` once per touched lane and
-  transaction. Earlier iterations also maintained a
+- **Lane cursors remain online:** queue-storage enqueue still reserves
+  sequence values once per touched lane and transaction, with
+  `queue_enqueue_heads` retained as the lane registry. Earlier iterations
+  also maintained a
   `queue_lanes.available_count` cache on the same path; that cache
   has been dropped (see [ADR-019](019-queue-storage-redesign.md) §
   `lane_state` and segment cursor tables) and the dispatcher now
-  derives availability from the head-table difference, so the only
-  remaining hot-lane write on the enqueue path is the cursor bump.
+  derives availability from the enqueue/claim sequence cursor difference.
 
 ## Relationship to ADR-019
 

--- a/docs/adr/019-queue-storage-redesign.md
+++ b/docs/adr/019-queue-storage-redesign.md
@@ -146,17 +146,18 @@ The implementation and migrations use these physical names:
 - Queue-local lane metadata is intentionally split so one row family does not
   absorb every enqueue and claim mutation.
 - `lane_state` itself is reduced to stable per-lane identity and legacy
-  fallback fields. The mutable enqueue cursor lives in `queue_enqueue_heads`
-  and the mutable claim cursor lives in `queue_claim_heads`.
+  fallback fields. `queue_enqueue_heads` and `queue_claim_heads` remain as
+  stable lane registries and lock targets; the mutable enqueue and claim
+  cursors live in PostgreSQL sequences referenced by those rows.
 - Availability counts have two grades, both cheap. The dispatcher
-  hot path reads `sum(queue_enqueue_heads.next_seq -
-  queue_claim_heads.claim_seq)` — two PK reads per lane, no scan over
-  `ready_entries`. Admin / UI calls (`queue_counts`) scan
-  `ready_entries WHERE lane_seq >= claim_seq` for an exact result.
-  The dispatcher tolerates the head difference's transient over-count
-  after admin DELETEs of unclaimed rows; the next claim attempt's
-  gap-recovery branch in `claim_ready_runtime` advances `claim_seq`
-  to close the gap. **historical:** earlier iterations cached this as
+  hot path reads `sum(enqueue_sequence_cursor - claim_sequence_cursor)` from
+  the lane heads — two PK reads plus sequence state reads per lane, no scan
+  over `ready_entries`. Admin / UI calls (`queue_counts`) scan
+  `ready_entries WHERE lane_seq >= claim_sequence_cursor` for an exact
+  result. The dispatcher tolerates transient over-count from committed gaps,
+  uncommitted sequence reservations, and admin DELETEs of unclaimed rows; the
+  cursor is only advanced after committed claims/cancels so it can lag but
+  cannot skip visible ready work. **historical:** earlier iterations cached this as
   `queue_lanes.available_count` (a third counter mutated on every
   enqueue / claim / completion); long-horizon profiling under pinned
   xmin showed the cache was the dominant dead-tuple source, so v016
@@ -164,14 +165,14 @@ The implementation and migrations use these physical names:
 - Completed-history rollups live in a separate cold cache table so prune can
   preserve queue counts without serializing on the hot `lane_state` rows.
 - Completion must not update `lane_state` on every terminal transition; the
-  hot path only mutates claim/enqueue control state. Per-completion
-  `running` / `completed` counter updates on a single busy lane collapse
-  throughput by an order of magnitude under benchmark, so `running` is
-  derived from `active_leases` and terminal counts come from live
-  `terminal_entries` plus the post-prune rollup rather than from a hot
-  completion counter. That rollup is written in the prune transaction, but to
-  a separate cold table rather than to `lane_state`, so the prune path does
-  not serialize on the same hot rows as claim and enqueue.
+  hot path only mutates claim/enqueue control state. `running` is derived from
+  active leases/receipts. Terminal counts use `queue_terminal_live_counts`
+  plus the post-prune rollup: the live counter is keyed by ready slot, queue,
+  priority, enqueue shard, and a deterministic `job_id` bucket so
+  completion-heavy queues do not form a single pinned-MVCC HOT chain. The
+  permanent rollup is written in the prune transaction to a separate cold
+  table rather than to `lane_state`, so prune does not serialize on the same
+  hot rows as claim and enqueue.
 - Ready and lease segment cursor tables tell dispatch and maintenance which
   physical segment is active, claimable, or prunable.
 - Lease prune order is derived from `lease_ring_state(current_slot,

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -271,7 +271,7 @@ maintenance leader:
 | Ring | Partitions | Default cadence | Rotate requires | Prune requires |
 |---|---|---:|---|---|
 | Queue | `ready_entries_*`, `done_entries_*` | `1000ms` | incoming ready/done slot is empty | oldest non-current slot has no active leases and no pending ready rows; terminal rows in that ready segment are reclaimed with their retained ready bodies |
-| Lease | `leases_*` | `50ms` | incoming lease slot is empty | oldest initialized non-current lease slot is empty |
+| Lease | `leases_*` | `250ms` | incoming lease slot is empty | oldest initialized non-current lease slot is empty |
 | Claim | `lease_claims_*`, `lease_claim_closures_*` | matches queue ring | incoming claims/closures slot is empty | every claim in the oldest non-current slot has a matching closure |
 
 The maintenance tick for each ring is deliberately small: attempt one rotate,

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -508,7 +508,7 @@ let client = Client::builder(pool.clone())
             ..Default::default()
         },
         Duration::from_millis(1_000),
-        Duration::from_millis(50),
+        Duration::from_millis(250),
     )
     .claim_rotate_interval(Duration::from_millis(1_000))
     .build()?;
@@ -525,7 +525,7 @@ await client.start(
     queue_storage_claim_slot_count=8,
     queue_storage_queue_stripe_count=1,
     queue_storage_queue_rotate_interval_ms=1000,
-    queue_storage_lease_rotate_interval_ms=50,
+    queue_storage_lease_rotate_interval_ms=250,
     queue_storage_claim_rotate_interval_ms=1000,
 )
 ```
@@ -540,7 +540,7 @@ await client.start(
 | `queue_stripe_count` / `queue_storage_queue_stripe_count` | `1` | Number of physical stripes behind each logical queue. `1` is the normal unstriped path. For a single very hot queue on many small replicas, `2` is the current tuned recommendation; higher values should be benchmarked before use. |
 | `lease_claim_receipts` | `true` | Use the receipt-plane short path (claim writes a row into `lease_claims`; completion writes a closure tombstone into `lease_claim_closures`; both reclaimed by claim-ring prune). Receipts mode supports per-claim deadlines: when `QueueConfig.deadline_duration > 0`, the claim writes `clock_timestamp() + interval` onto `lease_claims.deadline_at` and the maintenance rescue path force-closes expired claims with a `'deadline_expired'` closure. Set to `false` to force every claim through the legacy `leases` materialization path. See ADR-023. |
 | `queue_rotate_interval` | `1000ms` | How often ready/terminal segments rotate |
-| `lease_rotate_interval` | `50ms` | How often lease segments rotate |
+| `lease_rotate_interval` | `250ms` | How often lease segments rotate |
 | `claim_rotate_interval` | matches `queue_rotate_interval` | How often the ADR-023 claim-ring rotates. Set with `ClientBuilder::claim_rotate_interval` (Rust) or `queue_storage_claim_rotate_interval_ms` (Python). Test harnesses sometimes set this to a long interval to pin claim-ring layout for deterministic count assertions. |
 
 The benchmark harness in

--- a/docs/upgrade-0.5-to-0.6.md
+++ b/docs/upgrade-0.5-to-0.6.md
@@ -286,8 +286,10 @@ The only operator-visible caveat is the per-runtime `enqueue_shards_cache`: a ru
 
    ```sql
    SELECT priority, enqueue_shard,
-          enqueues.next_seq, claims.claim_seq,
-          enqueues.next_seq - claims.claim_seq AS lag
+          <queue_storage_schema>.sequence_next_value(enqueues.seq_name) AS enqueue_cursor,
+          <queue_storage_schema>.sequence_next_value(claims.seq_name) AS claim_cursor,
+          <queue_storage_schema>.sequence_next_value(enqueues.seq_name)
+            - <queue_storage_schema>.sequence_next_value(claims.seq_name) AS lag
    FROM <queue_storage_schema>.queue_claim_heads AS claims
    JOIN <queue_storage_schema>.queue_enqueue_heads AS enqueues
      USING (queue, priority, enqueue_shard)

--- a/docs/upgrade-0.5-to-0.6.md
+++ b/docs/upgrade-0.5-to-0.6.md
@@ -285,14 +285,15 @@ The only operator-visible caveat is the per-runtime `enqueue_shards_cache`: a ru
 3. Optionally watch per-shard lag drain to zero:
 
    ```sql
-   SELECT priority, enqueue_shard,
-          <queue_storage_schema>.sequence_next_value(enqueues.seq_name) AS enqueue_cursor,
-          <queue_storage_schema>.sequence_next_value(claims.seq_name) AS claim_cursor,
-          <queue_storage_schema>.sequence_next_value(enqueues.seq_name)
-            - <queue_storage_schema>.sequence_next_value(claims.seq_name) AS lag
+   SELECT priority, enqueue_shard, enqueue_cursor, claim_cursor,
+          enqueue_cursor - claim_cursor AS lag
    FROM <queue_storage_schema>.queue_claim_heads AS claims
    JOIN <queue_storage_schema>.queue_enqueue_heads AS enqueues
      USING (queue, priority, enqueue_shard)
+   CROSS JOIN LATERAL (
+     SELECT <queue_storage_schema>.sequence_next_value(enqueues.seq_name) AS enqueue_cursor,
+            <queue_storage_schema>.sequence_next_value(claims.seq_name) AS claim_cursor
+   ) AS cursor_values
    WHERE queue = 'my_hot_queue'
    ORDER BY priority, enqueue_shard;
    ```


### PR DESCRIPTION

## Summary

Pulls the #295 storage-shape work into v0.6:

- moves queue-storage enqueue/claim lane cursors from hot MVCC-updated rows to PostgreSQL sequences while retaining the head tables as lane registries and lock targets
- advances claim cursors post-commit so nontransactional sequence state cannot skip work on rollback
- stripes `queue_terminal_live_counts` by deterministic `job_id % 256` buckets so completion-heavy lanes do not hammer one counter row under pinned MVCC
- refreshes the default/custom queue-storage substrates via migration v26 and updates docs/tests for the new cursor semantics

## Benchmark evidence

Release-gate run: `custom-20260605T013419Z-0c45d0` in `hardbyte/postgresql-job-queue-benchmarking`, summary committed at `results/2026-06-05-v06-gate/SUMMARY.md`.

Shape: 1 replica, 32 workers, fixed 800 jobs/s producer; warmup 5m, clean 20m, idle-in-tx 60m, recovery 10m; compared Awa branch vs pgque submodule `55ddc1d`.

Headline: both Awa and pgque completed the 60-minute pinned-MVCC phase without a sustained throughput cliff. Awa idle median completion was `798.57/s` at `798.59/s` median enqueue, with p95 depth `20` and median e2e p95 `30.02 ms`. Pgque idle median completion was `800.05/s` at `800.13/s` median enqueue, with p95 depth `81` and median e2e p95 `131.55 ms`.

## Validation

- `cargo fmt --check`
- `git diff --check`
- `CARGO_TARGET_DIR=target/codex-check cargo check -p awa-model`
- `TEST_DATABASE_URL=postgres://postgres:test@localhost:15432/awa_test CARGO_TARGET_DIR=target/codex-check cargo test -p awa --test migration_test -- --nocapture` (37 passed)
- `TEST_DATABASE_URL=postgres://postgres:test@localhost:15432/awa_test CARGO_TARGET_DIR=target/codex-check cargo test -p awa --test queue_storage_runtime_test -- --nocapture` (79 passed)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sequence-driven cursor behavior for more accurate queue selection/counting; per-lane claim-cursor advances and rebucketed terminal counters.
  * Schema migration to install the new queue-storage substrate and rebucket existing counters.

* **Bug Fixes**
  * Fixed terminal-counter decrement to update the correct counter bucket.

* **Performance Improvements**
  * Increased lease rotation interval from 50ms to 250ms.

* **Documentation & Tests**
  * Updated ADRs/docs and added/updated tests for migration, counters, cursor behavior, and maintenance gating.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->