### PR TITLE
Use GitHub-style Markdown wrapping

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,3 @@
+{
+  "proseWrap": "never"
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,518 +1,200 @@
 # Changelog
 
-Notable changes between releases. Detailed migration notes for storage
-transitions live in [`docs/upgrade-0.5-to-0.6.md`](docs/upgrade-0.5-to-0.6.md).
+Notable changes between releases. Detailed migration notes for storage transitions live in [`docs/upgrade-0.5-to-0.6.md`](docs/upgrade-0.5-to-0.6.md).
 
 ## Unreleased
 
-- **Cron schedule pause / resume.** `cron_jobs` carries `paused_at` and
-  `paused_by` columns; `POST /api/cron/{name}/pause` and `/resume` toggle
-  the state. The evaluator skips paused rows and the `atomic_enqueue`
-  CTE re-checks `paused_at IS NULL` so a pause asserted between the
-  leader's read and CAS still takes effect. `last_enqueued_at` is left
-  untouched while paused, so the schedule's `missed_fire_policy` decides
-  catch-up behaviour on resume. Manual `trigger_cron_job` bypasses pause.
-  The `/cron` UI page gains Pause/Resume controls and shows a
-  "queue paused" badge when the target queue is itself paused.
+- **Cron schedule pause / resume.** `cron_jobs` carries `paused_at` and `paused_by` columns; `POST /api/cron/{name}/pause` and `/resume` toggle the state. The evaluator skips paused rows and the `atomic_enqueue` CTE re-checks `paused_at IS NULL` so a pause asserted between the leader's read and CAS still takes effect. `last_enqueued_at` is left untouched while paused, so the schedule's `missed_fire_policy` decides catch-up behaviour on resume. Manual `trigger_cron_job` bypasses pause. The `/cron` UI page gains Pause/Resume controls and shows a "queue paused" badge when the target queue is itself paused.
 
 ## [0.6.0-beta.1] — 2026-05-19
 
-First beta of the 0.6 line. Frames the user-facing diff between
-`0.5.x` and `0.6.0-beta.1` as one release; the `0.6.0-alpha.N`
-entries below remain as the granular development log.
+First beta of the 0.6 line. Frames the user-facing diff between `0.5.x` and `0.6.0-beta.1` as one release; the `0.6.0-alpha.N` entries below remain as the granular development log.
 
 ### What's new since 0.5.x
 
 **Storage and durability**
 
-- **Queue-storage engine, default-on**
-  ([ADR-019](docs/adr/019-queue-storage-redesign.md)). Append-only
-  `ready_entries`, `deferred_jobs`, `done_entries`, and `dlq_entries`
-  paired with a partitioned receipt ring keep dead-tuple footprint
-  bounded under sustained load. Replaces the row-mutating canonical
-  engine for fresh installs.
-- **Receipt-plane ring partitioning**
-  ([ADR-023](docs/adr/023-receipt-plane-ring-partitioning.md)).
-  `lease_claims` and `lease_claim_closures` partitioned by claim slot,
-  rotated by the maintenance leader.
-- **Per-claim deadlines** in receipts mode. Set
-  `QueueConfig.deadline_duration` to bound a single attempt; rescue
-  force-closes expired claims with `'deadline_expired'`.
-- **Staged 0.5 → 0.6 transition tooling**: `awa storage prepare`,
-  `prepare-queue-storage-schema`, `enter-mixed-transition`, `finalize`,
-  `abort`. Fresh installs auto-finalize on first `awa migrate`. Full
-  procedure in [`docs/upgrade-0.5-to-0.6.md`](docs/upgrade-0.5-to-0.6.md).
+- **Queue-storage engine, default-on** ([ADR-019](docs/adr/019-queue-storage-redesign.md)). Append-only `ready_entries`, `deferred_jobs`, `done_entries`, and `dlq_entries` paired with a partitioned receipt ring keep dead-tuple footprint bounded under sustained load. Replaces the row-mutating canonical engine for fresh installs.
+- **Receipt-plane ring partitioning** ([ADR-023](docs/adr/023-receipt-plane-ring-partitioning.md)). `lease_claims` and `lease_claim_closures` partitioned by claim slot, rotated by the maintenance leader.
+- **Per-claim deadlines** in receipts mode. Set `QueueConfig.deadline_duration` to bound a single attempt; rescue force-closes expired claims with `'deadline_expired'`.
+- **Staged 0.5 → 0.6 transition tooling**: `awa storage prepare`, `prepare-queue-storage-schema`, `enter-mixed-transition`, `finalize`, `abort`. Fresh installs auto-finalize on first `awa migrate`. Full procedure in [`docs/upgrade-0.5-to-0.6.md`](docs/upgrade-0.5-to-0.6.md).
 
 **Operator surfaces**
 
-- **Dead Letter Queue**
-  ([ADR-020](docs/adr/020-dead-letter-queue.md)). Per-queue
-  `dlq_enabled` policy plus a full admin surface:
-  `awa dlq depth | list | retry | retry-bulk | move | purge` (CLI),
-  matching admin UI tab, Rust/Python client APIs.
-- **Descriptor catalog**
-  ([ADR-022](docs/adr/022-descriptor-catalog.md)). Code-declared queue
-  and job-kind metadata (`display_name`, `description`, `owner`,
-  `tags`, `docs_url`) drives admin UI labels and drift detection.
-- **Cron missed-fire policy**. Periodic schedules persist an explicit
-  `missed_fire_policy`: `coalesce` (default) or `catch_up`. Exposed in
-  Rust/Python APIs and CLI schedule output.
-- **`awa-pg[ui]` Python extra** + `python -m awa serve`. The bare
-  `awa-pg` install stays small (workers/producers don't pay for the
-  ~10 MB axum + dashboard bundle); `pip install 'awa-pg[ui]'` pulls in
-  the `awa-cli` wheel and lets `python -m awa serve` launch the
-  embedded React dashboard.
-- **Managed-Postgres deployment guide**
-  ([`docs/deploying-on-managed-postgres.md`](docs/deploying-on-managed-postgres.md)).
-  Per-vCPU sizing data, Cloud SQL IAM grants, AlloyDB notes,
-  auth-proxy sidecar pattern.
+- **Dead Letter Queue** ([ADR-020](docs/adr/020-dead-letter-queue.md)). Per-queue `dlq_enabled` policy plus a full admin surface: `awa dlq depth | list | retry | retry-bulk | move | purge` (CLI), matching admin UI tab, Rust/Python client APIs.
+- **Descriptor catalog** ([ADR-022](docs/adr/022-descriptor-catalog.md)). Code-declared queue and job-kind metadata (`display_name`, `description`, `owner`, `tags`, `docs_url`) drives admin UI labels and drift detection.
+- **Cron missed-fire policy**. Periodic schedules persist an explicit `missed_fire_policy`: `coalesce` (default) or `catch_up`. Exposed in Rust/Python APIs and CLI schedule output.
+- **`awa-pg[ui]` Python extra** + `python -m awa serve`. The bare `awa-pg` install stays small (workers/producers don't pay for the ~10 MB axum + dashboard bundle); `pip install 'awa-pg[ui]'` pulls in the `awa-cli` wheel and lets `python -m awa serve` launch the embedded React dashboard.
+- **Managed-Postgres deployment guide** ([`docs/deploying-on-managed-postgres.md`](docs/deploying-on-managed-postgres.md)). Per-vCPU sizing data, Cloud SQL IAM grants, AlloyDB notes, auth-proxy sidecar pattern.
 
 **Producer APIs and tuning**
 
-- **Direct queue-storage COPY producer path** as the documented
-  high-volume entry point. Rust:
-  `QueueStorage::enqueue_params_copy(pool, &jobs)`. Python:
-  `Client.enqueue_many_copy(jobs)`. The compat-friendly
-  `insert_many_copy_from_pool` / `client.insert_many_copy` routes
-  through `awa.insert_job_compat()` once per row — fine for ad-hoc
-  inserts but ~100–150 ms per row through a real DB proxy, not what
-  you want for bursts.
-- **`InsertOpts::ordering_key: Option<Vec<u8>>`** pins related jobs to
-  the same shard at `enqueue_shards > 1`. Kafka-partition-key
-  analogue: jobs sharing a key inherit that shard's strict FIFO. `None`
-  rotates batches across shards.
-- **`awa.queue_meta.enqueue_shards` per-queue semantic switch**
-  ([ADR-025](docs/adr/025-sharded-enqueue-heads.md)). Default `1`
-  preserves strict `(queue, priority)` FIFO. Setting `≥ 2` switches
-  that queue to partitioned FIFO (strict within `(queue, priority,
-  enqueue_shard)`, no order across shards) — comparable to choosing
-  SQS Standard over FIFO.
-- **Queue-storage completion-batcher defaults tuned** to `(batch=512, flush=1ms)`.
-  Tunable via `AWA_COMPLETION_BATCH_SIZE` and `AWA_COMPLETION_FLUSH_MS`.
+- **Direct queue-storage COPY producer path** as the documented high-volume entry point. Rust: `QueueStorage::enqueue_params_copy(pool, &jobs)`. Python: `Client.enqueue_many_copy(jobs)`. The compat-friendly `insert_many_copy_from_pool` / `client.insert_many_copy` routes through `awa.insert_job_compat()` once per row — fine for ad-hoc inserts but ~100–150 ms per row through a real DB proxy, not what you want for bursts.
+- **`InsertOpts::ordering_key: Option<Vec<u8>>`** pins related jobs to the same shard at `enqueue_shards > 1`. Kafka-partition-key analogue: jobs sharing a key inherit that shard's strict FIFO. `None` rotates batches across shards.
+- **`awa.queue_meta.enqueue_shards` per-queue semantic switch** ([ADR-025](docs/adr/025-sharded-enqueue-heads.md)). Default `1` preserves strict `(queue, priority)` FIFO. Setting `≥ 2` switches that queue to partitioned FIFO (strict within `(queue, priority, enqueue_shard)`, no order across shards) — comparable to choosing SQS Standard over FIFO.
+- **Queue-storage completion-batcher defaults tuned** to `(batch=512, flush=1ms)`. Tunable via `AWA_COMPLETION_BATCH_SIZE` and `AWA_COMPLETION_FLUSH_MS`.
 
 **Telemetry**
 
-- **`awa-metrics` crate**. `AwaMetrics` and its `record_*` methods
-  live in their own crate so non-runtime callers (`awa-ui`, `awa-cli`)
-  can emit the same OTel counters as the worker. `awa-worker::AwaMetrics`
-  re-exports for source compatibility.
-- **Sub-second buckets on `awa.job.wait_duration`**. Previous boundaries
-  didn't resolve pickup latency below 5 s.
-- **`awa.enqueue.batch_size` and `awa.enqueue.duration`** histograms on
-  the direct COPY enqueue path.
-- **`awa.enqueue.shard` attribute on `awa.job.claimed`** so dashboards
-  can see per-shard claim throughput.
+- **`awa-metrics` crate**. `AwaMetrics` and its `record_*` methods live in their own crate so non-runtime callers (`awa-ui`, `awa-cli`) can emit the same OTel counters as the worker. `awa-worker::AwaMetrics` re-exports for source compatibility.
+- **Sub-second buckets on `awa.job.wait_duration`**. Previous boundaries didn't resolve pickup latency below 5 s.
+- **`awa.enqueue.batch_size` and `awa.enqueue.duration`** histograms on the direct COPY enqueue path.
+- **`awa.enqueue.shard` attribute on `awa.job.claimed`** so dashboards can see per-shard claim throughput.
 
 ### Upgrading from 0.5.x
 
-- Fresh installs: nothing to do. `awa migrate` auto-finalizes to the
-  queue-storage engine on first run.
-- Existing 0.5.x clusters: walk the staged transition documented in
-  [`docs/upgrade-0.5-to-0.6.md`](docs/upgrade-0.5-to-0.6.md). Roll out
-  0.6 workers first (they understand both engines and the transition
-  states), then walk `prepare → enter-mixed-transition → finalize`.
-  **Rollback boundary:** one-way after `enter-mixed-transition`
-  followed by any queue-storage write. Plan to restore from backup if
-  rollback is needed past that point.
-- Update the dependency: `awa = "0.6.0-beta.1"` (Rust) /
-  `awa-pg==0.6.0-beta.1` (Python).
+- Fresh installs: nothing to do. `awa migrate` auto-finalizes to the queue-storage engine on first run.
+- Existing 0.5.x clusters: walk the staged transition documented in [`docs/upgrade-0.5-to-0.6.md`](docs/upgrade-0.5-to-0.6.md). Roll out 0.6 workers first (they understand both engines and the transition states), then walk `prepare → enter-mixed-transition → finalize`. **Rollback boundary:** one-way after `enter-mixed-transition` followed by any queue-storage write. Plan to restore from backup if rollback is needed past that point.
+- Update the dependency: `awa = "0.6.0-beta.1"` (Rust) / `awa-pg==0.6.0-beta.1` (Python).
 
 ### Operating notes
 
-- **Set `enqueue_shards` explicitly per queue.** The default `1` is the
-  conservative FIFO-preserving choice but serialises producers on a
-  single head row. We recommend `4` for contended hot queues. The
-  trade-off is semantic, not a free perf win — see
-  [`docs/configuration.md`](docs/configuration.md#sharding-the-enqueue-head-per-queue).
-- **MVCC discipline.** If your application runs long-lived
-  `REPEATABLE READ` / `SERIALIZABLE` transactions on the same database
-  awa lives in, give awa its own database. Long-pinned `xmin` blocks
-  dead-tuple cleanup and degrades queue-storage throughput over long
-  horizons. Tracked in
-  [#169](https://github.com/hardbyte/awa/issues/169).
-- **Cloud SQL with IAM auth:** the runtime SA needs `cloudsqlsuperuser`
-  for `prepare_schema` to install. Run `GRANT cloudsqlsuperuser TO
-  "your-sa@project.iam"` once per instance. AlloyDB grants this
-  automatically. Full guide:
-  [`docs/deploying-on-managed-postgres.md`](docs/deploying-on-managed-postgres.md).
+- **Set `enqueue_shards` explicitly per queue.** The default `1` is the conservative FIFO-preserving choice but serialises producers on a single head row. We recommend `4` for contended hot queues. The trade-off is semantic, not a free perf win — see [`docs/configuration.md`](docs/configuration.md#sharding-the-enqueue-head-per-queue).
+- **MVCC discipline.** If your application runs long-lived `REPEATABLE READ` / `SERIALIZABLE` transactions on the same database awa lives in, give awa its own database. Long-pinned `xmin` blocks dead-tuple cleanup and degrades queue-storage throughput over long horizons. Tracked in [#169](https://github.com/hardbyte/awa/issues/169).
+- **Cloud SQL with IAM auth:** the runtime SA needs `cloudsqlsuperuser` for `prepare_schema` to install. Run `GRANT cloudsqlsuperuser TO "your-sa@project.iam"` once per instance. AlloyDB grants this automatically. Full guide: [`docs/deploying-on-managed-postgres.md`](docs/deploying-on-managed-postgres.md).
 
 ### Changes since 0.6.0-alpha.9
 
 For users already running an alpha:
 
-- v021 shard-aware lane indexes on `ready_entries` / `done_entries` /
-  `leases` partitions (#263). The narrow `(queue, priority, lane_seq)`
-  indexes from before v017 didn't include `enqueue_shard`; on heavy
-  backlog the planner discarded `(shards-1)/shards` of rows per
-  partition per claim. Drain throughput at depth restored to
-  equilibrium rate.
-- `prepare_schema` startup race fixed (#264, #266). Concurrent worker
-  startup on a fresh DB previously hung on PG18; install now runs in
-  a single transaction with `pg_advisory_xact_lock`.
-- `queue_storage_schema_ready` tightened to require every object the
-  runtime depends on, so a partial install can't report ready (#266).
+- v021 shard-aware lane indexes on `ready_entries` / `done_entries` / `leases` partitions (#263). The narrow `(queue, priority, lane_seq)` indexes from before v017 didn't include `enqueue_shard`; on heavy backlog the planner discarded `(shards-1)/shards` of rows per partition per claim. Drain throughput at depth restored to equilibrium rate.
+- `prepare_schema` startup race fixed (#264, #266). Concurrent worker startup on a fresh DB previously hung on PG18; install now runs in a single transaction with `pg_advisory_xact_lock`.
+- `queue_storage_schema_ready` tightened to require every object the runtime depends on, so a partial install can't report ready (#266).
 - Managed-Postgres deploy guide added (#265).
-- `awa.enqueue.batch_size` / `awa.enqueue.duration` histograms added
-  (#265).
-- Direct queue-storage COPY producer path is the documented
-  high-volume entry point (#263); compat path semantics unchanged.
+- `awa.enqueue.batch_size` / `awa.enqueue.duration` histograms added (#265).
+- Direct queue-storage COPY producer path is the documented high-volume entry point (#263); compat path semantics unchanged.
 
 ### Performance
-- Drop the `queue_lanes.available_count` cache (migration `v016`).
-  The dispatcher derives availability from
-  `queue_enqueue_heads.next_seq - queue_claim_heads.claim_seq` and
-  the admin API (`queue_counts`) scans `ready_entries` for an exact
-  count. Removes the queue-storage schema's largest dead-tuple
-  source under pinned-xmin workloads (long-running reader
-  transactions) without changing public API behaviour. See ADR-019
-  § `lane_state` and segment cursor tables.
-- Cache `(queue, priority, enqueue_shard)` lane presence in-process
-  on the queue-storage path so subsequent enqueue batches skip the
-  three `INSERT ... ON CONFLICT DO NOTHING` round-trips on
-  `queue_lanes` / `queue_enqueue_heads` / `queue_claim_heads`. The
-  cache invalidates and re-runs `ensure_lane` if a subsequent
-  `UPDATE queue_enqueue_heads` finds no row (the observable signal
-  of an earlier ensure_lane that ran inside a rolled-back
-  transaction), so correctness is preserved.
-- Shard the queue-storage active plane by `enqueue_shard` (migration
-  `v017`). `awa.queue_meta.enqueue_shards` (default 1, range 1..=64)
-  is a per-queue semantic mode switch — comparable to choosing SQS
-  Standard over SQS FIFO, raising Kafka partition count, or using
-  Pub/Sub ordering keys. The ordering contract at `enqueue_shards = 1`
-  is unchanged (strict FIFO per `(queue, priority)`); at
-  `enqueue_shards > 1` it becomes **partitioned FIFO** — strict FIFO
-  within `(queue, priority, enqueue_shard)`, no order promised
-  across shards. The shard column runs end-to-end:
-  `queue_enqueue_heads`, `queue_claim_heads`, `ready_entries`,
-  `leases`, and `done_entries` carry it in their primary keys;
-  `lease_claims` carries it as a regular column. Raising the value
-  per noisy queue delivers near-linear throughput scaling on
-  contended enqueue workloads: a 16-producer same-queue local sweep
-  measured 1.0× → 1.60× → 2.75× → 3.69× at S=1/2/4/8. Scope: this
-  addresses producer-side enqueue contention. The
-  high-worker-count rescue-path regression (1 replica × 256
-  workers, receipts on, `LEASE_DEADLINE_MS` A/B) is a separate
-  effect on the claim / rescue side and remains open for follow-up
-  measurement. See ADR-025 for the full design.
-- **Shard-aware lane indexes on `ready_entries`, `done_entries`, and
-  `leases` child partitions** (migration `v021`,
-  [#263](https://github.com/hardbyte/awa/pull/263)). The narrow
-  `(queue, priority, lane_seq)` lane indexes that predated v017 did
-  not include `enqueue_shard`, while `claim_ready_runtime` (since
-  v017) filters on it. Under `enqueue_shards > 1` and deep backlog
-  the planner scanned the lane index forward and post-filtered
-  shard, discarding roughly `(shards-1)/shards` of rows per
-  partition per claim. v021 replaces those with
-  `(queue, priority, enqueue_shard, lane_seq)` indexes and drops
-  the originals; `prepare_schema` is updated to match for fresh
-  installs. On a Cloud SQL PG18 16 vCPU staging instance with a 3.5M
-  row backlog, end-to-end drain went from ~1,300 jobs/s to
-  ~8,800–10,600 jobs/s (single-claim probe: 11.4 ms → 0.81 ms).
+
+- Drop the `queue_lanes.available_count` cache (migration `v016`). The dispatcher derives availability from `queue_enqueue_heads.next_seq - queue_claim_heads.claim_seq` and the admin API (`queue_counts`) scans `ready_entries` for an exact count. Removes the queue-storage schema's largest dead-tuple source under pinned-xmin workloads (long-running reader transactions) without changing public API behaviour. See ADR-019 § `lane_state` and segment cursor tables.
+- Cache `(queue, priority, enqueue_shard)` lane presence in-process on the queue-storage path so subsequent enqueue batches skip the three `INSERT ... ON CONFLICT DO NOTHING` round-trips on `queue_lanes` / `queue_enqueue_heads` / `queue_claim_heads`. The cache invalidates and re-runs `ensure_lane` if a subsequent `UPDATE queue_enqueue_heads` finds no row (the observable signal of an earlier ensure_lane that ran inside a rolled-back transaction), so correctness is preserved.
+- Shard the queue-storage active plane by `enqueue_shard` (migration `v017`). `awa.queue_meta.enqueue_shards` (default 1, range 1..=64) is a per-queue semantic mode switch — comparable to choosing SQS Standard over SQS FIFO, raising Kafka partition count, or using Pub/Sub ordering keys. The ordering contract at `enqueue_shards = 1` is unchanged (strict FIFO per `(queue, priority)`); at `enqueue_shards > 1` it becomes **partitioned FIFO** — strict FIFO within `(queue, priority, enqueue_shard)`, no order promised across shards. The shard column runs end-to-end: `queue_enqueue_heads`, `queue_claim_heads`, `ready_entries`, `leases`, and `done_entries` carry it in their primary keys; `lease_claims` carries it as a regular column. Raising the value per noisy queue delivers near-linear throughput scaling on contended enqueue workloads: a 16-producer same-queue local sweep measured 1.0× → 1.60× → 2.75× → 3.69× at S=1/2/4/8. Scope: this addresses producer-side enqueue contention. The high-worker-count rescue-path regression (1 replica × 256 workers, receipts on, `LEASE_DEADLINE_MS` A/B) is a separate effect on the claim / rescue side and remains open for follow-up measurement. See ADR-025 for the full design.
+- **Shard-aware lane indexes on `ready_entries`, `done_entries`, and `leases` child partitions** (migration `v021`, [#263](https://github.com/hardbyte/awa/pull/263)). The narrow `(queue, priority, lane_seq)` lane indexes that predated v017 did not include `enqueue_shard`, while `claim_ready_runtime` (since v017) filters on it. Under `enqueue_shards > 1` and deep backlog the planner scanned the lane index forward and post-filtered shard, discarding roughly `(shards-1)/shards` of rows per partition per claim. v021 replaces those with `(queue, priority, enqueue_shard, lane_seq)` indexes and drops the originals; `prepare_schema` is updated to match for fresh installs. On a Cloud SQL PG18 16 vCPU staging instance with a 3.5M row backlog, end-to-end drain went from ~1,300 jobs/s to ~8,800–10,600 jobs/s (single-claim probe: 11.4 ms → 0.81 ms).
 
 ### Added
-- `InsertOpts::ordering_key: Option<Vec<u8>>` pins related jobs to
-  the same shard at `enqueue_shards > 1`. The key bytes are mapped
-  by Awa's portable shard hash and reduced modulo the queue's shard
-  count, so Rust, SQL, and Python enqueue paths agree on routing.
-  Use it as a Kafka-partition-key analogue: jobs for the same
-  customer / order / account share a shard and inherit that shard's
-  strict FIFO. `None` falls back to one rotor pick per `(queue,
-  priority)` sub-batch. Ignored at `enqueue_shards = 1`.
-- `awa.job.claimed` counter now carries an `awa.enqueue.shard`
-  attribute on the queue-storage claim path so dashboards can see
-  per-shard claim throughput. Canonical claims continue to emit the
-  un-decorated series; the two attribute sets do not overlap, so
-  Prometheus `sum by (awa_enqueue_shard)(rate(awa_job_claimed[1m]))`
-  is the per-shard fairness panel.
-- Tune the queue-storage completion-batcher defaults to
-  `(batch=512, flush=1ms)`. The larger batch cap keeps the durable
-  completion path amortised under load, while the 1 ms flush keeps
-  low-latency finalization for short jobs. Tunable via
-  `AWA_COMPLETION_BATCH_SIZE` and `AWA_COMPLETION_FLUSH_MS`.
-- **Direct queue-storage COPY producer path is the documented
-  high-volume entry point** ([#263](https://github.com/hardbyte/awa/pull/263)).
-  Rust: `QueueStorage::enqueue_params_copy(pool, &jobs)`. Python:
-  `Client.enqueue_many_copy(jobs)`. `insert_many_copy_from_pool` /
-  `client.insert_many_copy` remain available as the compatibility
-  COPY surface and route through `awa.insert_job_compat()`. See
-  [`docs/configuration.md`](docs/configuration.md#producer-path-choice).
-- **Explicit sub-second buckets on `awa.job.wait_duration`**
-  ([#263](https://github.com/hardbyte/awa/pull/263)). Histogram now
-  resolves pickup latency below 5 s, which the previous bucket
-  boundaries did not.
-- **`awa.enqueue.batch_size` and `awa.enqueue.duration` histograms**
-  ([#265](https://github.com/hardbyte/awa/pull/265)). Per-batch
-  observability on the direct COPY enqueue path. Lets producers tell
-  "batches are tiny" from "batches are slow" when an enqueue rate
-  target is missed — neither was distinguishable from existing
-  metrics. Recorded by Python `Client.enqueue_many_copy` (sync and
-  async). Rust callers using `QueueStorage::enqueue_params_copy`
-  directly can record via
-  `AwaMetrics::from_global().record_enqueue_batch(queue, count, duration)`.
-- **Managed-Postgres deployment guide**
-  ([#265](https://github.com/hardbyte/awa/pull/265)). New
-  [`docs/deploying-on-managed-postgres.md`](docs/deploying-on-managed-postgres.md)
-  covering Cloud SQL and AlloyDB specifics: per-vCPU sizing
-  measurements from staging, Postgres-version recommendations, IAM
-  `cloudsqlsuperuser` grant for Cloud SQL IAM users, the auth-proxy
-  native-sidecar pattern, and `enqueue_shards` operator guidance.
+
+- `InsertOpts::ordering_key: Option<Vec<u8>>` pins related jobs to the same shard at `enqueue_shards > 1`. The key bytes are mapped by Awa's portable shard hash and reduced modulo the queue's shard count, so Rust, SQL, and Python enqueue paths agree on routing. Use it as a Kafka-partition-key analogue: jobs for the same customer / order / account share a shard and inherit that shard's strict FIFO. `None` falls back to one rotor pick per `(queue, priority)` sub-batch. Ignored at `enqueue_shards = 1`.
+- `awa.job.claimed` counter now carries an `awa.enqueue.shard` attribute on the queue-storage claim path so dashboards can see per-shard claim throughput. Canonical claims continue to emit the un-decorated series; the two attribute sets do not overlap, so Prometheus `sum by (awa_enqueue_shard)(rate(awa_job_claimed[1m]))` is the per-shard fairness panel.
+- Tune the queue-storage completion-batcher defaults to `(batch=512, flush=1ms)`. The larger batch cap keeps the durable completion path amortised under load, while the 1 ms flush keeps low-latency finalization for short jobs. Tunable via `AWA_COMPLETION_BATCH_SIZE` and `AWA_COMPLETION_FLUSH_MS`.
+- **Direct queue-storage COPY producer path is the documented high-volume entry point** ([#263](https://github.com/hardbyte/awa/pull/263)). Rust: `QueueStorage::enqueue_params_copy(pool, &jobs)`. Python: `Client.enqueue_many_copy(jobs)`. `insert_many_copy_from_pool` / `client.insert_many_copy` remain available as the compatibility COPY surface and route through `awa.insert_job_compat()`. See [`docs/configuration.md`](docs/configuration.md#producer-path-choice).
+- **Explicit sub-second buckets on `awa.job.wait_duration`** ([#263](https://github.com/hardbyte/awa/pull/263)). Histogram now resolves pickup latency below 5 s, which the previous bucket boundaries did not.
+- **`awa.enqueue.batch_size` and `awa.enqueue.duration` histograms** ([#265](https://github.com/hardbyte/awa/pull/265)). Per-batch observability on the direct COPY enqueue path. Lets producers tell "batches are tiny" from "batches are slow" when an enqueue rate target is missed — neither was distinguishable from existing metrics. Recorded by Python `Client.enqueue_many_copy` (sync and async). Rust callers using `QueueStorage::enqueue_params_copy` directly can record via `AwaMetrics::from_global().record_enqueue_batch(queue, count, duration)`.
+- **Managed-Postgres deployment guide** ([#265](https://github.com/hardbyte/awa/pull/265)). New [`docs/deploying-on-managed-postgres.md`](docs/deploying-on-managed-postgres.md) covering Cloud SQL and AlloyDB specifics: per-vCPU sizing measurements from staging, Postgres-version recommendations, IAM `cloudsqlsuperuser` grant for Cloud SQL IAM users, the auth-proxy native-sidecar pattern, and `enqueue_shards` operator guidance.
 
 ### Fixed
-- **`prepare_schema` no longer deadlocks on fresh-DB / small-pool /
-  concurrent worker startup** ([#264](https://github.com/hardbyte/awa/issues/264),
-  [#266](https://github.com/hardbyte/awa/pull/266)). Previously the
-  install acquired `pg_advisory_lock(…)` on one dedicated pool
-  connection but issued every DDL through `.execute(pool)`, which
-  acquired *different* connections per statement. With a one-
-  connection pool that self-deadlocked; with a small pool and
-  concurrent worker startup it exhausted the pool with every worker
-  holding one connection for the lock and competing for the rest for
-  DDL. The PG18-on-fresh-DB hang reported in #264 is the most
-  visible symptom. Install now runs in a single transaction on a
-  single connection with `pg_advisory_xact_lock(…)`; the lock
-  auto-releases on COMMIT/ROLLBACK and the install is atomic.
-- **`queue_storage_schema_ready` checks the full required surface**
-  ([#266](https://github.com/hardbyte/awa/pull/266)). Previously it
-  only checked for `queue_ring_state`, `ready_entries`, and `leases`;
-  if `prepare_schema` had failed partway through (a real failure
-  mode under the old non-atomic install) the schema could report
-  ready while `awa.job_id_seq`, `done_entries`, `deferred_jobs`, or
-  the `claim_ready_runtime` function were missing — at which point
-  producers got `relation "awa.job_id_seq" does not exist`. The
-  check now requires every queue-storage substrate object the
-  runtime depends on.
-- **`AwaMetrics::from_global()` no longer rebuilt per call on hot
-  paths** ([#265](https://github.com/hardbyte/awa/pull/265)).
-  `from_global()` registers the entire instrument set on every
-  invocation. The Python `Client`, `awa-ui` `AppState`, and
-  `awa-cli` DLQ command now cache a single `AwaMetrics` handle and
-  reuse it instead of rebuilding ~30 instruments per operation.
+
+- **`prepare_schema` no longer deadlocks on fresh-DB / small-pool / concurrent worker startup** ([#264](https://github.com/hardbyte/awa/issues/264), [#266](https://github.com/hardbyte/awa/pull/266)). Previously the install acquired `pg_advisory_lock(…)` on one dedicated pool connection but issued every DDL through `.execute(pool)`, which acquired _different_ connections per statement. With a one- connection pool that self-deadlocked; with a small pool and concurrent worker startup it exhausted the pool with every worker holding one connection for the lock and competing for the rest for DDL. The PG18-on-fresh-DB hang reported in #264 is the most visible symptom. Install now runs in a single transaction on a single connection with `pg_advisory_xact_lock(…)`; the lock auto-releases on COMMIT/ROLLBACK and the install is atomic.
+- **`queue_storage_schema_ready` checks the full required surface** ([#266](https://github.com/hardbyte/awa/pull/266)). Previously it only checked for `queue_ring_state`, `ready_entries`, and `leases`; if `prepare_schema` had failed partway through (a real failure mode under the old non-atomic install) the schema could report ready while `awa.job_id_seq`, `done_entries`, `deferred_jobs`, or the `claim_ready_runtime` function were missing — at which point producers got `relation "awa.job_id_seq" does not exist`. The check now requires every queue-storage substrate object the runtime depends on.
+- **`AwaMetrics::from_global()` no longer rebuilt per call on hot paths** ([#265](https://github.com/hardbyte/awa/pull/265)). `from_global()` registers the entire instrument set on every invocation. The Python `Client`, `awa-ui` `AppState`, and `awa-cli` DLQ command now cache a single `AwaMetrics` handle and reuse it instead of rebuilding ~30 instruments per operation.
 
 ## [0.6.0-alpha.9] — 2026-05-08
 
 ### Fixed
 
-- **Queue-storage priority-aging completions now preserve the lane priority in
-  terminal storage.** Workers still receive the aged effective priority, with
-  `_awa_original_priority` in metadata, but `done_entries` now uses the original
-  queue lane priority for its storage key. This prevents aged low-priority jobs
-  from colliding with high-priority jobs that share the same per-lane sequence.
+- **Queue-storage priority-aging completions now preserve the lane priority in terminal storage.** Workers still receive the aged effective priority, with `_awa_original_priority` in metadata, but `done_entries` now uses the original queue lane priority for its storage key. This prevents aged low-priority jobs from colliding with high-priority jobs that share the same per-lane sequence.
 
 ## [0.6.0-alpha.8] — 2026-05-08
 
 ### Added
 
-- **Lifecycle hooks now include `Started` events**. `JobEvent<T>` and
-  `UntypedJobEvent` fire `Started` after a claim commits and just before the
-  worker handler is invoked, so applications can observe job execution
-  beginning as well as final outcomes.
+- **Lifecycle hooks now include `Started` events**. `JobEvent<T>` and `UntypedJobEvent` fire `Started` after a claim commits and just before the worker handler is invoked, so applications can observe job execution beginning as well as final outcomes.
 
 ### Changed
 
-- **Breaking alpha API change:** exhaustive matches on `JobEvent<T>` or
-  `UntypedJobEvent` must handle the new `Started` variant. No stable Awa
-  release has been published yet, so this is documented as an alpha-series
-  source break.
+- **Breaking alpha API change:** exhaustive matches on `JobEvent<T>` or `UntypedJobEvent` must handle the new `Started` variant. No stable Awa release has been published yet, so this is documented as an alpha-series source break.
 
-- **Reduced queue-storage per-claim deadline overhead.** Fresh queue-storage
-  schemas now use a low-write BRIN index for `lease_claims.deadline_at`, and
-  the claim helper computes claim/deadline timestamps once per batch instead of
-  per returned row. Deadline rescue semantics are unchanged; this targets the
-  alpha.8 benchmark path where non-zero `QueueConfig::deadline_duration` is
-  enabled for short receipt-plane jobs.
+- **Reduced queue-storage per-claim deadline overhead.** Fresh queue-storage schemas now use a low-write BRIN index for `lease_claims.deadline_at`, and the claim helper computes claim/deadline timestamps once per batch instead of per returned row. Deadline rescue semantics are unchanged; this targets the alpha.8 benchmark path where non-zero `QueueConfig::deadline_duration` is enabled for short receipt-plane jobs.
 
 ## [0.6.0-alpha.7] — 2026-05-07
 
 ### Added
 
-- **Cron missed-fire policy** ([#239](https://github.com/hardbyte/awa/issues/239),
-  [#240](https://github.com/hardbyte/awa/pull/240)). Periodic schedules now
-  persist an explicit `missed_fire_policy`: `coalesce` remains the default and
-  enqueues only the latest due fire after delayed evaluation, while `catch_up`
-  enqueues missed fires in timestamp order for idempotent reconciliation jobs.
-  The policy is exposed through the Rust and Python APIs, CLI schedule output,
-  docs, and migration v015.
+- **Cron missed-fire policy** ([#239](https://github.com/hardbyte/awa/issues/239), [#240](https://github.com/hardbyte/awa/pull/240)). Periodic schedules now persist an explicit `missed_fire_policy`: `coalesce` remains the default and enqueues only the latest due fire after delayed evaluation, while `catch_up` enqueues missed fires in timestamp order for idempotent reconciliation jobs. The policy is exposed through the Rust and Python APIs, CLI schedule output, docs, and migration v015.
 
 ### Changed
 
-- **Cron evaluation runs in its own leader-scoped maintenance lane**
-  ([#240](https://github.com/hardbyte/awa/pull/240)). Slow cleanup, rotation,
-  or reconciliation work no longer starves the scheduler branch. Coalesced
-  schedules also use a bounded latest-fire lookup so a stale high-frequency
-  schedule does not scan every missed tick.
-- **Runtime grants now document required `TRUNCATE` privileges**
-  ([#239](https://github.com/hardbyte/awa/issues/239),
-  [#240](https://github.com/hardbyte/awa/pull/240)). The security guide now
-  includes `TRUNCATE` in runtime table grants and default privileges, with a
-  DB-backed regression covering the previously documented grants.
+- **Cron evaluation runs in its own leader-scoped maintenance lane** ([#240](https://github.com/hardbyte/awa/pull/240)). Slow cleanup, rotation, or reconciliation work no longer starves the scheduler branch. Coalesced schedules also use a bounded latest-fire lookup so a stale high-frequency schedule does not scan every missed tick.
+- **Runtime grants now document required `TRUNCATE` privileges** ([#239](https://github.com/hardbyte/awa/issues/239), [#240](https://github.com/hardbyte/awa/pull/240)). The security guide now includes `TRUNCATE` in runtime table grants and default privileges, with a DB-backed regression covering the previously documented grants.
 
 ### Fixed
 
-- **Queue-storage claim transactions commit before rescueable runtime payload
-  conversion** ([#222](https://github.com/hardbyte/awa/pull/222)). Runtime
-  claims now keep hot claim transactions shorter while preserving rollback
-  behavior for legacy zero-deadline claims that cannot be rescued after a
-  conversion error.
+- **Queue-storage claim transactions commit before rescueable runtime payload conversion** ([#222](https://github.com/hardbyte/awa/pull/222)). Runtime claims now keep hot claim transactions shorter while preserving rollback behavior for legacy zero-deadline claims that cannot be rescued after a conversion error.
 
 ## [0.6.0-alpha.6] — 2026-05-07
 
 ### Added
 
-- **`awa-metrics` crate** ([#176](https://github.com/hardbyte/awa/issues/176),
-  [#232](https://github.com/hardbyte/awa/pull/232)). The `AwaMetrics` type
-  and its `record_*` methods move from `awa-worker` into a dedicated
-  `awa-metrics` crate so non-runtime callers (`awa-ui`, `awa-cli`) can emit
-  the same OTel counters as the worker without depending on the
-  dispatcher/runtime crate graph. `awa-worker::AwaMetrics` re-exports for
-  source compatibility — no semver break for `awa-cli` or `awa-python`.
-  `awa-metrics::names` exposes public string constants for every metric, and
-  `AwaMetrics::new()` is built from those constants so registered
-  instruments and the public names can't drift.
+- **`awa-metrics` crate** ([#176](https://github.com/hardbyte/awa/issues/176), [#232](https://github.com/hardbyte/awa/pull/232)). The `AwaMetrics` type and its `record_*` methods move from `awa-worker` into a dedicated `awa-metrics` crate so non-runtime callers (`awa-ui`, `awa-cli`) can emit the same OTel counters as the worker without depending on the dispatcher/runtime crate graph. `awa-worker::AwaMetrics` re-exports for source compatibility — no semver break for `awa-cli` or `awa-python`. `awa-metrics::names` exposes public string constants for every metric, and `AwaMetrics::new()` is built from those constants so registered instruments and the public names can't drift.
 
 ### Changed
 
-- **Multi-queue NOTIFY collapses to one round-trip per enqueue tx**
-  ([#235](https://github.com/hardbyte/awa/pull/235)). The three queue-storage
-  enqueue paths (`enqueue_runtime_rows`, `enqueue_params_batch`,
-  `enqueue_params_copy`) used to issue one `pg_notify($1, '')` per distinct
-  destination queue inside the enqueue transaction. Now routed through
-  `notify_queues_tx`, which uses
-  `SELECT pg_notify(channel, '') FROM unnest($1::text[])` so any number of
-  queues becomes one round-trip. Single-queue enqueue (the common case) is
-  unchanged.
-- **Completion path: lease delete and `attempt_state` cleanup merge into a
-  single CTE-as-DML statement** ([#235](https://github.com/hardbyte/awa/pull/235)).
-  `complete_runtime_batch` previously issued two consecutive DELETEs (leases,
-  then `attempt_state`) on the receipt-disabled path and on the materialized
-  fallback inside the receipt-enabled path. They now share one statement —
-  one fewer round-trip per completion batch, identical atomicity and
-  return shape.
+- **Multi-queue NOTIFY collapses to one round-trip per enqueue tx** ([#235](https://github.com/hardbyte/awa/pull/235)). The three queue-storage enqueue paths (`enqueue_runtime_rows`, `enqueue_params_batch`, `enqueue_params_copy`) used to issue one `pg_notify($1, '')` per distinct destination queue inside the enqueue transaction. Now routed through `notify_queues_tx`, which uses `SELECT pg_notify(channel, '') FROM unnest($1::text[])` so any number of queues becomes one round-trip. Single-queue enqueue (the common case) is unchanged.
+- **Completion path: lease delete and `attempt_state` cleanup merge into a single CTE-as-DML statement** ([#235](https://github.com/hardbyte/awa/pull/235)). `complete_runtime_batch` previously issued two consecutive DELETEs (leases, then `attempt_state`) on the receipt-disabled path and on the materialized fallback inside the receipt-enabled path. They now share one statement — one fewer round-trip per completion batch, identical atomicity and return shape.
 
 ### Fixed
 
-- **`awa.job.dlq_retried` tagged with the source queue** ([#232](https://github.com/hardbyte/awa/pull/232)).
-  Single-job retry from `awa-ui` previously read `job.queue` from the
-  returned `JobRow`, which carries the *destination* queue if the request
-  body supplied a `queue` override. The metric now looks the source queue
-  up before retry runs (matching `record_dlq_purged`'s pattern).
+- **`awa.job.dlq_retried` tagged with the source queue** ([#232](https://github.com/hardbyte/awa/pull/232)). Single-job retry from `awa-ui` previously read `job.queue` from the returned `JobRow`, which carries the _destination_ queue if the request body supplied a `queue` override. The metric now looks the source queue up before retry runs (matching `record_dlq_purged`'s pattern).
 
 ## [0.6.0-alpha.5] — 2026-05-04
 
 ### Added
 
-- **`awa-pg[ui]` optional extra** ([#186](https://github.com/hardbyte/awa/issues/186)).
-  `pip install 'awa-pg[ui]'` pulls in the [`awa-cli`](https://pypi.org/project/awa-cli/)
-  wheel so `python -m awa serve` (and `awa serve` directly) launches the
-  embedded React dashboard. The default `awa-pg` install stays small —
-  workers and producers don't pay for the ~10 MB axum + UI bundle they
-  don't need.
-- `python -m awa serve` is now a subcommand. It detects the `awa` binary
-  in `sys.prefix/{bin,Scripts}` (where `awa-cli`'s wheel installs it) and
-  forwards the full argument tail verbatim. If the extra isn't installed,
-  it exits with a `pip install 'awa-pg[ui]'` hint.
+- **`awa-pg[ui]` optional extra** ([#186](https://github.com/hardbyte/awa/issues/186)). `pip install 'awa-pg[ui]'` pulls in the [`awa-cli`](https://pypi.org/project/awa-cli/) wheel so `python -m awa serve` (and `awa serve` directly) launches the embedded React dashboard. The default `awa-pg` install stays small — workers and producers don't pay for the ~10 MB axum + UI bundle they don't need.
+- `python -m awa serve` is now a subcommand. It detects the `awa` binary in `sys.prefix/{bin,Scripts}` (where `awa-cli`'s wheel installs it) and forwards the full argument tail verbatim. If the extra isn't installed, it exits with a `pip install 'awa-pg[ui]'` hint.
 
 ### Fixed
 
-- **Restored queue-storage dispatcher throughput under high concurrency**
-  ([#223](https://github.com/hardbyte/awa/issues/223)). Capacity-release wakes
-  still drain ready work immediately, but the dispatcher now uses the configured
-  fixed fallback poll interval instead of geometrically backing off after empty
-  or permit-saturated polls.
+- **Restored queue-storage dispatcher throughput under high concurrency** ([#223](https://github.com/hardbyte/awa/issues/223)). Capacity-release wakes still drain ready work immediately, but the dispatcher now uses the configured fixed fallback poll interval instead of geometrically backing off after empty or permit-saturated polls.
 
 ### Changed
 
-- Queue-storage throughput benchmarks can run against a non-canonical storage
-  schema and configurable worker count, making local A/B checks safer and
-  easier to reproduce.
-- Added TLA+ trace witnesses for receipt-only cancel, callback wait, and DLQ
-  purge paths, plus documentation alignment for the queue-storage design.
+- Queue-storage throughput benchmarks can run against a non-canonical storage schema and configurable worker count, making local A/B checks safer and easier to reproduce.
+- Added TLA+ trace witnesses for receipt-only cancel, callback wait, and DLQ purge paths, plus documentation alignment for the queue-storage design.
 
 ## [0.6.0-alpha.4] — 2026-05-03
 
 ### Changed
 
-- Added capacity-wake suppression to reduce empty claim churn in quiet queues.
-  This improved some operational churn metrics but regressed high-concurrency
-  queue-storage throughput; alpha.5 keeps the useful wake-drain repair while
-  restoring fixed fallback polling.
+- Added capacity-wake suppression to reduce empty claim churn in quiet queues. This improved some operational churn metrics but regressed high-concurrency queue-storage throughput; alpha.5 keeps the useful wake-drain repair while restoring fixed fallback polling.
 
 ## [0.6.0-alpha.3] — 2026-05-02
 
 ### Changed
 
-- **Completion-batcher default size lowered from `512` to `128`.** Cross-system
-  matrix runs (1–4 worker processes × 16–128 workers per process) showed `128`
-  delivered the lowest p99 in every cell and `512` bought no throughput while
-  hurting tail latency under multi-process deployments. Override via
-  `AWA_COMPLETION_BATCH_SIZE`. See `docs/benchmarking.md` for tuning notes.
-- **Reduced queue-storage claimer heartbeat churn.** Claimer leases now skip
-  refresh writes while still fresh, cutting coordination writes in the dispatch
-  path without changing claim ownership semantics.
-- **Updated architecture documentation.** The architecture guide now reflects
-  the queue-storage receipt path, lazy lease materialization, crash recovery,
-  maintenance leadership, and callback orchestration.
+- **Completion-batcher default size lowered from `512` to `128`.** Cross-system matrix runs (1–4 worker processes × 16–128 workers per process) showed `128` delivered the lowest p99 in every cell and `512` bought no throughput while hurting tail latency under multi-process deployments. Override via `AWA_COMPLETION_BATCH_SIZE`. See `docs/benchmarking.md` for tuning notes.
+- **Reduced queue-storage claimer heartbeat churn.** Claimer leases now skip refresh writes while still fresh, cutting coordination writes in the dispatch path without changing claim ownership semantics.
+- **Updated architecture documentation.** The architecture guide now reflects the queue-storage receipt path, lazy lease materialization, crash recovery, maintenance leadership, and callback orchestration.
 
 ### Fixed
 
-- **Receipt completion now serializes with heartbeat materialization.** The
-  queue-storage completion path locks the matching receipt claim before writing
-  its closure, preventing a concurrent heartbeat from recreating
-  `attempt_state` after completion.
-- **Hardened mixed Rust/Python chaos smoke coverage.** The mixed-fleet smoke
-  test now waits for worker-observed completions from both runtimes instead of
-  relying on transient terminal-row presence.
+- **Receipt completion now serializes with heartbeat materialization.** The queue-storage completion path locks the matching receipt claim before writing its closure, preventing a concurrent heartbeat from recreating `attempt_state` after completion.
+- **Hardened mixed Rust/Python chaos smoke coverage.** The mixed-fleet smoke test now waits for worker-observed completions from both runtimes instead of relying on transient terminal-row presence.
 
 ## [0.6.0-alpha.2] — 2026-05-02
 
 ### Added
 
-- **Vacuum-aware queue storage engine, default-on** ([ADR-019](docs/adr/019-queue-storage-redesign.md)).
-  Append-only `ready_entries`, `deferred_jobs`, `done_entries`, and
-  `dlq_entries` tables, paired with a partitioned receipt ring, keep the
-  dead-tuple footprint bounded under sustained load. Replaces the
-  canonical row-mutating engine for new installs.
-- **Receipt-plane ring partitioning** ([ADR-023](docs/adr/023-receipt-plane-ring-partitioning.md)).
-  `lease_claims` and `lease_claim_closures` are partitioned by claim
-  slot and rotated by the maintenance leader.
-- **Dead Letter Queue** ([ADR-020](docs/adr/020-dead-letter-queue.md)).
-  Per-queue `dlq_enabled` policy and a full operator surface:
-  `awa dlq depth | list | retry | retry-bulk | move | purge`, plus the
-  matching admin UI tab. See [`docs/dead-letter-queue.md`](docs/dead-letter-queue.md).
-- **Descriptor catalog** ([ADR-022](docs/adr/022-descriptor-catalog.md)).
-  Code-declared queue and job-kind metadata (`display_name`,
-  `description`, `owner`, `tags`, `docs_url`) drives admin UI labels
-  and stale/drift detection.
-- **Per-claim deadlines** in receipts mode. `QueueConfig.deadline_duration`
-  writes `lease_claims.deadline_at`; the rescue path force-closes
-  expired claims with `'deadline_expired'`.
-- **Storage transition tooling**. `awa storage prepare`,
-  `prepare-queue-storage-schema`, `enter-mixed-transition`, `finalize`,
-  and `abort` cover the staged upgrade path. Fresh installs auto-finalize
-  on first migrate.
-- **`transition_role` runtime capability**. The `enter_mixed_transition`
-  SQL gate requires a live `queue_storage_target` runtime, so a stale
-  fleet cannot accidentally skip the staged path.
+- **Vacuum-aware queue storage engine, default-on** ([ADR-019](docs/adr/019-queue-storage-redesign.md)). Append-only `ready_entries`, `deferred_jobs`, `done_entries`, and `dlq_entries` tables, paired with a partitioned receipt ring, keep the dead-tuple footprint bounded under sustained load. Replaces the canonical row-mutating engine for new installs.
+- **Receipt-plane ring partitioning** ([ADR-023](docs/adr/023-receipt-plane-ring-partitioning.md)). `lease_claims` and `lease_claim_closures` are partitioned by claim slot and rotated by the maintenance leader.
+- **Dead Letter Queue** ([ADR-020](docs/adr/020-dead-letter-queue.md)). Per-queue `dlq_enabled` policy and a full operator surface: `awa dlq depth | list | retry | retry-bulk | move | purge`, plus the matching admin UI tab. See [`docs/dead-letter-queue.md`](docs/dead-letter-queue.md).
+- **Descriptor catalog** ([ADR-022](docs/adr/022-descriptor-catalog.md)). Code-declared queue and job-kind metadata (`display_name`, `description`, `owner`, `tags`, `docs_url`) drives admin UI labels and stale/drift detection.
+- **Per-claim deadlines** in receipts mode. `QueueConfig.deadline_duration` writes `lease_claims.deadline_at`; the rescue path force-closes expired claims with `'deadline_expired'`.
+- **Storage transition tooling**. `awa storage prepare`, `prepare-queue-storage-schema`, `enter-mixed-transition`, `finalize`, and `abort` cover the staged upgrade path. Fresh installs auto-finalize on first migrate.
+- **`transition_role` runtime capability**. The `enter_mixed_transition` SQL gate requires a live `queue_storage_target` runtime, so a stale fleet cannot accidentally skip the staged path.
 - **Migrations** v012, v013, and v014. All idempotent.
 
 ### Changed
 
-- New installs default to the queue-storage engine; canonical
-  row-mutating storage is no longer the implicit backend.
+- New installs default to the queue-storage engine; canonical row-mutating storage is no longer the implicit backend.
 - Receipts mode is on by default for fresh deployments.
 
 ### Removed
 
-- `benchmarks/portable/` extracted to its own repo at
-  [hardbyte/postgresql-job-queue-benchmarking](https://github.com/hardbyte/postgresql-job-queue-benchmarking).
+- `benchmarks/portable/` extracted to its own repo at [hardbyte/postgresql-job-queue-benchmarking](https://github.com/hardbyte/postgresql-job-queue-benchmarking).
 - The pre-0.6 `EXPERIMENTAL_LEASE_CLAIM_RECEIPTS` env alias.
 
 ### Upgrade notes
 
-- Update your dependency to `awa = "0.6"` (Rust) /
-  `awa-cli`, `awa-pg` (Python) at the matching version.
-- Existing 0.5.x clusters with canonical data must walk the staged
-  storage transition documented in
-  [`docs/upgrade-0.5-to-0.6.md`](docs/upgrade-0.5-to-0.6.md). Fresh
-  installs auto-finalize.
-- Rollback after `enter-mixed-transition` followed by queue-storage
-  writes is one-way (database restore only).
+- Update your dependency to `awa = "0.6"` (Rust) / `awa-cli`, `awa-pg` (Python) at the matching version.
+- Existing 0.5.x clusters with canonical data must walk the staged storage transition documented in [`docs/upgrade-0.5-to-0.6.md`](docs/upgrade-0.5-to-0.6.md). Fresh installs auto-finalize.
+- Rollback after `enter-mixed-transition` followed by queue-storage writes is one-way (database restore only).

--- a/README.md
+++ b/README.md
@@ -2,39 +2,25 @@
 
 **Postgres-native job queue for Rust and Python.**
 
-Awa (Māori: river) fills the gap between Postgres event queues that are too
-narrow for real job-queue behavior and language-specific job frameworks (River,
-Oban, Sidekiq) that couple you to one ecosystem. If you run Rust or Python (or
-both) on Postgres and want priorities, cron, DLQ, and transactional enqueue
-without Redis or RabbitMQ, Awa is built for you.
+Awa (Māori: river) fills the gap between Postgres event queues that are too narrow for real job-queue behavior and language-specific job frameworks (River, Oban, Sidekiq) that couple you to one ecosystem. If you run Rust or Python (or both) on Postgres and want priorities, cron, DLQ, and transactional enqueue without Redis or RabbitMQ, Awa is built for you.
 
 ![AWA Web UI — Jobs (dark mode)](https://raw.githubusercontent.com/hardbyte/awa/main/docs/images/awa-ui-dark.png)
 
 ## Core Concepts
 
 - A **job** is a typed payload stored in Postgres until a worker handles it.
-- A **queue** is the operational boundary workers subscribe to; use separate
-  queues when workloads need different capacity, ownership, or failure policy.
-- A **scheduled job** has a future `run_at`. Awa stores scheduled jobs outside
-  the ready claim path and promotes them when due. Retry backoff and snooze use
-  the same deferred backlog.
-- A worker **claims** a job before running it. The claim increments
-  `run_lease`, which guards completion so stale workers cannot finish a newer
-  attempt.
-- A **lease** is the durable execution record for a live attempt. Short jobs
-  usually stay on the receipt path; jobs that need heartbeat, progress,
-  callbacks, or mutable attempt state materialize a lease row.
-- A **lane** is the ordered stream for one `(queue, priority, enqueue_shard)`.
-  FIFO is strict inside a lane; raising shard count creates partitioned FIFO.
-- A **segment** is a ring partition Awa can rotate and later truncate.
-  Segments keep high-churn queue history off long-lived row-vacuum paths.
-- A **ready tombstone** is a small marker saying an immutable ready row should
-  no longer be claimed, for example after cancelling or reprioritizing an
-  unclaimed job. The ready row itself stays append-only until segment prune.
+- A **queue** is the operational boundary workers subscribe to; use separate queues when workloads need different capacity, ownership, or failure policy.
+- A **scheduled job** has a future `run_at`. Awa stores scheduled jobs outside the ready claim path and promotes them when due. Retry backoff and snooze use the same deferred backlog.
+- A worker **claims** a job before running it. The claim increments `run_lease`, which guards completion so stale workers cannot finish a newer attempt.
+- A **lease** is the durable execution record for a live attempt. Short jobs usually stay on the receipt path; jobs that need heartbeat, progress, callbacks, or mutable attempt state materialize a lease row.
+- A **lane** is the ordered stream for one `(queue, priority, enqueue_shard)`. FIFO is strict inside a lane; raising shard count creates partitioned FIFO.
+- A **segment** is a ring partition Awa can rotate and later truncate. Segments keep high-churn queue history off long-lived row-vacuum paths.
+- A **ready tombstone** is a small marker saying an immutable ready row should no longer be claimed, for example after cancelling or reprioritizing an unclaimed job. The ready row itself stays append-only until segment prune.
 
 ## Features
 
 ### Core queue
+
 - **Transactional enqueue** — insert jobs inside your business transaction. Commit = visible. Rollback = gone.
 - **Unique jobs** — declare uniqueness by kind/queue/args; cancel by unique key without storing job IDs.
 - **Priorities, retries, snoozes** — exponential backoff with jitter; priority aging for fairness.
@@ -44,6 +30,7 @@ without Redis or RabbitMQ, Awa is built for you.
 - **Webhook callbacks** — park jobs for external completion with optional CEL-expression filtering.
 
 ### Runtime
+
 - **Rust and Python workers** — same queues, same storage engine, mixed deployments.
 - **Crash recovery** — heartbeat + hard deadline rescue. Stale jobs recovered automatically.
 - **Runtime-owned maintenance** — dispatch, rescue, queue/lease/claim ring rotation, pruning, and cleanup run in the worker fleet; no `pg_cron` ticker required.
@@ -53,6 +40,7 @@ without Redis or RabbitMQ, Awa is built for you.
 - **Weighted concurrency + rate limiting** — global worker pool with per-queue guarantees; per-queue token bucket.
 
 ### Operations
+
 - **Web UI** — dashboard, job inspector, queue management, cron controls, DLQ retry/purge.
 - **Structured progress** — handlers report percent, message, and checkpoint metadata; persisted across retries.
 - **OpenTelemetry metrics** — 20+ built-in counters, histograms, and gauges for Prometheus/Grafana. Python workers enable export with `awa.init_telemetry(endpoint, service)`; Rust workers install their own provider.
@@ -63,78 +51,35 @@ without Redis or RabbitMQ, Awa is built for you.
 
 ## Correctness
 
-Core concurrency invariants — no duplicate processing after rescue, stale
-completions rejected, no claim/rotate/prune deadlock, DLQ round-trip safety,
-prune-segment emptiness, heartbeat-driven short-job rescue — are checked by
-[TLA+ models](https://github.com/hardbyte/awa/blob/main/correctness/README.md)
-covering the segmented storage engine, the lock-ordering protocol, and the
-single/multi-instance worker runtime. The storage model has a trace-replay
-harness that verifies concrete runtime-test event sequences against the spec.
+Core concurrency invariants — no duplicate processing after rescue, stale completions rejected, no claim/rotate/prune deadlock, DLQ round-trip safety, prune-segment emptiness, heartbeat-driven short-job rescue — are checked by [TLA+ models](https://github.com/hardbyte/awa/blob/main/correctness/README.md) covering the segmented storage engine, the lock-ordering protocol, and the single/multi-instance worker runtime. The storage model has a trace-replay harness that verifies concrete runtime-test event sequences against the spec.
 
 ## Delivery Contract
 
-- **Transactional enqueue** is a core Postgres-native feature: enqueue inside
-  the same transaction as application data, and the job commits or rolls back
-  with that data.
-- **At-least-once delivery** is the contract. Awa rejects stale completions
-  and rescues stuck work, but it does not promise “exactly once”.
-- **Idempotency is recommended** for handlers, because retries and recovery are
-  part of the honest failure model.
-- **No lost work under failure** takes priority over clever fast paths. If a
-  design weakens crash/restart safety, it loses even if the benchmark looks
-  better.
-- **Strict FIFO per `(queue, priority)` by default.** Operators can opt a
-  contended queue into **partitioned FIFO** by raising
-  `awa.queue_meta.enqueue_shards` — the same kind of trade as choosing SQS
-  Standard over SQS FIFO, or raising Kafka partition count. Producers pin
-  related jobs to one shard with `ordering_key`. See
-  [ADR-025](docs/adr/025-sharded-enqueue-heads.md).
+- **Transactional enqueue** is a core Postgres-native feature: enqueue inside the same transaction as application data, and the job commits or rolls back with that data.
+- **At-least-once delivery** is the contract. Awa rejects stale completions and rescues stuck work, but it does not promise “exactly once”.
+- **Idempotency is recommended** for handlers, because retries and recovery are part of the honest failure model.
+- **No lost work under failure** takes priority over clever fast paths. If a design weakens crash/restart safety, it loses even if the benchmark looks better.
+- **Strict FIFO per `(queue, priority)` by default.** Operators can opt a contended queue into **partitioned FIFO** by raising `awa.queue_meta.enqueue_shards` — the same kind of trade as choosing SQS Standard over SQS FIFO, or raising Kafka partition count. Producers pin related jobs to one shard with `ordering_key`. See [ADR-025](docs/adr/025-sharded-enqueue-heads.md).
 
 ## Benchmarks
 
-The north-star benchmark is not enqueue-only speed. Awa is judged by
-end-to-end completion throughput, p99 end-to-end latency, queue depth under
-oversupply, WAL bytes per completed job, transaction commits per completed job,
-and dead tuples / prune lag. Enqueue-only rates are reported separately for
-producer-path regressions.
+The north-star benchmark is not enqueue-only speed. Awa is judged by end-to-end completion throughput, p99 end-to-end latency, queue depth under oversupply, WAL bytes per completed job, transaction commits per completed job, and dead tuples / prune lag. Enqueue-only rates are reported separately for producer-path regressions.
 
-Queue-storage soak reference, 5k-job runtime run: **9.5k jobs/s**, **22 ms p95
-pickup**, **417 exact final dead tuples**. Enqueue reference: ~30k/s
-single-producer, ~100k/s multi-producer.
+Queue-storage soak reference, 5k-job runtime run: **9.5k jobs/s**, **22 ms p95 pickup**, **417 exact final dead tuples**. Enqueue reference: ~30k/s single-producer, ~100k/s multi-producer.
 
-For high-volume queue-storage producers, use the direct queue-storage COPY
-path: Python `enqueue_many_copy()` or Rust
-`QueueStorage::enqueue_params_copy()`. Configure direct-copy producers with the
-same queue-storage routing knobs as the worker fleet, especially
-`queue_stripe_count` / `queue_storage_queue_stripe_count`. The older
-`insert_many_copy()` API is the compatibility insert surface; it remains useful
-for canonical-storage compatibility and adapters, but it is not the
-queue-storage producer fast path.
+For high-volume queue-storage producers, use the direct queue-storage COPY path: Python `enqueue_many_copy()` or Rust `QueueStorage::enqueue_params_copy()`. Configure direct-copy producers with the same queue-storage routing knobs as the worker fleet, especially `queue_stripe_count` / `queue_storage_queue_stripe_count`. The older `insert_many_copy()` API is the compatibility insert surface; it remains useful for canonical-storage compatibility and adapters, but it is not the queue-storage producer fast path.
 
-A phase-driven portable benchmark harness comparing Awa against pgque,
-procrastinate, pg-boss, river, oban, and pgmq on a shared Postgres
-instance lives in its own repository:
-[hardbyte/postgresql-job-queue-benchmarking](https://github.com/hardbyte/postgresql-job-queue-benchmarking).
-It records producer, subscriber, and end-to-end delivery latency
-alongside throughput, queue depth, dead tuples, WAL pressure, and transaction
-pressure over time.
+A phase-driven portable benchmark harness comparing Awa against pgque, procrastinate, pg-boss, river, oban, and pgmq on a shared Postgres instance lives in its own repository: [hardbyte/postgresql-job-queue-benchmarking](https://github.com/hardbyte/postgresql-job-queue-benchmarking). It records producer, subscriber, and end-to-end delivery latency alongside throughput, queue depth, dead tuples, WAL pressure, and transaction pressure over time.
 
-Methodology and caveats live in
-[benchmarking notes](docs/benchmarking.md). Validation artifacts:
-[ADR-019 (queue storage)](docs/adr/bench/019-queue-storage-validation-2026-04-19.md)
-and [ADR-023 (receipt-plane ring partitioning)](docs/adr/bench/023-receipt-ring-validation-2026-04-26.md).
+Methodology and caveats live in [benchmarking notes](docs/benchmarking.md). Validation artifacts: [ADR-019 (queue storage)](docs/adr/bench/019-queue-storage-validation-2026-04-19.md) and [ADR-023 (receipt-plane ring partitioning)](docs/adr/bench/023-receipt-ring-validation-2026-04-26.md).
 
 ## Where Awa Fits
 
-Awa is for teams that already trust Postgres and want a real job queue, not
-just a stream or a framework tied to one host language.
+Awa is for teams that already trust Postgres and want a real job queue, not just a stream or a framework tied to one host language.
 
-- Choose Awa when you want priorities, unique jobs, retries, cron, callbacks,
-  DLQ, and operator tooling on one Postgres-backed runtime.
-- Choose PgQue-style systems when you want an event queue with independent
-  consumer cursors and event-log semantics first.
-- Choose River or Oban Pro when you want a job framework tightly shaped around
-  one surrounding language ecosystem.
+- Choose Awa when you want priorities, unique jobs, retries, cron, callbacks, DLQ, and operator tooling on one Postgres-backed runtime.
+- Choose PgQue-style systems when you want an event queue with independent consumer cursors and event-log semantics first.
+- Choose River or Oban Pro when you want a job framework tightly shaped around one surrounding language ecosystem.
 
 See [docs/positioning.md](docs/positioning.md) for the category map and messaging guidance.
 
@@ -158,14 +103,7 @@ awa --database-url $DATABASE_URL job dump 123
 awa --database-url $DATABASE_URL job dump-run 123
 ```
 
-The Awa mental model: your app inserts durable queue entries inside Postgres,
-often in the same transaction as business data. Immediate jobs become ready for
-workers; scheduled jobs, retry backoff, and snoozes wait in the deferred backlog
-until maintenance promotes them. Workers claim runnable entries through guarded
-attempt identity and rescue stale work after crashes; long-running attempts
-touch `attempt_state` only when they need mutable data like progress or callback
-state. Operators inspect scheduled, live, terminal, and DLQ state through the
-CLI or the built-in UI.
+The Awa mental model: your app inserts durable queue entries inside Postgres, often in the same transaction as business data. Immediate jobs become ready for workers; scheduled jobs, retry backoff, and snoozes wait in the deferred backlog until maintenance promotes them. Workers claim runnable entries through guarded attempt identity and rescue stale work after crashes; long-running attempts touch `attempt_state` only when they need mutable data like progress or callback state. Operators inspect scheduled, live, terminal, and DLQ state through the CLI or the built-in UI.
 
 Language-specific guides:
 
@@ -180,10 +118,7 @@ Configuring real workloads:
 - [Dead Letter Queue](docs/configuration.md#dead-letter-queue) — when to enable, per-queue overrides, operator workflow
 - [Deploying on managed Postgres](docs/deploying-on-managed-postgres.md) — Cloud SQL / AlloyDB sizing data, IAM grants, auth-proxy sidecar, gotchas
 
-Already running 0.5? Read the [0.5 → 0.6 upgrade guide](docs/upgrade-0.5-to-0.6.md)
-before you bump — 0.6 introduces a staged storage transition (canonical →
-prepared → mixed_transition → active) with a refused-by-default gate that
-expects the operator to roll out queue-storage-capable workers first.
+Already running 0.5? Read the [0.5 → 0.6 upgrade guide](docs/upgrade-0.5-to-0.6.md) before you bump — 0.6 introduces a staged storage transition (canonical → prepared → mixed_transition → active) with a refused-by-default gate that expects the operator to roll out queue-storage-capable workers first.
 
 ## Python Example
 
@@ -253,9 +188,7 @@ async def create_order(session: AsyncSession, order_id: str) -> int:
     return job["id"]
 ```
 
-`AsyncClient` is the worker/admin/direct-producer handle. In web handlers,
-keep using SQLAlchemy, asyncpg, psycopg, Django, or your existing database
-stack, and call `awa.bridge.insert_job(...)` inside that transaction.
+`AsyncClient` is the worker/admin/direct-producer handle. In web handlers, keep using SQLAlchemy, asyncpg, psycopg, Django, or your existing database stack, and call `awa.bridge.insert_job(...)` inside that transaction.
 
 **Sync API** for synchronous workers/admin code:
 
@@ -265,9 +198,7 @@ client.migrate()
 job = client.insert(SendEmail(to="bob@example.com", subject="Hello"))
 ```
 
-For Django/Flask request transactions, use `awa.bridge.insert_job_sync(...)`
-with the framework's existing connection/session instead of routing app SQL
-through Awa.
+For Django/Flask request transactions, use `awa.bridge.insert_job_sync(...)` with the framework's existing connection/session instead of routing app SQL through Awa.
 
 **Sequential callbacks** — suspend a handler, wait for an external system, then resume:
 
@@ -358,21 +289,15 @@ tx.commit().await?;
 awa::admin::cancel_by_unique_key(&pool, "send_email", None, Some(&serde_json::json!({"to": "alice@example.com", "subject": "Welcome"})), None).await?;
 ```
 
-Lifecycle hooks receive `Started` after a claim commits as the worker handler
-is about to run, plus outcome events (`Completed`, `Retried`, `Exhausted`,
-`Cancelled`) after the corresponding state transition commits. Hooks run in
-detached tasks, so they do not block job execution.
+Lifecycle hooks receive `Started` after a claim commits as the worker handler is about to run, plus outcome events (`Completed`, `Retried`, `Exhausted`, `Cancelled`) after the corresponding state transition commits. Hooks run in detached tasks, so they do not block job execution.
 
 Cancellation is cooperative for running handlers:
 
 - Rust handlers can poll `ctx.is_cancelled()`.
 - Python handlers can poll `job.is_cancelled()`.
 - Shutdown and runtime rescue paths flip that flag.
-- Admin cancel (`awa::admin::cancel`, `client.cancel`) updates job state in
-  storage and signals the matching in-flight handler, when that exact running
-  attempt is still alive on a worker process.
-- If a handler ignores the signal or returns too late, stale completion/retry
-  results remain no-ops because the job is already cancelled in storage.
+- Admin cancel (`awa::admin::cancel`, `client.cancel`) updates job state in storage and signals the matching in-flight handler, when that exact running attempt is still alive on a worker process.
+- If a handler ignores the signal or returns too late, stale completion/retry results remain no-ops because the job is already cancelled in storage.
 
 ## Installation
 
@@ -385,10 +310,7 @@ pip install 'awa-pg[ui]'    # SDK + bundled `awa` binary for the dashboard
 pip install awa-cli         # CLI on its own: migrations, queue admin, web UI
 ```
 
-`pip install awa-pg` stays small for workers and producers. The `[ui]` extra
-pulls in [`awa-cli`](https://pypi.org/project/awa-cli/), which ships the
-`awa` binary plus the embedded React dashboard; afterwards `python -m awa
-serve` (or `awa serve` directly) launches it.
+`pip install awa-pg` stays small for workers and producers. The `[ui]` extra pulls in [`awa-cli`](https://pypi.org/project/awa-cli/), which ships the `awa` binary plus the embedded React dashboard; afterwards `python -m awa serve` (or `awa serve` directly) launches it.
 
 ### Rust
 
@@ -436,28 +358,25 @@ awa --database-url $DATABASE_URL job dump-run 123
    └────────┘└────────┘└────────┘
 ```
 
-All coordination through Postgres. The Rust runtime owns dispatch, leases,
-heartbeats, rescue, rotation, prune, and shutdown for both languages. Mixed
-Rust and Python workers coexist on the same queues. See
-[architecture overview](docs/architecture.md) for full details.
+All coordination through Postgres. The Rust runtime owns dispatch, leases, heartbeats, rescue, rotation, prune, and shutdown for both languages. Mixed Rust and Python workers coexist on the same queues. See [architecture overview](docs/architecture.md) for full details.
 
 ## Workspace
 
-| Crate | Purpose |
-|---|---|
-| `awa` | Main crate — re-exports `awa-model` + `awa-worker` |
-| `awa-model` | Types, queries, migrations, admin ops |
-| `awa-macros` | `#[derive(JobArgs)]` proc macro |
-| `awa-worker` | Runtime: dispatch, heartbeat, maintenance |
-| `awa-ui` | Web UI (axum API + embedded React frontend) |
-| `awa-cli` | CLI binary (migrations, admin, serve) |
-| `awa-python` | PyO3 extension module (`pip install awa-pg`) |
-| `awa-testing` | Test helpers (`TestClient`) |
+| Crate         | Purpose                                            |
+| ------------- | -------------------------------------------------- |
+| `awa`         | Main crate — re-exports `awa-model` + `awa-worker` |
+| `awa-model`   | Types, queries, migrations, admin ops              |
+| `awa-macros`  | `#[derive(JobArgs)]` proc macro                    |
+| `awa-worker`  | Runtime: dispatch, heartbeat, maintenance          |
+| `awa-ui`      | Web UI (axum API + embedded React frontend)        |
+| `awa-cli`     | CLI binary (migrations, admin, serve)              |
+| `awa-python`  | PyO3 extension module (`pip install awa-pg`)       |
+| `awa-testing` | Test helpers (`TestClient`)                        |
 
 ## Documentation
 
 | Doc | Description |
-|---|---|
+| --- | --- |
 | [Rust getting started](docs/getting-started-rust.md) | From `cargo add` to a job reaching `completed` |
 | [Python getting started](docs/getting-started-python.md) | From `pip install` to a job reaching `completed` |
 | [Deployment guide](docs/deployment.md) | Docker, Kubernetes, pool sizing, graceful shutdown |

--- a/awa-cli/README.md
+++ b/awa-cli/README.md
@@ -1,15 +1,10 @@
 # awa-cli
 
-Command-line interface for the [Awa](https://crates.io/crates/awa)
-Postgres-native job queue. Run migrations, inspect and manage jobs,
-walk the storage transition, drive the Dead Letter Queue, list cron
-schedules, and serve the web admin UI.
+Command-line interface for the [Awa](https://crates.io/crates/awa) Postgres-native job queue. Run migrations, inspect and manage jobs, walk the storage transition, drive the Dead Letter Queue, list cron schedules, and serve the web admin UI.
 
 ## Install
 
-The CLI is shipped as both a Rust binary and a Python wheel. Either
-distribution gives you the same `awa` executable, including the
-embedded React admin dashboard for `awa serve`.
+The CLI is shipped as both a Rust binary and a Python wheel. Either distribution gives you the same `awa` executable, including the embedded React admin dashboard for `awa serve`.
 
 ```bash
 # Python (no Rust toolchain needed)
@@ -19,15 +14,13 @@ pip install awa-cli
 cargo install awa-cli
 ```
 
-If you're already using the [`awa-pg`](https://pypi.org/project/awa-pg/)
-Python SDK, install both with one command:
+If you're already using the [`awa-pg`](https://pypi.org/project/awa-pg/) Python SDK, install both with one command:
 
 ```bash
 pip install 'awa-pg[ui]'
 ```
 
-That pulls in `awa-cli` as a dependency so `python -m awa serve` works
-end-to-end alongside the worker SDK.
+That pulls in `awa-cli` as a dependency so `python -m awa serve` works end-to-end alongside the worker SDK.
 
 ## Quick start
 
@@ -51,44 +44,42 @@ awa --database-url $DATABASE_URL serve
 # → http://127.0.0.1:3000
 ```
 
-`DATABASE_URL` may be passed as the `--database-url` flag or read from
-the environment.
+`DATABASE_URL` may be passed as the `--database-url` flag or read from the environment.
 
 ## Commands
 
-| Command                                      | Description                                                  |
-| -------------------------------------------- | ------------------------------------------------------------ |
-| `migrate`                                    | Apply migrations, or extract / print SQL with `--sql` /  `--extract-to` |
-| `job list`                                   | List jobs with `--state` / `--kind` / `--queue` filters      |
-| `job dump <id>`                              | Pretty-print one job and its full lifecycle metadata         |
-| `job dump-run <id> [--attempt N]`            | Pretty-print one attempt run                                 |
-| `job retry <id>`                             | Retry a failed or cancelled job                              |
-| `job cancel <id>`                            | Cancel a job                                                 |
-| `job retry-failed --kind K`                  | Retry every failed job of a given kind                       |
-| `job discard --kind K`                       | Delete every failed job of a given kind                      |
-| `queue stats`                                | Per-queue depth, lag, and throughput                         |
-| `queue pause / resume / drain <queue>`       | Queue admin                                                  |
-| `cron list / remove`                         | List or remove cron schedules                                |
-| `dlq depth [--queue Q]`                      | Total DLQ rows, optionally split by queue                    |
-| `dlq list`                                   | List DLQ entries with `--kind` / `--queue` / `--tag` / `--before-*` filters |
-| `dlq retry <id>`                             | Retry a single DLQ row                                       |
-| `dlq retry-bulk`                             | Retry every DLQ row matching the filter (`--all` required if no filter is given) |
-| `dlq move`                                   | Move existing failed terminal rows into the DLQ              |
-| `dlq purge`                                  | Delete DLQ rows matching the filter (`--all` required if no filter is given) |
-| `storage status`                             | Current storage-transition state                             |
-| `storage prepare --engine E`                 | Prepare a future storage engine without changing routing     |
-| `storage prepare-queue-storage-schema`       | Materialize the queue-storage schema (tables, indexes, functions) |
-| `storage enter-mixed-transition`             | Begin routing new writes to the prepared engine              |
-| `storage finalize`                           | Finalize the transition once drain and capability gates pass |
-| `storage abort`                              | Abort a prepared or mixed-transition rollout                 |
-| `serve`                                      | Start the embedded web admin UI                              |
+| Command | Description |
+| --- | --- |
+| `migrate` | Apply migrations, or extract / print SQL with `--sql` / `--extract-to` |
+| `job list` | List jobs with `--state` / `--kind` / `--queue` filters |
+| `job dump <id>` | Pretty-print one job and its full lifecycle metadata |
+| `job dump-run <id> [--attempt N]` | Pretty-print one attempt run |
+| `job retry <id>` | Retry a failed or cancelled job |
+| `job cancel <id>` | Cancel a job |
+| `job retry-failed --kind K` | Retry every failed job of a given kind |
+| `job discard --kind K` | Delete every failed job of a given kind |
+| `queue stats` | Per-queue depth, lag, and throughput |
+| `queue pause / resume / drain <queue>` | Queue admin |
+| `cron list / remove` | List or remove cron schedules |
+| `dlq depth [--queue Q]` | Total DLQ rows, optionally split by queue |
+| `dlq list` | List DLQ entries with `--kind` / `--queue` / `--tag` / `--before-*` filters |
+| `dlq retry <id>` | Retry a single DLQ row |
+| `dlq retry-bulk` | Retry every DLQ row matching the filter (`--all` required if no filter is given) |
+| `dlq move` | Move existing failed terminal rows into the DLQ |
+| `dlq purge` | Delete DLQ rows matching the filter (`--all` required if no filter is given) |
+| `storage status` | Current storage-transition state |
+| `storage prepare --engine E` | Prepare a future storage engine without changing routing |
+| `storage prepare-queue-storage-schema` | Materialize the queue-storage schema (tables, indexes, functions) |
+| `storage enter-mixed-transition` | Begin routing new writes to the prepared engine |
+| `storage finalize` | Finalize the transition once drain and capability gates pass |
+| `storage abort` | Abort a prepared or mixed-transition rollout |
+| `serve` | Start the embedded web admin UI |
 
 Run `awa <command> --help` for the flags on any subcommand.
 
 ## Storage transition
 
-For an existing 0.5.x cluster moving to the queue-storage engine, the
-typical sequence is:
+For an existing 0.5.x cluster moving to the queue-storage engine, the typical sequence is:
 
 ```bash
 awa --database-url $DATABASE_URL storage prepare-queue-storage-schema
@@ -99,26 +90,15 @@ awa --database-url $DATABASE_URL storage enter-mixed-transition
 awa --database-url $DATABASE_URL storage finalize
 ```
 
-See [`docs/upgrade-0.5-to-0.6.md`](../docs/upgrade-0.5-to-0.6.md) for
-the full pre-flight checklist, gate semantics, and rollback notes.
-Fresh installs auto-finalize on first migrate and do not need this
-sequence.
+See [`docs/upgrade-0.5-to-0.6.md`](../docs/upgrade-0.5-to-0.6.md) for the full pre-flight checklist, gate semantics, and rollback notes. Fresh installs auto-finalize on first migrate and do not need this sequence.
 
 ## Dead Letter Queue
 
-`dlq retry-bulk` and `dlq purge` require an explicit filter (`--kind`,
-`--queue`, or `--tag`) or `--all`. This is intentional — a bare bulk
-retry / purge with no filter would touch every DLQ row, which is
-almost never what you want. See
-[`docs/dead-letter-queue.md`](../docs/dead-letter-queue.md).
+`dlq retry-bulk` and `dlq purge` require an explicit filter (`--kind`, `--queue`, or `--tag`) or `--all`. This is intentional — a bare bulk retry / purge with no filter would touch every DLQ row, which is almost never what you want. See [`docs/dead-letter-queue.md`](../docs/dead-letter-queue.md).
 
 ## Web UI
 
-`awa serve` starts an embedded admin UI ([`awa-ui`](../awa-ui)) bound
-to `127.0.0.1:3000` by default. The UI is read-only when the database
-reports `transaction_read_only = on` (e.g. on a replica) or when
-`--read-only` is passed explicitly. Mutation endpoints return 503 in
-that mode.
+`awa serve` starts an embedded admin UI ([`awa-ui`](../awa-ui)) bound to `127.0.0.1:3000` by default. The UI is read-only when the database reports `transaction_read_only = on` (e.g. on a replica) or when `--read-only` is passed explicitly. Mutation endpoints return 503 in that mode.
 
 ## License
 

--- a/awa-macros/README.md
+++ b/awa-macros/README.md
@@ -1,18 +1,12 @@
 # awa-macros
 
-Procedural macros for the [Awa](https://crates.io/crates/awa)
-Postgres-native job queue.
+Procedural macros for the [Awa](https://crates.io/crates/awa) Postgres-native job queue.
 
-You don't normally depend on this crate directly — `#[derive(JobArgs)]`
-is re-exported by both [`awa`](https://crates.io/crates/awa) and
-[`awa-model`](https://crates.io/crates/awa-model). Add `awa` to your
-dependencies and the derive comes with it.
+You don't normally depend on this crate directly — `#[derive(JobArgs)]` is re-exported by both [`awa`](https://crates.io/crates/awa) and [`awa-model`](https://crates.io/crates/awa-model). Add `awa` to your dependencies and the derive comes with it.
 
 ## What's in here
 
-- `#[derive(JobArgs)]` — implements `awa::JobArgs` for a struct,
-  generating the `kind()` method that identifies the job type across
-  Rust and Python workers.
+- `#[derive(JobArgs)]` — implements `awa::JobArgs` for a struct, generating the `kind()` method that identifies the job type across Rust and Python workers.
 
 ## Usage
 
@@ -29,9 +23,7 @@ struct SendEmail {
 assert_eq!(SendEmail::kind(), "send_email");
 ```
 
-The default kind string is the struct's name converted from
-`CamelCase` to `snake_case`. Override it explicitly with
-`#[awa(kind = "...")]`:
+The default kind string is the struct's name converted from `CamelCase` to `snake_case`. Override it explicitly with `#[awa(kind = "...")]`:
 
 ```rust
 #[derive(Debug, Serialize, Deserialize, JobArgs)]
@@ -44,13 +36,9 @@ struct SendEmail {
 assert_eq!(SendEmail::kind(), "outbound_smtp_send");
 ```
 
-The macro resolves `JobArgs` through whichever of `awa` or
-`awa-model` is in your `Cargo.toml`, so the same derive works for
-applications using the facade crate and for libraries depending on
-`awa-model` directly.
+The macro resolves `JobArgs` through whichever of `awa` or `awa-model` is in your `Cargo.toml`, so the same derive works for applications using the facade crate and for libraries depending on `awa-model` directly.
 
-`Serialize` and `Deserialize` must be derived alongside `JobArgs` —
-the runtime serialises job arguments as JSON.
+`Serialize` and `Deserialize` must be derived alongside `JobArgs` — the runtime serialises job arguments as JSON.
 
 ## License
 

--- a/awa-metrics/README.md
+++ b/awa-metrics/README.md
@@ -1,24 +1,11 @@
 # awa-metrics
 
-OpenTelemetry metric definitions shared across the
-[Awa](https://github.com/hardbyte/awa) job queue crates.
+OpenTelemetry metric definitions shared across the [Awa](https://github.com/hardbyte/awa) job queue crates.
 
-`awa-metrics` is an implementation detail of Awa. The metric names and
-attribute sets are public (so dashboards / alerts can build against
-them), but the Rust API is not intended for direct use outside the Awa
-workspace — `awa-worker` re-exports `AwaMetrics` from this crate, and
-that's the supported entry point.
+`awa-metrics` is an implementation detail of Awa. The metric names and attribute sets are public (so dashboards / alerts can build against them), but the Rust API is not intended for direct use outside the Awa workspace — `awa-worker` re-exports `AwaMetrics` from this crate, and that's the supported entry point.
 
-The crate is published to crates.io because `awa-worker` depends on the
-type directly; `cargo publish` strips path dependencies, so consumers
-of `awa-worker` need to resolve `awa-metrics` from the registry.
+The crate is published to crates.io because `awa-worker` depends on the type directly; `cargo publish` strips path dependencies, so consumers of `awa-worker` need to resolve `awa-metrics` from the registry.
 
 ## Metric naming
 
-All metrics use the `awa` meter name and follow OpenTelemetry naming
-and unit guidance: dot-separated namespaces (`awa.job.*`,
-`awa.dispatch.*`, …), singular nouns, and UCUM units declared via
-`with_unit` where a unit applies. The metric names and attributes are
-Awa-specific rather than standardized semantic-convention metrics.
-Names are exported as constants from [`awa_metrics::names`](src/lib.rs)
-for tests asserting against an OTLP exporter.
+All metrics use the `awa` meter name and follow OpenTelemetry naming and unit guidance: dot-separated namespaces (`awa.job.*`, `awa.dispatch.*`, …), singular nouns, and UCUM units declared via `with_unit` where a unit applies. The metric names and attributes are Awa-specific rather than standardized semantic-convention metrics. Names are exported as constants from [`awa_metrics::names`](src/lib.rs) for tests asserting against an OTLP exporter.

--- a/awa-model/README.md
+++ b/awa-model/README.md
@@ -1,51 +1,24 @@
 # awa-model
 
-Schema, types, and admin surface for the [Awa](https://crates.io/crates/awa)
-Postgres-native job queue. This is the foundation crate: every other
-`awa-*` crate depends on it, and it owns the SQL migrations, the row
-types, and the admin queries that back both the CLI and the web UI.
+Schema, types, and admin surface for the [Awa](https://crates.io/crates/awa) Postgres-native job queue. This is the foundation crate: every other `awa-*` crate depends on it, and it owns the SQL migrations, the row types, and the admin queries that back both the CLI and the web UI.
 
-Most Rust applications should depend on the [`awa`](https://crates.io/crates/awa)
-facade rather than `awa-model` directly. Reach for this crate when you
-need a smaller dependency footprint (e.g. an enqueue-only producer that
-does not link the worker runtime), or when you are building tooling
-against the admin API.
+Most Rust applications should depend on the [`awa`](https://crates.io/crates/awa) facade rather than `awa-model` directly. Reach for this crate when you need a smaller dependency footprint (e.g. an enqueue-only producer that does not link the worker runtime), or when you are building tooling against the admin API.
 
 ## What's in here
 
-- **Job model** — `JobRow`, `JobState`, `InsertOpts`, `UniqueOpts`,
-  `InsertParams`.
-- **Insertion** — `insert`, `insert_with`, `insert_many`,
-  `insert_many_copy` for the compatibility insert surface, and
-  `QueueStorage::enqueue_params_copy` for direct queue-storage COPY ingestion
-  with an explicitly configured queue-storage engine.
-- **Migrations** — `migrations::run` applies the schema; `migrations`,
-  `migration_sql`, `migration_sql_range`, and `current_version` expose the
-  catalog for tooling.
-- **Admin** (`admin`) — retry, cancel (single, by unique key, bulk),
-  pause/resume/drain queues, queue and job-kind overviews, runtime
-  instance snapshots, dirty-key recompute, and descriptor sync
-  (`sync_queue_descriptors`, `sync_job_kind_descriptors`,
-  `cleanup_stale_descriptors`).
-- **Dead Letter Queue** (`dlq`) — `DlqRow`, `DlqMetadata`,
-  `ListDlqFilter`, `RetryFromDlqOpts`, list / retry / move / purge
-  helpers backing the `awa dlq` CLI and the DLQ admin UI tab.
-- **Cron** (`cron`) — `PeriodicJob`, `PeriodicJobBuilder`, `CronJobRow`
-  plus `pause_cron_job` / `resume_cron_job` operating on the
-  `paused_at` / `paused_by` columns.
-- **Queue storage** (`queue_storage`) — `QueueStorage`,
-  `QueueStorageConfig`, `ClaimedRuntimeJob`, `RotateOutcome`,
-  `PruneOutcome`. The vacuum-aware engine introduced in 0.6.
-- **Storage status** (`storage`) — `StorageStatus` and the
-  transition-state primitives the `awa storage` CLI surfaces.
-- **Adapter API** (`adapter`) — stable Postgres insert preparation and SQL
-  contract for external enqueue bridges.
+- **Job model** — `JobRow`, `JobState`, `InsertOpts`, `UniqueOpts`, `InsertParams`.
+- **Insertion** — `insert`, `insert_with`, `insert_many`, `insert_many_copy` for the compatibility insert surface, and `QueueStorage::enqueue_params_copy` for direct queue-storage COPY ingestion with an explicitly configured queue-storage engine.
+- **Migrations** — `migrations::run` applies the schema; `migrations`, `migration_sql`, `migration_sql_range`, and `current_version` expose the catalog for tooling.
+- **Admin** (`admin`) — retry, cancel (single, by unique key, bulk), pause/resume/drain queues, queue and job-kind overviews, runtime instance snapshots, dirty-key recompute, and descriptor sync (`sync_queue_descriptors`, `sync_job_kind_descriptors`, `cleanup_stale_descriptors`).
+- **Dead Letter Queue** (`dlq`) — `DlqRow`, `DlqMetadata`, `ListDlqFilter`, `RetryFromDlqOpts`, list / retry / move / purge helpers backing the `awa dlq` CLI and the DLQ admin UI tab.
+- **Cron** (`cron`) — `PeriodicJob`, `PeriodicJobBuilder`, `CronJobRow` plus `pause_cron_job` / `resume_cron_job` operating on the `paused_at` / `paused_by` columns.
+- **Queue storage** (`queue_storage`) — `QueueStorage`, `QueueStorageConfig`, `ClaimedRuntimeJob`, `RotateOutcome`, `PruneOutcome`. The vacuum-aware engine introduced in 0.6.
+- **Storage status** (`storage`) — `StorageStatus` and the transition-state primitives the `awa storage` CLI surfaces.
+- **Adapter API** (`adapter`) — stable Postgres insert preparation and SQL contract for external enqueue bridges.
 - **Bridge adapters** (`bridge`) — built-in tokio-postgres enqueue bridge.
-- **Errors** — `AwaError`, the single error type shared across the
-  workspace.
+- **Errors** — `AwaError`, the single error type shared across the workspace.
 
-`#[derive(JobArgs)]` is re-exported from [`awa-macros`](https://crates.io/crates/awa-macros)
-so applications get the macro automatically.
+`#[derive(JobArgs)]` is re-exported from [`awa-macros`](https://crates.io/crates/awa-macros) so applications get the macro automatically.
 
 ## Example: enqueue-only producer
 
@@ -80,9 +53,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
 ## Versioning
 
-`awa-model` is versioned in lockstep with the rest of the workspace.
-Pin to the same minor version as `awa` and `awa-worker` if you depend
-on multiple crates directly.
+`awa-model` is versioned in lockstep with the rest of the workspace. Pin to the same minor version as `awa` and `awa-worker` if you depend on multiple crates directly.
 
 ## See also
 

--- a/awa-python/README.md
+++ b/awa-python/README.md
@@ -1,8 +1,6 @@
 # awa-pg
 
-Python bindings for [awa](https://github.com/hardbyte/awa), a
-Postgres-native background job queue. Same engine, same SQL, same
-defaults as the Rust core; native-speed dispatch via PyO3.
+Python bindings for [awa](https://github.com/hardbyte/awa), a Postgres-native background job queue. Same engine, same SQL, same defaults as the Rust core; native-speed dispatch via PyO3.
 
 ```bash
 pip install awa-pg
@@ -44,38 +42,19 @@ async def main():
 asyncio.run(main())
 ```
 
-A synchronous worker model is also available via `awa.Client` for
-codebases that aren't async-first.
+A synchronous worker model is also available via `awa.Client` for codebases that aren't async-first.
 
-For application tables, keep using your existing database library. The
-`awa.bridge` helpers insert jobs through asyncpg, psycopg3, SQLAlchemy, or
-Django connections so app rows and jobs can commit in the same transaction.
+For application tables, keep using your existing database library. The `awa.bridge` helpers insert jobs through asyncpg, psycopg3, SQLAlchemy, or Django connections so app rows and jobs can commit in the same transaction.
 
 ## What you get
 
-- **Transactional enqueue** — enqueue inside the same Postgres transaction
-  as your application's writes, using your existing connection/session.
-- **Vacuum-aware storage** — append-only ready entries plus a partitioned
-  receipt ring keep dead-tuple pressure bounded under sustained load.
-  See [ADR-019](https://github.com/hardbyte/awa/blob/main/docs/adr/019-queue-storage-redesign.md)
-  and [ADR-023](https://github.com/hardbyte/awa/blob/main/docs/adr/023-receipt-plane-ring-partitioning.md).
-- **COPY ingestion** — `enqueue_many_copy` streams directly into queue
-  storage for high-volume Python producers. `insert_many_copy` remains the
-  compatibility insert surface for canonical-storage and adapter-style callers.
-  If workers use `queue_storage_queue_stripe_count > 1`, pass the same value
-  to `enqueue_many_copy`.
-- **Crash-safe execution** — heartbeat-based lease tracking; jobs whose
-  workers vanish are rescued automatically.
-- **Per-queue policy** — priorities, priority aging, weighted concurrency,
-  rate limits, deadlines, retry/backoff, cron, dead-letter queue.
-- **Progress tracking** — handlers can write structured progress that
-  survives across retries.
-- **Web UI (optional)** — `pip install 'awa-pg[ui]'` pulls in the
-  [`awa-cli`](https://pypi.org/project/awa-cli/) wheel, which ships the
-  dashboard binary. Then `python -m awa serve` (or `awa serve` directly)
-  runs a live queue inspector, DLQ triage console, and retry controls
-  on `http://127.0.0.1:3000`. The default `awa-pg` install stays small
-  for workers and producers that don't need the dashboard.
+- **Transactional enqueue** — enqueue inside the same Postgres transaction as your application's writes, using your existing connection/session.
+- **Vacuum-aware storage** — append-only ready entries plus a partitioned receipt ring keep dead-tuple pressure bounded under sustained load. See [ADR-019](https://github.com/hardbyte/awa/blob/main/docs/adr/019-queue-storage-redesign.md) and [ADR-023](https://github.com/hardbyte/awa/blob/main/docs/adr/023-receipt-plane-ring-partitioning.md).
+- **COPY ingestion** — `enqueue_many_copy` streams directly into queue storage for high-volume Python producers. `insert_many_copy` remains the compatibility insert surface for canonical-storage and adapter-style callers. If workers use `queue_storage_queue_stripe_count > 1`, pass the same value to `enqueue_many_copy`.
+- **Crash-safe execution** — heartbeat-based lease tracking; jobs whose workers vanish are rescued automatically.
+- **Per-queue policy** — priorities, priority aging, weighted concurrency, rate limits, deadlines, retry/backoff, cron, dead-letter queue.
+- **Progress tracking** — handlers can write structured progress that survives across retries.
+- **Web UI (optional)** — `pip install 'awa-pg[ui]'` pulls in the [`awa-cli`](https://pypi.org/project/awa-cli/) wheel, which ships the dashboard binary. Then `python -m awa serve` (or `awa serve` directly) runs a live queue inspector, DLQ triage console, and retry controls on `http://127.0.0.1:3000`. The default `awa-pg` install stays small for workers and producers that don't need the dashboard.
 
 ## Migrations
 
@@ -83,25 +62,13 @@ Django connections so app rows and jobs can commit in the same transaction.
 python -m awa --database-url "$DATABASE_URL" migrate
 ```
 
-Fresh installs go straight to the queue-storage engine on first migrate.
-Existing 0.5.x installations should follow
-[`docs/upgrade-0.5-to-0.6.md`](https://github.com/hardbyte/awa/blob/main/docs/upgrade-0.5-to-0.6.md)
-for the staged transition.
+Fresh installs go straight to the queue-storage engine on first migrate. Existing 0.5.x installations should follow [`docs/upgrade-0.5-to-0.6.md`](https://github.com/hardbyte/awa/blob/main/docs/upgrade-0.5-to-0.6.md) for the staged transition.
 
 ## Partitioned FIFO and ordering keys
 
-Queues default to strict FIFO per `(queue, priority)`. Operators
-can raise `awa.queue_meta.enqueue_shards` on a contended queue to
-trade strict FIFO for throughput; the contract then becomes
-**partitioned FIFO** — strict order within each shard, no ordering
-promised across shards. This is the same kind of decision as
-choosing SQS Standard over SQS FIFO, raising Kafka partition
-count, or using Pub/Sub ordering keys.
+Queues default to strict FIFO per `(queue, priority)`. Operators can raise `awa.queue_meta.enqueue_shards` on a contended queue to trade strict FIFO for throughput; the contract then becomes **partitioned FIFO** — strict order within each shard, no ordering promised across shards. This is the same kind of decision as choosing SQS Standard over SQS FIFO, raising Kafka partition count, or using Pub/Sub ordering keys.
 
-If your producer enqueues *related* jobs that must execute in
-order — events for one customer, steps in one workflow, writes for
-one account — pass `ordering_key` so all jobs sharing that key
-land on the same shard:
+If your producer enqueues _related_ jobs that must execute in order — events for one customer, steps in one workflow, writes for one account — pass `ordering_key` so all jobs sharing that key land on the same shard:
 
 ```python
 await client.insert(
@@ -111,12 +78,7 @@ await client.insert(
 )
 ```
 
-The key can be `bytes` or `str` (encoded UTF-8). Two enqueues with
-the same key always pick the same shard regardless of which
-producer process or batch they came from. At `enqueue_shards = 1`
-(the default) the key is ignored. See
-[`docs/adr/025-sharded-enqueue-heads.md`](https://github.com/hardbyte/awa/blob/main/docs/adr/025-sharded-enqueue-heads.md)
-for the full contract.
+The key can be `bytes` or `str` (encoded UTF-8). Two enqueues with the same key always pick the same shard regardless of which producer process or batch they came from. At `enqueue_shards = 1` (the default) the key is ignored. See [`docs/adr/025-sharded-enqueue-heads.md`](https://github.com/hardbyte/awa/blob/main/docs/adr/025-sharded-enqueue-heads.md) for the full contract.
 
 ## Documentation
 

--- a/awa-seaorm/README.md
+++ b/awa-seaorm/README.md
@@ -1,25 +1,14 @@
 # awa-seaorm
 
-SeaORM integration helpers for the [Awa](https://github.com/hardbyte/awa)
-job queue.
+SeaORM integration helpers for the [Awa](https://github.com/hardbyte/awa) job queue.
 
-This crate is intentionally small. Awa's core is SQLx/Postgres-native, and a
-SeaORM `DatabaseConnection` already wraps a `sqlx::PgPool`, so most integration
-needs no glue at all:
+This crate is intentionally small. Awa's core is SQLx/Postgres-native, and a SeaORM `DatabaseConnection` already wraps a `sqlx::PgPool`, so most integration needs no glue at all:
 
-- building a client, running migrations, or reading job state — reach the pool
-  with `awa_pool()` / `pool()` and use Awa's existing APIs unchanged.
+- building a client, running migrations, or reading job state — reach the pool with `awa_pool()` / `pool()` and use Awa's existing APIs unchanged.
 
-The one thing the pool **can't** do is enqueue a job on the same connection as
-an in-flight SeaORM transaction — `get_postgres_connection_pool()` hands back a
-separate pooled connection, so a job inserted through it commits independently
-of your ORM writes. The `insert` / `insert_with` / `insert_raw` functions run
-Awa's canonical insert SQL through SeaORM's `ConnectionTrait`, so they bind to a
-`DatabaseConnection` *or* a `DatabaseTransaction` and let you enqueue a job
-atomically with the rest of a transaction.
+The one thing the pool **can't** do is enqueue a job on the same connection as an in-flight SeaORM transaction — `get_postgres_connection_pool()` hands back a separate pooled connection, so a job inserted through it commits independently of your ORM writes. The `insert` / `insert_with` / `insert_raw` functions run Awa's canonical insert SQL through SeaORM's `ConnectionTrait`, so they bind to a `DatabaseConnection` _or_ a `DatabaseTransaction` and let you enqueue a job atomically with the rest of a transaction.
 
-It does **not** replace Awa's core `sqlx` API, reimplement Awa's admin/lifecycle
-operations, or introduce a new storage engine.
+It does **not** replace Awa's core `sqlx` API, reimplement Awa's admin/lifecycle operations, or introduce a new storage engine.
 
 ## Usage
 

--- a/awa-testing/README.md
+++ b/awa-testing/README.md
@@ -2,41 +2,22 @@
 
 Test utilities for the [Awa](https://crates.io/crates/awa) job queue.
 
-`awa-testing` lets you exercise job handlers and admin code paths in
-unit and integration tests without spinning up the full worker
-runtime. Use it for in-tree tests of the workspace, in your own
-crate's tests, or anywhere you want to drive a single job through a
-real Postgres without configuring queues, dispatchers, and
-maintenance leaders.
+`awa-testing` lets you exercise job handlers and admin code paths in unit and integration tests without spinning up the full worker runtime. Use it for in-tree tests of the workspace, in your own crate's tests, or anywhere you want to drive a single job through a real Postgres without configuring queues, dispatchers, and maintenance leaders.
 
-The crate is `dev-dependencies`-shaped: there is no embedded Postgres,
-you point it at a real test database (typically a local container on
-port `15432`).
+The crate is `dev-dependencies`-shaped: there is no embedded Postgres, you point it at a real test database (typically a local container on port `15432`).
 
 ## What's in here
 
 - `TestClient` — synchronous-feeling wrapper around a `PgPool`:
-  - `migrate()` runs the schema and resets the runtime backend so
-    tests start from a known state.
-  - `clean()` resets the runtime backend and deletes through the
-    `awa.jobs` compatibility surface plus `awa.queue_meta` for
-    cross-test isolation.
+  - `migrate()` runs the schema and resets the runtime backend so tests start from a known state.
+  - `clean()` resets the runtime backend and deletes through the `awa.jobs` compatibility surface plus `awa.queue_meta` for cross-test isolation.
   - `insert(&args)` enqueues one job.
-  - `work_one(&worker)` / `work_one_in_queue(&worker, queue)` claim
-    and execute exactly one job through the supplied `Worker`,
-    returning a `WorkResult` (`Completed`, `Failed`, `Snoozed`,
-    `Retryable`, `Cancelled`, `WaitingExternal`, `NoJob`).
+  - `work_one(&worker)` / `work_one_in_queue(&worker, queue)` claim and execute exactly one job through the supplied `Worker`, returning a `WorkResult` (`Completed`, `Failed`, `Snoozed`, `Retryable`, `Cancelled`, `WaitingExternal`, `NoJob`).
   - `get_job(id)` returns the current `JobRow`.
-- `WorkResult` — enum with `is_completed()`, `is_failed()`,
-  `is_waiting_external()`, `is_no_job()` predicates.
-- `setup` module — `database_url()`, `database_url_with_app_name()`,
-  `pool()`, `pool_with_url()` helpers and `reset_runtime_backend()`
-  for explicit test cleanup.
+- `WorkResult` — enum with `is_completed()`, `is_failed()`, `is_waiting_external()`, `is_no_job()` predicates.
+- `setup` module — `database_url()`, `database_url_with_app_name()`, `pool()`, `pool_with_url()` helpers and `reset_runtime_backend()` for explicit test cleanup.
 
-`TestClient` is intentionally a lightweight compatibility-surface harness. It
-does not exercise the full dispatcher, queue-storage receipt plane, or
-maintenance leader; use the worker runtime or integration benchmarks when a
-test needs production storage-path fidelity.
+`TestClient` is intentionally a lightweight compatibility-surface harness. It does not exercise the full dispatcher, queue-storage receipt plane, or maintenance leader; use the worker runtime or integration benchmarks when a test needs production storage-path fidelity.
 
 ## Usage
 
@@ -84,8 +65,7 @@ async fn send_email_completes() {
 
 - [Test plan](../docs/test-plan.md)
 - [Development](../docs/development.md)
-- For Python projects, the equivalent helpers live in
-  [`awa.testing`](../awa-python/python/awa/testing.py).
+- For Python projects, the equivalent helpers live in [`awa.testing`](../awa-python/python/awa/testing.py).
 
 ## License
 

--- a/awa-ui/README.md
+++ b/awa-ui/README.md
@@ -1,60 +1,33 @@
 # awa-ui
 
-Embedded web admin UI and REST API for the [Awa](https://crates.io/crates/awa)
-job queue.
+Embedded web admin UI and REST API for the [Awa](https://crates.io/crates/awa) job queue.
 
-`awa-ui` is shipped as an axum router and a static React/TypeScript
-bundle (built with [IntentUI](https://intentui.com) components and
-embedded via `rust-embed`). The CLI's `awa serve` mounts this router
-at `/` and `/api/*`; you can also embed it inside your own axum
-application.
+`awa-ui` is shipped as an axum router and a static React/TypeScript bundle (built with [IntentUI](https://intentui.com) components and embedded via `rust-embed`). The CLI's `awa serve` mounts this router at `/` and `/api/*`; you can also embed it inside your own axum application.
 
 ## Tabs
 
-- **Dashboard** — job state counts, throughput timeseries, runtime
-  capability summary.
-- **Jobs** — search, filter (state, kind, queue, has-error, tag),
-  bulk retry / cancel, and a detail view with progress, attempt
-  history, lifecycle hooks, and structured metadata.
-- **Kinds** — registered job kinds with descriptor metadata
-  (display name, description, owner, tags, docs URL) and stale /
-  drift indicators.
-- **Queues** — per-queue stats, descriptor metadata, pause / resume /
-  drain.
-- **Runtime** — live worker instances and their capabilities. Hosts
-  the **storage-transition card** when the cluster is mid-migration:
-  prepared / mixed / finalized state, drain progress, and the gates
-  blocking finalization.
-- **Cron** — registered periodic schedules with next-run preview,
-  per-schedule pause / resume / trigger controls, and a target-queue
-  paused indicator.
-- **DLQ** (`/dlq`) — Dead Letter Queue browser with kind / queue /
-  tag filters, single and bulk retry, move, and purge actions. The
-  DLQ tab is reachable from the Jobs tab via the row links on
-  DLQ-state jobs.
+- **Dashboard** — job state counts, throughput timeseries, runtime capability summary.
+- **Jobs** — search, filter (state, kind, queue, has-error, tag), bulk retry / cancel, and a detail view with progress, attempt history, lifecycle hooks, and structured metadata.
+- **Kinds** — registered job kinds with descriptor metadata (display name, description, owner, tags, docs URL) and stale / drift indicators.
+- **Queues** — per-queue stats, descriptor metadata, pause / resume / drain.
+- **Runtime** — live worker instances and their capabilities. Hosts the **storage-transition card** when the cluster is mid-migration: prepared / mixed / finalized state, drain progress, and the gates blocking finalization.
+- **Cron** — registered periodic schedules with next-run preview, per-schedule pause / resume / trigger controls, and a target-queue paused indicator.
+- **DLQ** (`/dlq`) — Dead Letter Queue browser with kind / queue / tag filters, single and bulk retry, move, and purge actions. The DLQ tab is reachable from the Jobs tab via the row links on DLQ-state jobs.
 
 ## Read-only mode
 
-When the backend is read-only — either Postgres reports
-`transaction_read_only = on` (e.g. a read replica) or the operator
-passes `--read-only` to `awa serve` — every mutation endpoint returns
-503 and `/api/capabilities` reports `read_only: true`. The frontend
-hides destructive actions in that mode.
+When the backend is read-only — either Postgres reports `transaction_read_only = on` (e.g. a read replica) or the operator passes `--read-only` to `awa serve` — every mutation endpoint returns 503 and `/api/capabilities` reports `read_only: true`. The frontend hides destructive actions in that mode.
 
 ## REST surface
 
-The router exposes JSON endpoints under `/api/*` covering jobs,
-queues, kinds, runtime instances, cron, DLQ, storage transition, and
-capabilities. See [the UI design doc](../docs/ui-design.md) for the
-endpoint catalogue and response shapes.
+The router exposes JSON endpoints under `/api/*` covering jobs, queues, kinds, runtime instances, cron, DLQ, storage transition, and capabilities. See [the UI design doc](../docs/ui-design.md) for the endpoint catalogue and response shapes.
 
 ## Frontend stack
 
 - React 18 with TanStack Router and TanStack Query
 - TypeScript
 - IntentUI / react-aria-components
-- Vite build, output embedded via `rust-embed` so `awa serve` ships a
-  single binary
+- Vite build, output embedded via `rust-embed` so `awa serve` ships a single binary
 
 ## License
 

--- a/awa-worker/README.md
+++ b/awa-worker/README.md
@@ -1,66 +1,28 @@
 # awa-worker
 
-Worker runtime for the [Awa](https://crates.io/crates/awa) Postgres-native
-job queue: dispatch, claim, heartbeat, completion-batching, maintenance,
-and lifecycle hooks.
+Worker runtime for the [Awa](https://crates.io/crates/awa) Postgres-native job queue: dispatch, claim, heartbeat, completion-batching, maintenance, and lifecycle hooks.
 
-Most Rust applications depend on the [`awa`](https://crates.io/crates/awa)
-facade and never reach for this crate directly. Use `awa-worker` when
-you need the runtime types without the re-export shim — typically when
-you are building higher-level frameworks or alternate transports on
-top of Awa.
+Most Rust applications depend on the [`awa`](https://crates.io/crates/awa) facade and never reach for this crate directly. Use `awa-worker` when you need the runtime types without the re-export shim — typically when you are building higher-level frameworks or alternate transports on top of Awa.
 
 ## What's in here
 
-- **Client** — `Client` and `ClientBuilder` configure queues, register
-  handlers, attach lifecycle hooks, and start the runtime. `HealthCheck`,
-  `QueueHealth`, `QueueCapacity`, and `TransitionWorkerRole` expose the
-  observability and transition-aware capabilities.
-- **Job context** — `JobContext` (with cancellation, structured
-  progress, and callback registration), `CallbackToken`,
-  `CallbackGuard`.
-- **Handler results** — `JobResult` (`Completed`, `RetryAfter`,
-  `Snooze`, `Cancel`, `WaitForCallback`) and `JobError`. Implement
-  the `Worker` trait directly or register typed closures with
-  `ClientBuilder::register`.
-- **Queue configuration** — `QueueConfig` (concurrency, weighted mode,
-  rate limiting, per-claim deadlines), `RateLimit`.
-- **Lifecycle hooks** — `JobEvent<T>` and `UntypedJobEvent` fire when
-  handler execution starts and after guarded finalization commits, useful
-  for cache invalidation, notifications, and metrics emission.
-- **HTTP worker** — `HttpWorker`, `HttpWorkerConfig`, `HttpWorkerMode`
-  dispatch jobs to serverless endpoints over HTTP with HMAC-BLAKE3
-  signing. See [ADR-018](../docs/adr/018-http-worker.md).
-- **Maintenance** — the elected maintenance leader runs rescue, promotion,
-  queue/lease/claim ring rotation and prune, DLQ cleanup, descriptor cleanup,
-  cron evaluation, and queue-health publication.
-- **Metrics** — `AwaMetrics` exposes the runtime metric surface for
-  Prometheus / OTel scrapers.
+- **Client** — `Client` and `ClientBuilder` configure queues, register handlers, attach lifecycle hooks, and start the runtime. `HealthCheck`, `QueueHealth`, `QueueCapacity`, and `TransitionWorkerRole` expose the observability and transition-aware capabilities.
+- **Job context** — `JobContext` (with cancellation, structured progress, and callback registration), `CallbackToken`, `CallbackGuard`.
+- **Handler results** — `JobResult` (`Completed`, `RetryAfter`, `Snooze`, `Cancel`, `WaitForCallback`) and `JobError`. Implement the `Worker` trait directly or register typed closures with `ClientBuilder::register`.
+- **Queue configuration** — `QueueConfig` (concurrency, weighted mode, rate limiting, per-claim deadlines), `RateLimit`.
+- **Lifecycle hooks** — `JobEvent<T>` and `UntypedJobEvent` fire when handler execution starts and after guarded finalization commits, useful for cache invalidation, notifications, and metrics emission.
+- **HTTP worker** — `HttpWorker`, `HttpWorkerConfig`, `HttpWorkerMode` dispatch jobs to serverless endpoints over HTTP with HMAC-BLAKE3 signing. See [ADR-018](../docs/adr/018-http-worker.md).
+- **Maintenance** — the elected maintenance leader runs rescue, promotion, queue/lease/claim ring rotation and prune, DLQ cleanup, descriptor cleanup, cron evaluation, and queue-health publication.
+- **Metrics** — `AwaMetrics` exposes the runtime metric surface for Prometheus / OTel scrapers.
 
 ## Capabilities
 
-- **Vacuum-aware queue storage** — workers default to the queue-storage
-  engine: append-only ready/terminal partitions, rotating lease and receipt
-  rings, and separate deferred/DLQ tables described in
-  [ADR-019](../docs/adr/019-queue-storage-redesign.md) and
-  [ADR-023](../docs/adr/023-receipt-plane-ring-partitioning.md).
-- **Dead Letter Queue** — terminal failures land in `dlq_entries` for
-  any queue with `dlq_enabled` set. Per-queue policy is configured
-  through `QueueConfig` and the `dlq_enabled_by_default` builder
-  setting; see [`docs/dead-letter-queue.md`](../docs/dead-letter-queue.md).
-- **Descriptor catalog** — `ClientBuilder::queue_descriptor` and
-  `job_kind_descriptor` declare display name, owner, tags, and docs
-  URL alongside the worker. The runtime syncs these to
-  `queue_descriptors` / `job_kind_descriptors` on start
-  ([ADR-022](../docs/adr/022-descriptor-catalog.md)).
-- **Per-claim deadlines** — `QueueConfig::deadline_duration` writes
-  `lease_claims.deadline_at` on claim. Expired claims are force-closed
-  by the rescue path with `'deadline_expired'`.
-- **Priority aging** — applied at claim time on the queue-storage engine
-  ([ADR-005](../docs/adr/005-priority-aging.md)).
-- **Heartbeat + deadline rescue** — two independent rescue paths cover
-  crash and runaway failure modes
-  ([ADR-003](../docs/adr/003-heartbeat-deadline-hybrid.md)).
+- **Vacuum-aware queue storage** — workers default to the queue-storage engine: append-only ready/terminal partitions, rotating lease and receipt rings, and separate deferred/DLQ tables described in [ADR-019](../docs/adr/019-queue-storage-redesign.md) and [ADR-023](../docs/adr/023-receipt-plane-ring-partitioning.md).
+- **Dead Letter Queue** — terminal failures land in `dlq_entries` for any queue with `dlq_enabled` set. Per-queue policy is configured through `QueueConfig` and the `dlq_enabled_by_default` builder setting; see [`docs/dead-letter-queue.md`](../docs/dead-letter-queue.md).
+- **Descriptor catalog** — `ClientBuilder::queue_descriptor` and `job_kind_descriptor` declare display name, owner, tags, and docs URL alongside the worker. The runtime syncs these to `queue_descriptors` / `job_kind_descriptors` on start ([ADR-022](../docs/adr/022-descriptor-catalog.md)).
+- **Per-claim deadlines** — `QueueConfig::deadline_duration` writes `lease_claims.deadline_at` on claim. Expired claims are force-closed by the rescue path with `'deadline_expired'`.
+- **Priority aging** — applied at claim time on the queue-storage engine ([ADR-005](../docs/adr/005-priority-aging.md)).
+- **Heartbeat + deadline rescue** — two independent rescue paths cover crash and runaway failure modes ([ADR-003](../docs/adr/003-heartbeat-deadline-hybrid.md)).
 
 ## Cancellation Semantics
 
@@ -73,9 +35,7 @@ Cancellation in Awa is cooperative.
   - stale-heartbeat rescue
   - deadline rescue
 
-That lets long-running handlers stop work gracefully and return an explicit
-result like `JobResult::Cancel(...)`, `JobResult::RetryAfter(...)`, or
-`awa.Cancel(...)` in Python.
+That lets long-running handlers stop work gracefully and return an explicit result like `JobResult::Cancel(...)`, `JobResult::RetryAfter(...)`, or `awa.Cancel(...)` in Python.
 
 There is an important distinction between:
 
@@ -85,11 +45,9 @@ There is an important distinction between:
 - **admin/job-state cancellation**
   - `admin::cancel(...)` / `client.cancel(...)` marks the job `cancelled` in storage
   - pending or waiting jobs transition immediately
-  - if the exact running attempt is still alive on a worker process, the
-    matching handler also sees its in-memory cancellation flag flip
+  - if the exact running attempt is still alive on a worker process, the matching handler also sees its in-memory cancellation flag flip
 
-If a running job is cancelled in storage and the handler keeps running, its
-later completion/retry/cancel attempt is treated as stale and ignored.
+If a running job is cancelled in storage and the handler keeps running, its later completion/retry/cancel attempt is treated as stale and ignored.
 
 ## See also
 

--- a/awa/README.md
+++ b/awa/README.md
@@ -1,13 +1,8 @@
 # awa
 
-Postgres-native background job queue. Transactional enqueue, heartbeat
-crash recovery, priority aging, retries with backoff, cron, callbacks,
-unique jobs, dead-letter queue, and a vacuum-aware storage engine
-designed to keep dead-tuple pressure bounded under sustained load.
+Postgres-native background job queue. Transactional enqueue, heartbeat crash recovery, priority aging, retries with backoff, cron, callbacks, unique jobs, dead-letter queue, and a vacuum-aware storage engine designed to keep dead-tuple pressure bounded under sustained load.
 
-This crate is the user-facing facade. It re-exports the worker
-(`awa-worker`) and model (`awa-model`) crates and is what most Rust
-applications depend on directly.
+This crate is the user-facing facade. It re-exports the worker (`awa-worker`) and model (`awa-model`) crates and is what most Rust applications depend on directly.
 
 ```toml
 [dependencies]
@@ -58,31 +53,17 @@ async fn main() -> anyhow::Result<()> {
 
 ## What you get
 
-- **Transactional enqueue** — enqueueing a job is a normal `INSERT` you can
-  commit alongside your application's writes.
-- **Vacuum-aware storage** — append-only ready/terminal partitions plus
-  rotating lease and receipt rings keep the hot queue tables' dead-tuple
-  footprint bounded under sustained load. See [ADR-019](../docs/adr/019-queue-storage-redesign.md)
-  and [ADR-023](../docs/adr/023-receipt-plane-ring-partitioning.md).
-- **Crash-safe execution** — heartbeat-based lease tracking; jobs whose
-  workers vanish are rescued automatically.
-- **Per-queue policy** — priorities, priority aging, weighted concurrency,
-  rate limits, deadlines, retry/backoff, cron, dead-letter queue.
-- **Unique jobs** — content-keyed deduplication windowed across pending /
-  running / completed.
-- **Callbacks and external waits** — wait for an external event without
-  burning a worker slot.
-- **First-class Python bindings** — same engine, same SQL, same defaults;
-  see [awa-pg on PyPI](https://pypi.org/project/awa-pg/).
+- **Transactional enqueue** — enqueueing a job is a normal `INSERT` you can commit alongside your application's writes.
+- **Vacuum-aware storage** — append-only ready/terminal partitions plus rotating lease and receipt rings keep the hot queue tables' dead-tuple footprint bounded under sustained load. See [ADR-019](../docs/adr/019-queue-storage-redesign.md) and [ADR-023](../docs/adr/023-receipt-plane-ring-partitioning.md).
+- **Crash-safe execution** — heartbeat-based lease tracking; jobs whose workers vanish are rescued automatically.
+- **Per-queue policy** — priorities, priority aging, weighted concurrency, rate limits, deadlines, retry/backoff, cron, dead-letter queue.
+- **Unique jobs** — content-keyed deduplication windowed across pending / running / completed.
+- **Callbacks and external waits** — wait for an external event without burning a worker slot.
+- **First-class Python bindings** — same engine, same SQL, same defaults; see [awa-pg on PyPI](https://pypi.org/project/awa-pg/).
 
 ## Partitioned FIFO and ordering keys
 
-Queues default to strict FIFO per `(queue, priority)`. Operators
-can raise `awa.queue_meta.enqueue_shards` on a contended queue to
-trade strict FIFO for throughput; the contract then becomes
-**partitioned FIFO** — strict order within each shard, no ordering
-promised across shards. Producers can pin related jobs to the same
-shard with `InsertOpts::ordering_key`:
+Queues default to strict FIFO per `(queue, priority)`. Operators can raise `awa.queue_meta.enqueue_shards` on a contended queue to trade strict FIFO for throughput; the contract then becomes **partitioned FIFO** — strict order within each shard, no ordering promised across shards. Producers can pin related jobs to the same shard with `InsertOpts::ordering_key`:
 
 ```rust
 let opts = InsertOpts {
@@ -93,11 +74,7 @@ let opts = InsertOpts {
 awa::insert_with(&pool, &UpdateCustomer { ... }, opts).await?;
 ```
 
-Jobs sharing an `ordering_key` always pick the same shard, so the
-shard's strict FIFO carries over to per-key FIFO. At
-`enqueue_shards = 1` the key is ignored. See
-[ADR-025](../docs/adr/025-sharded-enqueue-heads.md) for the full
-contract.
+Jobs sharing an `ordering_key` always pick the same shard, so the shard's strict FIFO carries over to per-key FIFO. At `enqueue_shards = 1` the key is ignored. See [ADR-025](../docs/adr/025-sharded-enqueue-heads.md) for the full contract.
 
 ## Documentation
 

--- a/correctness/README.md
+++ b/correctness/README.md
@@ -2,9 +2,7 @@
 
 This directory contains TLA+ correctness models for the Awa worker runtime.
 
-It contains small TLA+ models for the coordination protocol behind the worker
-runtime. The goal is to check the concurrency invariants that are easy to miss
-with integration tests:
+It contains small TLA+ models for the coordination protocol behind the worker runtime. The goal is to check the concurrency invariants that are easy to miss with integration tests:
 
 - a rescued or cancelled job cannot be finalized by a stale worker
 - graceful shutdown stops new claims before drain and keeps heartbeat alive
@@ -35,127 +33,29 @@ What is intentionally not modeled:
 - LISTEN/NOTIFY wakeups
 - Python bridge details
 - real-time token bucket math for rate limiting
-- unbounded retry histories; `AwaExtended` caps attempts so TLC can close the
-  state graph
+- unbounded retry histories; `AwaExtended` caps attempts so TLC can close the state graph
 - full advisory-lock mechanics; leadership is an abstract exclusive token
 - exact permit identity per task attempt; the model is job-centric and approximates task-held capacity closely enough to check the protocol invariants
-- **priority ordering and starvation.** No model includes a `priority` variable.
-  Priority is a scheduling heuristic, not a safety invariant — all formal
-  invariants (NoDuplicateClaim, TaskLeaseBounded, RunningHasPermit, etc.)
-  are independent of dispatch order. Cross-priority fairness is enforced by
-  the maintenance leader's priority aging task (see ADR-005)
-- **MVCC, vacuum, and storage reclamation.** The models do not attempt to
-  represent Postgres heap cleanup, autovacuum timing, or horizon pinning from
-  long-lived snapshots. Those are operational/performance concerns rather than
-  protocol-safety invariants, and are covered by runtime benchmarks instead
+- **priority ordering and starvation.** No model includes a `priority` variable. Priority is a scheduling heuristic, not a safety invariant — all formal invariants (NoDuplicateClaim, TaskLeaseBounded, RunningHasPermit, etc.) are independent of dispatch order. Cross-priority fairness is enforced by the maintenance leader's priority aging task (see ADR-005)
+- **MVCC, vacuum, and storage reclamation.** The models do not attempt to represent Postgres heap cleanup, autovacuum timing, or horizon pinning from long-lived snapshots. Those are operational/performance concerns rather than protocol-safety invariants, and are covered by runtime benchmarks instead
 
 ## Files
 
-- `AwaCore.tla` / `AwaCore.cfg`: focused model for rescue, admin cancel, and
-  stale completion protection
-- `storage/AwaSegmentedStorage.tla` / `storage/AwaSegmentedStorage.cfg`: focused
-  segmented-storage model covering `ready_entries`, `deferred_jobs`,
-  `ready_tombstones`, live `leases` including `waiting_external`, optional
-  `attempt_state`, `done_entries`, `dlq_entries`, queue-local append/claim
-  cursors, and segment rotation/prune safety for ready, tombstone, lease,
-  terminal, and claim
-  families. Heartbeat freshness lives on non-waiting leases, matching the
-  Rust implementation. DLQ modelling covers both executor-side `FailToDlq`
-  and admin-side `MoveFailedToDlq`, plus `RetryFromDlq` (with `run_lease`
-  reset) and `PurgeDlq`. See [`storage/MAPPING.md`](storage/MAPPING.md) for
-  the TLA+ ↔ Rust correspondence table.
-- `storage/AwaSegmentedStorageInterleavings.cfg`: alternate two-worker config
-  for the same segmented-storage spec, used to exercise stale completion and
-  waiting/resume interleavings without changing the base safety model
-- `storage/AwaSegmentedStorageRaces.tla` / `storage/AwaSegmentedStorageRaces.cfg`
-  / `storage/AwaSegmentedStorageRacesSafe.cfg`: focused race-exposure spec
-  that splits `Claim` into `BeginClaim` / `CommitClaim` to model the claim
-  path's cursor-read-without-lock behaviour. The race config produces a
-  counterexample trace (claim snapshots segment, rotate+prune fire, commit
-  lands lease in pruned segment — simultaneously the claim-vs-rotate race
-  and the prune check-then-act race). The safe config uses a checked
-  commit and passes. Production uses CAS on ring state plus child-partition
-  locks and busy checks, not `FOR SHARE` on `lease_ring_state` — see
-  `storage/MAPPING.md` for the full analysis.
-- `storage/AwaShardedPrune.tla` /
-  `storage/AwaShardedPrune.cfg` /
-  `storage/AwaShardedPruneBroken.cfg`: focused ADR-025 regression model for
-  queue-ring prune across enqueue shards. The passing config requires ready
-  rows to match done rows by `(enqueue_shard, lane_seq)` before prune can drop
-  a sealed queue slot. The broken config intentionally ignores
-  `enqueue_shard` and produces the historical counterexample: shard 0 has a
-  done row at `lane_seq = 1`, shard 1 still has a pending ready row at
-  `lane_seq = 1`, and broken prune drops both.
-- `storage/AwaStorageLockOrder.tla` / `storage/AwaStorageLockOrder.cfg` /
-  `storage/AwaStorageLockOrderDeadlockDemo.cfg` /
-  `storage/AwaStorageLockOrderOldStripedClaimDeadlock.cfg`: lock-ordering protocol
-  spec. Models each storage-engine transaction (enqueue, claim,
-  complete, close-receipt, rescue-receipts, ensure-running, cancel,
-  rotate, and prune) as an ordered sequence of Postgres lock acquisitions
-  with a shared/exclusive compatibility matrix. The striped enqueue path
-  takes multiple physical queue lanes in stable order; the current striped
-  claim path takes at most one physical stripe per transaction. Checks
-  `NoDeadlock` via a waits-for cycle detector. The demo configs use a
-  deliberately cycle-creating plan pair and the historical old striped
-  logical-claim plan to prove the detector catches real cycles.
-- `storage/AwaStorageTransition.tla` /
-  `storage/AwaStorageTransition.cfg` /
-  `storage/AwaStorageTransitionCurrentGate.cfg`: focused model for the
-  0.5.x-to-0.6 storage transition control plane. It covers prepare,
-  schema readiness, mixed-transition entry, canonical backlog drain,
-  queue-storage routing, finalize, and abort interlocks. The desired
-  config matches the v014+ SQL gate: it requires a live queue-storage target
-  executor at mixed-transition entry and passes cleanly. The
-  `CurrentGate`-named config is now a historical pre-v014 regression witness:
-  it models the old capability-only gate where an auto runtime started before
-  mixed transition reports `queue_storage` while prepared, then becomes
-  drain-only after routing flips.
-- `storage/AwaSegmentedStorageTrace.tla` /
-  `storage/AwaSegmentedStorageTrace.cfg` /
-  `storage/AwaSegmentedStorageTraceReceiptRescue.cfg` /
-  `storage/AwaSegmentedStorageTraceLostClaimAdvance.cfg` /
-  `storage/AwaSegmentedStorageTraceRunningCancel.cfg` /
-  `storage/AwaSegmentedStorageTraceReceiptOnlyCancel.cfg` /
-  `storage/AwaSegmentedStorageTraceCallbackWait.cfg` /
-  `storage/AwaSegmentedStorageTraceDlqRetry.cfg` /
-  `storage/AwaSegmentedStorageTraceDlqPurge.cfg` /
-  `storage/AwaSegmentedStorageTraceBroken.cfg`: trace-validation
-  harness. Takes hand-transcribed sequences of queue-storage runtime
-  events and verifies each transition is accepted by the storage spec.
-  Current positive traces cover snooze, receipt rescue, running cancel,
-  receipt-only cancel, callback wait/resume, DLQ retry, and DLQ purge.
-  A deliberately-broken variant trips deadlock at traceIdx = 2 to confirm
-  the checker rejects invalid sequences.
-- `storage/AwaDeadTupleContract.tla` / `storage/AwaDeadTupleContract.cfg`:
-  static architectural contract for table reclaim kinds, hot mutation
-  surfaces, and partition-truncate wiring.
-- `AwaExtended.tla` / `AwaExtended.cfg`: multi-instance model for shutdown
-  sequencing, split permit/claim/execute stages, leader failover, weighted
-  overflow capacity, bounded batch behavior, abstract rate limiting, and
-  post-timeout abandonment / recovery
-- `AwaBatcher.tla` / `AwaBatcher.cfg` / `AwaBatcherLiveness.cfg`: completion
-  batcher model verifying that the async batched completion path (handler →
-  batcher buffer → DB flush) preserves lease-guarded finalization, at-most-once
-  completion, and no-loss-on-shutdown, including the direct fallback path after
-  batcher failure
-- `AwaCbk.tla` / `AwaCbk.cfg` / `AwaCbkLiveness.cfg`: external callback
-  resolution model for the three-way race between complete/fail, timeout rescue,
-  and heartbeat rescue with Postgres row-lock semantics
-- `AwaDispatchClaim.tla` / `AwaDispatchClaimOld.cfg` /
-  `AwaDispatchClaimNew.cfg`: focused dispatcher-claim model; includes retry
-  cycles so `attempt > 1` is exercised as a legitimate path; the old config
-  intentionally fails the `NoDuplicateClaim` invariant and the new config
-  re-checks availability at claim time — matching the production dispatch
-  query's `WHERE state = 'available'` guard in both the subquery and the
-  UPDATE
-- `AwaViewTrigger.tla` / `AwaViewTrigger.cfg` / `AwaViewTriggerOld.cfg`:
-  INSTEAD OF UPDATE trigger concurrency model for the `awa.jobs` UNION ALL
-  view; the trigger implements UPDATE as DELETE + INSERT for cross-table
-  moves, and the v006 fix adds a version check (state, run_lease,
-  callback_id) on the DELETE so concurrent callers can't both succeed on
-  state-changing operations; the old config models the v001 bug from #132
-- `AwaCron.tla` / `AwaCron.cfg` / `AwaCronLiveness.cfg`: cron double-fire
-  prevention under leader failover with CAS on `last_enqueued_at`
+- `AwaCore.tla` / `AwaCore.cfg`: focused model for rescue, admin cancel, and stale completion protection
+- `storage/AwaSegmentedStorage.tla` / `storage/AwaSegmentedStorage.cfg`: focused segmented-storage model covering `ready_entries`, `deferred_jobs`, `ready_tombstones`, live `leases` including `waiting_external`, optional `attempt_state`, `done_entries`, `dlq_entries`, queue-local append/claim cursors, and segment rotation/prune safety for ready, tombstone, lease, terminal, and claim families. Heartbeat freshness lives on non-waiting leases, matching the Rust implementation. DLQ modelling covers both executor-side `FailToDlq` and admin-side `MoveFailedToDlq`, plus `RetryFromDlq` (with `run_lease` reset) and `PurgeDlq`. See [`storage/MAPPING.md`](storage/MAPPING.md) for the TLA+ ↔ Rust correspondence table.
+- `storage/AwaSegmentedStorageInterleavings.cfg`: alternate two-worker config for the same segmented-storage spec, used to exercise stale completion and waiting/resume interleavings without changing the base safety model
+- `storage/AwaSegmentedStorageRaces.tla` / `storage/AwaSegmentedStorageRaces.cfg` / `storage/AwaSegmentedStorageRacesSafe.cfg`: focused race-exposure spec that splits `Claim` into `BeginClaim` / `CommitClaim` to model the claim path's cursor-read-without-lock behaviour. The race config produces a counterexample trace (claim snapshots segment, rotate+prune fire, commit lands lease in pruned segment — simultaneously the claim-vs-rotate race and the prune check-then-act race). The safe config uses a checked commit and passes. Production uses CAS on ring state plus child-partition locks and busy checks, not `FOR SHARE` on `lease_ring_state` — see `storage/MAPPING.md` for the full analysis.
+- `storage/AwaShardedPrune.tla` / `storage/AwaShardedPrune.cfg` / `storage/AwaShardedPruneBroken.cfg`: focused ADR-025 regression model for queue-ring prune across enqueue shards. The passing config requires ready rows to match done rows by `(enqueue_shard, lane_seq)` before prune can drop a sealed queue slot. The broken config intentionally ignores `enqueue_shard` and produces the historical counterexample: shard 0 has a done row at `lane_seq = 1`, shard 1 still has a pending ready row at `lane_seq = 1`, and broken prune drops both.
+- `storage/AwaStorageLockOrder.tla` / `storage/AwaStorageLockOrder.cfg` / `storage/AwaStorageLockOrderDeadlockDemo.cfg` / `storage/AwaStorageLockOrderOldStripedClaimDeadlock.cfg`: lock-ordering protocol spec. Models each storage-engine transaction (enqueue, claim, complete, close-receipt, rescue-receipts, ensure-running, cancel, rotate, and prune) as an ordered sequence of Postgres lock acquisitions with a shared/exclusive compatibility matrix. The striped enqueue path takes multiple physical queue lanes in stable order; the current striped claim path takes at most one physical stripe per transaction. Checks `NoDeadlock` via a waits-for cycle detector. The demo configs use a deliberately cycle-creating plan pair and the historical old striped logical-claim plan to prove the detector catches real cycles.
+- `storage/AwaStorageTransition.tla` / `storage/AwaStorageTransition.cfg` / `storage/AwaStorageTransitionCurrentGate.cfg`: focused model for the 0.5.x-to-0.6 storage transition control plane. It covers prepare, schema readiness, mixed-transition entry, canonical backlog drain, queue-storage routing, finalize, and abort interlocks. The desired config matches the v014+ SQL gate: it requires a live queue-storage target executor at mixed-transition entry and passes cleanly. The `CurrentGate`-named config is now a historical pre-v014 regression witness: it models the old capability-only gate where an auto runtime started before mixed transition reports `queue_storage` while prepared, then becomes drain-only after routing flips.
+- `storage/AwaSegmentedStorageTrace.tla` / `storage/AwaSegmentedStorageTrace.cfg` / `storage/AwaSegmentedStorageTraceReceiptRescue.cfg` / `storage/AwaSegmentedStorageTraceLostClaimAdvance.cfg` / `storage/AwaSegmentedStorageTraceRunningCancel.cfg` / `storage/AwaSegmentedStorageTraceReceiptOnlyCancel.cfg` / `storage/AwaSegmentedStorageTraceCallbackWait.cfg` / `storage/AwaSegmentedStorageTraceDlqRetry.cfg` / `storage/AwaSegmentedStorageTraceDlqPurge.cfg` / `storage/AwaSegmentedStorageTraceBroken.cfg`: trace-validation harness. Takes hand-transcribed sequences of queue-storage runtime events and verifies each transition is accepted by the storage spec. Current positive traces cover snooze, receipt rescue, running cancel, receipt-only cancel, callback wait/resume, DLQ retry, and DLQ purge. A deliberately-broken variant trips deadlock at traceIdx = 2 to confirm the checker rejects invalid sequences.
+- `storage/AwaDeadTupleContract.tla` / `storage/AwaDeadTupleContract.cfg`: static architectural contract for table reclaim kinds, hot mutation surfaces, and partition-truncate wiring.
+- `AwaExtended.tla` / `AwaExtended.cfg`: multi-instance model for shutdown sequencing, split permit/claim/execute stages, leader failover, weighted overflow capacity, bounded batch behavior, abstract rate limiting, and post-timeout abandonment / recovery
+- `AwaBatcher.tla` / `AwaBatcher.cfg` / `AwaBatcherLiveness.cfg`: completion batcher model verifying that the async batched completion path (handler → batcher buffer → DB flush) preserves lease-guarded finalization, at-most-once completion, and no-loss-on-shutdown, including the direct fallback path after batcher failure
+- `AwaCbk.tla` / `AwaCbk.cfg` / `AwaCbkLiveness.cfg`: external callback resolution model for the three-way race between complete/fail, timeout rescue, and heartbeat rescue with Postgres row-lock semantics
+- `AwaDispatchClaim.tla` / `AwaDispatchClaimOld.cfg` / `AwaDispatchClaimNew.cfg`: focused dispatcher-claim model; includes retry cycles so `attempt > 1` is exercised as a legitimate path; the old config intentionally fails the `NoDuplicateClaim` invariant and the new config re-checks availability at claim time — matching the production dispatch query's `WHERE state = 'available'` guard in both the subquery and the UPDATE
+- `AwaViewTrigger.tla` / `AwaViewTrigger.cfg` / `AwaViewTriggerOld.cfg`: INSTEAD OF UPDATE trigger concurrency model for the `awa.jobs` UNION ALL view; the trigger implements UPDATE as DELETE + INSERT for cross-table moves, and the v006 fix adds a version check (state, run_lease, callback_id) on the DELETE so concurrent callers can't both succeed on state-changing operations; the old config models the v001 bug from #132
+- `AwaCron.tla` / `AwaCron.cfg` / `AwaCronLiveness.cfg`: cron double-fire prevention under leader failover with CAS on `last_enqueued_at`
 - `Dockerfile`: Docker-first TLC environment
 - `run-tlc.sh`: convenience wrapper for running TLC from the repo root
 
@@ -207,14 +107,9 @@ Expected counterexample or positive-witness configs:
 ./correctness/run-tlc.sh storage/AwaShardedPrune.tla storage/AwaShardedPruneBroken.cfg
 ```
 
-The `AwaSegmentedStorageTrace*` positive configs intentionally assert a
-`TraceIncomplete` invariant. A valid trace reaches the end and violates that
-invariant; a broken trace deadlocks at the first invalid step. The `Old`,
-`Broken`, `DeadlockDemo`, and `CurrentGate` configs are historical regression
-witnesses and should keep producing the named counterexamples.
+The `AwaSegmentedStorageTrace*` positive configs intentionally assert a `TraceIncomplete` invariant. A valid trace reaches the end and violates that invariant; a broken trace deadlocks at the first invalid step. The `Old`, `Broken`, `DeadlockDemo`, and `CurrentGate` configs are historical regression witnesses and should keep producing the named counterexamples.
 
-`AwaExtended` is the broadest state-space model. For local validation, prefer
-running it with TLC parallel workers, for example:
+`AwaExtended` is the broadest state-space model. For local validation, prefer running it with TLC parallel workers, for example:
 
 ```bash
 docker build -t awa-tlaplus -f correctness/Dockerfile correctness
@@ -224,11 +119,7 @@ docker run --rm -v "$PWD/correctness:/work" awa-tlaplus \
   /work/protocol/AwaExtended.tla
 ```
 
-The focused models above are the release-critical executable regression suite
-for the concrete storage, callback, cron, trigger, and transition bugs. If the
-full `AwaExtended` run becomes too large to close on typical developer
-hardware, reduce it by splitting a smaller exhaustive config rather than
-weakening the focused models.
+The focused models above are the release-critical executable regression suite for the concrete storage, callback, cron, trigger, and transition bugs. If the full `AwaExtended` run becomes too large to close on typical developer hardware, reduce it by splitting a smaller exhaustive config rather than weakening the focused models.
 
 Or directly:
 
@@ -240,78 +131,43 @@ docker run --rm -v "$PWD/correctness:/work" awa-tlaplus \
 
 ## Model Notes
 
-`AwaCore` is the smallest useful model. It now encodes a minimal lease-guarded
-finalization protocol:
+`AwaCore` is the smallest useful model. It now encodes a minimal lease-guarded finalization protocol:
 
 - `Claim` increments a durable `lease`
 - `StartTask` snapshots that lease into `taskLease`
 - `FinalizeAccepted` requires `taskLease = lease`
-- `FinalizeRejected` models the late-completion cleanup path after rescue,
-  cancel, or reclaim
+- `FinalizeRejected` models the late-completion cleanup path after rescue, cancel, or reclaim
 
-That maps much more closely to the Rust `run_lease` guard than the older
-owner-only core model.
+That maps much more closely to the Rust `run_lease` guard than the older owner-only core model.
 
-Like the extended model, the core model bounds lease growth (`MaxLease == 2`)
-so TLC explores a finite reclaim/finalize surface instead of an unbounded loop.
+Like the extended model, the core model bounds lease growth (`MaxLease == 2`) so TLC explores a finite reclaim/finalize surface instead of an unbounded loop.
 
 `AwaExtended` adds:
 
-- `Instances = {"i1", "i2"}` with per-instance `inFlight`, `taskLease`,
-  `cancelRequested`, `rateBudget`, and service lifecycles
+- `Instances = {"i1", "i2"}` with per-instance `inFlight`, `taskLease`, `cancelRequested`, `rateBudget`, and service lifecycles
 - shared database-facing job state via `jobState`, `attempt`, `lease`, and `dbOwner`
-- `dispatchersAlive`, `heartbeatAlive`, `maintenanceAlive`, and
-  `shutdownPhase = "running" | "stop_claim" | "draining" | "stopped"`
+- `dispatchersAlive`, `heartbeatAlive`, `maintenanceAlive`, and `shutdownPhase = "running" | "stop_claim" | "draining" | "stopped"`
 - `permitHolder[j]` / `permitKind[j]` distinct from execution ownership
 - `heartbeatFresh[j]` and `deadlineExpired[j]`
 - `leader` as the abstract maintenance lease holder
 - local permit floors via `MinWorkers`
 - weighted overflow via `Weight`, `GlobalOverflow`, and derived queue contention
-- `BatchMax` and per-runtime `rateBudget[i][q]` as bounded abstractions of
-  dispatcher batching and queue-level rate limiting. Multiple dispatcher
-  claimers inside one runtime refine this same abstraction: they share the
-  runtime's worker permits and queue rate limiter, so they increase claim
-  parallelism without increasing modeled capacity.
-- `DeferredRowsIdle`, which captures the hot/deferred storage split by requiring
-  `retryable` jobs to have no live owner, permit, or in-flight task
-- `DrainTimeout(i)`, `Abandoned(j)`, and `RecoverableAbandoned(j)` so one
-  instance can abandon a running or claimed attempt and another still-running
-  instance must rescue it
+- `BatchMax` and per-runtime `rateBudget[i][q]` as bounded abstractions of dispatcher batching and queue-level rate limiting. Multiple dispatcher claimers inside one runtime refine this same abstraction: they share the runtime's worker permits and queue rate limiter, so they increase claim parallelism without increasing modeled capacity.
+- `DeferredRowsIdle`, which captures the hot/deferred storage split by requiring `retryable` jobs to have no live owner, permit, or in-flight task
+- `DrainTimeout(i)`, `Abandoned(j)`, and `RecoverableAbandoned(j)` so one instance can abandon a running or claimed attempt and another still-running instance must rescue it
 
-To keep the state graph finite, `AwaExtended` bounds retries with
-`MaxAttempts == 2`. Admin cancel remains covered in `AwaCore`; the extended
-model is deliberately focused on the shutdown / rescue / permit / fairness
-protocol rather than re-exploring the full cancel surface.
+To keep the state graph finite, `AwaExtended` bounds retries with `MaxAttempts == 2`. Admin cancel remains covered in `AwaCore`; the extended model is deliberately focused on the shutdown / rescue / permit / fairness protocol rather than re-exploring the full cancel surface.
 
-`AwaSegmentedStorage` focuses on the storage split behind the vacuum-aware
-runtime direction rather than the full worker lifecycle protocol. It treats
-`ready_entries` as runnable queue records, `deferred_jobs` as the promoted
-backlog family, `leases` as the live claim surface including
-`waiting_external`, `attempt_state` as an optional per-attempt mutable row, and
-`done_entries` as reclaimable completion history. It also models `lane_state`
-with explicit append/claim cursors and a gap-skipping claim advance. The key
-invariants are that `attempt_state` can only exist for live leases, waiting is
-a lease state rather than a separate table, deferred jobs hold no live runtime
-state, and ready/lease/terminal/claim segments cannot be pruned while they
-still own live rows.
+`AwaSegmentedStorage` focuses on the storage split behind the vacuum-aware runtime direction rather than the full worker lifecycle protocol. It treats `ready_entries` as runnable queue records, `deferred_jobs` as the promoted backlog family, `leases` as the live claim surface including `waiting_external`, `attempt_state` as an optional per-attempt mutable row, and `done_entries` as reclaimable completion history. It also models `lane_state` with explicit append/claim cursors and a gap-skipping claim advance. The key invariants are that `attempt_state` can only exist for live leases, waiting is a lease state rather than a separate table, deferred jobs hold no live runtime state, and ready/lease/terminal/claim segments cannot be pruned while they still own live rows.
 
-`AwaShardedPrune` covers the cross-shard prune property that the lifecycle
-model deliberately abstracts away: `lane_seq` values are only unique within an
-`enqueue_shard`, so any ready/done anti-join used for queue-slot prune must
-include `enqueue_shard`. The passing config checks the fixed predicate; the
-broken config remains as a regression witness.
+`AwaShardedPrune` covers the cross-shard prune property that the lifecycle model deliberately abstracts away: `lane_seq` values are only unique within an `enqueue_shard`, so any ready/done anti-join used for queue-slot prune must include `enqueue_shard`. The passing config checks the fixed predicate; the broken config remains as a regression witness.
 
-`AwaBatcher` models the async completion path between handler return and DB
-update. In the real system (`awa-worker/src/completion.rs`), completed jobs
-are queued in a sharded in-memory buffer and flushed to the database in
-batches of up to 512 every 1ms. This introduces a window where a job has
-completed in the handler but not yet in the database — during which
-maintenance can rescue the job and a new worker can re-claim it.
+`AwaBatcher` models the async completion path between handler return and DB update. In the real system (`awa-worker/src/completion.rs`), completed jobs are queued in a sharded in-memory buffer and flushed to the database in batches of up to 512 every 1ms. This introduces a window where a job has completed in the handler but not yet in the database — during which maintenance can rescue the job and a new worker can re-claim it.
 
 ### Mapping to Rust code
 
 | TLA+ variable | Rust equivalent |
-|---------------|-----------------|
+| --- | --- |
 | `jobState`, `owner`, `lease` | `awa.jobs_hot` row: `state`, implicit owner, `run_lease` column |
 | `taskLease[w][j]` | `ctx.job.run_lease` snapshot captured at claim time (`executor.rs`) |
 | `handlerPhase[w][j]` | Executor control flow after `worker.perform()` returns |
@@ -320,7 +176,7 @@ maintenance can rescue the job and a new worker can re-claim it.
 | `dbCompletions` | Ghost variable (model-only) for checking `AtMostOneCompletion` |
 
 | TLA+ action | Rust code |
-|-------------|-----------|
+| --- | --- |
 | `Claim` | `dispatcher.poll_once()` — `UPDATE ... FROM (SELECT ... FOR UPDATE SKIP LOCKED) ... SET state='running', run_lease=run_lease+1` |
 | `HandlerComplete` | `completion_batcher.complete(job.id, job.run_lease)` (`executor.rs:364`) |
 | `BatcherFlushSuccess` | Flush SQL: `UPDATE ... WHERE run_lease=$2 AND state='running'` (`completion.rs:150`) |
@@ -334,28 +190,16 @@ maintenance can rescue the job and a new worker can re-claim it.
 
 ### What it verifies
 
-- The `run_lease` SQL guard prevents stale batcher flushes from overwriting a
-  re-claimed job (`BatcherFlushStale`)
-- When the batcher flush fails (DB connection error), the handler falls back
-  to direct single-job completion, which also applies the lease guard
-  (`DirectCompleteSuccess` / `DirectCompleteStale`)
+- The `run_lease` SQL guard prevents stale batcher flushes from overwriting a re-claimed job (`BatcherFlushStale`)
+- When the batcher flush fails (DB connection error), the handler falls back to direct single-job completion, which also applies the lease guard (`DirectCompleteSuccess` / `DirectCompleteStale`)
 - A job is DB-completed at most once regardless of path (`AtMostOneCompletion`)
-- Shutdown drains all pending batcher requests before exiting — the
-  `BatcherDrainStart` transition requires all `taskLease` values to be zero
-  and all handlers to be in `idle` or `done` phase
-- When both batch and direct completion fail (`DirectCompleteFail`), the
-  handler exits cleanly ("done") and the job stays `running` in the DB,
-  relying on heartbeat `Rescue` → `Promote` to retry
-- Under fairness, every `pending` handler eventually reaches `done` or `idle`
-  (`PendingEventuallyResolved`)
+- Shutdown drains all pending batcher requests before exiting — the `BatcherDrainStart` transition requires all `taskLease` values to be zero and all handlers to be in `idle` or `done` phase
+- When both batch and direct completion fail (`DirectCompleteFail`), the handler exits cleanly ("done") and the job stays `running` in the DB, relying on heartbeat `Rescue` → `Promote` to retry
+- Under fairness, every `pending` handler eventually reaches `done` or `idle` (`PendingEventuallyResolved`)
 
 ### Modeling note
 
-The initial model run caught a sequencing issue: `BatcherDrainStart` originally
-only required `handlerPhase ∈ {idle, done}`, but a handler could be `idle` with
-`taskLease > 0` (claimed but handler not yet returned). Tightening the guard to
-also require `taskLease = 0` matches the real system's `service_cancel` ordering
-where it only fires after all `job_set` tasks complete (`client.rs:742-752`).
+The initial model run caught a sequencing issue: `BatcherDrainStart` originally only required `handlerPhase ∈ {idle, done}`, but a handler could be `idle` with `taskLease > 0` (claimed but handler not yet returned). Tightening the guard to also require `taskLease = 0` matches the real system's `service_cancel` ordering where it only fires after all `job_set` tasks complete (`client.rs:742-752`).
 
 ## Checked Invariants
 
@@ -404,141 +248,68 @@ where it only fires after all `job_set` tasks complete (`client.rs:742-752`).
 - `I1DrainEventuallyStops`
 - `I1Q1OverflowProgress`
 
-`AwaExtended.tla` also defines `RecoverableAbandoned(j)` and
-`AbandonedJobsEventuallyLeaveRunning`, but that liveness property is not
-enabled in `AwaExtended.cfg`. In a finite two-instance model TLC can always
-choose to shut the last surviving instance down as well, so eventual rescue
-needs an extra environment assumption such as "some instance remains running".
+`AwaExtended.tla` also defines `RecoverableAbandoned(j)` and `AbandonedJobsEventuallyLeaveRunning`, but that liveness property is not enabled in `AwaExtended.cfg`. In a finite two-instance model TLC can always choose to shut the last surviving instance down as well, so eventual rescue needs an extra environment assumption such as "some instance remains running".
 
 ## Mapping Back To The Rust Runtime
 
-- `dbOwner[j]` corresponds to the worker attempt that can still satisfy the SQL
-  `WHERE state = 'running' AND run_lease = ...` guard
-- `inFlight[i][j]` and `taskLease[i][j]` approximate each instance's local
-  executor registry keyed by `(job_id, run_lease)`; the Rust runtime currently
-  implements this as a sharded local registry rather than a single global lock
-- `jobState[j] = "retryable"` corresponds to the row living in
-  `awa.scheduled_jobs`; the hot table only holds runnable / running / terminal
-  rows
-- `permitHolder[j]` is the reserved capacity backing the current claim or
-  execution attempt for that job row
-- `cancelRequested[i][j]` approximates the per-instance in-flight cancellation
-  signal that a handler observes through `ctx.is_cancelled()`
-- `shutdownPhase` plus the service booleans capture the intended ordering:
-  stop dispatchers -> drain with heartbeat and maintenance alive -> either
-  finish cleanly or time out and abandon
+- `dbOwner[j]` corresponds to the worker attempt that can still satisfy the SQL `WHERE state = 'running' AND run_lease = ...` guard
+- `inFlight[i][j]` and `taskLease[i][j]` approximate each instance's local executor registry keyed by `(job_id, run_lease)`; the Rust runtime currently implements this as a sharded local registry rather than a single global lock
+- `jobState[j] = "retryable"` corresponds to the row living in `awa.scheduled_jobs`; the hot table only holds runnable / running / terminal rows
+- `permitHolder[j]` is the reserved capacity backing the current claim or execution attempt for that job row
+- `cancelRequested[i][j]` approximates the per-instance in-flight cancellation signal that a handler observes through `ctx.is_cancelled()`
+- `shutdownPhase` plus the service booleans capture the intended ordering: stop dispatchers -> drain with heartbeat and maintenance alive -> either finish cleanly or time out and abandon
 - `leader` approximates the maintenance leader selected by advisory lock
 
 ## Known Divergences
 
-- The model shares only abstract database state and leadership between
-  instances. It does not model actual SQL, `SKIP LOCKED`, or trigger-driven
-  wakeups.
-- Leadership is an abstract exclusive token, not the full advisory-lock
-  protocol.
-- Drain timeout is modeled as an explicit transition rather than wall-clock
-  time.
-- `AwaExtended` only models two instances, so abandonment liveness is checked
-  only as protocol structure, not as an enabled TLC liveness property, because
-  the model intentionally allows the entire cluster to shut down.
-- Permit ownership is modeled at the job-row level. This is accurate enough for
-  the checked invariants, but it is still an abstraction of the real Rust task
-  handles and `DispatchPermit` lifetimes.
-- Public SQL projections (`awa.jobs`, `jobs_compat()`, admin state counts, and
-  worker health checks) are not modelled as separate derived views. The storage
-  specs cover the lifecycle state underneath them; projection exactness remains
-  a Rust SQL regression-test obligation.
+- The model shares only abstract database state and leadership between instances. It does not model actual SQL, `SKIP LOCKED`, or trigger-driven wakeups.
+- Leadership is an abstract exclusive token, not the full advisory-lock protocol.
+- Drain timeout is modeled as an explicit transition rather than wall-clock time.
+- `AwaExtended` only models two instances, so abandonment liveness is checked only as protocol structure, not as an enabled TLC liveness property, because the model intentionally allows the entire cluster to shut down.
+- Permit ownership is modeled at the job-row level. This is accurate enough for the checked invariants, but it is still an abstraction of the real Rust task handles and `DispatchPermit` lifetimes.
+- Public SQL projections (`awa.jobs`, `jobs_compat()`, admin state counts, and worker health checks) are not modelled as separate derived views. The storage specs cover the lifecycle state underneath them; projection exactness remains a Rust SQL regression-test obligation.
 
 ## Bugs the Models Did Not Catch
 
 ### Dispatcher stale-candidate double claim (v0.5.1-alpha.0, #134)
 
-The hot-path dispatcher claim SQL selected candidate IDs from `awa.jobs_hot`,
-then later locked and updated those rows to `running`. The locking/update step
-did not re-check `state = 'available'`, so a row that was chosen while
-available could still be claimed again after another worker had already moved it
-to `running`.
+The hot-path dispatcher claim SQL selected candidate IDs from `awa.jobs_hot`, then later locked and updated those rows to `running`. The locking/update step did not re-check `state = 'available'`, so a row that was chosen while available could still be claimed again after another worker had already moved it to `running`.
 
 In production terms the bad transition was:
 
-1. worker A claims `available -> running`, incrementing `attempt` and
-   `run_lease`
+1. worker A claims `available -> running`, incrementing `attempt` and `run_lease`
 2. worker B still has the same row in its stale candidate set
-3. worker B locks the row later and performs `running -> running`, incrementing
-   `attempt` and `run_lease` again
+3. worker B locks the row later and performs `running -> running`, incrementing `attempt` and `run_lease` again
 
-That produced exactly the observed flake in the callback failover chaos test:
-one attempt-1 handler lost ownership before `register_callback()`, the same job
-was re-dispatched as attempt 2 and completed, and the test got stuck at
-`{"waiting_external": 11, "completed": 1}` before failover even started.
+That produced exactly the observed flake in the callback failover chaos test: one attempt-1 handler lost ownership before `register_callback()`, the same job was re-dispatched as attempt 2 and completed, and the test got stuck at `{"waiting_external": 11, "completed": 1}` before failover even started.
 
 **Why the TLA+ model missed it:**
 
-1. **The abstraction boundary is above SQL candidate staleness.**
-   `AwaExtended.tla` models `Reserve*` and `ClaimReserved` as acting on the
-   current logical row state. `ClaimReserved(i, j)` requires `jobState[j] =
-   "available"` at claim time, which is the behavior the SQL should have had.
-   It does not model a two-phase SQL path of:
-   `select candidate ids -> later lock row -> later update row` with the row
-   state changing in between.
+1. **The abstraction boundary is above SQL candidate staleness.** `AwaExtended.tla` models `Reserve*` and `ClaimReserved` as acting on the current logical row state. `ClaimReserved(i, j)` requires `jobState[j] = "available"` at claim time, which is the behavior the SQL should have had. It does not model a two-phase SQL path of: `select candidate ids -> later lock row -> later update row` with the row state changing in between.
 
-2. **The model assumed the claim step revalidated availability.**
-   The checked invariants reason about the logical claim transition
-   `available -> running`. The real bug was that the implementation violated
-   that assumption by omitting the final `state = 'available'` recheck during
-   the locked update.
+2. **The model assumed the claim step revalidated availability.** The checked invariants reason about the logical claim transition `available -> running`. The real bug was that the implementation violated that assumption by omitting the final `state = 'available'` recheck during the locked update.
 
-3. **Generated traces already showed the shape once the abstraction was too
-   weak.** Some historical `AwaExtended` trace artifacts contain
-   `running -> running` / `attempt+1` transitions. Those traces are a sign that
-   the model's reserve/claim split was permissive enough to allow the same bad
-   shape, but the checked invariants did not explicitly forbid it.
+3. **Generated traces already showed the shape once the abstraction was too weak.** Some historical `AwaExtended` trace artifacts contain `running -> running` / `attempt+1` transitions. Those traces are a sign that the model's reserve/claim split was permissive enough to allow the same bad shape, but the checked invariants did not explicitly forbid it.
 
-**Fix:** The dispatcher SQL re-checks `state = 'available'` both in the
-`FOR UPDATE SKIP LOCKED` subquery and in the outer `UPDATE ... WHERE` clause,
-preventing a stale candidate from claiming a row that has already transitioned.
+**Fix:** The dispatcher SQL re-checks `state = 'available'` both in the `FOR UPDATE SKIP LOCKED` subquery and in the outer `UPDATE ... WHERE` clause, preventing a stale candidate from claiming a row that has already transitioned.
 
 ### Concurrent UPDATE race on the `awa.jobs` view (v0.5.1, #132)
 
-The `awa.jobs` UNION ALL view's INSTEAD OF UPDATE trigger implemented UPDATE
-as DELETE + INSERT. The DELETE matched only on `id`, so when two concurrent
-callers (e.g., two `resume_external` calls) raced on the same callback_id:
+The `awa.jobs` UNION ALL view's INSTEAD OF UPDATE trigger implemented UPDATE as DELETE + INSERT. The DELETE matched only on `id`, so when two concurrent callers (e.g., two `resume_external` calls) raced on the same callback_id:
 
 1. Both callers found the row in the view (both saw `callback_id = X`)
 2. Both entered the trigger with identical `OLD` records
-3. Transaction A's DELETE succeeded; transaction B's DELETE (after A committed)
-   found and deleted A's freshly re-inserted row
+3. Transaction A's DELETE succeeded; transaction B's DELETE (after A committed) found and deleted A's freshly re-inserted row
 4. Both INSERTs succeeded — both callers observed success
 
-This violated at-most-once callback resolution: two callers both returned
-a `JobRow` for the same callback, with A's state change silently lost.
+This violated at-most-once callback resolution: two callers both returned a `JobRow` for the same callback, with A's state change silently lost.
 
 **Why the TLA+ models missed it:**
 
-1. **Wrong abstraction boundary.** The models explicitly do not cover SQL
-   text, trigger mechanics, or the `awa.jobs` compatibility view
-   (see Known Divergences above). `AwaCbk` models a logical row with
-   row-lock semantics — it assumes a plain Postgres UPDATE that blocks,
-   re-evaluates, and returns 0 rows if the WHERE clause no longer matches.
-   The DELETE+INSERT trigger with stale `OLD` inputs is not representable
-   in that abstraction.
+1. **Wrong abstraction boundary.** The models explicitly do not cover SQL text, trigger mechanics, or the `awa.jobs` compatibility view (see Known Divergences above). `AwaCbk` models a logical row with row-lock semantics — it assumes a plain Postgres UPDATE that blocks, re-evaluates, and returns 0 rows if the WHERE clause no longer matches. The DELETE+INSERT trigger with stale `OLD` inputs is not representable in that abstraction.
 
-2. **Assumes row-level UPDATE atomicity.** In `AwaCbk.tla`, blocked
-   callback operations wait on `rowLock`, then re-evaluate preconditions
-   after the lock is released. This accurately models a normal row UPDATE.
-   It does not model "executor picked a row from a UNION ALL view, passed
-   a snapshot `OLD` to a trigger function, which then did a DELETE + INSERT
-   carrying that stale snapshot."
+2. **Assumes row-level UPDATE atomicity.** In `AwaCbk.tla`, blocked callback operations wait on `rowLock`, then re-evaluate preconditions after the lock is released. This accurately models a normal row UPDATE. It does not model "executor picked a row from a UNION ALL view, passed a snapshot `OLD` to a trigger function, which then did a DELETE + INSERT carrying that stale snapshot."
 
-3. **Does not track per-operation results.** The model checks `AtMostOnce
-   Resolution` (at most one DB state transition), but this race can produce
-   a plausible final DB state while still letting two callers observe success.
-   That is an API linearizability bug. The model does not track per-caller
-   return values (Success vs CallbackNotFound), so it had no way to detect
-   the symptom.
+3. **Does not track per-operation results.** The model checks `AtMostOnce Resolution` (at most one DB state transition), but this race can produce a plausible final DB state while still letting two callers observe success. That is an API linearizability bug. The model does not track per-caller return values (Success vs CallbackNotFound), so it had no way to detect the symptom.
 
-**Fix (v006 migration):** The trigger's DELETE now checks `state`, `run_lease`,
-and `callback_id` from `OLD`. After a concurrent transaction modifies the row,
-the second caller's DELETE matches 0 rows → `RETURN NULL` → 0 rows in
-`RETURNING` → `CallbackNotFound`. This restores the optimistic concurrency
-semantics that the TLA+ model assumes.
+**Fix (v006 migration):** The trigger's DELETE now checks `state`, `run_lease`, and `callback_id` from `OLD`. After a concurrent transaction modifies the row, the second caller's DELETE matches 0 rows → `RETURN NULL` → 0 rows in `RETURNING` → `CallbackNotFound`. This restores the optimistic concurrency semantics that the TLA+ model assumes.

--- a/correctness/core/README.md
+++ b/correctness/core/README.md
@@ -4,12 +4,8 @@ These are the smallest safety-oriented models.
 
 ## Files
 
-- `AwaCore.tla` / `AwaCore.cfg`
-  Covers lease-guarded finalization, rescue, admin cancel, and stale completion
-  rejection.
-- `AwaBatcher.tla` / `AwaBatcher.cfg` / `AwaBatcherLiveness.cfg`
-  Covers the async completion batching path, stale flush rejection, fallback
-  direct completion, and shutdown drain.
+- `AwaCore.tla` / `AwaCore.cfg` Covers lease-guarded finalization, rescue, admin cancel, and stale completion rejection.
+- `AwaBatcher.tla` / `AwaBatcher.cfg` / `AwaBatcherLiveness.cfg` Covers the async completion batching path, stale flush rejection, fallback direct completion, and shutdown drain.
 
 ## When To Use
 

--- a/correctness/protocol/README.md
+++ b/correctness/protocol/README.md
@@ -1,21 +1,15 @@
 # Protocol Models
 
-These models cover larger runtime protocols that involve multiple services or
-instances.
+These models cover larger runtime protocols that involve multiple services or instances.
 
 ## Files
 
-- `AwaExtended.tla` / `AwaExtended.cfg`
-  Covers two-instance shutdown sequencing, split reserve/claim/execute stages,
-  leader failover, permits, weighted overflow, rescue, abandonment, and bounded
-  rate limiting.
+- `AwaExtended.tla` / `AwaExtended.cfg` Covers two-instance shutdown sequencing, split reserve/claim/execute stages, leader failover, permits, weighted overflow, rescue, abandonment, and bounded rate limiting.
 
 ## When To Use
 
-- use `AwaExtended` for shutdown, rescue, leader failover, and permit protocol
-  questions
-- do not use it for raw SQL or low-level `SKIP LOCKED` races; those belong in a
-  smaller focused model under `races/`
+- use `AwaExtended` for shutdown, rescue, leader failover, and permit protocol questions
+- do not use it for raw SQL or low-level `SKIP LOCKED` races; those belong in a smaller focused model under `races/`
 
 ## Command
 

--- a/correctness/races/README.md
+++ b/correctness/races/README.md
@@ -1,35 +1,18 @@
 # Race Models
 
-These models cover feature-specific or bug-specific interleavings that are too
-low-level or too specialized for the larger protocol model.
+These models cover feature-specific or bug-specific interleavings that are too low-level or too specialized for the larger protocol model.
 
 ## Files
 
-- `AwaCbk.tla` / `AwaCbk.cfg` / `AwaCbkLiveness.cfg`
-  Covers callback completion/fail, timeout rescue, heartbeat rescue, and stale
-  token rejection.
-- `AwaCron.tla` / `AwaCron.cfg` / `AwaCronLiveness.cfg`
-  Covers cron double-fire prevention under leader failover.
-- `AwaDispatchClaim.tla` / `AwaDispatchClaimOld.cfg` /
-  `AwaDispatchClaimNew.cfg`
-  Focused proof for issue #134. Includes retry cycles (completed → available)
-  so `attempt > 1` is exercised as a legitimate path. Uses `NoDuplicateClaim`
-  invariant (claims-per-available-round ≤ 1) instead of absolute attempt count.
-  The old config reproduces the stale-candidate double-claim; the new config
-  models the availability re-check and passes.
-- `AwaViewTrigger.tla` / `AwaViewTrigger.cfg` / `AwaViewTriggerOld.cfg`
-  INSTEAD OF UPDATE trigger concurrency on the `awa.jobs` UNION ALL view
-  (#132). The trigger implements UPDATE as DELETE + INSERT for cross-table
-  moves; the v006 fix adds a version check (state, run_lease, callback_id)
-  so concurrent callers can't both succeed on state-changing operations.
-  The old config reproduces the double-apply race.
+- `AwaCbk.tla` / `AwaCbk.cfg` / `AwaCbkLiveness.cfg` Covers callback completion/fail, timeout rescue, heartbeat rescue, and stale token rejection.
+- `AwaCron.tla` / `AwaCron.cfg` / `AwaCronLiveness.cfg` Covers cron double-fire prevention under leader failover.
+- `AwaDispatchClaim.tla` / `AwaDispatchClaimOld.cfg` / `AwaDispatchClaimNew.cfg` Focused proof for issue #134. Includes retry cycles (completed → available) so `attempt > 1` is exercised as a legitimate path. Uses `NoDuplicateClaim` invariant (claims-per-available-round ≤ 1) instead of absolute attempt count. The old config reproduces the stale-candidate double-claim; the new config models the availability re-check and passes.
+- `AwaViewTrigger.tla` / `AwaViewTrigger.cfg` / `AwaViewTriggerOld.cfg` INSTEAD OF UPDATE trigger concurrency on the `awa.jobs` UNION ALL view (#132). The trigger implements UPDATE as DELETE + INSERT for cross-table moves; the v006 fix adds a version check (state, run_lease, callback_id) so concurrent callers can't both succeed on state-changing operations. The old config reproduces the double-apply race.
 
 ## When To Use
 
-- use these models when the bug sits below the abstraction boundary of
-  `AwaExtended`
-- prefer adding a small focused model here over expanding the state space of a
-  larger model unless the behavior is truly protocol-wide
+- use these models when the bug sits below the abstraction boundary of `AwaExtended`
+- prefer adding a small focused model here over expanding the state space of a larger model unless the behavior is truly protocol-wide
 
 ## Commands
 

--- a/correctness/storage/MAPPING.md
+++ b/correctness/storage/MAPPING.md
@@ -1,19 +1,13 @@
 # AwaSegmentedStorage — Rust correspondence
 
-This doc pins each TLA+ action in `AwaSegmentedStorage.tla` to the Rust
-code and SQL that implements it. It is intended as a mechanical cross-check
-as names and internals evolve.
+This doc pins each TLA+ action in `AwaSegmentedStorage.tla` to the Rust code and SQL that implements it. It is intended as a mechanical cross-check as names and internals evolve.
 
-Line numbers in this doc refer to `awa-model/src/queue_storage.rs`
-unless stated otherwise. They drift under active development; treat
-them as a hint and re-grep for the function name if the line is wrong.
-This table maps the logical storage names used in ADR-019 / ADR-023
-onto the current Rust / SQL implementation.
+Line numbers in this doc refer to `awa-model/src/queue_storage.rs` unless stated otherwise. They drift under active development; treat them as a hint and re-grep for the function name if the line is wrong. This table maps the logical storage names used in ADR-019 / ADR-023 onto the current Rust / SQL implementation.
 
 ## Variable mapping
 
 | TLA+ variable | Rust / SQL equivalent |
-|---|---|
+| --- | --- |
 | `readyEntries` | `{schema}.ready_entries` parent partitioned table |
 | `readyTombstones` | `{schema}.ready_tombstones`, keyed by ready segment/generation and lane identity. The TLA+ model stores lane records so reprioritizing a job can tombstone the old lane while the new lane remains claimable. |
 | `deferredEntries` | `{schema}.deferred_jobs` |
@@ -34,15 +28,12 @@ onto the current Rust / SQL implementation.
 | `claimSegments[seg]` state | same semantics as other segment families; `{schema}.claim_ring_state.current_slot` identifies the open partition, `{schema}.claim_ring_slots(slot)` tracks per-partition generation. Seeded in `prepare_schema`; rotated by `rotate_claims`. |
 | `claimSegmentCursor` | `{schema}.claim_ring_state.current_slot`. |
 
-The TLA+ model does not represent the cold completed-history rollup cache.
-Rust currently stores that in `{schema}.queue_terminal_rollups`, with
-`queue_lanes.pruned_completed_count` kept only as a transitional legacy source
-for backfill / fallback reads during upgrades.
+The TLA+ model does not represent the cold completed-history rollup cache. Rust currently stores that in `{schema}.queue_terminal_rollups`, with `queue_lanes.pruned_completed_count` kept only as a transitional legacy source for backfill / fallback reads during upgrades.
 
 ## Action mapping
 
 | TLA+ action | Rust function | SQL / DDL |
-|---|---|---|
+| --- | --- | --- |
 | `EnqueueReady(j)` | `QueueStorage::insert_ready_rows_tx` and `QueueStorage::insert_ready_rows_copy_tx`; producer entry points include `enqueue_batch`, `enqueue_runtime_rows`, `enqueue_params_batch`, and `enqueue_params_copy` | reserve `{schema}.queue_enqueue_heads.next_seq`, sync enqueue-time uniqueness claims, append to `{schema}.ready_entries` via INSERT or COPY, and notify logical queues in one tx |
 | `EnqueueDeferred(j)` | `QueueStorage::insert_deferred_rows_tx` and `QueueStorage::insert_deferred_rows_copy_tx`; producer entry points include `enqueue_params_batch` and `enqueue_params_copy` | allocate job ids, sync enqueue-time uniqueness claims, append to `{schema}.deferred_jobs` via INSERT or COPY in one tx |
 | `PromoteDeferred(j)` | maintenance promote loop in `awa-worker/src/maintenance.rs::promote_due_state` | `DELETE FROM deferred_jobs ... INSERT INTO ready_entries ...` in one tx |
@@ -81,7 +72,7 @@ for backfill / fallback reads during upgrades.
 ## Invariant mapping
 
 | TLA+ invariant | Rust enforcement |
-|---|---|
+| --- | --- |
 | `ActiveLeasesSubsetReadyEntries` | every `leases` row FK-references `ready_entries(queue, priority, enqueue_shard, lane_seq)` (check the CREATE TABLE DDL in the `install` fn) |
 | `WaitingIsLeaseState` | `waiting_external` is represented by a row in `leases`, not by a separate waiting table |
 | `AttemptStateRequiresLiveLease` | callback/progress attempt state is associated with a live lease row and is deleted on terminal/retry/rescue paths |
@@ -97,42 +88,22 @@ for backfill / fallback reads during upgrades.
 | `PrunedClaimSegmentsAreEmpty` (ADR-023) | `prune_oldest_claims` requires no open claim in the partition before TRUNCATE; rescue-before-truncate closes stragglers in the same transaction |
 | `NoLostClaim` (ADR-023) | receipts and their closures both live in `claim_slot`-partitioned tables; partitions only truncate once all their receipts are closed, so no open claim is physically dropped |
 | `ClaimOpenAndClosedDisjoint` (ADR-023) | closure insertion and receipt-clearing are a single transaction; a partition's receipt+closure pair is either both present or both dropped by `TRUNCATE` |
-| `LaneStateConsistent` | live availability is derived from `{schema}.queue_enqueue_heads.next_seq` minus `{schema}.queue_claim_heads.claim_seq` for the same `(queue, priority, enqueue_shard)` lane, plus exact scans of live ready/receipt/lease rows where needed. Rust's hot-path queue signal path (`QueueStorage::queue_claimer_signal`) and exact admin reads use the same shard-aware head identity rather than a mutable `available_count` cache. Completed totals are *not* maintained as hot counters — Rust derives them from live `done_entries` plus the cold `{schema}.queue_terminal_rollups` cache, with `queue_lanes.pruned_completed_count` read only as a transitional legacy fallback |
+| `LaneStateConsistent` | live availability is derived from `{schema}.queue_enqueue_heads.next_seq` minus `{schema}.queue_claim_heads.claim_seq` for the same `(queue, priority, enqueue_shard)` lane, plus exact scans of live ready/receipt/lease rows where needed. Rust's hot-path queue signal path (`QueueStorage::queue_claimer_signal`) and exact admin reads use the same shard-aware head identity rather than a mutable `available_count` cache. Completed totals are _not_ maintained as hot counters — Rust derives them from live `done_entries` plus the cold `{schema}.queue_terminal_rollups` cache, with `queue_lanes.pruned_completed_count` read only as a transitional legacy fallback |
 
 ## Public read and compatibility surfaces
 
-`AwaSegmentedStorage.tla` models storage state, not every SQL projection over
-that state. Public and admin reads are therefore refinement obligations on the
-SQL implementation:
+`AwaSegmentedStorage.tla` models storage state, not every SQL projection over that state. Public and admin reads are therefore refinement obligations on the SQL implementation:
 
-- `awa.jobs` / `awa.jobs_compat()` is the compatibility view used by SQL
-  adapters and operational queries. Migration
-  `awa-model/migrations/v028_ready_tombstones.sql` keeps queue-storage
-  available rows shard-aware, uses the sequence-backed claim cursor, and
-  anti-joins `ready_tombstones`; lease-backed rows join ready bodies by
-  `(queue, priority, enqueue_shard, lane_seq)`.
-- `awa-model/src/admin.rs::queue_storage_current_jobs_cte`,
-  `awa-model/src/admin.rs::state_counts`, and
-  `awa-worker/src/client.rs::health_check` are the Rust read-side equivalents.
-  They must preserve the same enqueue-shard predicates or multi-shard queues
-  can overcount available rows or hydrate a row from the wrong shard.
-- `test_queue_storage_multi_shard_public_available_counts_are_exact` is the
-  code-level regression test for this projection boundary. A future TLA+
-  projection model could make this formal by deriving `JobsCompatAvailable`
-  from the storage variables and asserting it equals `CurrentReady`; the
-  current storage model stops at the underlying lifecycle and prune state.
+- `awa.jobs` / `awa.jobs_compat()` is the compatibility view used by SQL adapters and operational queries. Migration `awa-model/migrations/v028_ready_tombstones.sql` keeps queue-storage available rows shard-aware, uses the sequence-backed claim cursor, and anti-joins `ready_tombstones`; lease-backed rows join ready bodies by `(queue, priority, enqueue_shard, lane_seq)`.
+- `awa-model/src/admin.rs::queue_storage_current_jobs_cte`, `awa-model/src/admin.rs::state_counts`, and `awa-worker/src/client.rs::health_check` are the Rust read-side equivalents. They must preserve the same enqueue-shard predicates or multi-shard queues can overcount available rows or hydrate a row from the wrong shard.
+- `test_queue_storage_multi_shard_public_available_counts_are_exact` is the code-level regression test for this projection boundary. A future TLA+ projection model could make this formal by deriving `JobsCompatAvailable` from the storage variables and asserting it equals `CurrentReady`; the current storage model stops at the underlying lifecycle and prune state.
 
 ## Storage-transition model mapping
 
-`AwaStorageTransition.tla` maps to the transition SQL in
-`awa-model/migrations/v010_storage_transition_prep.sql`,
-`awa-model/migrations/v012_queue_storage_compat.sql`, and the executor
-gate in `awa-model/migrations/v014_storage_transition_role.sql`, plus
-the worker role/effective-storage resolution in
-`awa-worker/src/client.rs`.
+`AwaStorageTransition.tla` maps to the transition SQL in `awa-model/migrations/v010_storage_transition_prep.sql`, `awa-model/migrations/v012_queue_storage_compat.sql`, and the executor gate in `awa-model/migrations/v014_storage_transition_role.sql`, plus the worker role/effective-storage resolution in `awa-worker/src/client.rs`.
 
 | TLA+ variable / action | Rust / SQL equivalent |
-|---|---|
+| --- | --- |
 | `state`, `currentEngine`, `preparedEngine` | `awa.storage_transition_state.state`, `current_engine`, `prepared_engine` |
 | `preparedSchemaReady` | `queue_storage_schema_ready()` / SQL checks for the queue-storage substrate needed by producers and claimers: `{schema}.job_id_seq`, `queue_ring_state`, `ready_entries`, `ready_tombstones`, `done_entries`, `leases`, `deferred_jobs`, `lease_claims`, `lease_claim_closures`, and `claim_ready_runtime(...)` |
 | `oldCanonicalLive` | live `awa.runtime_instances` rows with `storage_capability = 'canonical'` |
@@ -149,56 +120,23 @@ the worker role/effective-storage resolution in
 | `Finalize` | `awa.storage_finalize()`: requires `canonical_live_backlog() = 0` and no live `canonical` / `canonical_drain_only` runtimes |
 | `AbortMixed` | `awa.storage_abort()`: rejects rollback while live `queue_storage` runtimes or queue-storage rows exist |
 
-The model deliberately keeps `MixedHasQueueExecutor` as an entry-gate
-property, not a permanent liveness invariant: a queue-storage target can
-stop after the transition. As of v014 the SQL gate enforces
-`transition_role = 'queue_storage_target' AND storage_capability =
-'queue_storage'`, which is the same property `LiveQueueExecutor > 0`
-expresses in the model — `AwaStorageTransition.cfg` (with
-`RequireQueueExecutorOnEnter = TRUE`) is the configuration that matches
-production. `AwaStorageTransitionCurrentGate.cfg` is retained as a
-historical reproducer of the pre-v014 gap, where
-`storage_capability = 'queue_storage'` alone was used and the
-`MixedHasQueueExecutor` invariant could fail because an
-`autoPreMixedLive` runtime satisfied the gate pre-flip and downgraded to
-drain-only post-flip.
+The model deliberately keeps `MixedHasQueueExecutor` as an entry-gate property, not a permanent liveness invariant: a queue-storage target can stop after the transition. As of v014 the SQL gate enforces `transition_role = 'queue_storage_target' AND storage_capability = 'queue_storage'`, which is the same property `LiveQueueExecutor > 0` expresses in the model — `AwaStorageTransition.cfg` (with `RequireQueueExecutorOnEnter = TRUE`) is the configuration that matches production. `AwaStorageTransitionCurrentGate.cfg` is retained as a historical reproducer of the pre-v014 gap, where `storage_capability = 'queue_storage'` alone was used and the `MixedHasQueueExecutor` invariant could fail because an `autoPreMixedLive` runtime satisfied the gate pre-flip and downgraded to drain-only post-flip.
 
 ## Local runtime note
 
-The TLA+ storage model does not represent local worker-capacity accounting.
-Rust now releases local queue capacity immediately after handler execution and
-progress snapshotting, while durable completion continues asynchronously
-through the completion batcher. That changes throughput and scheduling
-behavior, but it does not change the modeled storage safety boundary because
-the `run_lease`-guarded finalization and rescue semantics are unchanged.
+The TLA+ storage model does not represent local worker-capacity accounting. Rust now releases local queue capacity immediately after handler execution and progress snapshotting, while durable completion continues asynchronously through the completion batcher. That changes throughput and scheduling behavior, but it does not change the modeled storage safety boundary because the `run_lease`-guarded finalization and rescue semantics are unchanged.
 
 ## Producer batching note
 
-The TLA+ storage model treats `EnqueueReady` and `EnqueueDeferred` as
-logical per-job state transitions. Rust may batch the SQL implementation
-of producer side effects: allocating a contiguous lane sequence range,
-syncing enqueue-time `job_unique_claims` with one array-backed statement,
-and inserting rows with multi-row `INSERT` or COPY. Those batching choices
-refine the same logical actions as long as they commit in the same
-transaction as the ready/deferred append.
+The TLA+ storage model treats `EnqueueReady` and `EnqueueDeferred` as logical per-job state transitions. Rust may batch the SQL implementation of producer side effects: allocating a contiguous lane sequence range, syncing enqueue-time `job_unique_claims` with one array-backed statement, and inserting rows with multi-row `INSERT` or COPY. Those batching choices refine the same logical actions as long as they commit in the same transaction as the ready/deferred append.
 
-Uniqueness itself is intentionally outside this storage model: duplicate
-rejection is covered by Rust integration tests around `job_unique_claims`.
-The model's enqueue preconditions start after a job has been admitted to
-the storage state, so batching uniqueness claims changes implementation
-granularity rather than the modeled lifecycle, lane, lease, or prune
-invariants.
+Uniqueness itself is intentionally outside this storage model: duplicate rejection is covered by Rust integration tests around `job_unique_claims`. The model's enqueue preconditions start after a job has been admitted to the storage state, so batching uniqueness claims changes implementation granularity rather than the modeled lifecycle, lane, lease, or prune invariants.
 
 ## Enqueue-shard prune note
 
-`AwaSegmentedStorage.tla` models a single `(queue, priority, enqueue_shard)`
-lane. That keeps the lifecycle state-space small and is enough for per-shard
-FIFO, lease, receipt, terminal, DLQ, and prune safety. It does not model two
-shards whose `lane_seq` values collide by design.
+`AwaSegmentedStorage.tla` models a single `(queue, priority, enqueue_shard)` lane. That keeps the lifecycle state-space small and is enough for per-shard FIFO, lease, receipt, terminal, DLQ, and prune safety. It does not model two shards whose `lane_seq` values collide by design.
 
-`AwaShardedPrune.tla` is the focused cross-shard companion. It models two
-independent shard counters and the queue-ring prune anti-join. The production
-predicate is:
+`AwaShardedPrune.tla` is the focused cross-shard companion. It models two independent shard counters and the queue-ring prune anti-join. The production predicate is:
 
 ```sql
 done.ready_generation = ready.ready_generation
@@ -208,365 +146,144 @@ AND done.enqueue_shard = ready.enqueue_shard
 AND done.lane_seq = ready.lane_seq
 ```
 
-Dropping `done.enqueue_shard = ready.enqueue_shard` is exactly the historical
-bug reproduced by `AwaShardedPruneBroken.cfg`.
+Dropping `done.enqueue_shard = ready.enqueue_shard` is exactly the historical bug reproduced by `AwaShardedPruneBroken.cfg`.
 
 ## Known modelling gaps with implementation implications
 
 ### Claim vs Rotate race — resolved by checked commit on lease rotation state
 
-The race-exposure spec
-[`AwaSegmentedStorageRaces.tla`](./AwaSegmentedStorageRaces.tla) proves
-that a claim that snapshots the lease segment cursor without further
-synchronisation can land a lease in a segment that has since been
-rotated and pruned.
+The race-exposure spec [`AwaSegmentedStorageRaces.tla`](./AwaSegmentedStorageRaces.tla) proves that a claim that snapshots the lease segment cursor without further synchronisation can land a lease in a segment that has since been rotated and pruned.
 
-**Status in the implementation: mitigated.** The current Rust code no
-longer takes `FOR SHARE` on `lease_ring_state`. Instead:
+**Status in the implementation: mitigated.** The current Rust code no longer takes `FOR SHARE` on `lease_ring_state`. Instead:
 
-- claim reads the current lease slot / generation from `lease_ring_state`
-  inside the claim statement and writes that generation into the claim
-- `rotate_leases` advances `lease_ring_state` with a compare-and-swap update
-  on `(current_slot, generation)`
-- `prune_oldest_leases` derives the oldest initialized slot from
-  `lease_ring_state`, locks the child partition, then rechecks that the slot
-  is not current before truncating
+- claim reads the current lease slot / generation from `lease_ring_state` inside the claim statement and writes that generation into the claim
+- `rotate_leases` advances `lease_ring_state` with a compare-and-swap update on `(current_slot, generation)`
+- `prune_oldest_leases` derives the oldest initialized slot from `lease_ring_state`, locks the child partition, then rechecks that the slot is not current before truncating
 
-So the race still exists at the abstract spec level, but the production
-implementation closes it by treating `lease_ring_state` as a checked-commit
-cursor rather than an unlocked hint. The race spec remains valuable because
-it proves that weakening that discipline would reintroduce the bug.
+So the race still exists at the abstract spec level, but the production implementation closes it by treating `lease_ring_state` as a checked-commit cursor rather than an unlocked hint. The race spec remains valuable because it proves that weakening that discipline would reintroduce the bug.
 
 ### prune_oldest (ready) check-then-act — resolved
 
-The spec's PruneLeaseSegment transition also captures the analogous
-concern on `prune_oldest` (for ready partitions) at
-`queue_storage.rs:9080`.
+The spec's PruneLeaseSegment transition also captures the analogous concern on `prune_oldest` (for ready partitions) at `queue_storage.rs:9080`.
 
 **Status in the implementation: mitigated.** The prune path:
 
-1. `FOR UPDATE` on `queue_ring_state` to serialise against concurrent
-   rotates
+1. `FOR UPDATE` on `queue_ring_state` to serialise against concurrent rotates
 2. `FOR UPDATE` on the target `queue_ring_slots` row
-3. `SET LOCAL lock_timeout = '50ms'`, then `LOCK TABLE ... IN ACCESS
-   EXCLUSIVE MODE` on the ready and done partition children — this
-   blocks the AccessShare lock that the claim CTE takes when reading
-   `{schema}.ready_entries_%s`, forcing prune to wait for in-flight
-   claims to commit (or bail via the 50 ms `lock_timeout`)
-4. Only AFTER the lock is held does the count-active-leases check
-   run inside the same transaction — so any lease inserted by a
-   concurrent claim will be visible to the check
+3. `SET LOCAL lock_timeout = '50ms'`, then `LOCK TABLE ... IN ACCESS EXCLUSIVE MODE` on the ready and done partition children — this blocks the AccessShare lock that the claim CTE takes when reading `{schema}.ready_entries_%s`, forcing prune to wait for in-flight claims to commit (or bail via the 50 ms `lock_timeout`)
+4. Only AFTER the lock is held does the count-active-leases check run inside the same transaction — so any lease inserted by a concurrent claim will be visible to the check
 
-All prune paths set `SET LOCAL lock_timeout = '50ms'` so they abort
-gracefully under contention rather than stalling.
+All prune paths set `SET LOCAL lock_timeout = '50ms'` so they abort gracefully under contention rather than stalling.
 
-So the "check-then-act" framing is inaccurate: the Rust code is
-"lock-then-check-then-act", with the lock being the load-bearing part.
+So the "check-then-act" framing is inaccurate: the Rust code is "lock-then-check-then-act", with the lock being the load-bearing part.
 
 ### Role of the race spec going forward
 
-The spec plus `AwaSegmentedStorageRaces.cfg` (race-exposing) and
-`AwaSegmentedStorageRacesSafe.cfg` (checked-commit) is a regression
-harness. If any future refactor weakens the checked-commit discipline on
-`lease_ring_state`, or weakens the `ACCESS EXCLUSIVE` on the partition
-children, the race spec will still produce a counterexample and the safe
-spec will still pass — making the invariant the checked-commit enforces a
-clear statement of what the SQL coordination is buying.
+The spec plus `AwaSegmentedStorageRaces.cfg` (race-exposing) and `AwaSegmentedStorageRacesSafe.cfg` (checked-commit) is a regression harness. If any future refactor weakens the checked-commit discipline on `lease_ring_state`, or weakens the `ACCESS EXCLUSIVE` on the partition children, the race spec will still produce a counterexample and the safe spec will still pass — making the invariant the checked-commit enforces a clear statement of what the SQL coordination is buying.
 
 ### Lock-order regression harness
 
-`AwaStorageLockOrder.tla` (see [`README.md`](./README.md)) is the
-complementary positive artifact: it models the Postgres locks
-directly and checks that no interleaving of claim / complete /
-close-receipt / rescue-receipts / ensure-running / cancel /
-rotate-leases / prune-leases / rotate-ready / prune-ready /
-rotate-claims / prune-claims transactions produces a waits-for cycle.
-It also models the striped producer path that updates multiple physical
-queue lanes in a stable order, while the current runtime claim path claims
-only one physical stripe per transaction. A deliberately-broken demo config
-(`AwaStorageLockOrderDeadlockDemo.cfg`) confirms the deadlock detector fires
-when a cycle exists, and `AwaStorageLockOrderOldStripedClaimDeadlock.cfg`
-captures the historical unsafe shape where one logical claim transaction
-walked multiple physical stripes in the opposite order from enqueue.
+`AwaStorageLockOrder.tla` (see [`README.md`](./README.md)) is the complementary positive artifact: it models the Postgres locks directly and checks that no interleaving of claim / complete / close-receipt / rescue-receipts / ensure-running / cancel / rotate-leases / prune-leases / rotate-ready / prune-ready / rotate-claims / prune-claims transactions produces a waits-for cycle. It also models the striped producer path that updates multiple physical queue lanes in a stable order, while the current runtime claim path claims only one physical stripe per transaction. A deliberately-broken demo config (`AwaStorageLockOrderDeadlockDemo.cfg`) confirms the deadlock detector fires when a cycle exists, and `AwaStorageLockOrderOldStripedClaimDeadlock.cfg` captures the historical unsafe shape where one logical claim transaction walked multiple physical stripes in the opposite order from enqueue.
 
 Together the two specs cover complementary risks:
-- `AwaSegmentedStorageRaces` catches data-level races that would
-  occur if the locks were removed — proves the locks are necessary
-- `AwaStorageLockOrder` catches deadlock-order bugs that would
-  occur if the lock ordering were changed — proves the current
-  ordering is safe
+
+- `AwaSegmentedStorageRaces` catches data-level races that would occur if the locks were removed — proves the locks are necessary
+- `AwaStorageLockOrder` catches deadlock-order bugs that would occur if the lock ordering were changed — proves the current ordering is safe
 
 ## Trace validation
 
-`AwaSegmentedStorageTrace.tla` takes a hand-transcribed sequence of
-events from a queue-storage runtime test and verifies each transition
-is a legal firing of the corresponding base spec action. It is a
-single-threaded replay harness — one step at a time, no exploration
-of interleavings — but it catches:
+`AwaSegmentedStorageTrace.tla` takes a hand-transcribed sequence of events from a queue-storage runtime test and verifies each transition is a legal firing of the corresponding base spec action. It is a single-threaded replay harness — one step at a time, no exploration of interleavings — but it catches:
 
-- **transcription errors**: if the transcribed sequence does not
-  correspond to any valid base spec behaviour, TLC reports deadlock
-  at the first failing step, and the traceIdx variable names the
-  event that could not fire
-- **spec regressions**: if a future edit to the base spec tightens a
-  precondition, an existing trace that used to pass will now fail;
-  TLC reports deadlock at the newly-rejected step
-- **inherited invariant regressions**: every safety invariant from
-  AwaSegmentedStorage is checked at every step of the replay, so a
-  trace that sneaks through an invalid intermediate state is caught
+- **transcription errors**: if the transcribed sequence does not correspond to any valid base spec behaviour, TLC reports deadlock at the first failing step, and the traceIdx variable names the event that could not fire
+- **spec regressions**: if a future edit to the base spec tightens a precondition, an existing trace that used to pass will now fail; TLC reports deadlock at the newly-rejected step
+- **inherited invariant regressions**: every safety invariant from AwaSegmentedStorage is checked at every step of the replay, so a trace that sneaks through an invalid intermediate state is caught
 
 ### Transcribing a new trace
 
-Pick a test in `awa/tests/queue_storage_runtime_test.rs` whose
-lifecycle is clear. Typical shape: one enqueue, one or two claims,
-a terminal transition (complete / fail-to-dlq / cancel / etc.),
-optionally a retry-from-deferred or retry-from-dlq round trip.
+Pick a test in `awa/tests/queue_storage_runtime_test.rs` whose lifecycle is clear. Typical shape: one enqueue, one or two claims, a terminal transition (complete / fail-to-dlq / cancel / etc.), optionally a retry-from-deferred or retry-from-dlq round trip.
 
-1. Read the test and its custom Worker impl. Work out the sequence of
-   **logical** transitions the test exercises — not the individual
-   SQL statements. The correspondence table above maps test-level
-   concepts (snooze, terminal failure, callback timeout) to base
-   spec actions.
-2. Write the sequence as a `<<...>>` tuple of event records in the
-   TLA file. Each event has an `action` field (the action name as a
-   string) and the arguments that action takes: `job` for most
-   events, plus `worker` for events that take `(w, j)`. See the
-   `SnoozeTrace` and `BrokenTrace` operators for shape.
-3. Add a specification in the TLA file:
-   `SpecYourTrace == TraceInit /\ [][TraceNextFor(YourTrace)]_<<vars, traceIdx>>`.
-4. Add a negative-witness invariant:
-   `YourTraceIncomplete == traceIdx < Len(YourTrace)`.
-5. Add a config file (e.g. `AwaSegmentedStorageTraceYours.cfg`) with
-   `SPECIFICATION SpecYourTrace` and `INVARIANTS ... YourTraceIncomplete`.
-6. Run with `./correctness/run-tlc.sh storage/AwaSegmentedStorageTrace.tla storage/AwaSegmentedStorageTraceYours.cfg`.
-   Expected outcome for a valid trace: `Invariant YourTraceIncomplete
-   is violated` (the positive witness that the trace was fully consumed).
+1. Read the test and its custom Worker impl. Work out the sequence of **logical** transitions the test exercises — not the individual SQL statements. The correspondence table above maps test-level concepts (snooze, terminal failure, callback timeout) to base spec actions.
+2. Write the sequence as a `<<...>>` tuple of event records in the TLA file. Each event has an `action` field (the action name as a string) and the arguments that action takes: `job` for most events, plus `worker` for events that take `(w, j)`. See the `SnoozeTrace` and `BrokenTrace` operators for shape.
+3. Add a specification in the TLA file: `SpecYourTrace == TraceInit /\ [][TraceNextFor(YourTrace)]_<<vars, traceIdx>>`.
+4. Add a negative-witness invariant: `YourTraceIncomplete == traceIdx < Len(YourTrace)`.
+5. Add a config file (e.g. `AwaSegmentedStorageTraceYours.cfg`) with `SPECIFICATION SpecYourTrace` and `INVARIANTS ... YourTraceIncomplete`.
+6. Run with `./correctness/run-tlc.sh storage/AwaSegmentedStorageTrace.tla storage/AwaSegmentedStorageTraceYours.cfg`. Expected outcome for a valid trace: `Invariant YourTraceIncomplete is violated` (the positive witness that the trace was fully consumed).
 
 ### What the checker does not catch
 
-- **Races that require concurrent transactions.** The trace replay is
-  single-threaded. If a test's behaviour depends on a
-  rotate-mid-claim interleaving, the trace spec won't exercise that
-  path — use `AwaSegmentedStorageRaces` for race concerns.
-- **Timing-dependent maintenance steps.** The sample traces omit
-  heartbeat and rotate/prune events because they are noise the tests
-  tolerate. If a test's correctness DEPENDS on a specific
-  rotate-then-claim ordering, transcribe those events in too.
-- **Events outside the transcribed set.** If a test fires an action
-  the harness doesn't know about (e.g. a future `RetryFromDeferred`
-  variant we haven't modelled), extend the disjunction in
-  `TraceStep` to include it.
+- **Races that require concurrent transactions.** The trace replay is single-threaded. If a test's behaviour depends on a rotate-mid-claim interleaving, the trace spec won't exercise that path — use `AwaSegmentedStorageRaces` for race concerns.
+- **Timing-dependent maintenance steps.** The sample traces omit heartbeat and rotate/prune events because they are noise the tests tolerate. If a test's correctness DEPENDS on a specific rotate-then-claim ordering, transcribe those events in too.
+- **Events outside the transcribed set.** If a test fires an action the harness doesn't know about (e.g. a future `RetryFromDeferred` variant we haven't modelled), extend the disjunction in `TraceStep` to include it.
 
 ### Current traces
 
-- `SnoozeTrace`: 6 events — EnqueueReady → Claim → RetryToDeferred →
-  PromoteDeferred → Claim → FastComplete. Accepts cleanly with 7
-  states (1 init + 6 steps). Transcribed from
-  `test_queue_storage_runtime_snooze`.
-- `ReceiptRescueTrace`: 3 events — EnqueueReady →
-  SeedOpenReceiptOnlyClaim → RescueStaleReceipt. Accepts cleanly with
-  4 states. `SeedOpenReceiptOnlyClaim` is trace-only scaffolding for
-  the implementation's receipt-only window before lease materialization;
-  the base storage spec's `Claim` action materializes a lease immediately.
-- `RunningCancelTrace`: 3 events — EnqueueReady → Claim →
-  CancelRunningToTerminal. Accepts cleanly with 4 states.
-- `DlqRetryTrace`: 6 events — EnqueueReady → Claim → FailToDlq →
-  RetryFromDlq → Claim → FastComplete. Accepts cleanly with 7 states.
-- `ReceiptOnlyCancelTrace`: 3 events — EnqueueReady →
-  SeedOpenReceiptOnlyClaim → CancelReceiptOnlyToTerminal. Accepts
-  cleanly with 4 states. Models `awa::admin::cancel` racing with a
-  freshly-opened receipt before the lease row materialises;
-  complements `RunningCancelTrace` (active lease) and
-  `ReceiptRescueTrace` (stale receipt left by a vanished worker).
-- `CallbackWaitTrace`: 6 events — EnqueueReady → Claim →
-  MaterializeAttemptState → ParkToWaiting → ResumeWaitingToRunning →
-  StatefulComplete. Accepts cleanly with 7 states. Covers the
-  external-callback `WaitForCallback` round-trip; distinct from
-  `SnoozeTrace`, which never enters `waiting_external`.
-- `DlqPurgeTrace`: 4 events — EnqueueReady → Claim → FailToDlq →
-  PurgeDlq. Accepts cleanly with 5 states. Validates the operator
-  `awa dlq purge` path; complements `DlqRetryTrace` which revives the
-  row instead of removing it.
-- `BrokenTrace`: same 6 events but with steps 3 and 4 swapped so
-  PromoteDeferred fires before RetryToDeferred. TLC reports deadlock
-  at traceIdx = 2 (after EnqueueReady + Claim, before the
-  out-of-order PromoteDeferred). Confirms the checker rejects invalid
-  traces.
+- `SnoozeTrace`: 6 events — EnqueueReady → Claim → RetryToDeferred → PromoteDeferred → Claim → FastComplete. Accepts cleanly with 7 states (1 init + 6 steps). Transcribed from `test_queue_storage_runtime_snooze`.
+- `ReceiptRescueTrace`: 3 events — EnqueueReady → SeedOpenReceiptOnlyClaim → RescueStaleReceipt. Accepts cleanly with 4 states. `SeedOpenReceiptOnlyClaim` is trace-only scaffolding for the implementation's receipt-only window before lease materialization; the base storage spec's `Claim` action materializes a lease immediately.
+- `RunningCancelTrace`: 3 events — EnqueueReady → Claim → CancelRunningToTerminal. Accepts cleanly with 4 states.
+- `DlqRetryTrace`: 6 events — EnqueueReady → Claim → FailToDlq → RetryFromDlq → Claim → FastComplete. Accepts cleanly with 7 states.
+- `ReceiptOnlyCancelTrace`: 3 events — EnqueueReady → SeedOpenReceiptOnlyClaim → CancelReceiptOnlyToTerminal. Accepts cleanly with 4 states. Models `awa::admin::cancel` racing with a freshly-opened receipt before the lease row materialises; complements `RunningCancelTrace` (active lease) and `ReceiptRescueTrace` (stale receipt left by a vanished worker).
+- `CallbackWaitTrace`: 6 events — EnqueueReady → Claim → MaterializeAttemptState → ParkToWaiting → ResumeWaitingToRunning → StatefulComplete. Accepts cleanly with 7 states. Covers the external-callback `WaitForCallback` round-trip; distinct from `SnoozeTrace`, which never enters `waiting_external`.
+- `DlqPurgeTrace`: 4 events — EnqueueReady → Claim → FailToDlq → PurgeDlq. Accepts cleanly with 5 states. Validates the operator `awa dlq purge` path; complements `DlqRetryTrace` which revives the row instead of removing it.
+- `BrokenTrace`: same 6 events but with steps 3 and 4 swapped so PromoteDeferred fires before RetryToDeferred. TLC reports deadlock at traceIdx = 2 (after EnqueueReady + Claim, before the out-of-order PromoteDeferred). Confirms the checker rejects invalid traces.
 
 ### Bulk ops atomicity
 
-`bulk_retry_from_dlq` / `purge_dlq` / `bulk_move_failed_to_dlq` run as
-single transactions in the Rust code. The spec models them as independent
-`\E j \in Jobs : RetryFromDlq(j)` firings. This is a strictly weaker
-claim (safety invariants hold under any interleaving, including the ones
-a real tx would prevent).
+`bulk_retry_from_dlq` / `purge_dlq` / `bulk_move_failed_to_dlq` run as single transactions in the Rust code. The spec models them as independent `\E j \in Jobs : RetryFromDlq(j)` firings. This is a strictly weaker claim (safety invariants hold under any interleaving, including the ones a real tx would prevent).
 
-If a bulk-level invariant becomes interesting — e.g., "a retry-bulk that
-sees a unique conflict on any row leaves all rows intact" — add a
-`bulkScope: SUBSET Jobs` variable and express the op as a single atomic
-action over that set.
+If a bulk-level invariant becomes interesting — e.g., "a retry-bulk that sees a unique conflict on any row leaves all rows intact" — add a `bulkScope: SUBSET Jobs` variable and express the op as a single atomic action over that set.
 
 ### Heartbeat time abstraction
 
-`heartbeatFresh` is a set (fresh or not). Real heartbeats are timestamps
-with a maintenance cutoff. The spec's `LoseHeartbeat(j)` is enabled any
-time the lease exists — it doesn't model "the cutoff moved". For the
-safety invariants this is fine; the abstraction is conservative. A
-liveness-oriented refinement would need an explicit time variable.
+`heartbeatFresh` is a set (fresh or not). Real heartbeats are timestamps with a maintenance cutoff. The spec's `LoseHeartbeat(j)` is enabled any time the lease exists — it doesn't model "the cutoff moved". For the safety invariants this is fine; the abstraction is conservative. A liveness-oriented refinement would need an explicit time variable.
 
 ### Unique-claim keys
 
-The Rust `retry_from_dlq` contract says: if a replacement owns the
-unique-claim slot, the retry returns `UniqueConflict` and leaves the DLQ
-row intact (tested in `awa/tests/queue_storage_runtime_test.rs::
-test_queue_storage_retry_from_dlq_surfaces_unique_conflict`). The spec
-has no unique keys, so it simply allows `RetryFromDlq(j)` whenever
-`j \in dlqEntries`. A refinement adding `uniqueKey: Jobs -> UniqueKeys`
-and a `uniqueClaim: UniqueKeys -> Jobs \cup {NoJob}` variable could check
-the invariant directly.
+The Rust `retry_from_dlq` contract says: if a replacement owns the unique-claim slot, the retry returns `UniqueConflict` and leaves the DLQ row intact (tested in `awa/tests/queue_storage_runtime_test.rs:: test_queue_storage_retry_from_dlq_surfaces_unique_conflict`). The spec has no unique keys, so it simply allows `RetryFromDlq(j)` whenever `j \in dlqEntries`. A refinement adding `uniqueKey: Jobs -> UniqueKeys` and a `uniqueClaim: UniqueKeys -> Jobs \cup {NoJob}` variable could check the invariant directly.
 
 ## ADR-023 receipt-plane coverage
 
-The TLA+ specs cover the ADR-023 claim-ring shape end-to-end. In both
-the base spec and the race / lock specs:
+The TLA+ specs cover the ADR-023 claim-ring shape end-to-end. In both the base spec and the race / lock specs:
 
-- `claimSegmentOf`, `claimOpen`, `claimClosed`, `claimSegments`,
-  `claimSegmentCursor` track the receipt plane parallel to the existing
-  lease plane.
-- `Claim` now appends a receipt into the current claim segment.
-  Attempt-ending transitions (`FastComplete`, `StatefulComplete`,
-  `FailToDlq`, `RetryToDeferred`, `RescueToReady`,
-  `CancelWaitingToTerminal`, `TimeoutWaitingToDlq`,
-  `TimeoutWaitingToReady`) append a closure row
-  in the same partition.
-- `ParkToWaiting` does NOT close the receipt — the attempt is still
-  alive in callback wait. `ResumeWaitingToRunning` keeps the same receipt
-  open; timeout/cancel/terminal resolution close it.
-- `RescueStaleReceipt(j, r)` models Tier-A receipt rescue: force-close
-  a straggler receipt whose attempt is no longer alive — either the job
-  has moved past `r` to a newer attempt (`runLease[j] > r`) or the job
-  is fully off the ready / leased / waiting lifecycle. This is the
-  rescue-before-truncate precondition that `prune_oldest_claims` will
-  invoke. The `(j, r)` keying lets the model reach race orderings where
-  rescue closes an old attempt's receipt *concurrently with* a newer
-  Claim having already opened a fresh receipt under `(j, r+1)`.
-- `RotateClaimSegments` and `PruneClaimSegment(seg)` parallel the
-  lease-ring rotation/prune pattern.
-- `AwaStorageLockOrder` includes `ClaimRingStateResource`,
-  `ClaimRingSlotResource`, `ClaimChildResource`, `ClosureChildResource`,
-  and `ClaimReceiptsPlan` / `ClaimLegacyPlan` for the two execution
-  modes with `RowExclusive` on the appropriate child. The
-  `*_ring_state` reads in the claim CTE are bare `SELECT`s in Rust
-  (no `FOR SHARE`); claim is serialised against rotate via the
-  rotator's CAS UPDATE on `(current_slot, generation)`, not via
-  row-level locks. `CompletePlan`, `RotateClaimsPlan`,
-  `PruneClaimsPlan`, `CloseReceiptPlan`, `RescueReceiptsPlan`,
-  `EnsureRunningPlan`, and `CancelReceiptPlan` round out the
-  receipt-plane transactions.
-- `AwaSegmentedStorageRaces` adds `claimSeg` to the claim-intent
-  snapshot and exposes the claim-ring version of the naive commit race.
+- `claimSegmentOf`, `claimOpen`, `claimClosed`, `claimSegments`, `claimSegmentCursor` track the receipt plane parallel to the existing lease plane.
+- `Claim` now appends a receipt into the current claim segment. Attempt-ending transitions (`FastComplete`, `StatefulComplete`, `FailToDlq`, `RetryToDeferred`, `RescueToReady`, `CancelWaitingToTerminal`, `TimeoutWaitingToDlq`, `TimeoutWaitingToReady`) append a closure row in the same partition.
+- `ParkToWaiting` does NOT close the receipt — the attempt is still alive in callback wait. `ResumeWaitingToRunning` keeps the same receipt open; timeout/cancel/terminal resolution close it.
+- `RescueStaleReceipt(j, r)` models Tier-A receipt rescue: force-close a straggler receipt whose attempt is no longer alive — either the job has moved past `r` to a newer attempt (`runLease[j] > r`) or the job is fully off the ready / leased / waiting lifecycle. This is the rescue-before-truncate precondition that `prune_oldest_claims` will invoke. The `(j, r)` keying lets the model reach race orderings where rescue closes an old attempt's receipt _concurrently with_ a newer Claim having already opened a fresh receipt under `(j, r+1)`.
+- `RotateClaimSegments` and `PruneClaimSegment(seg)` parallel the lease-ring rotation/prune pattern.
+- `AwaStorageLockOrder` includes `ClaimRingStateResource`, `ClaimRingSlotResource`, `ClaimChildResource`, `ClosureChildResource`, and `ClaimReceiptsPlan` / `ClaimLegacyPlan` for the two execution modes with `RowExclusive` on the appropriate child. The `*_ring_state` reads in the claim CTE are bare `SELECT`s in Rust (no `FOR SHARE`); claim is serialised against rotate via the rotator's CAS UPDATE on `(current_slot, generation)`, not via row-level locks. `CompletePlan`, `RotateClaimsPlan`, `PruneClaimsPlan`, `CloseReceiptPlan`, `RescueReceiptsPlan`, `EnsureRunningPlan`, and `CancelReceiptPlan` round out the receipt-plane transactions.
+- `AwaSegmentedStorageRaces` adds `claimSeg` to the claim-intent snapshot and exposes the claim-ring version of the naive commit race.
 
 Invariants added:
 
-- `OneOpenClaimSegment`, `ClaimCursorIsOpen`,
-  `PrunedClaimSegmentsAreEmpty` (every segment family shape).
+- `OneOpenClaimSegment`, `ClaimCursorIsOpen`, `PrunedClaimSegmentsAreEmpty` (every segment family shape).
 - `NoLostClaim`: every open receipt's segment is not pruned.
-- `ClaimOpenAndClosedDisjoint`, `OpenClaimHasSegment`,
-  `ClosedClaimHasSegment`: the receipt-lifecycle bookkeeping is sound.
+- `ClaimOpenAndClosedDisjoint`, `OpenClaimHasSegment`, `ClosedClaimHasSegment`: the receipt-lifecycle bookkeeping is sound.
 
 Model checking results:
 
-- `AwaSegmentedStorage.cfg`: 33,920 distinct states, clean. Admin
-  cancel actions (`CancelRunningToTerminal`,
-  `CancelReceiptOnlyToTerminal`) clear all workers' `taskLease`
-  snapshots since admin cancel has no worker context, preserving
-  `TaskLeaseBounded`.
-- `AwaSegmentedStorageInterleavings.cfg` (2 workers): 74,432 distinct
-  states, clean.
+- `AwaSegmentedStorage.cfg`: 33,920 distinct states, clean. Admin cancel actions (`CancelRunningToTerminal`, `CancelReceiptOnlyToTerminal`) clear all workers' `taskLease` snapshots since admin cancel has no worker context, preserving `TaskLeaseBounded`.
+- `AwaSegmentedStorageInterleavings.cfg` (2 workers): 74,432 distinct states, clean.
 - `AwaSegmentedStorageTrace.cfg`: snooze trace accepted cleanly.
-- `AwaSegmentedStorageTraceBroken.cfg`: broken trace rejected with the
-  expected deadlock at traceIdx = 2.
-- `AwaSegmentedStorageRaces.cfg`: race exposed
-  (`PrunedLeaseSegmentsAreEmpty` violated — the naive commit lets a row
-  land in a pruned segment). Claim-ring race has the same shape and
-  would trip `PrunedClaimSegmentsAreEmpty` if the state-space search
-  hit it first.
+- `AwaSegmentedStorageTraceBroken.cfg`: broken trace rejected with the expected deadlock at traceIdx = 2.
+- `AwaSegmentedStorageRaces.cfg`: race exposed (`PrunedLeaseSegmentsAreEmpty` violated — the naive commit lets a row land in a pruned segment). Claim-ring race has the same shape and would trip `PrunedClaimSegmentsAreEmpty` if the state-space search hit it first.
 - `AwaSegmentedStorageRacesSafe.cfg`: safe commit, clean.
-- `AwaSegmentedStorageRacesMultiWorker.cfg`: safe commit with 3 workers,
-  clean.
-- `AwaShardedPrune.cfg`: 1,028 distinct states, clean. This checks the
-  fixed queue-ring prune predicate that matches ready rows to done rows by
-  `(enqueue_shard, lane_seq)`.
-- `AwaShardedPruneBroken.cfg`: expected failure. It ignores
-  `enqueue_shard` in the ready/done match and produces the counterexample
-  where shard 0's completed `lane_seq = 1` row masks shard 1's still-pending
-  `lane_seq = 1` row.
-- `AwaStorageLockOrder.cfg`: 69,057 distinct states, clean. Models
-  the receipts and legacy claim modes separately, plus
-  `CloseReceiptPlan`, `RescueReceiptsPlan`, `EnsureRunningPlan`,
-  `CancelReceiptOnlyPlan`, and `CancelRunningPlan`.
-- `AwaStorageLockOrderDeadlockDemo.cfg`: trips `NoDeadlock` in 5
-  steps, confirming the detector works.
-- `AwaDeadTupleContract.cfg`: 1 distinct state, clean. The
-  ASSUME-style architectural-contract checks
-  (`HotTablesAreNotRowVacuum`, `PartitionTruncateTablesAreReclaimed`,
-  `WarmTablesDocumentTheirBound`,
-  `BacklogRowVacuumTablesDocumentTheirBound`,
-  `OnlyBoundedKindsHaveBoundedBy`,
-  `AppendOnlyAcceptsOnlyInsert`, `VacuumKindTablesNotTruncated`) all
-  hold for the current schema and transaction list. Workflow: when
-  adding a new table to `prepare_schema()` or a new SQL site to
-  queue_storage.rs, register it in `AwaDeadTupleContract.tla` with
-  the correct reclaim kind, hotness, optional `bounded_by`, and
-  mutation list. An `open_receipt_claims`-style proposal (hot table,
-  RowVacuum reclaim, INSERT+DELETE traffic) fires
-  `HotTablesAreNotRowVacuum` at parse time; a `Warm` table without a
-  declared `bounded_by` fires `WarmTablesDocumentTheirBound`.
+- `AwaSegmentedStorageRacesMultiWorker.cfg`: safe commit with 3 workers, clean.
+- `AwaShardedPrune.cfg`: 1,028 distinct states, clean. This checks the fixed queue-ring prune predicate that matches ready rows to done rows by `(enqueue_shard, lane_seq)`.
+- `AwaShardedPruneBroken.cfg`: expected failure. It ignores `enqueue_shard` in the ready/done match and produces the counterexample where shard 0's completed `lane_seq = 1` row masks shard 1's still-pending `lane_seq = 1` row.
+- `AwaStorageLockOrder.cfg`: 69,057 distinct states, clean. Models the receipts and legacy claim modes separately, plus `CloseReceiptPlan`, `RescueReceiptsPlan`, `EnsureRunningPlan`, `CancelReceiptOnlyPlan`, and `CancelRunningPlan`.
+- `AwaStorageLockOrderDeadlockDemo.cfg`: trips `NoDeadlock` in 5 steps, confirming the detector works.
+- `AwaDeadTupleContract.cfg`: 1 distinct state, clean. The ASSUME-style architectural-contract checks (`HotTablesAreNotRowVacuum`, `PartitionTruncateTablesAreReclaimed`, `WarmTablesDocumentTheirBound`, `BacklogRowVacuumTablesDocumentTheirBound`, `OnlyBoundedKindsHaveBoundedBy`, `AppendOnlyAcceptsOnlyInsert`, `VacuumKindTablesNotTruncated`) all hold for the current schema and transaction list. Workflow: when adding a new table to `prepare_schema()` or a new SQL site to queue_storage.rs, register it in `AwaDeadTupleContract.tla` with the correct reclaim kind, hotness, optional `bounded_by`, and mutation list. An `open_receipt_claims`-style proposal (hot table, RowVacuum reclaim, INSERT+DELETE traffic) fires `HotTablesAreNotRowVacuum` at parse time; a `Warm` table without a declared `bounded_by` fires `WarmTablesDocumentTheirBound`.
 
 ### Receipt-plane shape
 
-- `lease_claims` and `lease_claim_closures` are partitioned parents
-  (`relkind = 'p'`); `lease_claims_0..N-1` and
-  `lease_claim_closures_0..N-1` are the children. PK on both is
-  `(claim_slot, job_id, run_lease)` (partition-key-in-PK), with a
-  secondary `(job_id, run_lease)` index for completion / rescue /
-  materialize paths that don't carry `claim_slot` in hand.
-- The "currently open" set is derived at query time as
-  `lease_claims` ⨝̸ `lease_claim_closures` over the active partitions.
-  Sites: the running-count CTE in `queue_counts_exact`,
-  `ensure_running_leases_from_receipts_tx`, the heartbeat / progress
-  upsert paths, `close_receipt_tx`, `rescue_stale_receipt_claims_tx`,
-  `complete_runtime_batch`'s receipt branch, and `load_job`. None of
-  these touch `open_receipt_claims`.
-- `ClaimedEntry` carries `claim_slot: i32` so completion can route
-  the closure INSERT to the matching partition without an extra
-  lookup.
-- `prepare_schema()` drops `open_receipt_claims` on every install
-  (refusing if it has rows). `reset()` does the same and clears any
-  `_legacy` tables left over from a partial migration.
-- `claim_slot_count` (default 8, minimum 2) sets the partition count.
-  `claim_rotate_interval` (defaulting to `queue_rotate_interval`)
-  drives the rotation cadence; `ClientBuilder::claim_rotate_interval`
-  overrides per-test or per-bench.
-- `rotate_claims` advances the cursor with a `FOR UPDATE` on
-  `claim_ring_state` and a busy-check on both child partitions of the
-  next slot — the rotation invariant is "the slot we're flipping
-  onto must be empty". `prune_oldest_claims` walks the full
-  ring-state → slot-row → child `ACCESS EXCLUSIVE` lock sequence and
-  refuses to TRUNCATE while any claim in the partition lacks a
-  matching closure (`PartitionTruncateSafety`).
+- `lease_claims` and `lease_claim_closures` are partitioned parents (`relkind = 'p'`); `lease_claims_0..N-1` and `lease_claim_closures_0..N-1` are the children. PK on both is `(claim_slot, job_id, run_lease)` (partition-key-in-PK), with a secondary `(job_id, run_lease)` index for completion / rescue / materialize paths that don't carry `claim_slot` in hand.
+- The "currently open" set is derived at query time as `lease_claims` ⨝̸ `lease_claim_closures` over the active partitions. Sites: the running-count CTE in `queue_counts_exact`, `ensure_running_leases_from_receipts_tx`, the heartbeat / progress upsert paths, `close_receipt_tx`, `rescue_stale_receipt_claims_tx`, `complete_runtime_batch`'s receipt branch, and `load_job`. None of these touch `open_receipt_claims`.
+- `ClaimedEntry` carries `claim_slot: i32` so completion can route the closure INSERT to the matching partition without an extra lookup.
+- `prepare_schema()` drops `open_receipt_claims` on every install (refusing if it has rows). `reset()` does the same and clears any `_legacy` tables left over from a partial migration.
+- `claim_slot_count` (default 8, minimum 2) sets the partition count. `claim_rotate_interval` (defaulting to `queue_rotate_interval`) drives the rotation cadence; `ClientBuilder::claim_rotate_interval` overrides per-test or per-bench.
+- `rotate_claims` advances the cursor with a `FOR UPDATE` on `claim_ring_state` and a busy-check on both child partitions of the next slot — the rotation invariant is "the slot we're flipping onto must be empty". `prune_oldest_claims` walks the full ring-state → slot-row → child `ACCESS EXCLUSIVE` lock sequence and refuses to TRUNCATE while any claim in the partition lacks a matching closure (`PartitionTruncateSafety`).
 
 ### Coverage
 
-`queue_storage_runtime_test` (49 tests) covers the lifecycle:
-partition routing, rotation isolation, partition migration on schema
-upgrade, the rotate / prune busy-and-safety predicates, admin cancel
-of running attempts, the open-receipt-claims absence invariant, the
-full short-job lifecycle, and the rescue paths for
-heartbeat / deadline / receipt-only attempts.
+`queue_storage_runtime_test` (49 tests) covers the lifecycle: partition routing, rotation isolation, partition migration on schema upgrade, the rotate / prune busy-and-safety predicates, admin cancel of running attempts, the open-receipt-claims absence invariant, the full short-job lifecycle, and the rescue paths for heartbeat / deadline / receipt-only attempts.
 
-`receipt_plane_chaos_test` (4 `#[ignore]`-d nightly tests) covers
-flood / concurrency / lock-order scenarios: rescue throughput under
-overload, prune-skips-active under concurrent traffic, the
-`ACCESS EXCLUSIVE` barrier between TRUNCATE and concurrent inserts,
-and admin-cancel-during-materialize orphan-lease cleanup.
+`receipt_plane_chaos_test` (4 `#[ignore]`-d nightly tests) covers flood / concurrency / lock-order scenarios: rescue throughput under overload, prune-skips-active under concurrent traffic, the `ACCESS EXCLUSIVE` barrier between TRUNCATE and concurrent inserts, and admin-cancel-during-materialize orphan-lease cleanup.

--- a/correctness/storage/README.md
+++ b/correctness/storage/README.md
@@ -1,7 +1,6 @@
 # Segmented Storage Model
 
-`AwaSegmentedStorage` is a focused TLA+ model for the 0.6 segmented
-runtime storage layout.
+`AwaSegmentedStorage` is a focused TLA+ model for the 0.6 segmented runtime storage layout.
 
 It uses the storage naming set:
 
@@ -16,10 +15,7 @@ It uses the storage naming set:
 - `ready_segments` / `ready_segment_cursor`
 - `lease_segments` / `lease_segment_cursor`
 - `terminal_segments` / `terminal_segment_cursor`
-- `claim_segments` / `claim_segment_cursor` (ADR-023: `lease_claims` and
-  `lease_claim_closures` partitioned by `claim_slot`, reclaimed by
-  rotation and `TRUNCATE` instead of the earlier `open_receipt_claims`
-  INSERT+DELETE frontier)
+- `claim_segments` / `claim_segment_cursor` (ADR-023: `lease_claims` and `lease_claim_closures` partitioned by `claim_slot`, reclaimed by rotation and `TRUNCATE` instead of the earlier `open_receipt_claims` INSERT+DELETE frontier)
 
 What it models:
 
@@ -42,37 +38,23 @@ What it models:
 - `retry_from_dlq` round trip back to `ready_entries`
 - admin purge of DLQ rows
 - stale completion rejection via per-worker lease snapshots
-- segment rotation and prune safety for ready, tombstone, lease, terminal,
-  **and claim** segment families (retention by partition rotation rather than
-  row-by-row cleanup, per ADR-019 and ADR-023)
+- segment rotation and prune safety for ready, tombstone, lease, terminal, **and claim** segment families (retention by partition rotation rather than row-by-row cleanup, per ADR-019 and ADR-023)
 - unpartitioned backlog row-vacuum handling for `deferred_jobs` and `dlq_entries`
-- receipt-plane append-only receipts and closures matched into the same
-  `claim_slot` partition, with `RescueStaleReceipt` modelling Tier-A
-  rescue-before-truncate
+- receipt-plane append-only receipts and closures matched into the same `claim_slot` partition, with `RescueStaleReceipt` modelling Tier-A rescue-before-truncate
 - a second config with two workers to exercise interleavings on the same storage invariants
 
-Heartbeat freshness is tracked at the lease level (not `attempt_state`) to
-match the Rust implementation. `ParkToWaiting` clears heartbeat freshness
-while keeping the lease row live; `ResumeWaitingToRunning` restores a running
-lease on the same `run_lease`.
+Heartbeat freshness is tracked at the lease level (not `attempt_state`) to match the Rust implementation. `ParkToWaiting` clears heartbeat freshness while keeping the lease row live; `ResumeWaitingToRunning` restores a running lease on the same `run_lease`.
 
 Key safety checks include:
 
 - waiting jobs are live lease rows
-- deferred and DLQ jobs are not current-ready, even when an immutable
-  `ready_entries` body is retained for hydration until queue prune
+- deferred and DLQ jobs are not current-ready, even when an immutable `ready_entries` body is retained for hydration until queue prune
 - `attempt_state` only exists for live leases
 - claim cursors never move behind live runnable rows
 - DLQ rows hold no live runtime (no lease, attempt_state, etc.)
-- `dlq_entries` and `terminal_entries` are disjoint (a job is in exactly one
-  terminal family at a time)
-- pruned terminal segments hold no live terminal rows; terminal rotation
-  is deadlock-free and respects the same open/sealed/pruned lifecycle as
-  the other families
-- pruned claim segments hold no open receipts (`NoLostClaim`,
-  `PrunedClaimSegmentsAreEmpty` from ADR-023); `PruneClaimSegment`
-  requires every claim in the partition to have a matching closure
-  before `TRUNCATE` fires
+- `dlq_entries` and `terminal_entries` are disjoint (a job is in exactly one terminal family at a time)
+- pruned terminal segments hold no live terminal rows; terminal rotation is deadlock-free and respects the same open/sealed/pruned lifecycle as the other families
+- pruned claim segments hold no open receipts (`NoLostClaim`, `PrunedClaimSegmentsAreEmpty` from ADR-023); `PruneClaimSegment` requires every claim in the partition to have a matching closure before `TRUNCATE` fires
 
 What it intentionally does not model:
 
@@ -80,13 +62,8 @@ What it intentionally does not model:
 - MVCC horizons or autovacuum timing
 - queue priorities and fairness
 - local worker-capacity accounting and completion-batcher scheduling
-- `queue_counts()` caching details such as the cold
-  `{schema}.queue_terminal_rollups` table and the transitional
-  `queue_lanes.pruned_completed_count` fallback; Rust keeps those as
-  post-prune rollups rather than as part of the completion hot path
-- unique-claim key semantics; the Rust `retry_from_dlq` unique-conflict
-  contract (see `awa-model/src/dlq.rs::retry_from_dlq`) is enforced at the
-  SQL layer via `release_queue_storage_unique_claim` and is out of scope here
+- `queue_counts()` caching details such as the cold `{schema}.queue_terminal_rollups` table and the transitional `queue_lanes.pruned_completed_count` fallback; Rust keeps those as post-prune rollups rather than as part of the completion hot path
+- unique-claim key semantics; the Rust `retry_from_dlq` unique-conflict contract (see `awa-model/src/dlq.rs::retry_from_dlq`) is enforced at the SQL layer via `release_queue_storage_unique_claim` and is out of scope here
 - liveness/fairness properties; this spec is still safety-oriented
 
 Run it with:
@@ -96,91 +73,57 @@ Run it with:
 ./correctness/run-tlc.sh storage/AwaSegmentedStorage.tla storage/AwaSegmentedStorageInterleavings.cfg
 ```
 
-The checked-in configs are intentionally small so TLC completes quickly in
-CI-like environments. They exercise waiting/resume, stale completion rejection,
-retry, rescue (including short-job rescue), DLQ round-trip, ready tombstones,
-terminal-family rotation and prune, and queue-family prune safety, but not
-multi-job fairness or priority-aging liveness.
+The checked-in configs are intentionally small so TLC completes quickly in CI-like environments. They exercise waiting/resume, stale completion rejection, retry, rescue (including short-job rescue), DLQ round-trip, ready tombstones, terminal-family rotation and prune, and queue-family prune safety, but not multi-job fairness or priority-aging liveness.
 
 ## DLQ coverage
 
-Action coverage from a `-coverage 1` run of the base config confirms each DLQ
-transition is reachable:
+Action coverage from a `-coverage 1` run of the base config confirms each DLQ transition is reachable:
 
-| Action |
-|---|
-| `FailToDlq` |
+| Action                |
+| --------------------- |
+| `FailToDlq`           |
 | `TimeoutWaitingToDlq` |
-| `RescueToReady` |
-| `PurgeDlq` |
-| `MoveFailedToDlq` |
-| `RetryFromDlq` |
+| `RescueToReady`       |
+| `PurgeDlq`            |
+| `MoveFailedToDlq`     |
+| `RetryFromDlq`        |
 
-`RescueToReady` firing in a single-worker config confirms the heartbeat-fix
-path (short jobs, no `attempt_state`) is reachable — the previous spec's
-`FreshHeartbeatRequiresAttemptState` subset constraint had silently excluded
-that path from exploration.
+`RescueToReady` firing in a single-worker config confirms the heartbeat-fix path (short jobs, no `attempt_state`) is reachable — the previous spec's `FreshHeartbeatRequiresAttemptState` subset constraint had silently excluded that path from exploration.
 
 ## Terminal family coverage
 
-The terminal family mirrors the DLQ family's segment lifecycle. A coverage run
-checks these actions are reachable:
+The terminal family mirrors the DLQ family's segment lifecycle. A coverage run checks these actions are reachable:
 
-| Action |
-|---|
-| `FastComplete` (tags `terminalSegmentOf`) |
-| `StatefulComplete` (tags `terminalSegmentOf`) |
+| Action                                               |
+| ---------------------------------------------------- |
+| `FastComplete` (tags `terminalSegmentOf`)            |
+| `StatefulComplete` (tags `terminalSegmentOf`)        |
 | `CancelWaitingToTerminal` (tags `terminalSegmentOf`) |
-| `MoveFailedToDlq` (clears `terminalSegmentOf`) |
-| `RotateTerminalSegments` |
-| `PruneTerminalSegment` |
+| `MoveFailedToDlq` (clears `terminalSegmentOf`)       |
+| `RotateTerminalSegments`                             |
+| `PruneTerminalSegment`                               |
 
-This removes the previous gap where `terminal_entries` was the only
-"monotonic-growing" set in the spec — it now shares the rotate/prune
-reclaim story with the other families, matching the ADR-019 retention
-model.
+This removes the previous gap where `terminal_entries` was the only "monotonic-growing" set in the spec — it now shares the rotate/prune reclaim story with the other families, matching the ADR-019 retention model.
 
-ADR-026 adds the retained-body shape for ready-backed terminal rows.
-`TerminalHasRetainedReadyBody` asserts that every modelled terminal fact keeps
-its ready row and lane key until queue prune removes the ready segment. Moving
-a failed terminal row into the DLQ removes the terminal fact but keeps the
-retained ready body; DLQ liveness is defined by `CurrentReady`, not by physical
-absence from `ready_entries`. `PruneReadySegment` removes terminal facts and
-tombstones in the pruned ready segment so the model matches queue-ring
-reclamation.
+ADR-026 adds the retained-body shape for ready-backed terminal rows. `TerminalHasRetainedReadyBody` asserts that every modelled terminal fact keeps its ready row and lane key until queue prune removes the ready segment. Moving a failed terminal row into the DLQ removes the terminal fact but keeps the retained ready body; DLQ liveness is defined by `CurrentReady`, not by physical absence from `ready_entries`. `PruneReadySegment` removes terminal facts and tombstones in the pruned ready segment so the model matches queue-ring reclamation.
 
 ## Mapping to Rust code
 
-See [`MAPPING.md`](./MAPPING.md) for the action-by-action correspondence
-between TLA+ transitions and the Rust implementation, including the SQL
-statements that enforce each guard.
+See [`MAPPING.md`](./MAPPING.md) for the action-by-action correspondence between TLA+ transitions and the Rust implementation, including the SQL statements that enforce each guard.
 
 ## Lock-order companion spec
 
-[`AwaStorageLockOrder.tla`](./AwaStorageLockOrder.tla) models each
-storage-engine transaction (claim, rotate-leases, prune-leases,
-rotate-ready, prune-ready) as an ordered sequence of Postgres lock
-acquisitions, with a simplified shared/exclusive compatibility matrix
-that captures the cases relevant to deadlock analysis. Invariants:
+[`AwaStorageLockOrder.tla`](./AwaStorageLockOrder.tla) models each storage-engine transaction (claim, rotate-leases, prune-leases, rotate-ready, prune-ready) as an ordered sequence of Postgres lock acquisitions, with a simplified shared/exclusive compatibility matrix that captures the cases relevant to deadlock analysis. Invariants:
 
 - `NoDeadlock`: the waits-for graph is acyclic
 - `LockCompatibility`: no two incompatible locks on the same resource
 - `HeldOnlyByRunningTxs`: committed transactions hold no locks
-- `NoGlobalStall`: there is always some running transaction that can
-  make progress (a stall-free-safety-check stand-in for liveness)
+- `NoGlobalStall`: there is always some running transaction that can make progress (a stall-free-safety-check stand-in for liveness)
 
 Configs:
 
-- [`AwaStorageLockOrder.cfg`](./AwaStorageLockOrder.cfg): main run
-  against the real Rust lock plans — **39,040 distinct states, clean**.
-  Models claim (receipts and legacy modes), complete, close-receipt,
-  rescue-receipts, ensure-running, the two cancel branches, plus
-  rotate / prune for the queue, lease, and claim rings. This is the
-  positive artifact saying the current SQL lock ordering is
-  deadlock-free and the lock compatibility contract holds.
-- [`AwaStorageLockOrderDeadlockDemo.cfg`](./AwaStorageLockOrderDeadlockDemo.cfg):
-  sanity harness using a deliberately cycle-creating pair of plans —
-  **NoDeadlock tripped in 5 steps** (confirms the checker works).
+- [`AwaStorageLockOrder.cfg`](./AwaStorageLockOrder.cfg): main run against the real Rust lock plans — **39,040 distinct states, clean**. Models claim (receipts and legacy modes), complete, close-receipt, rescue-receipts, ensure-running, the two cancel branches, plus rotate / prune for the queue, lease, and claim rings. This is the positive artifact saying the current SQL lock ordering is deadlock-free and the lock compatibility contract holds.
+- [`AwaStorageLockOrderDeadlockDemo.cfg`](./AwaStorageLockOrderDeadlockDemo.cfg): sanity harness using a deliberately cycle-creating pair of plans — **NoDeadlock tripped in 5 steps** (confirms the checker works).
 
 Run:
 
@@ -189,82 +132,34 @@ Run:
 ./correctness/run-tlc.sh storage/AwaStorageLockOrder.tla storage/AwaStorageLockOrderDeadlockDemo.cfg
 ```
 
-Coverage note: the plans model the lock steps that actually appear in
-the Rust SQL (`FOR UPDATE` / `FOR SHARE` / `LOCK TABLE ACCESS
-EXCLUSIVE` / the implicit AccessShare of SELECT on partition
-children). They do NOT model implicit table-level locks beyond what
-is named, or Postgres's lock-timeout / deadlock-detector abort choice.
-The spec treats a waits-for cycle as a safety violation, which is
-conservative — Postgres would abort one transaction and let the other
-proceed. For our purposes "this sequence of lock requests could
-produce a cycle" is the thing we want to catch, regardless of how
-the runtime resolves it.
+Coverage note: the plans model the lock steps that actually appear in the Rust SQL (`FOR UPDATE` / `FOR SHARE` / `LOCK TABLE ACCESS EXCLUSIVE` / the implicit AccessShare of SELECT on partition children). They do NOT model implicit table-level locks beyond what is named, or Postgres's lock-timeout / deadlock-detector abort choice. The spec treats a waits-for cycle as a safety violation, which is conservative — Postgres would abort one transaction and let the other proceed. For our purposes "this sequence of lock requests could produce a cycle" is the thing we want to catch, regardless of how the runtime resolves it.
 
 ## Race-exposure companion spec
 
-[`AwaSegmentedStorageRaces.tla`](./AwaSegmentedStorageRaces.tla) refines the
-Claim action into a two-step `BeginClaim(w, j)` / `CommitClaim(w)` with a
-per-worker `claimIntent` snapshot, and enables `RotateLeaseSegments` /
-`PruneLeaseSegment` to fire between the steps. The checked-in configs both
-run with two workers so the race is exercised under real contention rather
-than a single-worker self-interleaving. Two configs:
+[`AwaSegmentedStorageRaces.tla`](./AwaSegmentedStorageRaces.tla) refines the Claim action into a two-step `BeginClaim(w, j)` / `CommitClaim(w)` with a per-worker `claimIntent` snapshot, and enables `RotateLeaseSegments` / `PruneLeaseSegment` to fire between the steps. The checked-in configs both run with two workers so the race is exercised under real contention rather than a single-worker self-interleaving. Two configs:
 
-- [`AwaSegmentedStorageRaces.cfg`](./AwaSegmentedStorageRaces.cfg):
-  naive `CommitClaim` (uses the snapshotted segment without re-check).
-  **TLC finds `PrunedLeaseSegmentsAreEmpty` violated in 6 steps** — the
-  trace shows Init → EnqueueReady → BeginClaim (snapshot seg 1) →
-  RotateLeaseSegments (seg 1 → sealed) → PruneLeaseSegment(1) (seg 1 →
-  pruned, precondition passes because the pending claim isn't committed
-  yet so `activeLeases = {}`) → CommitClaim lands a lease in segment 1,
-  now pruned. This is simultaneously the claim-vs-rotate race and the
-  prune check-then-act race.
-- [`AwaSegmentedStorageRacesSafe.cfg`](./AwaSegmentedStorageRacesSafe.cfg):
-  `CommitClaimChecked` re-reads `leaseSegments[leaseSeg] = "open"` at
-  commit time. TLC completes cleanly with no invariant violations.
-- [`AwaSegmentedStorageRacesMultiWorker.cfg`](./AwaSegmentedStorageRacesMultiWorker.cfg):
-  same safe refinement, but with three workers to exercise the checked
-  claim path under higher claimant contention. TLC completes cleanly.
+- [`AwaSegmentedStorageRaces.cfg`](./AwaSegmentedStorageRaces.cfg): naive `CommitClaim` (uses the snapshotted segment without re-check). **TLC finds `PrunedLeaseSegmentsAreEmpty` violated in 6 steps** — the trace shows Init → EnqueueReady → BeginClaim (snapshot seg 1) → RotateLeaseSegments (seg 1 → sealed) → PruneLeaseSegment(1) (seg 1 → pruned, precondition passes because the pending claim isn't committed yet so `activeLeases = {}`) → CommitClaim lands a lease in segment 1, now pruned. This is simultaneously the claim-vs-rotate race and the prune check-then-act race.
+- [`AwaSegmentedStorageRacesSafe.cfg`](./AwaSegmentedStorageRacesSafe.cfg): `CommitClaimChecked` re-reads `leaseSegments[leaseSeg] = "open"` at commit time. TLC completes cleanly with no invariant violations.
+- [`AwaSegmentedStorageRacesMultiWorker.cfg`](./AwaSegmentedStorageRacesMultiWorker.cfg): same safe refinement, but with three workers to exercise the checked claim path under higher claimant contention. TLC completes cleanly.
 
-Run either with `./correctness/run-tlc.sh`. The race-exposing config is
-expected to produce a counterexample; the safe config is expected to pass.
+Run either with `./correctness/run-tlc.sh`. The race-exposing config is expected to produce a counterexample; the safe config is expected to pass.
 
-What this proves: the race is real at the data-spec abstraction level. The
-safe config models a checked-commit discipline; the Rust implementation does
-not use `FOR SHARE` on `lease_ring_state`. Production instead relies on the
-rotator's compare-and-swap on `(current_slot, generation)`, child-partition
-locking, and the busy-check before rotation/prune. The lock-order companion
-spec documents that actual SQL lock shape. See [`MAPPING.md`](./MAPPING.md)
-for the full lock-interaction analysis.
+What this proves: the race is real at the data-spec abstraction level. The safe config models a checked-commit discipline; the Rust implementation does not use `FOR SHARE` on `lease_ring_state`. Production instead relies on the rotator's compare-and-swap on `(current_slot, generation)`, child-partition locking, and the busy-check before rotation/prune. The lock-order companion spec documents that actual SQL lock shape. See [`MAPPING.md`](./MAPPING.md) for the full lock-interaction analysis.
 
 ## Storage-transition companion spec
 
-[`AwaStorageTransition.tla`](./AwaStorageTransition.tla) models the
-`0.5.x canonical -> 0.6 queue_storage` control plane from #180. It is
-deliberately smaller than the segmented-storage data model: it tracks the
-transition singleton, prepared schema readiness, runtime capability reports,
-effective queue executors, canonical backlog count, queue-storage row count,
-producer routing, finalize, and abort interlocks.
+[`AwaStorageTransition.tla`](./AwaStorageTransition.tla) models the `0.5.x canonical -> 0.6 queue_storage` control plane from #180. It is deliberately smaller than the segmented-storage data model: it tracks the transition singleton, prepared schema readiness, runtime capability reports, effective queue executors, canonical backlog count, queue-storage row count, producer routing, finalize, and abort interlocks.
 
-The model separates three runtime populations that collapse to similar
-database rows in parts of the implementation:
+The model separates three runtime populations that collapse to similar database rows in parts of the implementation:
 
 - old canonical-only runtimes (`storage_capability = 'canonical'`)
-- auto 0.6 runtimes started before mixed transition, which report
-  `queue_storage` while prepared but become `canonical_drain_only` after
-  routing flips
-- explicit queue-storage targets, which can actually execute queue-storage
-  work immediately after mixed transition starts
+- auto 0.6 runtimes started before mixed transition, which report `queue_storage` while prepared but become `canonical_drain_only` after routing flips
+- explicit queue-storage targets, which can actually execute queue-storage work immediately after mixed transition starts
 
 Configs:
 
-- [`AwaStorageTransition.cfg`](./AwaStorageTransition.cfg): desired gate,
-  requiring a live queue-storage executor at `EnterMixedTransition`. TLC
-  completes cleanly with **222 distinct states**.
-- [`AwaStorageTransitionCurrentGate.cfg`](./AwaStorageTransitionCurrentGate.cfg):
-  historical pre-v014 failing witness for the old SQL-level capability-only gate.
-  TLC trips `MixedHasQueueExecutor` in 5 steps: prepare queue storage,
-  prepare schema, start an auto pre-mixed runtime, enter mixed transition,
-  and end up with queue-storage routing but no queue executor.
+- [`AwaStorageTransition.cfg`](./AwaStorageTransition.cfg): desired gate, requiring a live queue-storage executor at `EnterMixedTransition`. TLC completes cleanly with **222 distinct states**.
+- [`AwaStorageTransitionCurrentGate.cfg`](./AwaStorageTransitionCurrentGate.cfg): historical pre-v014 failing witness for the old SQL-level capability-only gate. TLC trips `MixedHasQueueExecutor` in 5 steps: prepare queue storage, prepare schema, start an auto pre-mixed runtime, enter mixed transition, and end up with queue-storage routing but no queue executor.
 
 Run:
 
@@ -273,78 +168,34 @@ Run:
 ./correctness/run-tlc.sh storage/AwaStorageTransition.tla storage/AwaStorageTransitionCurrentGate.cfg
 ```
 
-What this proves: the finalize and abort gates are captured at the same
-abstraction level as the migration SQL, and the mixed-transition gate needs
-to prove executor liveness rather than only queue-storage capability. The
-current implementation can require explicit operator discipline, but the SQL
-gate itself cannot distinguish a pre-mixed auto runtime from an explicit
-queue-storage target.
+What this proves: the finalize and abort gates are captured at the same abstraction level as the migration SQL, and the mixed-transition gate needs to prove executor liveness rather than only queue-storage capability. The current implementation can require explicit operator discipline, but the SQL gate itself cannot distinguish a pre-mixed auto runtime from an explicit queue-storage target.
 
 ## Dead-tuple architectural contract
 
-[`AwaDeadTupleContract.tla`](./AwaDeadTupleContract.tla) is the
-companion to ADR-023 that catches dead-tuple regressions at design
-time, before they show up as autovacuum running behind in production.
-Each table declares a `kind` and a `hot` flag; each transaction
-declares the `Insert` / `Update` / `Delete` / `Truncate` operations
-it performs.
+[`AwaDeadTupleContract.tla`](./AwaDeadTupleContract.tla) is the companion to ADR-023 that catches dead-tuple regressions at design time, before they show up as autovacuum running behind in production. Each table declares a `kind` and a `hot` flag; each transaction declares the `Insert` / `Update` / `Delete` / `Truncate` operations it performs.
 
 Reclaim kinds:
 
-- `PartitionTruncate`: partition rotation + `TRUNCATE` reclaims an
-  entire child child at a time. Suitable for hot tables whose row
-  count grows with traffic.
-- `Warm`: row count is high-mutation but **bounded** by something
-  that does not scale with traffic (worker fleet size, queue lane
-  count, etc.). Autovacuum scans a small heap and keeps up cheaply.
-  Requires a non-empty `bounded_by` field naming the bound — that
-  bound is the operator's commitment, and breaking it (e.g. letting
-  `attempt_state` retain terminated rows) graduates the table to
-  `PartitionTruncate`.
-- `RowVacuum`: low mutation rate; cold metadata. Autovacuum trivially
-  keeps up.
+- `PartitionTruncate`: partition rotation + `TRUNCATE` reclaims an entire child child at a time. Suitable for hot tables whose row count grows with traffic.
+- `Warm`: row count is high-mutation but **bounded** by something that does not scale with traffic (worker fleet size, queue lane count, etc.). Autovacuum scans a small heap and keeps up cheaply. Requires a non-empty `bounded_by` field naming the bound — that bound is the operator's commitment, and breaking it (e.g. letting `attempt_state` retain terminated rows) graduates the table to `PartitionTruncate`.
+- `RowVacuum`: low mutation rate; cold metadata. Autovacuum trivially keeps up.
 - `AppendOnly`: never reclaimed; archive shape.
 
 The static checks:
 
-- `HotTablesAreNotRowVacuum`: a hot-mutation table must be
-  `PartitionTruncate` or `Warm`. This is the rule the original
-  `open_receipt_claims` design violated. A new entry like
-  `open_receipt_claims |-> [kind |-> "RowVacuum", hot |-> "hot"]`
-  fires this assumption.
-- `PartitionTruncateTablesAreReclaimed`: every partitioned hot table
-  must have at least one transaction in the model that performs
-  `Truncate` on it (i.e. a `prune_*` maintenance path is wired).
-  Without this, partitions never get reclaimed and the table grows
-  monotonically.
-- `WarmTablesDocumentTheirBound`: every `Warm` table must declare a
-  non-empty `bounded_by` and be marked `hot`. Forces the operator
-  to name the bound rather than wave it through with a comment.
-- `BacklogRowVacuumTablesDocumentTheirBound`: unpartitioned backlog
-  tables such as `deferred_jobs` and `dlq_entries` must name the
-  backlog or retention policy that bounds live rows. This is a release
-  validation hook, not a structural truncate proof.
-- `OnlyBoundedKindsHaveBoundedBy`: only `Warm` and
-  `BacklogRowVacuum` tables may set `bounded_by`; on every other kind
-  the field is dead weight.
-- `AppendOnlyAcceptsOnlyInsert`: archive / never-reclaimed tables
-  forbid `Update` and `Delete`.
-- `VacuumKindTablesNotTruncated`: `TRUNCATE` is the
-  `PartitionTruncate` reclaim mechanism; using it on a `RowVacuum`
-  `Warm`, or `BacklogRowVacuum` table either contradicts the kind or
-  means the kind is wrong.
+- `HotTablesAreNotRowVacuum`: a hot-mutation table must be `PartitionTruncate` or `Warm`. This is the rule the original `open_receipt_claims` design violated. A new entry like `open_receipt_claims |-> [kind |-> "RowVacuum", hot |-> "hot"]` fires this assumption.
+- `PartitionTruncateTablesAreReclaimed`: every partitioned hot table must have at least one transaction in the model that performs `Truncate` on it (i.e. a `prune_*` maintenance path is wired). Without this, partitions never get reclaimed and the table grows monotonically.
+- `WarmTablesDocumentTheirBound`: every `Warm` table must declare a non-empty `bounded_by` and be marked `hot`. Forces the operator to name the bound rather than wave it through with a comment.
+- `BacklogRowVacuumTablesDocumentTheirBound`: unpartitioned backlog tables such as `deferred_jobs` and `dlq_entries` must name the backlog or retention policy that bounds live rows. This is a release validation hook, not a structural truncate proof.
+- `OnlyBoundedKindsHaveBoundedBy`: only `Warm` and `BacklogRowVacuum` tables may set `bounded_by`; on every other kind the field is dead weight.
+- `AppendOnlyAcceptsOnlyInsert`: archive / never-reclaimed tables forbid `Update` and `Delete`.
+- `VacuumKindTablesNotTruncated`: `TRUNCATE` is the `PartitionTruncate` reclaim mechanism; using it on a `RowVacuum` `Warm`, or `BacklogRowVacuum` table either contradicts the kind or means the kind is wrong.
 
-The checks are TLA+ `ASSUME` declarations evaluated during
-semantic analysis, so a violation surfaces as a parse-time error
-rather than a model-checker counterexample. Workflow when adding a
-new SQL site or a new table:
+The checks are TLA+ `ASSUME` declarations evaluated during semantic analysis, so a violation surfaces as a parse-time error rather than a model-checker counterexample. Workflow when adding a new SQL site or a new table:
 
-1. Add the table to `TableSpec` in the spec with the right `kind`
-   and honest `hot/cold` label.
-2. Add (or update) the matching `Tx` definition with the mutation
-   list of its `INSERT` / `UPDATE` / `DELETE` / `TRUNCATE`s.
-3. Re-run the TLC check. If anything is wrong, an `ASSUME` fires
-   with the line number of the broken invariant.
+1. Add the table to `TableSpec` in the spec with the right `kind` and honest `hot/cold` label.
+2. Add (or update) the matching `Tx` definition with the mutation list of its `INSERT` / `UPDATE` / `DELETE` / `TRUNCATE`s.
+3. Re-run the TLC check. If anything is wrong, an `ASSUME` fires with the line number of the broken invariant.
 
 Run:
 
@@ -352,40 +203,19 @@ Run:
 ./correctness/run-tlc.sh storage/AwaDeadTupleContract.tla
 ```
 
-Expected outcome: clean run, no assumption violation. The whole
-check is a single TLC initial state and finishes in well under a
-second.
+Expected outcome: clean run, no assumption violation. The whole check is a single TLC initial state and finishes in well under a second.
 
-This spec models the **architectural contract** for dead tuples.
-For partitioned hot tables it checks that a real truncate path exists.
-For `BacklogRowVacuum` tables it deliberately does not claim a static
-proof: the complementary numerical check (how many dead tuples does the
-system actually accumulate under load X?) lives in the external
-`hardbyte/postgresql-job-queue-benchmarking` harness; see the long-horizon
-runner and the per-table dead-tuple columns in the `summary.json` it produces.
+This spec models the **architectural contract** for dead tuples. For partitioned hot tables it checks that a real truncate path exists. For `BacklogRowVacuum` tables it deliberately does not claim a static proof: the complementary numerical check (how many dead tuples does the system actually accumulate under load X?) lives in the external `hardbyte/postgresql-job-queue-benchmarking` harness; see the long-horizon runner and the per-table dead-tuple columns in the `summary.json` it produces.
 
 ## Trace-validation harness
 
-[`AwaSegmentedStorageTrace.tla`](./AwaSegmentedStorageTrace.tla)
-extends the base spec with a replay harness that verifies a concrete
-sequence of events transcribed from a real queue-storage runtime
-test is accepted by the spec. The current checked-in traces:
+[`AwaSegmentedStorageTrace.tla`](./AwaSegmentedStorageTrace.tla) extends the base spec with a replay harness that verifies a concrete sequence of events transcribed from a real queue-storage runtime test is accepted by the spec. The current checked-in traces:
 
-- `SnoozeTrace` (6 events: enqueue → claim → retry-to-deferred →
-  promote → claim → fast-complete) — accepted cleanly, 7 states.
-  Transcribed from `test_queue_storage_runtime_snooze`.
-- `ReceiptRescueTrace` (3 events: enqueue → seed receipt-only claim →
-  rescue stale receipt) — accepted cleanly, 4 states. The seed action
-  is trace-only scaffolding because the base spec's `Claim` action
-  materializes a lease immediately while the implementation has a short
-  receipt-only window before materialization.
-- `RunningCancelTrace` (3 events: enqueue → claim → running admin
-  cancel) — accepted cleanly, 4 states.
-- `DlqRetryTrace` (6 events: enqueue → claim → fail-to-DLQ →
-  retry-from-DLQ → claim → fast-complete) — accepted cleanly, 7 states.
-- `BrokenTrace` (same events with steps 3 and 4 swapped) —
-  rejected with a deadlock at traceIdx = 2, proving the harness
-  catches invalid sequences.
+- `SnoozeTrace` (6 events: enqueue → claim → retry-to-deferred → promote → claim → fast-complete) — accepted cleanly, 7 states. Transcribed from `test_queue_storage_runtime_snooze`.
+- `ReceiptRescueTrace` (3 events: enqueue → seed receipt-only claim → rescue stale receipt) — accepted cleanly, 4 states. The seed action is trace-only scaffolding because the base spec's `Claim` action materializes a lease immediately while the implementation has a short receipt-only window before materialization.
+- `RunningCancelTrace` (3 events: enqueue → claim → running admin cancel) — accepted cleanly, 4 states.
+- `DlqRetryTrace` (6 events: enqueue → claim → fail-to-DLQ → retry-from-DLQ → claim → fast-complete) — accepted cleanly, 7 states.
+- `BrokenTrace` (same events with steps 3 and 4 swapped) — rejected with a deadlock at traceIdx = 2, proving the harness catches invalid sequences.
 
 Run:
 
@@ -400,43 +230,16 @@ Run:
 
 Expected outcomes:
 
-- Positive trace configs: TLC reports the matching `*TraceIncomplete`
-  invariant violation — this is the **positive witness** that the trace
-  was fully consumed.
-- Broken config: TLC reports `Deadlock reached` at traceIdx = 2 —
-  the third event (`PromoteDeferred`) has no matching enabled spec
-  action.
+- Positive trace configs: TLC reports the matching `*TraceIncomplete` invariant violation — this is the **positive witness** that the trace was fully consumed.
+- Broken config: TLC reports `Deadlock reached` at traceIdx = 2 — the third event (`PromoteDeferred`) has no matching enabled spec action.
 
-See [`MAPPING.md`](./MAPPING.md#trace-validation) for the full
-description of how to transcribe and add a new trace.
+See [`MAPPING.md`](./MAPPING.md#trace-validation) for the full description of how to transcribe and add a new trace.
 
 ## Known modelling gaps
 
-See [`../README.md`](../README.md) for the full Known Divergences list.
-Specific to this spec:
+See [`../README.md`](../README.md) for the full Known Divergences list. Specific to this spec:
 
-- **Public SQL projections are not modelled as separate views.**
-  `AwaSegmentedStorage` models the storage state and invariants underneath
-  `ready_entries`, `ready_tombstones`, `leases`, `done_entries`,
-  `dlq_entries`, and receipt partitions. It does not separately derive
-  `awa.jobs`, `terminal_jobs`, admin state counts, or health-check
-  availability. Those projection paths are covered by Rust regression tests
-  and the correspondence notes in
-  [`MAPPING.md`](./MAPPING.md#public-read-and-compatibility-surfaces).
-- **Enqueue-shard routing is split across specs.** The base storage model
-  uses one `(queue, priority, enqueue_shard)` lane. Cross-shard `lane_seq`
-  collisions are checked by `AwaShardedPrune`, but the producer shard chooser,
-  per-queue `enqueue_shards` changes, and projection exactness across shards
-  remain code-tested rather than represented in a single unified TLA+ state.
-- **DLQ bulk ops are modelled as quantified single-row actions.** The Rust
-  `bulk_retry_from_dlq` / `purge_dlq` paths are transactionally atomic across
-  the matching rows; the spec explores arbitrary interleavings of individual
-  `RetryFromDlq(j)` / `PurgeDlq(j)` which is a strictly weaker claim. Safety
-  invariants hold under both framings; a refinement with a `BulkScope` set
-  variable could tighten this.
-- **Unique-claim conflicts on `retry_from_dlq`.** The Rust contract says
-  retry-from-dlq returns `UniqueConflict` and leaves the DLQ row intact when
-  a replacement owns the unique slot. The model doesn't have unique keys, so
-  TLC simply explores `RetryFromDlq(j)` whenever the precondition holds.
-  Preserving-the-DLQ-row-on-conflict is enforced in SQL
-  (`awa-model/src/queue_storage.rs::sync_unique_claim`).
+- **Public SQL projections are not modelled as separate views.** `AwaSegmentedStorage` models the storage state and invariants underneath `ready_entries`, `ready_tombstones`, `leases`, `done_entries`, `dlq_entries`, and receipt partitions. It does not separately derive `awa.jobs`, `terminal_jobs`, admin state counts, or health-check availability. Those projection paths are covered by Rust regression tests and the correspondence notes in [`MAPPING.md`](./MAPPING.md#public-read-and-compatibility-surfaces).
+- **Enqueue-shard routing is split across specs.** The base storage model uses one `(queue, priority, enqueue_shard)` lane. Cross-shard `lane_seq` collisions are checked by `AwaShardedPrune`, but the producer shard chooser, per-queue `enqueue_shards` changes, and projection exactness across shards remain code-tested rather than represented in a single unified TLA+ state.
+- **DLQ bulk ops are modelled as quantified single-row actions.** The Rust `bulk_retry_from_dlq` / `purge_dlq` paths are transactionally atomic across the matching rows; the spec explores arbitrary interleavings of individual `RetryFromDlq(j)` / `PurgeDlq(j)` which is a strictly weaker claim. Safety invariants hold under both framings; a refinement with a `BulkScope` set variable could tighten this.
+- **Unique-claim conflicts on `retry_from_dlq`.** The Rust contract says retry-from-dlq returns `UniqueConflict` and leaves the DLQ row intact when a replacement owns the unique slot. The model doesn't have unique keys, so TLC simply explores `RetryFromDlq(j)` whenever the precondition holds. Preserving-the-DLQ-row-on-conflict is enforced in SQL (`awa-model/src/queue_storage.rs::sync_unique_claim`).

--- a/docker/observability/README.md
+++ b/docker/observability/README.md
@@ -1,10 +1,6 @@
 # Observability side-stack
 
-OTel collector + Prometheus + Grafana for visualising metrics from Awa workers
-or from the external
-[`hardbyte/postgresql-job-queue-benchmarking`](https://github.com/hardbyte/postgresql-job-queue-benchmarking)
-harness. The stack is independent of the workload under test, so it can be
-brought up and down without disturbing the benchmark's Postgres.
+OTel collector + Prometheus + Grafana for visualising metrics from Awa workers or from the external [`hardbyte/postgresql-job-queue-benchmarking`](https://github.com/hardbyte/postgresql-job-queue-benchmarking) harness. The stack is independent of the workload under test, so it can be brought up and down without disturbing the benchmark's Postgres.
 
 ## Quick start
 
@@ -14,8 +10,7 @@ cd docker/observability
 docker compose up -d
 ```
 
-Then run a worker or benchmark with the OTLP endpoint set. For example, from a
-checkout of the external benchmark harness:
+Then run a worker or benchmark with the OTLP endpoint set. For example, from a checkout of the external benchmark harness:
 
 ```bash
 cd /path/to/postgresql-job-queue-benchmarking
@@ -27,16 +22,13 @@ OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317 \
     --skip-build
 ```
 
-Grafana lives at <http://localhost:13000> (admin/admin). The Awa dashboard
-is auto-loaded under the **Awa** folder.
+Grafana lives at <http://localhost:13000> (admin/admin). The Awa dashboard is auto-loaded under the **Awa** folder.
 
-Prometheus is at <http://localhost:19090>; the OTel collector's scrape
-endpoint is at <http://localhost:8889/metrics>.
+Prometheus is at <http://localhost:19090>; the OTel collector's scrape endpoint is at <http://localhost:8889/metrics>.
 
 ## What it captures
 
-Every metric `awa-metrics/src/lib.rs` declares, including ring-rotation and
-prune signals:
+Every metric `awa-metrics/src/lib.rs` declares, including ring-rotation and prune signals:
 
 - `awa_maintenance_rotate_attempts_total{awa_ring,awa_ring_outcome,awa_ring_blocker}`
 - `awa_maintenance_rotate_skipped_rows_bucket` (histogram)
@@ -45,21 +37,17 @@ prune signals:
 - `awa_ring_current_slot{awa_ring}`
 - `awa_ring_generation{awa_ring}`
 
-Plus the existing job/queue/dispatch metrics: `awa_job_*`, `awa_dispatch_*`,
-`awa_queue_*`, `awa_completion_*`, `awa_jobs_in_flight`, `awa_dlq_*`,
-`awa_storage_*`.
+Plus the existing job/queue/dispatch metrics: `awa_job_*`, `awa_dispatch_*`, `awa_queue_*`, `awa_completion_*`, `awa_jobs_in_flight`, `awa_dlq_*`, `awa_storage_*`.
 
 ## Resource budget
 
-| service | RSS limit | what it stores |
-|---------|-----------|----------------|
-| otel-collector | 512 MB | none (forwarding) |
-| prometheus | 1 GB | 24h retention |
-| grafana | 512 MB | dashboard cache |
+| service        | RSS limit | what it stores    |
+| -------------- | --------- | ----------------- |
+| otel-collector | 512 MB    | none (forwarding) |
+| prometheus     | 1 GB      | 24h retention     |
+| grafana        | 512 MB    | dashboard cache   |
 
-A 12 h overnight bench at the 4×8×200/s profile produces ≈70 MB of
-prometheus tsdb data. The retention is set to 24 h so back-to-back
-overnight runs don't trip the disk pressure auto-purge.
+A 12 h overnight bench at the 4×8×200/s profile produces ≈70 MB of prometheus tsdb data. The retention is set to 24 h so back-to-back overnight runs don't trip the disk pressure auto-purge.
 
 ## Tearing down
 

--- a/docs/adr/001-postgres-only.md
+++ b/docs/adr/001-postgres-only.md
@@ -85,13 +85,4 @@ Backoff calculation (`awa.backoff_duration`) and uniqueness bitmask checks (`awa
 
 ## Relationship to ADR-019
 
-ADR-019 changed Awa's primary physical storage layout from the canonical
-`jobs_hot` / `scheduled_jobs` split (described in this ADR's examples) to
-queue segments plus `active_leases`, `attempt_state`, and `lane_state`. The
-decision in this ADR still stands: Awa remains Postgres-only, and the
-redesign continues to lean on Postgres-native primitives (`FOR UPDATE SKIP
-LOCKED`, advisory locks, `LISTEN/NOTIFY`, `FOR SHARE` row locks across the
-segmented ring state) rather than a pluggable storage abstraction. The
-partial-index examples in this ADR reflect the pre-ADR-019 schema; the
-current hot-path indexes live on `ready_entries`, `active_leases`, and
-`deferred_jobs` — see [ADR-019](019-queue-storage-redesign.md).
+ADR-019 changed Awa's primary physical storage layout from the canonical `jobs_hot` / `scheduled_jobs` split (described in this ADR's examples) to queue segments plus `active_leases`, `attempt_state`, and `lane_state`. The decision in this ADR still stands: Awa remains Postgres-only, and the redesign continues to lean on Postgres-native primitives (`FOR UPDATE SKIP LOCKED`, advisory locks, `LISTEN/NOTIFY`, `FOR SHARE` row locks across the segmented ring state) rather than a pluggable storage abstraction. The partial-index examples in this ADR reflect the pre-ADR-019 schema; the current hot-path indexes live on `ready_entries`, `active_leases`, and `deferred_jobs` — see [ADR-019](019-queue-storage-redesign.md).

--- a/docs/adr/002-blake3-uniqueness.md
+++ b/docs/adr/002-blake3-uniqueness.md
@@ -42,11 +42,11 @@ At 128 bits, the birthday bound is approximately 2^64 (~18.4 quintillion). To re
 
 For reference, at 16 bytes the probability of at least one collision among `n` keys is approximately `n^2 / (2 * 2^128)`:
 
-| Jobs | Collision probability |
-|---|---|
-| 1 billion (10^9) | ~1.5 x 10^-21 |
-| 1 trillion (10^12) | ~1.5 x 10^-15 |
-| 1 quadrillion (10^15) | ~1.5 x 10^-9 |
+| Jobs                  | Collision probability |
+| --------------------- | --------------------- |
+| 1 billion (10^9)      | ~1.5 x 10^-21         |
+| 1 trillion (10^12)    | ~1.5 x 10^-15         |
+| 1 quadrillion (10^15) | ~1.5 x 10^-9          |
 
 This is far beyond the operational lifetime of any job queue.
 

--- a/docs/adr/003-heartbeat-deadline-hybrid.md
+++ b/docs/adr/003-heartbeat-deadline-hybrid.md
@@ -97,14 +97,4 @@ For a worker crash, heartbeat recovery kicks in within ~90-120 seconds (stalenes
 
 ## Relationship to ADR-019
 
-ADR-019 moved the mutable runtime fields (`heartbeat_at`, `deadline_at`,
-`run_lease`, callback token/timeout) from `awa.jobs_hot` onto the
-`{schema}.active_leases` rows, keyed by `(job_id, run_lease)`. The recovery
-policy in this ADR is unchanged: heartbeat staleness and deadline expiry are
-both scanned on the maintenance leader, and rescued leases are re-enqueued
-into `ready_entries`. The `UPDATE awa.jobs_hot AS jobs SET heartbeat_at =
-now() ...` SQL example above reflects the pre-ADR-019 schema; the current
-batched heartbeat UPDATE targets `active_leases` with the same
-`(job_id, run_lease)` key. The spec-level guarantees are verified in
-`AwaSegmentedStorage.tla` (short-job rescue reachable via lease-level
-heartbeat freshness) — see [ADR-019](019-queue-storage-redesign.md).
+ADR-019 moved the mutable runtime fields (`heartbeat_at`, `deadline_at`, `run_lease`, callback token/timeout) from `awa.jobs_hot` onto the `{schema}.active_leases` rows, keyed by `(job_id, run_lease)`. The recovery policy in this ADR is unchanged: heartbeat staleness and deadline expiry are both scanned on the maintenance leader, and rescued leases are re-enqueued into `ready_entries`. The `UPDATE awa.jobs_hot AS jobs SET heartbeat_at = now() ...` SQL example above reflects the pre-ADR-019 schema; the current batched heartbeat UPDATE targets `active_leases` with the same `(job_id, run_lease)` key. The spec-level guarantees are verified in `AwaSegmentedStorage.tla` (short-job rescue reachable via lease-level heartbeat freshness) — see [ADR-019](019-queue-storage-redesign.md).

--- a/docs/adr/004-pyo3-async-bridge.md
+++ b/docs/adr/004-pyo3-async-bridge.md
@@ -23,17 +23,13 @@ Use PyO3 with `pyo3-async-runtimes` for in-process Python integration.
 
 A proof-of-concept spike (`spike/pyo3-async/`) validated four critical requirements before committing to this approach:
 
-1. **Rust tokio can call a Python `async def` and await its result.**
-   `pyo3_async_runtimes::tokio::future_into_py` converts Rust futures to Python awaitables. `pyo3_async_runtimes::into_future_with_locals` converts Python coroutines to Rust futures when the worker is executing on a Rust background task. Round-trip latency is sub-microsecond.
+1. **Rust tokio can call a Python `async def` and await its result.** `pyo3_async_runtimes::tokio::future_into_py` converts Rust futures to Python awaitables. `pyo3_async_runtimes::into_future_with_locals` converts Python coroutines to Rust futures when the worker is executing on a Rust background task. Round-trip latency is sub-microsecond.
 
-2. **A Rust background task can heartbeat while a Python handler runs.**
-   The heartbeat task runs as a separate tokio task that never acquires the GIL. The spike proved that heartbeat increments continue accumulating while a Python handler is blocked in `asyncio.sleep`.
+2. **A Rust background task can heartbeat while a Python handler runs.** The heartbeat task runs as a separate tokio task that never acquires the GIL. The spike proved that heartbeat increments continue accumulating while a Python handler is blocked in `asyncio.sleep`.
 
-3. **Python exceptions propagate to Rust as structured errors.**
-   PyO3 converts Python exceptions to `PyErr`, which carries the exception type, message, and traceback. The spike confirmed that type name, message, and traceback are all accessible from Rust.
+3. **Python exceptions propagate to Rust as structured errors.** PyO3 converts Python exceptions to `PyErr`, which carries the exception type, message, and traceback. The spike confirmed that type name, message, and traceback are all accessible from Rust.
 
-4. **`ctx.is_cancelled()` works from Python when Rust signals shutdown.**
-   A shared `AtomicBool` (wrapped in a `#[pyclass]`) is checked by Python and set by Rust. The spike confirmed that cancellation signalled from a Rust background task is visible to the Python handler within milliseconds.
+4. **`ctx.is_cancelled()` works from Python when Rust signals shutdown.** A shared `AtomicBool` (wrapped in a `#[pyclass]`) is checked by Python and set by Rust. The spike confirmed that cancellation signalled from a Rust background task is visible to the Python handler within milliseconds.
 
 ### How Heartbeats Survive GIL Blocks
 

--- a/docs/adr/005-priority-aging.md
+++ b/docs/adr/005-priority-aging.md
@@ -6,10 +6,7 @@ Accepted
 
 ## Context
 
-Awa supports four priority levels (1 = highest, 4 = lowest) per job. Priority
-determines the order in which jobs are claimed from a queue. Without any aging
-mechanism, low-priority jobs can be starved indefinitely if higher-priority jobs
-are continuously enqueued.
+Awa supports four priority levels (1 = highest, 4 = lowest) per job. Priority determines the order in which jobs are claimed from a queue. Without any aging mechanism, low-priority jobs can be starved indefinitely if higher-priority jobs are continuously enqueued.
 
 Starvation is a real operational problem:
 
@@ -21,55 +18,39 @@ Starvation is a real operational problem:
 
 ### Dispatch ordering
 
-The dispatch query claims jobs in strict `priority ASC, run_at ASC, id ASC`
-order using a single `FOR UPDATE SKIP LOCKED` index scan on
-`idx_awa_jobs_hot_dequeue (queue, priority, run_at, id) WHERE state = 'available'`.
+The dispatch query claims jobs in strict `priority ASC, run_at ASC, id ASC` order using a single `FOR UPDATE SKIP LOCKED` index scan on `idx_awa_jobs_hot_dequeue (queue, priority, run_at, id) WHERE state = 'available'`.
 
-This keeps the dispatch query simple and fast — a single index scan with no
-expression evaluation, which scales linearly with worker count.
+This keeps the dispatch query simple and fast — a single index scan with no expression evaluation, which scales linearly with worker count.
 
 ### Starvation prevention via aging
 
-The queue-storage implementation computes effective priority at claim time.
-The canonical implementation uses a periodic `age_waiting_priorities` task at
-`priority_aging_interval` (default: 60 seconds) that finds `available` jobs
-with `priority > 1` that have been waiting longer than their aging threshold
-and decrements their `priority` column.
+The queue-storage implementation computes effective priority at claim time. The canonical implementation uses a periodic `age_waiting_priorities` task at `priority_aging_interval` (default: 60 seconds) that finds `available` jobs with `priority > 1` that have been waiting longer than their aging threshold and decrements their `priority` column.
 
-The effective priority improves by one level for each `priority_aging_interval`
-that a job has waited:
+The effective priority improves by one level for each `priority_aging_interval` that a job has waited:
 
-| Original Priority | Wait Time  | Effective Priority |
-|-------------------|------------|--------------------|
-| 4 (lowest)        | 0s         | 4                  |
-| 4                 | 60s        | 3                  |
-| 4                 | 120s       | 2                  |
-| 4                 | 180s+      | 1 (clamped)        |
-| 3                 | 0s         | 3                  |
-| 3                 | 60s        | 2                  |
-| 3                 | 120s+      | 1 (clamped)        |
-| 2                 | 0s         | 2                  |
-| 2                 | 60s+       | 1 (clamped)        |
-| 1 (highest)       | any        | 1 (already highest) |
+| Original Priority | Wait Time | Effective Priority  |
+| ----------------- | --------- | ------------------- |
+| 4 (lowest)        | 0s        | 4                   |
+| 4                 | 60s       | 3                   |
+| 4                 | 120s      | 2                   |
+| 4                 | 180s+     | 1 (clamped)         |
+| 3                 | 0s        | 3                   |
+| 3                 | 60s       | 2                   |
+| 3                 | 120s+     | 1 (clamped)         |
+| 2                 | 0s        | 2                   |
+| 2                 | 60s+      | 1 (clamped)         |
+| 1 (highest)       | any       | 1 (already highest) |
 
-A priority-4 job waiting 3 minutes is promoted to priority-1, equal to a freshly
-enqueued high-priority job. When priorities tie, `run_at ASC, id ASC` breaks the
-tie — older jobs go first.
+A priority-4 job waiting 3 minutes is promoted to priority-1, equal to a freshly enqueued high-priority job. When priorities tie, `run_at ASC, id ASC` breaks the tie — older jobs go first.
 
 ### Configuration
 
 The aging interval is configurable:
 
-- **Per queue:** `QueueConfig::priority_aging_interval` (default: 60s), used by
-  the queue-storage claim path.
-- **Canonical maintenance service:** `ClientBuilder::priority_aging_interval`
-  / `MaintenanceService::priority_aging_interval()` (default: 60s), used only
-  by the legacy canonical-storage physical aging pass.
+- **Per queue:** `QueueConfig::priority_aging_interval` (default: 60s), used by the queue-storage claim path.
+- **Canonical maintenance service:** `ClientBuilder::priority_aging_interval` / `MaintenanceService::priority_aging_interval()` (default: 60s), used only by the legacy canonical-storage physical aging pass.
 
-A shorter interval ages jobs faster (stronger starvation prevention, weaker
-priority enforcement). A longer interval ages jobs slower (stricter priority
-ordering, weaker starvation prevention). Setting the interval to a very large
-value effectively disables aging.
+A shorter interval ages jobs faster (stronger starvation prevention, weaker priority enforcement). A longer interval ages jobs slower (stricter priority ordering, weaker starvation prevention). Setting the interval to a very large value effectively disables aging.
 
 ### Why the canonical engine used maintenance-based rather than query-time aging
 
@@ -81,48 +62,25 @@ ORDER BY GREATEST(1, priority - FLOOR(EXTRACT(EPOCH FROM (now() - run_at)) / agi
 
 This was moved to the maintenance task because:
 
-1. **Dispatch scalability.** The dispatch query is the hottest path in the
-   system. Under high concurrency (200+ workers), keeping it as a simple index
-   scan reduces `SKIP LOCKED` contention and avoids CTE materialization fences
-   that amplify lock collisions.
-2. **Index compatibility.** The strict `ORDER BY priority, run_at, id` matches
-   the dequeue index exactly, allowing Postgres to satisfy both the ORDER BY
-   and the range predicate from a single index scan with no sort step.
-3. **Write amplification is bounded.** The maintenance task only updates jobs
-   whose effective priority has actually changed, and limits each pass to 1,000
-   rows. At the default 60s interval, this is negligible compared to the
-   insert/complete write volume.
+1. **Dispatch scalability.** The dispatch query is the hottest path in the system. Under high concurrency (200+ workers), keeping it as a simple index scan reduces `SKIP LOCKED` contention and avoids CTE materialization fences that amplify lock collisions.
+2. **Index compatibility.** The strict `ORDER BY priority, run_at, id` matches the dequeue index exactly, allowing Postgres to satisfy both the ORDER BY and the range predicate from a single index scan with no sort step.
+3. **Write amplification is bounded.** The maintenance task only updates jobs whose effective priority has actually changed, and limits each pass to 1,000 rows. At the default 60s interval, this is negligible compared to the insert/complete write volume.
 
 ## Consequences
 
 ### Positive
 
 - **No starvation.** Every waiting job eventually reaches priority 1.
-- **Simple dispatch query.** The claim SQL is a single index scan with no
-  expression evaluation — maximizes throughput under contention.
+- **Simple dispatch query.** The claim SQL is a single index scan with no expression evaluation — maximizes throughput under contention.
 - **Tunable.** Operators can adjust aging per queue based on workload.
-- **Observable.** The `priority` column reflects the current effective priority
-  at all times, making queue state inspectable without formula knowledge.
+- **Observable.** The `priority` column reflects the current effective priority at all times, making queue state inspectable without formula knowledge.
 
 ### Negative
 
-- **Aging granularity is bounded by the maintenance interval.** A job's priority
-  updates at most once per aging tick, unlike the continuous query-time formula.
-  At the default 60s interval this is invisible in practice.
-- **Mutates the priority column.** Operators inspecting the queue see the aged
-  priority, not the original enqueue priority. The original priority is not
-  separately preserved (it could be reconstructed from `run_at` and the aging
-  interval if needed).
-- **Leader dependency.** Aging only runs on the maintenance leader. If leader
-  election stalls, aging stops. This is the same dependency as rescue and
-  promotion — acceptable given the advisory-lock-based leader model.
+- **Aging granularity is bounded by the maintenance interval.** A job's priority updates at most once per aging tick, unlike the continuous query-time formula. At the default 60s interval this is invisible in practice.
+- **Mutates the priority column.** Operators inspecting the queue see the aged priority, not the original enqueue priority. The original priority is not separately preserved (it could be reconstructed from `run_at` and the aging interval if needed).
+- **Leader dependency.** Aging only runs on the maintenance leader. If leader election stalls, aging stops. This is the same dependency as rescue and promotion — acceptable given the advisory-lock-based leader model.
 
 ## Relationship to ADR-019
 
-The starvation-prevention policy in this ADR still applies. The
-implementation detail changes under queue storage: the canonical engine
-aged rows in place on `awa.jobs_hot` with an `UPDATE ... SET priority =
-priority - 1`, while the queue storage engine keeps ready rows in their
-original priority lanes and computes an effective priority in
-`claim_ready_runtime(...)` when choosing which lane to claim next. The
-aging-interval contract is unchanged — see [ADR-019](019-queue-storage-redesign.md).
+The starvation-prevention policy in this ADR still applies. The implementation detail changes under queue storage: the canonical engine aged rows in place on `awa.jobs_hot` with an `UPDATE ... SET priority = priority - 1`, while the queue storage engine keeps ready rows in their original priority lanes and computes an effective priority in `claim_ready_runtime(...)` when choosing which lane to claim next. The aging-interval contract is unchanged — see [ADR-019](019-queue-storage-redesign.md).

--- a/docs/adr/007-periodic-cron-jobs.md
+++ b/docs/adr/007-periodic-cron-jobs.md
@@ -64,7 +64,7 @@ The evaluator skips paused rows up front to avoid wasted CAS work, and the `atom
 
 `last_enqueued_at` is not touched while paused. On resume, the existing `missed_fire_policy` decides catch-up behaviour — a coalesced schedule fires once on resume; a catch-up schedule replays missed fires in order, bounded by the per-pass limit. Operators choose the catch-up shape when they register the schedule; pausing does not change it.
 
-Manual triggers (`trigger_cron_job`) bypass pause. Pause stops *automatic* fires; an explicit operator action is always allowed. Operators who want the schedule to be entirely inert should delete the row.
+Manual triggers (`trigger_cron_job`) bypass pause. Pause stops _automatic_ fires; an explicit operator action is always allowed. Operators who want the schedule to be entirely inert should delete the row.
 
 #### In-flight jobs and queue pause
 

--- a/docs/adr/008-copy-batch-ingestion.md
+++ b/docs/adr/008-copy-batch-ingestion.md
@@ -6,11 +6,7 @@ Accepted
 
 ## Context
 
-The PRD (section 18) calls for a high-throughput insert path using PostgreSQL's
-COPY protocol. The existing `insert_many` uses multi-row `INSERT` statements
-with parameterized queries, which is limited by PostgreSQL's 65,535 parameter
-limit (requiring chunking at roughly 5,950 rows with 11 params per row) and
-the overhead of query planning per statement.
+The PRD (section 18) calls for a high-throughput insert path using PostgreSQL's COPY protocol. The existing `insert_many` uses multi-row `INSERT` statements with parameterized queries, which is limited by PostgreSQL's 65,535 parameter limit (requiring chunking at roughly 5,950 rows with 11 params per row) and the overhead of query planning per statement.
 
 The original COPY design predated later architectural changes:
 
@@ -18,54 +14,34 @@ The original COPY design predated later architectural changes:
 - `awa.jobs` is a compatibility view rather than the main hot-path heap
 - uniqueness is enforced through `awa.job_unique_claims`
 - callers may invoke COPY multiple times inside one outer transaction
-- ADR-019 queue storage writes producer hot-path rows into
-  `{schema}.ready_entries` and scheduled rows into `{schema}.deferred_jobs`
+- ADR-019 queue storage writes producer hot-path rows into `{schema}.ready_entries` and scheduled rows into `{schema}.deferred_jobs`
 
 ## Decision
 
 Maintain the existing compatibility COPY path as a staging-table approach:
 
-1. Create or reuse a session-local temp table in `pg_temp` with
-   `ON COMMIT DELETE ROWS`
+1. Create or reuse a session-local temp table in `pg_temp` with `ON COMMIT DELETE ROWS`
 2. `COPY` CSV-encoded rows into that staging table
-3. Route staged rows through the compatibility insert path, which preserves
-   hot/deferred routing and uniqueness semantics for the active storage backend
-4. For non-unique batches, use one `INSERT ... SELECT ... RETURNING *` from
-   staging into the chosen target table
-5. For batches containing unique jobs, read staged rows back and insert them
-   one at a time under savepoints, skipping `23505` uniqueness conflicts
-6. Explicitly clear staged rows after use so multiple COPY calls can happen
-   safely inside the same outer transaction
+3. Route staged rows through the compatibility insert path, which preserves hot/deferred routing and uniqueness semantics for the active storage backend
+4. For non-unique batches, use one `INSERT ... SELECT ... RETURNING *` from staging into the chosen target table
+5. For batches containing unique jobs, read staged rows back and insert them one at a time under savepoints, skipping `23505` uniqueness conflicts
+6. Explicitly clear staged rows after use so multiple COPY calls can happen safely inside the same outer transaction
 
 For queue storage producers, add a direct COPY path:
 
 1. Prepare `InsertParams` with the same code as `enqueue_params_batch`
-2. Apply queue striping, allocate job ids, reserve per-lane sequence ranges,
-   sync uniqueness claims in one statement for new enqueues, and update lane
-   counters inside one transaction
-3. Stream available jobs into
-   `{schema}.ready_entries (ready_slot, ready_generation, job_id, kind, queue,
-   args, priority, attempt, run_lease, max_attempts, lane_seq, run_at,
-   attempted_at, created_at, unique_key, unique_states, payload)`
-4. Stream scheduled jobs into
-   `{schema}.deferred_jobs (job_id, kind, queue, args, state, priority,
-   attempt, run_lease, max_attempts, run_at, attempted_at, finalized_at,
-   created_at, unique_key, unique_states, payload)`
-5. Notify logical queues after ready rows have been copied, matching
-   `enqueue_params_batch`
+2. Apply queue striping, allocate job ids, reserve per-lane sequence ranges, sync uniqueness claims in one statement for new enqueues, and update lane counters inside one transaction
+3. Stream available jobs into `{schema}.ready_entries (ready_slot, ready_generation, job_id, kind, queue, args, priority, attempt, run_lease, max_attempts, lane_seq, run_at, attempted_at, created_at, unique_key, unique_states, payload)`
+4. Stream scheduled jobs into `{schema}.deferred_jobs (job_id, kind, queue, args, state, priority, attempt, run_lease, max_attempts, run_at, attempted_at, finalized_at, created_at, unique_key, unique_states, payload)`
+5. Notify logical queues after ready rows have been copied, matching `enqueue_params_batch`
 
 ### Why staging table instead of direct COPY into `awa.jobs`
 
-- The staging table has no constraints, no indexes, and no Awa triggers, so
-  the COPY phase stays simple and fast
-- The final insert still goes through Awa's real insert semantics, including
-  hot/deferred routing and enqueue side effects
-- The compatibility `awa.jobs` surface is a view, so direct COPY into it is
-  not a practical general solution
-- Reusing a session-local temp table avoids repeated catalog churn under
-  concurrent producers
-- `ON COMMIT DELETE ROWS` still gives transactional cleanup on
-  commit/rollback
+- The staging table has no constraints, no indexes, and no Awa triggers, so the COPY phase stays simple and fast
+- The final insert still goes through Awa's real insert semantics, including hot/deferred routing and enqueue side effects
+- The compatibility `awa.jobs` surface is a view, so direct COPY into it is not a practical general solution
+- Reusing a session-local temp table avoids repeated catalog churn under concurrent producers
+- `ON COMMIT DELETE ROWS` still gives transactional cleanup on commit/rollback
 
 ### API signatures
 
@@ -77,12 +53,7 @@ impl QueueStorage {
 }
 ```
 
-Accepting `&mut PgConnection` allows callers to use COPY within a broader
-transaction (Transaction derefs to PgConnection in sqlx 0.8).
-`QueueStorage::enqueue_params_copy` takes a pool because it needs one
-transaction that combines sequence allocation, lane reservation, uniqueness
-claim sync, direct COPY into queue-storage tables, lane-counter updates, and
-queue notification.
+Accepting `&mut PgConnection` allows callers to use COPY within a broader transaction (Transaction derefs to PgConnection in sqlx 0.8). `QueueStorage::enqueue_params_copy` takes a pool because it needs one transaction that combines sequence allocation, lane reservation, uniqueness claim sync, direct COPY into queue-storage tables, lane-counter updates, and queue notification.
 
 ### CSV serialization
 
@@ -96,59 +67,26 @@ Custom CSV serialization handles escaping and null encoding for:
 
 ### NOTIFY trigger impact
 
-The enqueue notify trigger fires when the final insert reaches the hot table.
-This is acceptable: PostgreSQL coalesces notifications within a transaction,
-and dispatchers handle duplicates gracefully.
+The enqueue notify trigger fires when the final insert reaches the hot table. This is acceptable: PostgreSQL coalesces notifications within a transaction, and dispatchers handle duplicates gracefully.
 
 ## Consequences
 
 ### Positive
 
 - **No parameter limit:** COPY path bypasses the 65,535 parameter limit entirely.
-- **Reusable staging path:** Session-local staging avoids repeated temp-table
-  create/drop churn under contention.
-- **Shared internals:** `PreparedRow` / `precompute_rows` are reused between
-  `insert_many` and `insert_many_copy`; queue-storage COPY reuses
-  `prepare_row_raw` and the queue-storage enqueue pipeline.
-- **Direct queue-storage producer:** queue storage can bypass the
-  compatibility view/function and COPY directly into `ready_entries` and
-  `deferred_jobs` while preserving job id, lane, counter, uniqueness, and
-  notification invariants.
-- **Batched queue-storage uniqueness:** direct queue-storage producers batch
-  enqueue-time uniqueness claims with one `unnest(bytea[], bigint[])` driven
-  `INSERT ... ON CONFLICT` statement. Duplicate keys inside the request are
-  rejected before COPY; conflicts against existing claims abort the transaction
-  before any ready/deferred rows are copied.
-- **Python support:** Python bindings expose `insert_many_copy` /
-  `insert_many_copy_sync` for compatibility COPY and `enqueue_many_copy` /
-  `enqueue_many_copy_sync` for direct queue-storage COPY.
+- **Reusable staging path:** Session-local staging avoids repeated temp-table create/drop churn under contention.
+- **Shared internals:** `PreparedRow` / `precompute_rows` are reused between `insert_many` and `insert_many_copy`; queue-storage COPY reuses `prepare_row_raw` and the queue-storage enqueue pipeline.
+- **Direct queue-storage producer:** queue storage can bypass the compatibility view/function and COPY directly into `ready_entries` and `deferred_jobs` while preserving job id, lane, counter, uniqueness, and notification invariants.
+- **Batched queue-storage uniqueness:** direct queue-storage producers batch enqueue-time uniqueness claims with one `unnest(bytea[], bigint[])` driven `INSERT ... ON CONFLICT` statement. Duplicate keys inside the request are rejected before COPY; conflicts against existing claims abort the transaction before any ready/deferred rows are copied.
+- **Python support:** Python bindings expose `insert_many_copy` / `insert_many_copy_sync` for compatibility COPY and `enqueue_many_copy` / `enqueue_many_copy_sync` for direct queue-storage COPY.
 
 ### Negative
 
-- **CSV serialization complexity:** Custom CSV encoding for JSONB, `TEXT[]`,
-  `BYTEA`, and `TIMESTAMPTZ` requires careful escaping and adds a non-trivial
-  code path to maintain.
-- **Split unique path:** Unique jobs do not use one bulk `ON CONFLICT` path
-  anymore; they fall back to savepoint-guarded row inserts after staging.
-- **Staging overhead remains:** COPY still pays for staging and a final insert
-  into the real Awa tables, so it is not automatically faster than chunked
-  multi-row `INSERT` in every workload.
-- **Lane cursors remain online:** queue-storage enqueue still reserves
-  sequence values once per touched lane and transaction, with
-  `queue_enqueue_heads` retained as the lane registry. Earlier iterations
-  also maintained a
-  `queue_lanes.available_count` cache on the same path; that cache
-  has been dropped (see [ADR-019](019-queue-storage-redesign.md) §
-  `lane_state` and segment cursor tables) and the dispatcher now
-  derives availability from the enqueue/claim sequence cursor difference.
+- **CSV serialization complexity:** Custom CSV encoding for JSONB, `TEXT[]`, `BYTEA`, and `TIMESTAMPTZ` requires careful escaping and adds a non-trivial code path to maintain.
+- **Split unique path:** Unique jobs do not use one bulk `ON CONFLICT` path anymore; they fall back to savepoint-guarded row inserts after staging.
+- **Staging overhead remains:** COPY still pays for staging and a final insert into the real Awa tables, so it is not automatically faster than chunked multi-row `INSERT` in every workload.
+- **Lane cursors remain online:** queue-storage enqueue still reserves sequence values once per touched lane and transaction, with `queue_enqueue_heads` retained as the lane registry. Earlier iterations also maintained a `queue_lanes.available_count` cache on the same path; that cache has been dropped (see [ADR-019](019-queue-storage-redesign.md) § `lane_state` and segment cursor tables) and the dispatcher now derives availability from the enqueue/claim sequence cursor difference.
 
 ## Relationship to ADR-019
 
-ADR-019 supersedes the hot/deferred physical layout as Awa's primary storage
-engine. The staging-table decision in this ADR still stands for
-compatibility-surface COPY (`insert_many_copy`). Queue-storage producers use
-`QueueStorage::enqueue_params_copy` to COPY directly into
-`{schema}.ready_entries` and `{schema}.deferred_jobs` after preparing all
-derived state in Rust and SQL. References in this ADR to `awa.jobs_hot` /
-`awa.scheduled_jobs` describe the canonical compatibility path, not the
-queue-storage hot path; see [ADR-019](019-queue-storage-redesign.md).
+ADR-019 supersedes the hot/deferred physical layout as Awa's primary storage engine. The staging-table decision in this ADR still stands for compatibility-surface COPY (`insert_many_copy`). Queue-storage producers use `QueueStorage::enqueue_params_copy` to COPY directly into `{schema}.ready_entries` and `{schema}.deferred_jobs` after preparing all derived state in Rust and SQL. References in this ADR to `awa.jobs_hot` / `awa.scheduled_jobs` describe the canonical compatibility path, not the queue-storage hot path; see [ADR-019](019-queue-storage-redesign.md).

--- a/docs/adr/009-python-sync-support.md
+++ b/docs/adr/009-python-sync-support.md
@@ -26,28 +26,29 @@ fn insert_sync(&self, py: Python<'_>, ...) -> PyResult<PyJob> {
 
 ### Sync methods added
 
-| Async method | Sync counterpart |
-|---|---|
-| `insert()` | `insert_sync()` |
-| `migrate()` | `migrate_sync()` |
-| `transaction()` | `transaction_sync()` -> `SyncTransaction` |
-| `retry(job_id)` | `retry_sync(job_id)` |
-| `cancel(job_id)` | `cancel_sync(job_id)` |
-| `retry_failed(...)` | `retry_failed_sync(...)` |
-| `discard_failed(kind)` | `discard_failed_sync(kind)` |
-| `pause_queue(...)` | `pause_queue_sync(...)` |
-| `resume_queue(queue)` | `resume_queue_sync(queue)` |
-| `drain_queue(queue)` | `drain_queue_sync(queue)` |
-| `queue_stats()` | `queue_stats_sync()` |
-| `list_jobs(...)` | `list_jobs_sync(...)` |
-| `health_check()` | `health_check_sync()` |
-| `insert_many_copy()` | `insert_many_copy_sync()` |
+| Async method           | Sync counterpart                          |
+| ---------------------- | ----------------------------------------- |
+| `insert()`             | `insert_sync()`                           |
+| `migrate()`            | `migrate_sync()`                          |
+| `transaction()`        | `transaction_sync()` -> `SyncTransaction` |
+| `retry(job_id)`        | `retry_sync(job_id)`                      |
+| `cancel(job_id)`       | `cancel_sync(job_id)`                     |
+| `retry_failed(...)`    | `retry_failed_sync(...)`                  |
+| `discard_failed(kind)` | `discard_failed_sync(kind)`               |
+| `pause_queue(...)`     | `pause_queue_sync(...)`                   |
+| `resume_queue(queue)`  | `resume_queue_sync(queue)`                |
+| `drain_queue(queue)`   | `drain_queue_sync(queue)`                 |
+| `queue_stats()`        | `queue_stats_sync()`                      |
+| `list_jobs(...)`       | `list_jobs_sync(...)`                     |
+| `health_check()`       | `health_check_sync()`                     |
+| `insert_many_copy()`   | `insert_many_copy_sync()`                 |
 
 **NOT synced:** `worker()`, `periodic()`, `start()`, `shutdown()` — these are worker lifecycle methods that are inherently async.
 
 ### `SyncTransaction` class
 
 New `PySyncTransaction` wrapping `Arc<Mutex<Option<Transaction>>>`:
+
 - Sync methods: `execute()`, `fetch_one()`, `fetch_optional()`, `fetch_all()`, `insert()`, `insert_many()`, `commit()`, `rollback()`
 - Sync context manager: `__enter__`/`__exit__` (not `__aenter__`/`__aexit__`)
 - Usage: `with client.transaction_sync() as tx:` — simpler than async's `async with await client.transaction() as tx:`

--- a/docs/adr/010-rate-limiting.md
+++ b/docs/adr/010-rate-limiting.md
@@ -71,7 +71,4 @@ Build-time validation rejects `max_rate <= 0.0`.
 
 ## Relationship to ADR-019
 
-Rate limiting sits above the storage engine: token consumption happens in
-the dispatcher before the claim query fires, and composes identically with
-canonical and queue-storage backends. The per-worker token bucket is
-storage-plane-agnostic. See [ADR-019](019-queue-storage-redesign.md).
+Rate limiting sits above the storage engine: token consumption happens in the dispatcher before the claim query fires, and composes identically with canonical and queue-storage backends. The per-worker token bucket is storage-plane-agnostic. See [ADR-019](019-queue-storage-redesign.md).

--- a/docs/adr/011-weighted-concurrency.md
+++ b/docs/adr/011-weighted-concurrency.md
@@ -9,6 +9,7 @@ Accepted
 In the default hard-reserved mode, each queue owns an independent semaphore with `max_workers` permits. This is simple but wasteful: if queue A is idle, its 50 reserved permits sit unused while queue B is overloaded and capped at its own 10.
 
 Operators want a **global worker pool** where queues share capacity, with:
+
 1. **Minimum guarantees** — each queue gets at least N workers even under contention.
 2. **Work-conserving allocation** — idle capacity flows to loaded queues.
 3. **Weighted fairness** — overflow capacity is split proportionally to configured weights.
@@ -31,11 +32,13 @@ overflow_capacity = global_max_workers - sum(min_workers)
 ```
 
 Each dispatcher calls `try_acquire(queue, wanted)` to request overflow permits. The pool tracks:
+
 - **held**: how many overflow permits each queue currently holds
 - **demand**: how many each queue last requested (updated every poll)
 - **weights**: configured per-queue weight (immutable)
 
 Fair share is computed as:
+
 ```
 contending_weight = sum of weights for queues with demand > 0 OR held > 0
 my_fair_share = ceil(total * my_weight / contending_weight)
@@ -49,6 +52,7 @@ This is work-conserving: when only one queue has demand, its fair share equals t
 The critical invariant is that every job marked `running` in the database must have a reserved execution slot. The previous design (snapshot available permits → claim → acquire) was racy with a shared pool.
 
 The new `poll_once()` flow:
+
 1. **Pre-acquire permits** (non-blocking `try_acquire_owned` + `OverflowPool::try_acquire`)
 2. **Apply rate limit** (truncate permits if rate-limited)
 3. **Claim from DB** (only as many as held permits)
@@ -82,6 +86,7 @@ impl ClientBuilder {
 ```
 
 Build-time validation:
+
 - `sum(min_workers) > global_max_workers` → `BuildError::MinWorkersExceedGlobal`
 - `weight == 0` → `BuildError::InvalidWeight`
 
@@ -114,10 +119,4 @@ pub enum QueueCapacity {
 
 ## Relationship to ADR-019
 
-Permit pre-acquisition is storage-plane-agnostic: it runs in the worker
-dispatcher before any claim SQL, so the weighted-concurrency decision
-carries through unchanged under queue storage. The claim query that
-consumes the pre-acquired permit targets `{schema}.ready_entries` +
-`{schema}.active_leases` instead of `awa.jobs_hot`, but the permit
-semantics and the permit-before-claim invariant are identical. See
-[ADR-019](019-queue-storage-redesign.md).
+Permit pre-acquisition is storage-plane-agnostic: it runs in the worker dispatcher before any claim SQL, so the weighted-concurrency decision carries through unchanged under queue storage. The claim query that consumes the pre-acquired permit targets `{schema}.ready_entries` + `{schema}.active_leases` instead of `awa.jobs_hot`, but the permit semantics and the permit-before-claim invariant are identical. See [ADR-019](019-queue-storage-redesign.md).

--- a/docs/adr/012-hot-deferred-job-storage.md
+++ b/docs/adr/012-hot-deferred-job-storage.md
@@ -6,21 +6,15 @@ Superseded by ADR-019
 
 ## Context
 
-The original schema stored every job lifecycle state in one `awa.jobs` table.
-That worked well for modest queue sizes, but performance investigations
-exposed a bad scaling shape once large deferred frontiers were introduced.
+The original schema stored every job lifecycle state in one `awa.jobs` table. That worked well for modest queue sizes, but performance investigations exposed a bad scaling shape once large deferred frontiers were introduced.
 
-The critical issue was not just due-row lookup. With millions of future-dated
-rows present, every job still churned through the same heap and indexes:
+The critical issue was not just due-row lookup. With millions of future-dated rows present, every job still churned through the same heap and indexes:
 
 - `scheduled -> available`
 - `available -> running`
 - `running -> completed`
 
-Even after adding due-time indexes, cold deferred rows and hot execution rows
-shared the same physical structure. This made dispatch query plans more
-fragile, increased write amplification, and let background promotion work
-interfere with hot-path dispatch performance.
+Even after adding due-time indexes, cold deferred rows and hot execution rows shared the same physical structure. This made dispatch query plans more fragile, increased write amplification, and let background promotion work interfere with hot-path dispatch performance.
 
 ## Decision
 
@@ -42,15 +36,11 @@ This is a manual hot/cold split, not native table partitioning.
 
 ### Compatibility Surface
 
-`awa.jobs` remains available as a compatibility view so raw SQL, tests, and
-external producers do not need an immediate breaking change. `INSTEAD OF`
-triggers route writes to the correct physical table.
+`awa.jobs` remains available as a compatibility view so raw SQL, tests, and external producers do not need an immediate breaking change. `INSTEAD OF` triggers route writes to the correct physical table.
 
 ### Uniqueness
 
-Cross-table uniqueness is enforced through `awa.job_unique_claims` rather than
-through a partial unique index on the jobs heap. This keeps the uniqueness
-boundary intact across both physical tables.
+Cross-table uniqueness is enforced through `awa.job_unique_claims` rather than through a partial unique index on the jobs heap. This keeps the uniqueness boundary intact across both physical tables.
 
 ## Consequences
 
@@ -64,32 +54,15 @@ boundary intact across both physical tables.
 ### Negative
 
 - Adds trigger/view complexity to the schema
-- Introduces some risk that compatibility-view queries hide physical-table
-  costs if benchmarks or runtime code accidentally use the view on the hot path
-- Requires explicit care in tests and admin paths to query the right physical
-  table when measuring behavior
-- Lock-taking queries (`SELECT ... FOR UPDATE`, rescue operations) must target
-  the physical tables directly, not the `awa.jobs` view — `FOR UPDATE` is not
-  reliably supported on UNION ALL views, and the view's INSTEAD OF trigger
-  uses DELETE+INSERT which does not provide true row-level update atomicity
-- Reduces queue-local heap churn, but does not protect the primary from
-  unrelated long-lived snapshots pinning MVCC cleanup on `awa.jobs_hot`
+- Introduces some risk that compatibility-view queries hide physical-table costs if benchmarks or runtime code accidentally use the view on the hot path
+- Requires explicit care in tests and admin paths to query the right physical table when measuring behavior
+- Lock-taking queries (`SELECT ... FOR UPDATE`, rescue operations) must target the physical tables directly, not the `awa.jobs` view — `FOR UPDATE` is not reliably supported on UNION ALL views, and the view's INSTEAD OF trigger uses DELETE+INSERT which does not provide true row-level update atomicity
+- Reduces queue-local heap churn, but does not protect the primary from unrelated long-lived snapshots pinning MVCC cleanup on `awa.jobs_hot`
 
 ## Notes
 
-This decision deliberately favors explicit physical tables over native Postgres
-partitioning. State transitions would cause frequent row movement under
-state-based partitioning, while range partitioning would still leave hot and
-cold workloads intertwined. The manual split gives clearer operational control
-and simpler hot-path query tuning.
+This decision deliberately favors explicit physical tables over native Postgres partitioning. State transitions would cause frequent row movement under state-based partitioning, while range partitioning would still leave hot and cold workloads intertwined. The manual split gives clearer operational control and simpler hot-path query tuning.
 
 ## Relationship to ADR-019
 
-This ADR remains the historical explanation for the canonical hot/deferred
-split. ADR-019 replaces it as the primary storage direction for the queue
-storage engine: mutable state rows become append-only queue segments,
-`active_leases` hold the narrow dispatch/rescue fields, `attempt_state` holds
-optional per-attempt mutable data, and `lane_state` + segment cursors make
-up the control plane. The uniqueness decision in this ADR (claims in
-`awa.job_unique_claims`) carries through unchanged. See
-[ADR-019](019-queue-storage-redesign.md).
+This ADR remains the historical explanation for the canonical hot/deferred split. ADR-019 replaces it as the primary storage direction for the queue storage engine: mutable state rows become append-only queue segments, `active_leases` hold the narrow dispatch/rescue fields, `attempt_state` holds optional per-attempt mutable data, and `lane_state` + segment cursors make up the control plane. The uniqueness decision in this ADR (claims in `awa.job_unique_claims`) carries through unchanged. See [ADR-019](019-queue-storage-redesign.md).

--- a/docs/adr/013-run-lease-and-guarded-finalization.md
+++ b/docs/adr/013-run-lease-and-guarded-finalization.md
@@ -2,47 +2,33 @@
 
 ## Status
 
-Accepted. Queue storage keeps the same `run_lease` invariant, but the physical
-attempt identity is carried by queue-storage claim / lease state rather than by
-mutating a single canonical jobs heap row.
+Accepted. Queue storage keeps the same `run_lease` invariant, but the physical attempt identity is carried by queue-storage claim / lease state rather than by mutating a single canonical jobs heap row.
 
 ## Context
 
-The earlier completion contract allowed a stale worker to finalize the wrong
-running attempt if a job had been rescued, reclaimed, and started again before
-the old completion reached Postgres.
+The earlier completion contract allowed a stale worker to finalize the wrong running attempt if a job had been rescued, reclaimed, and started again before the old completion reached Postgres.
 
-That made completion correctness too weak for further optimization work,
-especially batching. A batched finalizer is only safe if the database can
-distinguish "the current running attempt" from "an old completion arriving
-late".
+That made completion correctness too weak for further optimization work, especially batching. A batched finalizer is only safe if the database can distinguish "the current running attempt" from "an old completion arriving late".
 
-The TLA+ models already treated running attempts as lease-bearing identities,
-but the Rust runtime still needed a durable database-level token to match that
-model.
+The TLA+ models already treated running attempts as lease-bearing identities, but the Rust runtime still needed a durable database-level token to match that model.
 
 ## Decision
 
-Add a monotonic `run_lease` to the running attempt identity and require all
-heartbeat/finalization/callback state transitions to match on:
+Add a monotonic `run_lease` to the running attempt identity and require all heartbeat/finalization/callback state transitions to match on:
 
 - `id`
 - `state = 'running'`
 - `run_lease`
 
-The runtime increments `run_lease` on every claim to `running`. Local in-flight
-state is keyed by `(job_id, run_lease)`.
+The runtime increments `run_lease` on every claim to `running`. Local in-flight state is keyed by `(job_id, run_lease)`.
 
 ### Finalization Rule
 
-Finalization succeeds only if the current storage state still matches the
-claiming attempt's lease. If the guarded transition affects zero rows, the
-result is stale and must be discarded.
+Finalization succeeds only if the current storage state still matches the claiming attempt's lease. If the guarded transition affects zero rows, the result is stale and must be discarded.
 
 ### Batched Completion
 
-`Completed` outcomes may be flushed in batches, but local in-flight tracking and
-capacity are not released until the batch flush acknowledges either:
+`Completed` outcomes may be flushed in batches, but local in-flight tracking and capacity are not released until the batch flush acknowledges either:
 
 - successful guarded transition, or
 - stale rejection (`rows_affected = 0`)
@@ -61,27 +47,13 @@ This keeps shutdown drain, heartbeat, and stale-completion safety aligned.
 ### Negative
 
 - Every claim now mutates an additional column
-- Runtime state is slightly more complex because local tracking is per-attempt
-  rather than per-job
+- Runtime state is slightly more complex because local tracking is per-attempt rather than per-job
 - Any code path that touches running jobs must propagate the lease token
 
 ## Notes
 
-`attempt` is not used as the safety guard because it has ABA holes: snooze and
-admin retry can reset or decrement it. `run_lease` is monotonic and only
-advances on a new running claim, which makes it suitable as the durable attempt
-identity.
+`attempt` is not used as the safety guard because it has ABA holes: snooze and admin retry can reset or decrement it. `run_lease` is monotonic and only advances on a new running claim, which makes it suitable as the durable attempt identity.
 
 ## Relationship to ADR-019
 
-The `run_lease` guard decision carries into queue storage unchanged. Under
-ADR-019, `run_lease` becomes the second component of the composite key
-`(job_id, run_lease)` identifying `{schema}.active_leases` and
-`{schema}.attempt_state` rows. Every heartbeat, flush-progress,
-register-callback, complete, and rescue path still matches on both columns;
-stale completions are rejected because the UPDATE matches zero rows when
-the lease row has been deleted or replaced. The `AwaSegmentedStorageRaces`
-TLA+ model checks that stale `run_lease` commits cannot land a lease in a
-retired segment, and `AwaSegmentedStorageTrace` replays concrete test
-sequences to validate the guard end-to-end. See
-[ADR-019](019-queue-storage-redesign.md).
+The `run_lease` guard decision carries into queue storage unchanged. Under ADR-019, `run_lease` becomes the second component of the composite key `(job_id, run_lease)` identifying `{schema}.active_leases` and `{schema}.attempt_state` rows. Every heartbeat, flush-progress, register-callback, complete, and rescue path still matches on both columns; stale completions are rejected because the UPDATE matches zero rows when the lease row has been deleted or replaced. The `AwaSegmentedStorageRaces` TLA+ model checks that stale `run_lease` commits cannot land a lease in a retired segment, and `AwaSegmentedStorageTrace` replays concrete test sequences to validate the guard end-to-end. See [ADR-019](019-queue-storage-redesign.md).

--- a/docs/adr/014-structured-progress.md
+++ b/docs/adr/014-structured-progress.md
@@ -2,121 +2,67 @@
 
 ## Status
 
-Accepted. This ADR records the original canonical-storage implementation.
-Queue-storage deployments keep the user-facing progress API but store mutable
-progress snapshots in `{schema}.attempt_state`; see
-[Relationship to ADR-019](#relationship-to-adr-019).
+Accepted. This ADR records the original canonical-storage implementation. Queue-storage deployments keep the user-facing progress API but store mutable progress snapshots in `{schema}.attempt_state`; see [Relationship to ADR-019](#relationship-to-adr-019).
 
 ## Context
 
-Long-running handlers had no way to report progress or update checkpoint
-metadata during execution. The only mid-execution signal was the binary
-heartbeat (alive/dead). This made it impossible to:
+Long-running handlers had no way to report progress or update checkpoint metadata during execution. The only mid-execution signal was the binary heartbeat (alive/dead). This made it impossible to:
 
 - Show users what percentage of a batch job is complete
 - Checkpoint work so a retried job can resume rather than restart
-- Attach handler-specific metadata (e.g., last processed ID) that survives
-  across attempts
+- Attach handler-specific metadata (e.g., last processed ID) that survives across attempts
 
 ## Decision
 
-Add a nullable `progress JSONB` column to both `jobs_hot` and
-`scheduled_jobs`. The column stores a structured object:
+Add a nullable `progress JSONB` column to both `jobs_hot` and `scheduled_jobs`. The column stores a structured object:
 
 ```json
 {
   "percent": 50,
   "message": "Processing batch 5 of 10",
-  "metadata": {"last_processed_id": 1234}
+  "metadata": { "last_processed_id": 1234 }
 }
 ```
 
 ### Why JSONB instead of separate columns
 
-A single JSONB column avoids namespace collision with the user-owned
-`metadata` column (which is free-form, set at insert time via multiple paths
-including COPY ingestion and cron metadata). It also allows the progress
-schema to evolve without migrations.
+A single JSONB column avoids namespace collision with the user-owned `metadata` column (which is free-form, set at insert time via multiple paths including COPY ingestion and cron metadata). It also allows the progress schema to evolve without migrations.
 
 ### Write path: generation-buffered, three flush modes
 
-Handlers write to an in-memory `ProgressState` buffer shared with the
-heartbeat service via `Arc<std::sync::Mutex<...>>`. The buffer uses a
-generation counter for change tracking:
+Handlers write to an in-memory `ProgressState` buffer shared with the heartbeat service via `Arc<std::sync::Mutex<...>>`. The buffer uses a generation counter for change tracking:
 
-1. **Heartbeat piggyback** — on every heartbeat cycle, jobs with pending
-   progress updates get a combined `SET heartbeat_at = now(), progress =
-   v.progress` query. Jobs without changes get the original heartbeat-only
-   query. At most two queries per cycle regardless of job count.
+1. **Heartbeat piggyback** — on every heartbeat cycle, jobs with pending progress updates get a combined `SET heartbeat_at = now(), progress = v.progress` query. Jobs without changes get the original heartbeat-only query. At most two queries per cycle regardless of job count.
 
-2. **State-transition atomic** — when `complete_job()` runs, the latest
-   progress snapshot is included in the same UPDATE that transitions state.
-   If the UPDATE fails (stale run_lease), the progress is lost with the
-   transition — which is correct.
+2. **State-transition atomic** — when `complete_job()` runs, the latest progress snapshot is included in the same UPDATE that transitions state. If the UPDATE fails (stale run_lease), the progress is lost with the transition — which is correct.
 
-3. **Explicit flush** — `flush_progress()` performs a direct `UPDATE
-   jobs_hot SET progress = $2 WHERE id = $1 AND run_lease = $3`. This is
-   the reliable path for critical checkpoints and does not return until the
-   write is confirmed or the job is no longer running.
+3. **Explicit flush** — `flush_progress()` performs a direct `UPDATE jobs_hot SET progress = $2 WHERE id = $1 AND run_lease = $3`. This is the reliable path for critical checkpoints and does not return until the write is confirmed or the job is no longer running.
 
 ### Why std::sync::Mutex, not tokio::Mutex
 
-The critical section is pure in-memory work: JSON cloning, integer
-increment, Option swap. No `.await` points are ever held under the lock.
-`std::sync::Mutex` is cheaper and simpler for this pattern.
+The critical section is pure in-memory work: JSON cloning, integer increment, Option swap. No `.await` points are ever held under the lock. `std::sync::Mutex` is cheaper and simpler for this pattern.
 
 ### Lifecycle semantics
 
-Completed jobs clear progress to NULL (ephemeral — the job succeeded and
-progress is no longer relevant). All other transitions preserve progress:
-retries and snoozes preserve it for checkpoint resumption, failures and
-cancellations preserve it for operator inspection. Rescue operations
-(stale heartbeat, expired deadline, callback timeout) preserve progress
-because the rescue queries in `maintenance.rs` target `awa.jobs_hot`
-directly and don't include `progress` in the SET clause — PostgreSQL
-leaves unmentioned columns unchanged.
+Completed jobs clear progress to NULL (ephemeral — the job succeeded and progress is no longer relevant). All other transitions preserve progress: retries and snoozes preserve it for checkpoint resumption, failures and cancellations preserve it for operator inspection. Rescue operations (stale heartbeat, expired deadline, callback timeout) preserve progress because the rescue queries in `maintenance.rs` target `awa.jobs_hot` directly and don't include `progress` in the SET clause — PostgreSQL leaves unmentioned columns unchanged.
 
 ### Shallow merge for metadata
 
-`update_metadata` performs a shallow merge on the `metadata` sub-object:
-top-level keys overwrite, nested objects are replaced (not deep-merged).
-This is an in-memory operation — no `JSONB ||` at the database level. The
-entire progress JSON is written as a unit on flush.
+`update_metadata` performs a shallow merge on the `metadata` sub-object: top-level keys overwrite, nested objects are replaced (not deep-merged). This is an in-memory operation — no `JSONB ||` at the database level. The entire progress JSON is written as a unit on flush.
 
 ## Consequences
 
-- **Zero overhead for jobs that don't use progress.** The heartbeat
-  partitions jobs into two tiers; jobs without pending progress use the
-  original query unchanged.
-- **No additional round-trips.** Progress writes piggyback on existing
-  heartbeats rather than requiring separate queries.
-- **Checkpoint resumption is opt-in.** Handlers read
-  `ctx.job.progress.metadata` to pick up where they left off. Nothing
-  forces handlers to use progress.
-- **Unbounded metadata growth risk.** There is no enforced size limit on
-  the progress JSONB. A pathological handler could accumulate large values
-  via repeated `update_metadata` calls. A size guard should be added if
-  this becomes a production concern.
+- **Zero overhead for jobs that don't use progress.** The heartbeat partitions jobs into two tiers; jobs without pending progress use the original query unchanged.
+- **No additional round-trips.** Progress writes piggyback on existing heartbeats rather than requiring separate queries.
+- **Checkpoint resumption is opt-in.** Handlers read `ctx.job.progress.metadata` to pick up where they left off. Nothing forces handlers to use progress.
+- **Unbounded metadata growth risk.** There is no enforced size limit on the progress JSONB. A pathological handler could accumulate large values via repeated `update_metadata` calls. A size guard should be added if this becomes a production concern.
 
 ## Alternatives Considered
 
-- **Separate `progress_percent` / `progress_message` columns.** Simpler
-  schema but inflexible — no room for handler-specific checkpoint data
-  without another column.
-- **External progress store (Redis).** Violates the Postgres-only
-  principle (ADR-001).
-- **Write progress on every `set_progress` call.** Too many round-trips
-  for high-frequency updates. The buffered approach coalesces writes
-  naturally.
+- **Separate `progress_percent` / `progress_message` columns.** Simpler schema but inflexible — no room for handler-specific checkpoint data without another column.
+- **External progress store (Redis).** Violates the Postgres-only principle (ADR-001).
+- **Write progress on every `set_progress` call.** Too many round-trips for high-frequency updates. The buffered approach coalesces writes naturally.
 
 ## Relationship to ADR-019
 
-ADR-019 moved progress storage off the `jobs_hot` / `scheduled_jobs`
-`progress` columns described here and onto `{schema}.attempt_state`
-(keyed by `(job_id, run_lease)`) plus the deferred / terminal payload
-for persisted snapshots. The user-facing progress model — `set_progress`,
-`update_metadata`, `flush_progress`, generation-based buffering, lifecycle
-semantics — is unchanged. Short jobs now complete without ever allocating
-an `attempt_state` row, so the buffered approach matters even more: only
-long-running or callback-heavy jobs pay the upsert cost. See
-[ADR-019](019-queue-storage-redesign.md).
+ADR-019 moved progress storage off the `jobs_hot` / `scheduled_jobs` `progress` columns described here and onto `{schema}.attempt_state` (keyed by `(job_id, run_lease)`) plus the deferred / terminal payload for persisted snapshots. The user-facing progress model — `set_progress`, `update_metadata`, `flush_progress`, generation-based buffering, lifecycle semantics — is unchanged. Short jobs now complete without ever allocating an `attempt_state` row, so the buffered approach matters even more: only long-running or callback-heavy jobs pay the upsert cost. See [ADR-019](019-queue-storage-redesign.md).

--- a/docs/adr/015-post-commit-lifecycle-hooks.md
+++ b/docs/adr/015-post-commit-lifecycle-hooks.md
@@ -6,25 +6,20 @@ Accepted
 
 ## Context
 
-An earlier attempt added `Worker::on_exhausted()` as a trait method, then
-backed it out after review because it was the wrong abstraction:
+An earlier attempt added `Worker::on_exhausted()` as a trait method, then backed it out after review because it was the wrong abstraction:
 
 - It was inaccessible from the typed `register::<T, F>()` path
 - It coupled job execution with follow-up side effects
 - It encouraged growing the `Worker` trait for every new lifecycle need
 
-Awa still needed a way for applications to react to job execution starts and
-committed job outcomes:
+Awa still needed a way for applications to react to job execution starts and committed job outcomes:
 
 - Job-type-specific cleanup on permanent failure
 - Cross-cutting metrics or alerting for a specific kind
 - A hook model that works for both typed and raw worker registration
-- Outcome semantics that do not fire for stale completions or uncommitted
-  outcomes
+- Outcome semantics that do not fire for stale completions or uncommitted outcomes
 
-The solution also had to fit Awa's existing execution model. Finalization is
-guarded by `run_lease` (ADR-013), and queue capacity must not be held open by
-slow side-effect handlers.
+The solution also had to fit Awa's existing execution model. Finalization is guarded by `run_lease` (ADR-013), and queue capacity must not be held open by slow side-effect handlers.
 
 ## Decision
 
@@ -42,59 +37,37 @@ Supported events are:
 - `Exhausted`
 - `Cancelled`
 
-> Later extended with `WaitingForCallback` and callback-resolution events —
-> see [Amendment: callback lifecycle events](#amendment-callback-lifecycle-events).
+> Later extended with `WaitingForCallback` and callback-resolution events — see [Amendment: callback lifecycle events](#amendment-callback-lifecycle-events).
 
 No lifecycle outcome event is emitted for:
 
-- `Snooze`, because it is an internal reschedule rather than a meaningful
-  outcome for observers
-- `WaitForCallback`, because the job has only parked; the meaningful outcome
-  happens later when the callback completes, retries, fails, or is cancelled
-  (superseded by the amendment, which emits `WaitingForCallback` at park and a
-  terminal event at resolution)
+- `Snooze`, because it is an internal reschedule rather than a meaningful outcome for observers
+- `WaitForCallback`, because the job has only parked; the meaningful outcome happens later when the callback completes, retries, fails, or is cancelled (superseded by the amendment, which emits `WaitingForCallback` at park and a terminal event at resolution)
 
 ### Emission Semantics
 
-`Started` dispatch is scheduled after the claim transaction commits and before
-the worker handler is invoked. The event carries the claimed `JobRow`, so
-`job.state` reflects `running`.
+`Started` dispatch is scheduled after the claim transaction commits and before the worker handler is invoked. The event carries the claimed `JobRow`, so `job.state` reflects `running`.
 
-Outcome hooks run only after the corresponding database state transition
-commits successfully. The event carries the updated `JobRow`, so `job.state`
-reflects the post-transition state.
+Outcome hooks run only after the corresponding database state transition commits successfully. The event carries the updated `JobRow`, so `job.state` reflects the post-transition state.
 
-If guarded finalization rejects the outcome as stale, no lifecycle outcome
-event is emitted. A `Started` event may already have been emitted for the
-claimed attempt.
+If guarded finalization rejects the outcome as stale, no lifecycle outcome event is emitted. A `Started` event may already have been emitted for the claimed attempt.
 
 ### Execution Semantics
 
 Hooks are best-effort, in-process notifications:
 
-- `Started` hooks run in detached tasks while the attempt is in flight; outcome
-  hooks run in detached tasks after the in-flight permit is released
+- `Started` hooks run in detached tasks while the attempt is in flight; outcome hooks run in detached tasks after the in-flight permit is released
 - Hooks do not block executor progress or queue capacity
 - `shutdown()` does not wait for them
-- Handlers for a kind run sequentially; panics are logged and later handlers
-  still run
-- `Started` dispatch is detached so a slow hook does not delay handler
-  execution; very fast jobs may therefore complete before a started hook
-  finishes, and observers should not rely on strict started-before-outcome
-  delivery ordering for short jobs
-- If a hook side effect must be durable or retried, that logic should enqueue
-  another job instead
+- Handlers for a kind run sequentially; panics are logged and later handlers still run
+- `Started` dispatch is detached so a slow hook does not delay handler execution; very fast jobs may therefore complete before a started hook finishes, and observers should not rely on strict started-before-outcome delivery ordering for short jobs
+- If a hook side effect must be durable or retried, that logic should enqueue another job instead
 
 ### API Shape
 
-The final API is builder-wide rather than returning a per-registration
-sub-builder. Handlers are still logically scoped by job kind, but the builder
-API keeps registration order flexible and avoids introducing a temporary
-registration type solely to attach hooks.
+The final API is builder-wide rather than returning a per-registration sub-builder. Handlers are still logically scoped by job kind, but the builder API keeps registration order flexible and avoids introducing a temporary registration type solely to attach hooks.
 
-Typed handlers deserialize args from the committed job snapshot immediately
-before dispatch. This keeps hook dispatch aligned with the post-commit storage
-snapshot instead of depending on executor-local typed state.
+Typed handlers deserialize args from the committed job snapshot immediately before dispatch. This keeps hook dispatch aligned with the post-commit storage snapshot instead of depending on executor-local typed state.
 
 ## Consequences
 
@@ -112,63 +85,37 @@ snapshot instead of depending on executor-local typed state.
 - Hooks are not durable; they can be lost on process crash or shutdown
 - Typed hooks pay a second arg deserialization step during dispatch
 - There is no single global hook surface for all job kinds
-- `Snooze` and `WaitForCallback` do not produce immediate notifications, which
-  may surprise users expecting every `JobResult` variant to map to an event
+- `Snooze` and `WaitForCallback` do not produce immediate notifications, which may surprise users expecting every `JobResult` variant to map to an event
 
 ## Alternatives Considered
 
 ### Trait methods on `Worker`
 
-Rejected. The earlier `on_exhausted()` direction expands the `Worker` trait
-surface, does not help the typed registration path, and mixes execution with
-side-effect policy.
+Rejected. The earlier `on_exhausted()` direction expands the `Worker` trait surface, does not help the typed registration path, and mixes execution with side-effect policy.
 
 ### Typed per-registration sub-builder
 
-Considered, but not adopted. A separate registration builder adds API
-complexity without changing the underlying storage model, which is keyed by job
-kind on `ClientBuilder`.
+Considered, but not adopted. A separate registration builder adds API complexity without changing the underlying storage model, which is keyed by job kind on `ClientBuilder`.
 
 ### Global untyped hooks only
 
-Rejected as the primary interface. Global untyped hooks are suitable for
-metrics or alerting, but most cleanup logic is job-type-specific and benefits
-from typed args.
+Rejected as the primary interface. Global untyped hooks are suitable for metrics or alerting, but most cleanup logic is job-type-specific and benefits from typed args.
 
 ### Middleware / layer system
 
-Rejected as unnecessary abstraction for Awa's current scope. Lifecycle hooks
-cover the concrete post-commit use case without turning the worker runtime into
-an extensible middleware stack.
+Rejected as unnecessary abstraction for Awa's current scope. Lifecycle hooks cover the concrete post-commit use case without turning the worker runtime into an extensible middleware stack.
 
 ## Relationship to ADR-019
 
-Hooks fire after the job's final state has been committed and its in-flight
-permit released, regardless of whether that commit targeted the canonical
-`awa.jobs_hot` row or a queue-storage `active_leases` deletion plus terminal
-append. The guarded-finalization contract that gates hook emission lives on
-`(job_id, run_lease)` and is unchanged under queue storage. See
-[ADR-019](019-queue-storage-redesign.md).
+Hooks fire after the job's final state has been committed and its in-flight permit released, regardless of whether that commit targeted the canonical `awa.jobs_hot` row or a queue-storage `active_leases` deletion plus terminal append. The guarded-finalization contract that gates hook emission lives on `(job_id, run_lease)` and is unchanged under queue storage. See [ADR-019](019-queue-storage-redesign.md).
 
 ## Amendment: callback lifecycle events
 
-The original decision left `WaitForCallback` without any event, on the reasoning
-that "the meaningful outcome happens later when the callback completes, retries,
-fails, or is cancelled." In practice nothing was emitted at that later point
-either: callback resolution runs in `awa_model::admin` (the storage layer, which
-has no handler registry and is often invoked from a different process than the
-worker), so a job that parked on a callback could fire `Started` and then go
-silent through to its terminal state — invisible to lifecycle hooks. This
-amendment closes that gap.
+The original decision left `WaitForCallback` without any event, on the reasoning that "the meaningful outcome happens later when the callback completes, retries, fails, or is cancelled." In practice nothing was emitted at that later point either: callback resolution runs in `awa_model::admin` (the storage layer, which has no handler registry and is often invoked from a different process than the worker), so a job that parked on a callback could fire `Started` and then go silent through to its terminal state — invisible to lifecycle hooks. This amendment closes that gap.
 
 ### `WaitingForCallback`
 
-A new event, emitted by the executor when a handler returns
-`JobResult::WaitForCallback` and the `waiting_external` transition commits. It
-carries the parked `JobRow` (so `job.state` is `waiting_external`, and
-`job.callback_id` / `job.callback_timeout_at` identify the pending callback).
-This makes the park observable and, paired with the resolution event below,
-lets callers measure external-wait latency. The supported event set becomes:
+A new event, emitted by the executor when a handler returns `JobResult::WaitForCallback` and the `waiting_external` transition commits. It carries the parked `JobRow` (so `job.state` is `waiting_external`, and `job.callback_id` / `job.callback_timeout_at` identify the pending callback). This makes the park observable and, paired with the resolution event below, lets callers measure external-wait latency. The supported event set becomes:
 
 - `Started`
 - `WaitingForCallback`
@@ -181,48 +128,26 @@ lets callers measure external-wait latency. The supported event set becomes:
 
 ### Resolution events
 
-Callback resolution maps onto the existing terminal events rather than
-introducing callback-specific variants — an outcome is an outcome, and
-`WaitingForCallback` already marks that the job took the callback path:
+Callback resolution maps onto the existing terminal events rather than introducing callback-specific variants — an outcome is an outcome, and `WaitingForCallback` already marks that the job took the callback path:
 
 | Resolution | Event |
-|---|---|
+| --- | --- |
 | callback completes the job | `Completed` |
 | callback fails the job (terminal) | `Exhausted` |
 | callback requeues the job for retry | `Retried` |
 | callback is cancelled | `Cancelled` |
 | callback resumes the job to `running` | none — the job re-enters execution and the executor emits `Started` plus a terminal event as usual |
 
-For a callback-driven `Completed`, the `duration` field is `Duration::ZERO`:
-no handler executed during this phase, and conflating it with the parked-wait
-time would overload the field's "handler execution time" meaning. If wait
-latency is needed later, it should be a dedicated field sourced from a recorded
-park timestamp, not this one.
+For a callback-driven `Completed`, the `duration` field is `Duration::ZERO`: no handler executed during this phase, and conflating it with the parked-wait time would overload the field's "handler execution time" meaning. If wait latency is needed later, it should be a dedicated field sourced from a recorded park timestamp, not this one.
 
 ### Where resolution events are dispatched
 
-Resolution events are dispatched **in-process, at the resolving call site**, by
-worker-`Client` methods (`Client::resolve_callback`, `complete_external`,
-`fail_external`, `retry_external`). Each calls the corresponding
-`awa_model::admin` function and then, after the transition commits, dispatches
-the mapped event through the same guarded path as inline outcome hooks.
+Resolution events are dispatched **in-process, at the resolving call site**, by worker-`Client` methods (`Client::resolve_callback`, `complete_external`, `fail_external`, `retry_external`). Each calls the corresponding `awa_model::admin` function and then, after the transition commits, dispatches the mapped event through the same guarded path as inline outcome hooks.
 
-This keeps the storage layer free of the handler registry and preserves
-at-most-once dispatch: exactly one process performs a given resolution, so
-exactly one dispatch occurs — mirroring how an inline outcome fires once from
-the single worker that claimed the job. A broadcast/NOTIFY fan-out (as used for
-`awa:cancel`) was rejected here precisely because it would re-fire the hook in
-every process that holds handlers, breaking at-most-once for metrics.
+This keeps the storage layer free of the handler registry and preserves at-most-once dispatch: exactly one process performs a given resolution, so exactly one dispatch occurs — mirroring how an inline outcome fires once from the single worker that claimed the job. A broadcast/NOTIFY fan-out (as used for `awa:cancel`) was rejected here precisely because it would re-fire the hook in every process that holds handlers, breaking at-most-once for metrics.
 
-The boundary is therefore: resolving a callback through the worker `Client`
-fires hooks; resolving it through the bare `awa_model::admin::*` functions, the
-CLI, or a process without the worker `Client` does not. This matches the
-existing contract that lifecycle hooks are a worker-side, best-effort,
-in-process facility.
+The boundary is therefore: resolving a callback through the worker `Client` fires hooks; resolving it through the bare `awa_model::admin::*` functions, the CLI, or a process without the worker `Client` does not. This matches the existing contract that lifecycle hooks are a worker-side, best-effort, in-process facility.
 
 ### Superseded consequences
 
-The original Negative bullet — "`Snooze` and `WaitForCallback` do not produce
-immediate notifications" — now applies only to `Snooze`. `WaitForCallback`
-produces a `WaitingForCallback` event at park and a terminal event at
-resolution (when resolved via the worker `Client`).
+The original Negative bullet — "`Snooze` and `WaitForCallback` do not produce immediate notifications" — now applies only to `Snooze`. `WaitForCallback` produces a `WaitingForCallback` event at park and a terminal event at resolution (when resolved via the worker `Client`).

--- a/docs/adr/016-rust-postgres-enqueue-adapter-api.md
+++ b/docs/adr/016-rust-postgres-enqueue-adapter-api.md
@@ -32,10 +32,7 @@ Expose the stable public preparation surface under `awa::adapter::postgres` and 
 
 External Rust crates can execute `INSERT_JOB_SQL` through their own connection or transaction type while binding values from `PreparedJobInsert`. Awa remains responsible for insert semantics; the adapter remains responsible for driver-specific execution and row decoding.
 
-The native sqlx path is not required to use this driver-friendly SQL. It may
-keep a typed `PgExecutor` query that binds `JobState` directly and returns
-`SELECT *`, while external adapters use `INSERT_JOB_SQL` with text casts and
-`state_str` for portable enum decoding.
+The native sqlx path is not required to use this driver-friendly SQL. It may keep a typed `PgExecutor` query that binds `JobState` directly and returns `SELECT *`, while external adapters use `INSERT_JOB_SQL` with text casts and `state_str` for portable enum decoding.
 
 ### tokio-postgres adapter
 
@@ -51,10 +48,7 @@ The tokio-postgres bridge uses the public adapter API internally, so it acts as 
 
 ### Scope boundaries
 
-- **Insert-only adapter contract.** Worker polling, heartbeating, claiming,
-  and completion remain Awa runtime responsibilities. Applications may still
-  use SeaORM, Diesel, or another stack inside handlers by passing those
-  dependencies through worker state.
+- **Insert-only adapter contract.** Worker polling, heartbeating, claiming, and completion remain Awa runtime responsibilities. Applications may still use SeaORM, Diesel, or another stack inside handlers by passing those dependencies through worker state.
 - **No connection sharing.** Each driver owns its own connection lifecycle.
 - **No batch/COPY bridging.** The COPY path requires `PgConnection::copy_in_raw()` and is sqlx-specific. Bridge adapters support single-row parameterized INSERT only.
 - **Native bulk paths remain native.** `insert_many_copy_from_pool` and `QueueStorage::enqueue_params_copy` stay on the SQLx/Awa runtime side. External adapters can add their own driver-specific bulk support later, but the public adapter contract does not promise a portable COPY abstraction.

--- a/docs/adr/017-python-transaction-bridging.md
+++ b/docs/adr/017-python-transaction-bridging.md
@@ -67,8 +67,4 @@ Expose a public Python bridge module, `awa.bridge`, with insert-only helpers tha
 
 ## Relationship to ADR-016
 
-ADR-016 applies the same insert-only bridge principle to Rust driver
-integrations. Rust adapters use the public `awa::adapter::postgres`
-preparation and SQL contract; Python bridges keep their Python-facing API but
-must preserve the same validation, state selection, uniqueness, and
-transaction-participation semantics.
+ADR-016 applies the same insert-only bridge principle to Rust driver integrations. Rust adapters use the public `awa::adapter::postgres` preparation and SQL contract; Python bridges keep their Python-facing API but must preserve the same validation, state selection, uniqueness, and transaction-participation semantics.

--- a/docs/adr/018-http-worker.md
+++ b/docs/adr/018-http-worker.md
@@ -73,17 +73,9 @@ This suits short-lived functions (< 30s) where the HTTP round-trip is acceptable
 
 ### Callback authentication
 
-The callback endpoint must verify that incoming requests are legitimate. The
-worker signs the callback ID using BLAKE3 keyed hashing (already a workspace
-dependency via ADR-002) and includes the signature in the POST to the function
-as `X-Awa-Signature`. The function normally forwards that same header when it
-calls back; the callback endpoint verifies it before accepting `complete`,
-`fail`, or `heartbeat`.
+The callback endpoint must verify that incoming requests are legitimate. The worker signs the callback ID using BLAKE3 keyed hashing (already a workspace dependency via ADR-002) and includes the signature in the POST to the function as `X-Awa-Signature`. The function normally forwards that same header when it calls back; the callback endpoint verifies it before accepting `complete`, `fail`, or `heartbeat`.
 
-This is simpler and more performant than JWT or OAuth for this use case: the
-signature is tied to a specific callback ID, is cheap to compute, and doesn't
-require key rotation infrastructure. The concrete endpoint and signature
-contract lives in [HTTP workers and callback signatures](../http-callbacks.md).
+This is simpler and more performant than JWT or OAuth for this use case: the signature is tied to a specific callback ID, is cheap to compute, and doesn't require key rotation infrastructure. The concrete endpoint and signature contract lives in [HTTP workers and callback signatures](../http-callbacks.md).
 
 ### Feature gating
 
@@ -152,7 +144,7 @@ These are thin wrappers around the existing admin API. Users who don't run `awa-
 ## Prior Art
 
 | System | Pattern | How Awa compares |
-|--------|---------|-----------------|
+| --- | --- | --- |
 | Step Functions + Lambda | State machine invokes Lambda via task token | `HttpWorker` async mode + callback |
 | Temporal activity workers | Activity task dispatched to remote worker | Similar, but Awa is simpler (no workflow engine) |
 | Celery + HTTP backend | Custom HTTP transport | Awa's callback auth and timeout rescue are built-in |

--- a/docs/adr/019-queue-storage-redesign.md
+++ b/docs/adr/019-queue-storage-redesign.md
@@ -2,68 +2,35 @@
 
 ## Status
 
-Accepted. The receipt-plane portion of this design (`open_receipt_claims`
-as a bounded live-frontier table) is **superseded by
-[ADR-023: Receipt Plane Ring Partitioning](023-receipt-plane-ring-partitioning.md)**,
-which replaces the flat `open_receipt_claims` table with partitioned
-`lease_claims` / `lease_claim_closures` reclaimed by ring rotation +
-`TRUNCATE`. The rest of ADR-019 (queue plane, lease ring, ready/done
-partitioning) is unchanged. References to `open_receipt_claims` below
-are kept verbatim as historical context — read them as "the live
-frontier", which is now derived from the anti-join.
+Accepted. The receipt-plane portion of this design (`open_receipt_claims` as a bounded live-frontier table) is **superseded by [ADR-023: Receipt Plane Ring Partitioning](023-receipt-plane-ring-partitioning.md)**, which replaces the flat `open_receipt_claims` table with partitioned `lease_claims` / `lease_claim_closures` reclaimed by ring rotation + `TRUNCATE`. The rest of ADR-019 (queue plane, lease ring, ready/done partitioning) is unchanged. References to `open_receipt_claims` below are kept verbatim as historical context — read them as "the live frontier", which is now derived from the anti-join.
 
 ## Context
 
-The canonical Awa storage model keeps the queue row and the lifecycle state
-machine in the same mutable heap row. Claim, heartbeat, callback wait, retry,
-completion, and cleanup all update or delete that row. Under overlapping
-readers, that shape produces avoidable MVCC churn and dead tuples on the hot
-path.
+The canonical Awa storage model keeps the queue row and the lifecycle state machine in the same mutable heap row. Claim, heartbeat, callback wait, retry, completion, and cleanup all update or delete that row. Under overlapping readers, that shape produces avoidable MVCC churn and dead tuples on the hot path.
 
-ADR-012 reduced the problem by splitting hot and deferred storage, but it did
-not remove the core issue: the dispatch path still mutates the same execution
-rows repeatedly. Benchmarking showed that this leaves a persistent gap to
-append-only queue designs on dead tuples, and eventually on throughput under
-overlap.
+ADR-012 reduced the problem by splitting hot and deferred storage, but it did not remove the core issue: the dispatch path still mutates the same execution rows repeatedly. Benchmarking showed that this leaves a persistent gap to append-only queue designs on dead tuples, and eventually on throughput under overlap.
 
 ## Design goals and non-goals
 
 This ADR is guided by the following `0.6` priorities:
 
-- Preserve Postgres-native **transactional enqueue**. A job created alongside
-  application data must commit or roll back with that data, with no outbox
-  gap.
-- Prefer **no lost work under failure** over benchmark wins. Crashes,
-  restarts, network partitions, and worker death must not silently drop
-  runnable jobs.
-- State the delivery contract honestly: **at-least-once**, not marketing
-  “exactly once”. Retries must be safe, idempotency should be encouraged, and
-  stale writers must be rejected by `(job_id, run_lease)`.
-- Keep the **claim path fast under contention** with short transactions,
-  queue-local cursors, and `SKIP LOCKED`-style claiming rather than global
-  head-of-line blocking.
-- Keep **lease / heartbeat recovery**, **retry discipline**, and
-  **observability** as first-class runtime concerns rather than operational
-  afterthoughts.
-- Remain **vacuum-friendly** by keeping historical state out of the hot claim
-  path and avoiding row-rewrite-heavy designs.
+- Preserve Postgres-native **transactional enqueue**. A job created alongside application data must commit or roll back with that data, with no outbox gap.
+- Prefer **no lost work under failure** over benchmark wins. Crashes, restarts, network partitions, and worker death must not silently drop runnable jobs.
+- State the delivery contract honestly: **at-least-once**, not marketing “exactly once”. Retries must be safe, idempotency should be encouraged, and stale writers must be rejected by `(job_id, run_lease)`.
+- Keep the **claim path fast under contention** with short transactions, queue-local cursors, and `SKIP LOCKED`-style claiming rather than global head-of-line blocking.
+- Keep **lease / heartbeat recovery**, **retry discipline**, and **observability** as first-class runtime concerns rather than operational afterthoughts.
+- Remain **vacuum-friendly** by keeping historical state out of the hot claim path and avoiding row-rewrite-heavy designs.
 
 Non-goals and filters:
 
 - Do not claim “exactly once”.
-- Do not turn Awa into a replayable event log or Kafka replacement; the
-  design remains a job queue with one active attempt owner at a time.
-- Do not introduce optimizations that weaken “no lost work under failure”, even
-  if they benchmark well.
-- Do not solve contention by moving back to a single hot mutable jobs table or
-  by holding long-lived transactions around claim/execute/ack.
+- Do not turn Awa into a replayable event log or Kafka replacement; the design remains a job queue with one active attempt owner at a time.
+- Do not introduce optimizations that weaken “no lost work under failure”, even if they benchmark well.
+- Do not solve contention by moving back to a single hot mutable jobs table or by holding long-lived transactions around claim/execute/ack.
 
 ## Decision
 
-Adopt a single queue storage engine built around append-only queue records, a
-small ready-tombstone ledger for rare out-of-band ready mutations, a narrow
-fast-rotating execution lease table, and an optional per-attempt `attempt_state`
-row for mutable runtime data that cannot stay in the immutable queue record.
+Adopt a single queue storage engine built around append-only queue records, a small ready-tombstone ledger for rare out-of-band ready mutations, a narrow fast-rotating execution lease table, and an optional per-attempt `attempt_state` row for mutable runtime data that cannot stay in the immutable queue record.
 
 ### Terminology
 
@@ -71,8 +38,7 @@ This ADR uses the following storage vocabulary:
 
 - Queue plane: `ready_entries`, `ready_tombstones`, `terminal_entries`
 - Execution plane: `active_leases`, `attempt_state`
-- Control plane: `lane_state`, `ready_segments`, `ready_segment_cursor`,
-  `lease_segments`, `lease_segment_cursor`
+- Control plane: `lane_state`, `ready_segments`, `ready_segment_cursor`, `lease_segments`, `lease_segment_cursor`
 
 The implementation and migrations use these physical names:
 
@@ -88,46 +54,29 @@ The implementation and migrations use these physical names:
 
 - Immediate jobs are appended to rotating ready partitions.
 - Ready rows are immutable once written.
-- Claim order is driven by queue-local lane metadata rather than scanning a
-  large mutable heap.
+- Claim order is driven by queue-local lane metadata rather than scanning a large mutable heap.
 
 2. `ready_tombstones`
 
-- Unclaimed cancellation, priority aging, and similar ready-lane mutations
-  append a tombstone keyed by ready segment generation and lane identity.
-- Claim and exact-count paths anti-join tombstones and treat a tombstoned head
-  lane as committed spent evidence for safe claim-cursor advancement.
-- Tombstones are reclaimed by truncating the matching ready segment; they do
-  not create row-vacuum work on the hot ready table.
+- Unclaimed cancellation, priority aging, and similar ready-lane mutations append a tombstone keyed by ready segment generation and lane identity.
+- Claim and exact-count paths anti-join tombstones and treat a tombstoned head lane as committed spent evidence for safe claim-cursor advancement.
+- Tombstones are reclaimed by truncating the matching ready segment; they do not create row-vacuum work on the hot ready table.
 
 3. `active_leases`
 
-- The common path still records every claim, but the implementation can now do
-  that in two stages:
-  - append-only `lease_claims` receipts for every claim (the receipt path is
-    now the default, not a zero-deadline-only short cut)
-  - **historical:** a bounded `open_receipt_claims` frontier for currently-live
-    receipt-backed attempts. ADR-023 replaces this with partitioned
-    `lease_claims` / `lease_claim_closures`; "currently open" is derived as an
-    anti-join over the active claim partitions.
-  - lazy materialization into `active_leases` when the attempt needs the
-    mutable execution path
-- Leases keep only dispatch and rescue-critical fields: ready reference,
-  attempt identity, lane ordering, heartbeat/deadline state, and callback
-  token/timeout.
-- Lease partitions rotate much faster than queue partitions and are pruned
-  independently.
+- The common path still records every claim, but the implementation can now do that in two stages:
+  - append-only `lease_claims` receipts for every claim (the receipt path is now the default, not a zero-deadline-only short cut)
+  - **historical:** a bounded `open_receipt_claims` frontier for currently-live receipt-backed attempts. ADR-023 replaces this with partitioned `lease_claims` / `lease_claim_closures`; "currently open" is derived as an anti-join over the active claim partitions.
+  - lazy materialization into `active_leases` when the attempt needs the mutable execution path
+- Leases keep only dispatch and rescue-critical fields: ready reference, attempt identity, lane ordering, heartbeat/deadline state, and callback token/timeout.
+- Lease partitions rotate much faster than queue partitions and are pruned independently.
 
 3. `attempt_state`
 
 - `attempt_state` is optional and keyed by `(job_id, run_lease)`.
-- It exists only for mutable per-attempt data that cannot remain in the
-  immutable queue row: current progress, callback expressions, and a temporary
-  callback result for resumed handlers.
-- Short jobs must be able to claim and complete without touching
-  `attempt_state` at all.
-- Transition paths delete `attempt_state` immediately when an attempt leaves
-  `running` or `waiting_external`.
+- It exists only for mutable per-attempt data that cannot remain in the immutable queue row: current progress, callback expressions, and a temporary callback result for resumed handlers.
+- Short jobs must be able to claim and complete without touching `attempt_state` at all.
+- Transition paths delete `attempt_state` immediately when an attempt leaves `running` or `waiting_external`.
 
 4. `deferred_jobs`
 
@@ -138,127 +87,57 @@ The implementation and migrations use these physical names:
 5. `terminal_entries`
 
 - Completion appends a terminal history row.
-- Done partitions are append-only and are pruned with their ready segment once
-  the segment is sealed and no active lease or pending ready row still
-  references it.
+- Done partitions are append-only and are pruned with their ready segment once the segment is sealed and no active lease or pending ready row still references it.
 
 6. `dlq_entries`
 
 - Dead-letter handling is part of the storage engine, not an add-on.
-- Terminal failures can move directly into the DLQ instead of the main done
-  history.
-- Operators can inspect, retry, and purge DLQ rows through the model/admin
-  surface.
+- Terminal failures can move directly into the DLQ instead of the main done history.
+- Operators can inspect, retry, and purge DLQ rows through the model/admin surface.
 
 7. `lane_state` and segment cursor tables
 
-- Queue-local lane metadata is intentionally split so one row family does not
-  absorb every enqueue and claim mutation.
-- `lane_state` itself is reduced to stable per-lane identity and legacy
-  fallback fields. `queue_enqueue_heads` and `queue_claim_heads` remain as
-  stable lane registries and lock targets; the mutable enqueue and claim
-  cursors live in PostgreSQL sequences referenced by those rows.
-- Availability counts have two grades, both cheap. The dispatcher
-  hot path reads `sum(enqueue_sequence_cursor - claim_sequence_cursor)` from
-  the lane heads — two PK reads plus sequence state reads per lane, no scan
-  over `ready_entries`. Admin / UI calls (`queue_counts`) scan
-  `ready_entries WHERE lane_seq >= claim_sequence_cursor` anti-joined with
-  `ready_tombstones` for an exact result. The dispatcher tolerates transient
-  over-count from committed gaps, uncommitted sequence reservations, and
-  tombstoned unclaimed rows; the cursor is only advanced after committed
-  claims/cancels and only across committed spent/tombstoned prefixes, so it can
-  lag but cannot skip visible ready work. **historical:** earlier iterations cached this as
-  `queue_lanes.available_count` (a third counter mutated on every
-  enqueue / claim / completion); long-horizon profiling under pinned
-  xmin showed the cache was the dominant dead-tuple source, so v016
-  removed it in favour of the head-difference derivation.
-- Completed-history rollups live in a separate cold cache table so prune can
-  preserve queue counts without serializing on the hot `lane_state` rows.
-- Completion must not update `lane_state` on every terminal transition; the
-  hot path only mutates claim/enqueue control state. `running` is derived from
-  active leases/receipts. Terminal counts use `queue_terminal_live_counts`
-  plus the post-prune rollup: the live counter is keyed by ready slot, queue,
-  priority, enqueue shard, and a deterministic `job_id` bucket so
-  completion-heavy queues do not form a single pinned-MVCC HOT chain. The
-  permanent rollup is written in the prune transaction to a separate cold
-  table rather than to `lane_state`, so prune does not serialize on the same
-  hot rows as claim and enqueue.
-- Ready and lease segment cursor tables tell dispatch and maintenance which
-  physical segment is active, claimable, or prunable.
-- Lease prune order is derived from `lease_ring_state(current_slot,
-  generation, slot_count)`. The older `{schema}.lease_ring_slots` table
-  remains as transitional compatibility/inspection state, but it is no longer
-  updated on every rotation and is not the authoritative ordering source.
-- Rotation state for queue and lease segments is owned by the maintenance
-  leader.
-- This split is an explicit response to the remaining MVCC hotspot discovered
-  during long-horizon event benchmarks: a single hot `queue_lanes` row per
-  `(queue, priority)` recreated dead-tuple pressure under pinned-reader
-  workloads even after the rest of the storage engine moved to append-only
-  structures. Separate enqueue/claim heads reduce that mutation frequency and
-  leave `lane_state` cold enough to survive long-running readers.
+- Queue-local lane metadata is intentionally split so one row family does not absorb every enqueue and claim mutation.
+- `lane_state` itself is reduced to stable per-lane identity and legacy fallback fields. `queue_enqueue_heads` and `queue_claim_heads` remain as stable lane registries and lock targets; the mutable enqueue and claim cursors live in PostgreSQL sequences referenced by those rows.
+- Availability counts have two grades, both cheap. The dispatcher hot path reads `sum(enqueue_sequence_cursor - claim_sequence_cursor)` from the lane heads — two PK reads plus sequence state reads per lane, no scan over `ready_entries`. Admin / UI calls (`queue_counts`) scan `ready_entries WHERE lane_seq >= claim_sequence_cursor` anti-joined with `ready_tombstones` for an exact result. The dispatcher tolerates transient over-count from committed gaps, uncommitted sequence reservations, and tombstoned unclaimed rows; the cursor is only advanced after committed claims/cancels and only across committed spent/tombstoned prefixes, so it can lag but cannot skip visible ready work. **historical:** earlier iterations cached this as `queue_lanes.available_count` (a third counter mutated on every enqueue / claim / completion); long-horizon profiling under pinned xmin showed the cache was the dominant dead-tuple source, so v016 removed it in favour of the head-difference derivation.
+- Completed-history rollups live in a separate cold cache table so prune can preserve queue counts without serializing on the hot `lane_state` rows.
+- Completion must not update `lane_state` on every terminal transition; the hot path only mutates claim/enqueue control state. `running` is derived from active leases/receipts. Terminal counts use `queue_terminal_live_counts` plus the post-prune rollup: the live counter is keyed by ready slot, queue, priority, enqueue shard, and a deterministic `job_id` bucket so completion-heavy queues do not form a single pinned-MVCC HOT chain. The permanent rollup is written in the prune transaction to a separate cold table rather than to `lane_state`, so prune does not serialize on the same hot rows as claim and enqueue.
+- Ready and lease segment cursor tables tell dispatch and maintenance which physical segment is active, claimable, or prunable.
+- Lease prune order is derived from `lease_ring_state(current_slot, generation, slot_count)`. The older `{schema}.lease_ring_slots` table remains as transitional compatibility/inspection state, but it is no longer updated on every rotation and is not the authoritative ordering source.
+- Rotation state for queue and lease segments is owned by the maintenance leader.
+- This split is an explicit response to the remaining MVCC hotspot discovered during long-horizon event benchmarks: a single hot `queue_lanes` row per `(queue, priority)` recreated dead-tuple pressure under pinned-reader workloads even after the rest of the storage engine moved to append-only structures. Separate enqueue/claim heads reduce that mutation frequency and leave `lane_state` cold enough to survive long-running readers.
 
 ### Lifecycle mapping
 
 - Enqueue immediate job: append to `ready_entries`.
-- Claim: lock the queue's `queue_claim_heads` row, join the matching
-  `queue_enqueue_heads` row, select the next ready entries anti-joined with
-  `ready_tombstones`, increment `run_lease`, append a receipt into
-  `lease_claims` by default, and advance the claim cursor based on committed
-  spent evidence plus the rows actually selected after commit.
-- Receipt-backed deadlines: per-queue deadlines live on
-  `lease_claims.deadline_at` until the attempt materializes into the lease
-  plane for callbacks, progress, or other mutable state.
-- Receipt rescue before materialization: close the stale receipt append-only
-  and requeue it without first materializing a mutable `leases` row.
-- Runtime reads that need the current live receipt-backed set (`queue_counts`,
-  receipt rescue, and receipt-backed `load_job`) consult only the active
-  claim-ring partitions, not the full append-only claim history. **historical:**
-  ADR-019 used a bounded `open_receipt_claims` table for this; ADR-023 derives
-  the same set as an anti-join over partitioned `lease_claims` /
-  `lease_claim_closures`.
-- First heartbeat or progress flush for a receipt-backed attempt: lazily
-  materialize the claim into `attempt_state` while keeping the claim on the
-  append-only receipt path.
-- Callback registration or other lease-specific mutation for a receipt-backed
-  attempt: lazily materialize the claim into `active_leases`.
-- Heartbeat after lease materialization / callback wait: update the active
-  lease row only.
-- Progress flush / callback expressions / callback result: create or update
-  `attempt_state` only when needed.
-- Retry or snooze: delete the active lease row, merge any `attempt_state`,
-  append to `deferred_jobs`.
-- Complete: delete the active lease row, ignore or merge any `attempt_state`
-  as needed, append to `terminal_entries`.
-- Terminal failure with DLQ enabled: delete the active lease row, merge any
-  `attempt_state`, append to
-  `dlq_entries`.
+- Claim: lock the queue's `queue_claim_heads` row, join the matching `queue_enqueue_heads` row, select the next ready entries anti-joined with `ready_tombstones`, increment `run_lease`, append a receipt into `lease_claims` by default, and advance the claim cursor based on committed spent evidence plus the rows actually selected after commit.
+- Receipt-backed deadlines: per-queue deadlines live on `lease_claims.deadline_at` until the attempt materializes into the lease plane for callbacks, progress, or other mutable state.
+- Receipt rescue before materialization: close the stale receipt append-only and requeue it without first materializing a mutable `leases` row.
+- Runtime reads that need the current live receipt-backed set (`queue_counts`, receipt rescue, and receipt-backed `load_job`) consult only the active claim-ring partitions, not the full append-only claim history. **historical:** ADR-019 used a bounded `open_receipt_claims` table for this; ADR-023 derives the same set as an anti-join over partitioned `lease_claims` / `lease_claim_closures`.
+- First heartbeat or progress flush for a receipt-backed attempt: lazily materialize the claim into `attempt_state` while keeping the claim on the append-only receipt path.
+- Callback registration or other lease-specific mutation for a receipt-backed attempt: lazily materialize the claim into `active_leases`.
+- Heartbeat after lease materialization / callback wait: update the active lease row only.
+- Progress flush / callback expressions / callback result: create or update `attempt_state` only when needed.
+- Retry or snooze: delete the active lease row, merge any `attempt_state`, append to `deferred_jobs`.
+- Complete: delete the active lease row, ignore or merge any `attempt_state` as needed, append to `terminal_entries`.
+- Terminal failure with DLQ enabled: delete the active lease row, merge any `attempt_state`, append to `dlq_entries`.
 
 ### Attempt state invariants
 
 - There is at most one live `attempt_state` row per active attempt.
-- `attempt_state` is guarded by `(job_id, run_lease)` so stale writers from a
-  rescued or retried attempt cannot mutate the next attempt.
-- Dispatch must not join `attempt_state`; claim performance should be
-  insensitive to `attempt_state` size.
-- `attempt_state` must not store history arrays or long-retention terminal
-  state. Error history remains in immutable queue payload.
+- `attempt_state` is guarded by `(job_id, run_lease)` so stale writers from a rescued or retried attempt cannot mutate the next attempt.
+- Dispatch must not join `attempt_state`; claim performance should be insensitive to `attempt_state` size.
+- `attempt_state` must not store history arrays or long-retention terminal state. Error history remains in immutable queue payload.
 - Rescue scans inspect lease and `attempt_state` tables, not queue history.
 
 Healthy operating signals for this design are:
 
-- `attempt_state` row count roughly tracks active long-running attempts, not
-  total queue depth or total completions.
+- `attempt_state` row count roughly tracks active long-running attempts, not total queue depth or total completions.
 - short jobs complete without creating an `attempt_state` row.
-- short zero-deadline jobs can also complete without ever creating a mutable
-  `active_leases` row.
-- the live receipt frontier stays bounded to open receipt-backed attempts
-  rather than growing with total claims and closures.
-- short zero-deadline jobs that never heartbeat can be rescued from
-  `lease_claims` after the grace window without first creating
-  `active_leases`.
-- heartbeat/progress-only long attempts can stay on `lease_claims` plus
-  `attempt_state` without creating `active_leases`.
+- short zero-deadline jobs can also complete without ever creating a mutable `active_leases` row.
+- the live receipt frontier stays bounded to open receipt-backed attempts rather than growing with total claims and closures.
+- short zero-deadline jobs that never heartbeat can be rescued from `lease_claims` after the grace window without first creating `active_leases`.
+- heartbeat/progress-only long attempts can stay on `lease_claims` plus `attempt_state` without creating `active_leases`.
 - prune and cleanup horizons for `attempt_state` are immediate or very short.
 
 ### Maintenance ownership
@@ -269,183 +148,86 @@ The leader-elected maintenance service owns:
 - rescuing stale heartbeats, deadlines, and callback timeouts
 - rotating and pruning queue partitions
 - rotating and pruning lease partitions
-- rotating and pruning claim-ring partitions (added by ADR-023; replaces the
-  ADR-019 `open_receipt_claims` cleanup path)
+- rotating and pruning claim-ring partitions (added by ADR-023; replaces the ADR-019 `open_receipt_claims` cleanup path)
 - queue depth publication
 - DLQ retention cleanup
 
-All prune paths remain best-effort and use short lock timeouts. The explicit
-lock contract is:
+All prune paths remain best-effort and use short lock timeouts. The explicit lock contract is:
 
-- claim takes `FOR UPDATE OF claims SKIP LOCKED` on `queue_claim_heads` while
-  it advances the claim cursor and inserts the claim
-- rotate publishes the next lease slot with a compare-and-swap update on
-  `lease_ring_state`
-- prune-ready takes `FOR UPDATE` on `queue_ring_state`, `FOR UPDATE` on the
-  target `queue_ring_slots` row, and `ACCESS EXCLUSIVE` on the child
-  partitions before it rechecks liveness and truncates
-- prune-leases derives the oldest initialized slot from `lease_ring_state`,
-  locks the child partition `ACCESS EXCLUSIVE`, rechecks that the slot is not
-  current, then truncates if it is empty
-- prune-claim-ring (added by ADR-023) takes `FOR UPDATE` on `claim_ring_state`,
-  `FOR UPDATE` on the target `claim_ring_slots` row, and `ACCESS EXCLUSIVE` on
-  both the matching `lease_claims_*` and `lease_claim_closures_*` partitions,
-  verifies every claim in the slot has a matching closure, then `TRUNCATE`s
-  both partitions in lockstep. Open claims make prune skip the slot until
-  normal completion or the separate receipt-rescue scans close them.
+- claim takes `FOR UPDATE OF claims SKIP LOCKED` on `queue_claim_heads` while it advances the claim cursor and inserts the claim
+- rotate publishes the next lease slot with a compare-and-swap update on `lease_ring_state`
+- prune-ready takes `FOR UPDATE` on `queue_ring_state`, `FOR UPDATE` on the target `queue_ring_slots` row, and `ACCESS EXCLUSIVE` on the child partitions before it rechecks liveness and truncates
+- prune-leases derives the oldest initialized slot from `lease_ring_state`, locks the child partition `ACCESS EXCLUSIVE`, rechecks that the slot is not current, then truncates if it is empty
+- prune-claim-ring (added by ADR-023) takes `FOR UPDATE` on `claim_ring_state`, `FOR UPDATE` on the target `claim_ring_slots` row, and `ACCESS EXCLUSIVE` on both the matching `lease_claims_*` and `lease_claim_closures_*` partitions, verifies every claim in the slot has a matching closure, then `TRUNCATE`s both partitions in lockstep. Open claims make prune skip the slot until normal completion or the separate receipt-rescue scans close them.
 
-That order is deliberate. The TLA+ storage race / lock-order models exist to
-prove that claim, rotate, and prune cannot interleave into “claim lands in a
-pruned segment” behavior.
+That order is deliberate. The TLA+ storage race / lock-order models exist to prove that claim, rotate, and prune cannot interleave into “claim lands in a pruned segment” behavior.
 
 Rotation and prune policy is also part of this decision:
 
-- lease and claim-ring segments rotate quickly because their churn is the
-  remaining hot-path source
-- ready / terminal segments rotate more slowly than the lease and claim rings;
-  deferred and DLQ rows are plain backlog/hold tables with their own promotion,
-  retry, purge, and retention cleanup paths
+- lease and claim-ring segments rotate quickly because their churn is the remaining hot-path source
+- ready / terminal segments rotate more slowly than the lease and claim rings; deferred and DLQ rows are plain backlog/hold tables with their own promotion, retry, purge, and retention cleanup paths
 - prune walks sealed segments oldest-first
-- prune uses `SET LOCAL lock_timeout = '50ms'` and returns gracefully when a
-  reader or writer still holds the segment
-- long-lived readers can still pin a segment horizon, so operators are
-  expected to run analytical reads on replicas and keep primary-side
-  `statement_timeout` discipline
+- prune uses `SET LOCAL lock_timeout = '50ms'` and returns gracefully when a reader or writer still holds the segment
+- long-lived readers can still pin a segment horizon, so operators are expected to run analytical reads on replicas and keep primary-side `statement_timeout` discipline
 
-Ordinary queue-storage terminal history is therefore a rotation-and-prune
-story, not a row-by-row delete story. DLQ retention remains a bounded cleanup
-pass against the separate `dlq_entries` hold table, and the canonical
-compatibility path still has row-retention cleanup.
+Ordinary queue-storage terminal history is therefore a rotation-and-prune story, not a row-by-row delete story. DLQ retention remains a bounded cleanup pass against the separate `dlq_entries` hold table, and the canonical compatibility path still has row-retention cleanup.
 
 ### Hot-path requirements
 
-The decision above pins two hot-path requirements that surface repeatedly
-in implementation:
+The decision above pins two hot-path requirements that surface repeatedly in implementation:
 
-- Claim runs as a single server-side step: one SQL function locks
-  `queue_claim_heads`, selects the oldest runnable segment-local entry for the
-  shard-qualified lane, and appends either a `lease_claims` receipt or a
-  materialized `leases` row. Dispatch must not round-trip between the cursor
-  read and the claim insert.
-- Short successful completion carries the immutable claim-time job snapshot
-  through the completion batcher so the terminal append does not reload
-  `ready_entries`.
-- The completion batcher therefore owns a claim-time snapshot pass-through
-  path: short completions append terminal rows from the already-carried
-  immutable claim snapshot, while stale completions still lose via the
-  `(job_id, run_lease)` guarded delete against the live execution row.
-- Local worker capacity is released when handler execution ends and the
-  progress snapshot is captured; durable completion then continues through the
-  detached completion batcher path. This keeps execution capacity tied to
-  active handler work rather than to completion flush latency while leaving
-  the `run_lease`-guarded rescue boundary unchanged.
-- Crash safety for the batcher relies on the normal rescue path, not an
-  auxiliary replay log. If an in-memory completion batch is lost with the
-  worker process, the live attempt remains visible to heartbeat/deadline
-  rescue and is reclaimed that way.
+- Claim runs as a single server-side step: one SQL function locks `queue_claim_heads`, selects the oldest runnable segment-local entry for the shard-qualified lane, and appends either a `lease_claims` receipt or a materialized `leases` row. Dispatch must not round-trip between the cursor read and the claim insert.
+- Short successful completion carries the immutable claim-time job snapshot through the completion batcher so the terminal append does not reload `ready_entries`.
+- The completion batcher therefore owns a claim-time snapshot pass-through path: short completions append terminal rows from the already-carried immutable claim snapshot, while stale completions still lose via the `(job_id, run_lease)` guarded delete against the live execution row.
+- Local worker capacity is released when handler execution ends and the progress snapshot is captured; durable completion then continues through the detached completion batcher path. This keeps execution capacity tied to active handler work rather than to completion flush latency while leaving the `run_lease`-guarded rescue boundary unchanged.
+- Crash safety for the batcher relies on the normal rescue path, not an auxiliary replay log. If an in-memory completion batch is lost with the worker process, the live attempt remains visible to heartbeat/deadline rescue and is reclaimed that way.
 
 ## Validation
 
-Recorded local 5k-job runtime soak: **9,537 jobs/s**, **3.671 ms pickup p50**,
-**22.013 ms pickup p95**, **417 exact final dead tuples** (canonical runtime
-under the same workload: 9,686 jobs/s, 38.998 ms p95, dead tuples not
-sampled). The full command log, raw output, and per-table dead-tuple
-breakdown are in
-[`bench/019-queue-storage-validation-2026-04-19.md`](bench/019-queue-storage-validation-2026-04-19.md).
+Recorded local 5k-job runtime soak: **9,537 jobs/s**, **3.671 ms pickup p50**, **22.013 ms pickup p95**, **417 exact final dead tuples** (canonical runtime under the same workload: 9,686 jobs/s, 38.998 ms p95, dead tuples not sampled). The full command log, raw output, and per-table dead-tuple breakdown are in [`bench/019-queue-storage-validation-2026-04-19.md`](bench/019-queue-storage-validation-2026-04-19.md).
 
-The phase-driven portable comparison harness lives in a separate repo:
-[postgresql-job-queue-benchmarking](https://github.com/hardbyte/postgresql-job-queue-benchmarking).
-That harness records producer, subscriber, and end-to-end latency on a
-shared timebase while also sampling throughput, queue depth, and dead
-tuples over time. Recent runs place Awa ahead of pgque on end-to-end
-latency and on sustained throughput in clean-phase scenarios, while
-pgque holds a comparable dead-tuple profile (both are append-only /
-partition-rotated). See
-[`SYSTEM_COMPARISONS.md`](https://github.com/hardbyte/postgresql-job-queue-benchmarking/blob/main/SYSTEM_COMPARISONS.md)
-for the per-system architectural notes and
-[docs/benchmarking.md](../benchmarking.md) for awa's own regression
-methodology.
+The phase-driven portable comparison harness lives in a separate repo: [postgresql-job-queue-benchmarking](https://github.com/hardbyte/postgresql-job-queue-benchmarking). That harness records producer, subscriber, and end-to-end latency on a shared timebase while also sampling throughput, queue depth, and dead tuples over time. Recent runs place Awa ahead of pgque on end-to-end latency and on sustained throughput in clean-phase scenarios, while pgque holds a comparable dead-tuple profile (both are append-only / partition-rotated). See [`SYSTEM_COMPARISONS.md`](https://github.com/hardbyte/postgresql-job-queue-benchmarking/blob/main/SYSTEM_COMPARISONS.md) for the per-system architectural notes and [docs/benchmarking.md](../benchmarking.md) for awa's own regression methodology.
 
-The current pressure frontier after the split-head change is the lease plane:
-`queue_lanes` is no longer the dominant MVCC hotspot, but the mutable
-`active_leases` family still absorbs steady insert/delete churn and heartbeat
-updates. The current implementation now includes a short-job receipt path
-(`lease_claims` plus lazy materialization) that substantially reduces dead
-tuples for zero-deadline short jobs. Long-horizon profiling also showed that
-the append-only history alone was not enough: open claims had to be tracked
-explicitly so rescue and queue counts would not degrade into history scans.
-The original ADR-019 design used a bounded `open_receipt_claims` table for
-this; ADR-023 replaces it with partitioned `lease_claims` / `lease_claim_closures`
-where "currently open" is derived at query time as an anti-join over the
-active partitions, eliminating the last MVCC churn source on the receipt
-plane. Further lease-plane work is still
-tracked in
-[`lease-plane-redesign-spike.md`](../archive/0.6-storage-design/lease-plane-redesign-spike.md).
-The remaining queue-level coordination controls are implemented as bounded
-claimers, queue striping (`queue_stripe_count`), and per-queue enqueue-head
-sharding (`queue_meta.enqueue_shards`). The archived
-[`bounded-claimers-plan.md`](../archive/0.6-storage-design/bounded-claimers-plan.md)
-and
-[`queue-striping-plan.md`](../archive/0.6-storage-design/queue-striping-plan.md)
-capture design history; current operator guidance lives in
-[`configuration.md`](../configuration.md#queue-storage-tuning).
+The current pressure frontier after the split-head change is the lease plane: `queue_lanes` is no longer the dominant MVCC hotspot, but the mutable `active_leases` family still absorbs steady insert/delete churn and heartbeat updates. The current implementation now includes a short-job receipt path (`lease_claims` plus lazy materialization) that substantially reduces dead tuples for zero-deadline short jobs. Long-horizon profiling also showed that the append-only history alone was not enough: open claims had to be tracked explicitly so rescue and queue counts would not degrade into history scans. The original ADR-019 design used a bounded `open_receipt_claims` table for this; ADR-023 replaces it with partitioned `lease_claims` / `lease_claim_closures` where "currently open" is derived at query time as an anti-join over the active partitions, eliminating the last MVCC churn source on the receipt plane. Further lease-plane work is still tracked in [`lease-plane-redesign-spike.md`](../archive/0.6-storage-design/lease-plane-redesign-spike.md). The remaining queue-level coordination controls are implemented as bounded claimers, queue striping (`queue_stripe_count`), and per-queue enqueue-head sharding (`queue_meta.enqueue_shards`). The archived [`bounded-claimers-plan.md`](../archive/0.6-storage-design/bounded-claimers-plan.md) and [`queue-striping-plan.md`](../archive/0.6-storage-design/queue-striping-plan.md) capture design history; current operator guidance lives in [`configuration.md`](../configuration.md#queue-storage-tuning).
 
-Spec-level safety is checked by the segmented-storage TLA+ family —
-`AwaSegmentedStorage`, `AwaSegmentedStorageRaces`, `AwaStorageLockOrder`,
-`AwaSegmentedStorageTrace` — under
-[`correctness/storage/`](../../correctness/storage/). The TLA+ action →
-Rust function correspondence is in
-[`correctness/storage/MAPPING.md`](../../correctness/storage/MAPPING.md).
+Spec-level safety is checked by the segmented-storage TLA+ family — `AwaSegmentedStorage`, `AwaSegmentedStorageRaces`, `AwaStorageLockOrder`, `AwaSegmentedStorageTrace` — under [`correctness/storage/`](../../correctness/storage/). The TLA+ action → Rust function correspondence is in [`correctness/storage/MAPPING.md`](../../correctness/storage/MAPPING.md).
 
 ## Consequences
 
 ### Positive
 
-- Dead tuples are bounded by the lease rotation window and the tiny
-  `lane_state` cache, not by total queue history.
-- Queue throughput is now near-parity with the canonical runtime while still
-  substantially reducing claim-tail latency under the benchmark workload.
-- DLQ becomes a first-class storage concern instead of an afterthought bolted
-  onto the hot table model.
+- Dead tuples are bounded by the lease rotation window and the tiny `lane_state` cache, not by total queue history.
+- Queue throughput is now near-parity with the canonical runtime while still substantially reducing claim-tail latency under the benchmark workload.
+- DLQ becomes a first-class storage concern instead of an afterthought bolted onto the hot table model.
 - Retention moves from row-by-row cleanup toward partition rotation and prune.
 
 ### Negative
 
 - This is a breaking storage redesign rather than an incremental tweak.
-- Admin and producer paths must become backend-aware instead of assuming the
-  canonical hot/deferred tables are the only physical layout.
-- Queue storage has to replace some old row-rewrite maintenance patterns with
-  storage-specific equivalents, such as claim-time effective priority aging
-  instead of physically rewriting ready rows.
+- Admin and producer paths must become backend-aware instead of assuming the canonical hot/deferred tables are the only physical layout.
+- Queue storage has to replace some old row-rewrite maintenance patterns with storage-specific equivalents, such as claim-time effective priority aging instead of physically rewriting ready rows.
 - Long-running readers can still delay best-effort partition prune.
 
 ## Alternatives Considered
 
 ### Keep the canonical hot/deferred split
 
-Rejected. It helps planner shape, but it does not remove the lifecycle-row MVCC
-churn that causes dead tuples on the hot path.
+Rejected. It helps planner shape, but it does not remove the lifecycle-row MVCC churn that causes dead tuples on the hot path.
 
 ### Rotate mutable canonical rows directly
 
-Rejected. Rotating the same mutable state-machine rows preserves the core
-problem; it only spreads churn across more tables.
+Rejected. Rotating the same mutable state-machine rows preserves the core problem; it only spreads churn across more tables.
 
 ### Append-only history plus a single global lease heap
 
-Rejected. This improves queue-row churn, but the lease heap still bloats in
-proportion to total runtime churn.
+Rejected. This improves queue-row churn, but the lease heap still bloats in proportion to total runtime churn.
 
 ### Two user-facing storage modes
 
-Rejected. The storage engine can use multiple physical table families without
-exposing multiple public queue models.
+Rejected. The storage engine can use multiple physical table families without exposing multiple public queue models.
 
 ## Relationship to Earlier ADRs
 
 - ADR-012 becomes historical background rather than the target architecture.
-- ADR-003 still defines the heartbeat/deadline rescue policy; queue storage only
-  changes where those timestamps live.
-- ADR-014 still defines the user-facing progress model; queue storage changes
-  the physical persistence path from dedicated columns to `attempt_state` and
-  `active_leases`.
+- ADR-003 still defines the heartbeat/deadline rescue policy; queue storage only changes where those timestamps live.
+- ADR-014 still defines the user-facing progress model; queue storage changes the physical persistence path from dedicated columns to `attempt_state` and `active_leases`.

--- a/docs/adr/020-dead-letter-queue.md
+++ b/docs/adr/020-dead-letter-queue.md
@@ -6,36 +6,24 @@ Accepted
 
 ## Context
 
-The queue-storage redesign keeps runnable work, lease churn, and control-plane
-metadata on separate paths. Permanently failed jobs still need a durable,
-operator-facing home that is not part of the claim path and that can outlive
-normal failed-row retention windows.
+The queue-storage redesign keeps runnable work, lease churn, and control-plane metadata on separate paths. Permanently failed jobs still need a durable, operator-facing home that is not part of the claim path and that can outlive normal failed-row retention windows.
 
 Without a dedicated DLQ:
 
 - terminal failures stay mixed with ordinary terminal history
 - forensic retention competes with routine cleanup
 - retry and purge tooling has no explicit operator target
-- UI, CLI, and Python admin surfaces cannot distinguish "historical failure"
-  from "actionable dead-letter entry"
+- UI, CLI, and Python admin surfaces cannot distinguish "historical failure" from "actionable dead-letter entry"
 
-In the queue-storage model, the right home for that state is a separate
-append-only table inside the active queue-storage schema.
+In the queue-storage model, the right home for that state is a separate append-only table inside the active queue-storage schema.
 
 ## Decision
 
-Add a first-class Dead Letter Queue as `{schema}.dlq_entries` inside the active
-queue-storage backend. DLQ entries are not claimable. They are populated from
-terminal failure paths or explicit admin moves, retained independently from the
-main terminal history, and surfaced consistently through Rust, Python, CLI,
-REST, and Web UI APIs.
+Add a first-class Dead Letter Queue as `{schema}.dlq_entries` inside the active queue-storage backend. DLQ entries are not claimable. They are populated from terminal failure paths or explicit admin moves, retained independently from the main terminal history, and surfaced consistently through Rust, Python, CLI, REST, and Web UI APIs.
 
 ### Separate table, not a new live state
 
-DLQ rows are stored in `{schema}.dlq_entries`, not in `ready_entries`,
-`deferred_jobs`, or `terminal_entries`, and not as a new dispatchable
-`job_state`.
-The row keeps the failed job snapshot plus:
+DLQ rows are stored in `{schema}.dlq_entries`, not in `ready_entries`, `deferred_jobs`, or `terminal_entries`, and not as a new dispatchable `job_state`. The row keeps the failed job snapshot plus:
 
 - `dlq_reason`
 - `dlq_at`
@@ -50,13 +38,9 @@ There are two ways DLQ rows are created:
 1. Runtime routing for terminal failures on DLQ-enabled queues.
 2. Operator-initiated bulk or single-row moves of already-failed terminal rows.
 
-Runtime routing is the primary path. Terminal failures and exhausted
-callback-timeout failures move directly into `dlq_entries` so the active
-attempt leaves the hot execution plane immediately.
+Runtime routing is the primary path. Terminal failures and exhausted callback-timeout failures move directly into `dlq_entries` so the active attempt leaves the hot execution plane immediately.
 
-Admin moves operate on already-failed terminal history, allowing operators to
-backfill older failures into the DLQ after enabling policy on an existing
-queue.
+Admin moves operate on already-failed terminal history, allowing operators to backfill older failures into the DLQ after enabling policy on an existing queue.
 
 ### Retry and purge
 
@@ -70,9 +54,7 @@ Retry deletes the DLQ row and reinserts a fresh job into queue storage:
 
 Purge deletes the DLQ row permanently.
 
-Bulk retry and purge require at least one of `kind`, `queue`, or `tag`, unless
-the caller explicitly opts in with `allow_all=true`. This prevents empty-filter
- actions from reviving or deleting the entire DLQ by mistake.
+Bulk retry and purge require at least one of `kind`, `queue`, or `tag`, unless the caller explicitly opts in with `allow_all=true`. This prevents empty-filter actions from reviving or deleting the entire DLQ by mistake.
 
 ### Retention
 
@@ -82,8 +64,7 @@ DLQ retention is independent from ordinary terminal retention.
 - per-queue override: `RetentionPolicy.dlq`
 - maintenance performs bounded cleanup passes against `dlq_entries`
 
-This keeps forensic retention separate from the shorter-lived cleanup horizon
-for normal completed/failed/cancelled history.
+This keeps forensic retention separate from the shorter-lived cleanup horizon for normal completed/failed/cancelled history.
 
 ### Admin surfaces
 
@@ -94,8 +75,7 @@ The DLQ is a first-class operator surface:
 - REST: `/api/dlq...`
 - Web UI: `/dlq` list and `/dlq/:id` detail
 
-`GET /api/jobs/:id` also exposes DLQ metadata when a job has already moved to
-the DLQ, so direct links and admin lookups continue to work after routing.
+`GET /api/jobs/:id` also exposes DLQ metadata when a job has already moved to the DLQ, so direct links and admin lookups continue to work after routing.
 
 ## Consequences
 
@@ -104,16 +84,13 @@ the DLQ, so direct links and admin lookups continue to work after routing.
 - dead-letter history stays off the runnable path
 - DLQ retention is decoupled from normal terminal retention
 - retry/purge operations have an explicit, auditable target
-- UI, CLI, and Python tooling can treat DLQ rows as a first-class operator
-  state rather than inferring from generic failed history
+- UI, CLI, and Python tooling can treat DLQ rows as a first-class operator state rather than inferring from generic failed history
 
 ### Negative
 
-- operators now have two terminal-history surfaces to understand:
-  ordinary terminal history and DLQ history
+- operators now have two terminal-history surfaces to understand: ordinary terminal history and DLQ history
 - admin tooling must deliberately surface when a job has moved to the DLQ
-- bulk actions need stronger safety guards because the DLQ is intentionally
-  operator-facing and long-lived
+- bulk actions need stronger safety guards because the DLQ is intentionally operator-facing and long-lived
 
 ## References
 

--- a/docs/adr/021-enhanced-external-wait.md
+++ b/docs/adr/021-enhanced-external-wait.md
@@ -2,9 +2,7 @@
 
 ## Status
 
-Accepted. This ADR records the user-facing callback semantics. ADR-019 moved
-the physical callback fields from canonical storage onto queue-storage lease /
-attempt state; see [Relationship to ADR-019](#relationship-to-adr-019).
+Accepted. This ADR records the user-facing callback semantics. ADR-019 moved the physical callback fields from canonical storage onto queue-storage lease / attempt state; see [Relationship to ADR-019](#relationship-to-adr-019).
 
 ## Context
 
@@ -27,6 +25,7 @@ Enhance the single-callback model with two backward-compatible additions:
 `complete_external` gains an optional `resume: bool` flag (default `false`). When `true`, instead of transitioning to `completed`, the job transitions back to `running` and the handler resumes execution with the callback payload.
 
 **Rust API:**
+
 ```rust
 // Handler registers first callback
 let token = ctx.register_callback(Duration::from_secs(3600)).await?;
@@ -47,6 +46,7 @@ Ok(JobResult::Completed)
 ```
 
 **Python API:**
+
 ```python
 @client.task(ProcessOrder, queue="orders")
 async def handle(job):
@@ -64,6 +64,7 @@ async def handle(job):
 ```
 
 **Implementation:** `wait_for_callback(token)` is a new method on `JobContext` / `Job` that:
+
 1. Transitions the job to `waiting_external` (same as today's `WaitForCallback` return)
 2. Suspends the handler's async task and polls the storage-backed job snapshot until the callback resolves
 3. `resume_external(callback_id, payload)` transitions the job back to `running` and stores the payload in `metadata._awa_callback_result`
@@ -76,6 +77,7 @@ The wait is token-specific: the handler only waits on the exact callback ID it r
 The job stays in `running` → `waiting_external` → `running` → `waiting_external` → ... → `completed` without being re-dispatched. The existing heartbeat keeps the job alive between waits. The run_lease stays valid throughout.
 
 **State transitions:**
+
 ```
 running → waiting_external (register_callback + wait)
 waiting_external → running (complete_external with resume=true)
@@ -88,6 +90,7 @@ waiting_external → completed (complete_external with resume=false, or handler 
 New `heartbeat_callback(callback_id)` function that resets `callback_timeout_at` without completing the job. External systems call this periodically for long-running operations.
 
 **API:**
+
 ```python
 # External system (e.g., ML training service)
 while training_in_progress:
@@ -99,12 +102,13 @@ await client.complete_external(callback_id, payload={"model_url": "s3://..."})
 ```
 
 **Rust:**
+
 ```rust
 awa::admin::heartbeat_callback(&pool, callback_id).await?;
 ```
 
-**Implementation:** Single SQL update against the active lease row (ADR-019
-moved `callback_timeout_at` onto `{schema}.active_leases`):
+**Implementation:** Single SQL update against the active lease row (ADR-019 moved `callback_timeout_at` onto `{schema}.active_leases`):
+
 ```sql
 UPDATE {schema}.active_leases
 SET callback_timeout_at = now() + make_interval(secs => $2)
@@ -151,7 +155,7 @@ No schema changes — reuses the existing `callback_timeout_at` column.
 ## Prior Art
 
 | System | Pattern | Awa equivalent |
-|--------|---------|----------------|
+| --- | --- | --- |
 | Temporal signals | Multiple `waitForSignal()` in sequence | `wait_for_callback()` in a loop |
 | Restate awakeables | `ctx.awakeable().promise` | `job.wait_for_callback(token)` |
 | Step Functions task tokens | `.waitForTaskToken` with heartbeat | `register_callback` + `heartbeat_callback` |
@@ -159,8 +163,4 @@ No schema changes — reuses the existing `callback_timeout_at` column.
 
 ## Relationship to ADR-019
 
-ADR-019 moved callback state from the canonical `awa.jobs` row onto
-queue-storage execution state: `leases_*` holds the dispatch / timeout fields
-and `attempt_state` holds mutable per-attempt payloads keyed by
-`(job_id, run_lease)`. User-facing semantics are unchanged — sequential waits,
-callback heartbeats, and timeout handling remain exactly as described here.
+ADR-019 moved callback state from the canonical `awa.jobs` row onto queue-storage execution state: `leases_*` holds the dispatch / timeout fields and `attempt_state` holds mutable per-attempt payloads keyed by `(job_id, run_lease)`. User-facing semantics are unchanged — sequential waits, callback heartbeats, and timeout handling remain exactly as described here.

--- a/docs/adr/022-descriptor-catalog.md
+++ b/docs/adr/022-descriptor-catalog.md
@@ -6,66 +6,35 @@ Accepted
 
 ## Context
 
-Awa is a polyglot runtime: Rust and Python workers run against the same
-Postgres schema and the same queues. Operators need consistent names,
-descriptions, ownership, and documentation links for each queue and each job
-kind, regardless of which runtime is hosting a particular worker. Previously
-the admin surfaces inferred queue existence from `queue_state_counts`, which
-meant an idle-but-declared queue disappeared from listings and a queue's
-human-readable name lived only in handler code.
+Awa is a polyglot runtime: Rust and Python workers run against the same Postgres schema and the same queues. Operators need consistent names, descriptions, ownership, and documentation links for each queue and each job kind, regardless of which runtime is hosting a particular worker. Previously the admin surfaces inferred queue existence from `queue_state_counts`, which meant an idle-but-declared queue disappeared from listings and a queue's human-readable name lived only in handler code.
 
 ## Decision
 
-Add two catalog tables, `awa.queue_descriptors` and `awa.job_kind_descriptors`,
-that hold operator-facing metadata distinct from per-job payload metadata.
+Add two catalog tables, `awa.queue_descriptors` and `awa.job_kind_descriptors`, that hold operator-facing metadata distinct from per-job payload metadata.
 
-- **Code-declared**: whichever runtime hosts the workers declares the
-  descriptors via the Rust `ClientBuilder` or the Python `AsyncClient`. Both
-  SDKs use the same catalog tables and the same canonicalised-JSON BLAKE3
-  hashing scheme, so a mixed Rust + Python fleet produces consistent rows.
-- **Batched upsert on startup + every snapshot tick** (default 10 s): one
-  multi-row `INSERT ... ON CONFLICT` per catalog per tick, chunked at 5000
-  rows.
-- **Derived liveness signals**: at read time the admin path joins
-  `awa.runtime_instances.descriptor_hashes` against the catalog to derive
-  `stale` (no live runtime refreshed the descriptor) and `drift` (two
-  runtimes report different hashes for the same queue/kind).
-- **Retention**: the maintenance leader garbage-collects descriptors whose
-  `last_seen_at` is older than the configured `descriptor_retention`
-  (default 30 days).
+- **Code-declared**: whichever runtime hosts the workers declares the descriptors via the Rust `ClientBuilder` or the Python `AsyncClient`. Both SDKs use the same catalog tables and the same canonicalised-JSON BLAKE3 hashing scheme, so a mixed Rust + Python fleet produces consistent rows.
+- **Batched upsert on startup + every snapshot tick** (default 10 s): one multi-row `INSERT ... ON CONFLICT` per catalog per tick, chunked at 5000 rows.
+- **Derived liveness signals**: at read time the admin path joins `awa.runtime_instances.descriptor_hashes` against the catalog to derive `stale` (no live runtime refreshed the descriptor) and `drift` (two runtimes report different hashes for the same queue/kind).
+- **Retention**: the maintenance leader garbage-collects descriptors whose `last_seen_at` is older than the configured `descriptor_retention` (default 30 days).
 
-Descriptors are explicitly off the hot path — dispatcher, claim, completion
-batcher, heartbeat, and maintenance rescue never touch the catalog or the
-per-runtime hash columns.
+Descriptors are explicitly off the hot path — dispatcher, claim, completion batcher, heartbeat, and maintenance rescue never touch the catalog or the per-runtime hash columns.
 
 ## Consequences
 
 ### Positive
 
-- Queue and kind names, descriptions, tags, docs URLs, and ownership live in
-  one place, visible from the UI, CLI, and REST API regardless of runtime.
+- Queue and kind names, descriptions, tags, docs URLs, and ownership live in one place, visible from the UI, CLI, and REST API regardless of runtime.
 - Declared-but-idle queues stay visible.
-- Rolling-deploy drift (two runtimes disagreeing on ownership or docs URL)
-  is detectable from admin reads, not from application logs.
-- Python and Rust share the same catalog semantics without either SDK
-  reimplementing the hashing or retention logic.
+- Rolling-deploy drift (two runtimes disagreeing on ownership or docs URL) is detectable from admin reads, not from application logs.
+- Python and Rust share the same catalog semantics without either SDK reimplementing the hashing or retention logic.
 
 ### Negative
 
-- Additional write volume at startup and every snapshot tick. Measured at
-  ~24 ms for 2000 descriptors; negligible at realistic fleet sizes.
-- Read-side derivation of liveness signals is `O(live_runtimes × declared_descriptors)`.
-  Sits behind the `/api/queues` cache; very large fleets (≥1000 runtimes ×
-  ≥500 descriptors) would want a materialised view.
+- Additional write volume at startup and every snapshot tick. Measured at ~24 ms for 2000 descriptors; negligible at realistic fleet sizes.
+- Read-side derivation of liveness signals is `O(live_runtimes × declared_descriptors)`. Sits behind the `/api/queues` cache; very large fleets (≥1000 runtimes × ≥500 descriptors) would want a materialised view.
 
 ## Relationship to ADR-019
 
-Descriptors are deliberately off the queue-storage hot path. Dispatch,
-claim, and completion never touch `awa.queue_descriptors` or
-`awa.job_kind_descriptors`; only `awa.queue_meta` (pause/resume) remains on
-the dispatcher's queue-state read. This preserves the ADR-019 property that
-operator-facing metadata changes cannot affect dispatch throughput.
+Descriptors are deliberately off the queue-storage hot path. Dispatch, claim, and completion never touch `awa.queue_descriptors` or `awa.job_kind_descriptors`; only `awa.queue_meta` (pause/resume) remains on the dispatcher's queue-state read. This preserves the ADR-019 property that operator-facing metadata changes cannot affect dispatch throughput.
 
-See [architecture.md → Descriptors And Runtime Liveness](../architecture.md#descriptors-and-runtime-liveness)
-for the implementation details, hashing algorithm, and measured
-performance profile.
+See [architecture.md → Descriptors And Runtime Liveness](../architecture.md#descriptors-and-runtime-liveness) for the implementation details, hashing algorithm, and measured performance profile.

--- a/docs/adr/023-receipt-plane-ring-partitioning.md
+++ b/docs/adr/023-receipt-plane-ring-partitioning.md
@@ -2,301 +2,152 @@
 
 ## Status
 
-Accepted (implemented). `lease_claim_receipts` is the default in 0.6.
-The validation artifact under `docs/adr/bench/` is the empirical
-evidence the design holds; this ADR is the architectural record.
+Accepted (implemented). `lease_claim_receipts` is the default in 0.6. The validation artifact under `docs/adr/bench/` is the empirical evidence the design holds; this ADR is the architectural record.
 
 ## Context
 
-ADR-019 committed the hot queue plane to a vacuum-aware discipline: ready and
-terminal queue entries reclaim space by partition rotation and `TRUNCATE`,
-not by row-level cleanup. The remaining planes have narrower, explicit churn:
-materialized leases live in a bounded mutable lease ring, `deferred_jobs` is a
-plain scheduled/retryable backlog table promoted by delete-and-insert, and
-`dlq_entries` is an operator hold table with bounded retention cleanup. The
-ADR-019 validation artifact recorded 276 exact dead tuples across the entire
-schema after a 1000/s soak — `queue_lanes=19, ready=0, done=255, leases=2,
-attempt_state=0` — consistent with the design intent.
+ADR-019 committed the hot queue plane to a vacuum-aware discipline: ready and terminal queue entries reclaim space by partition rotation and `TRUNCATE`, not by row-level cleanup. The remaining planes have narrower, explicit churn: materialized leases live in a bounded mutable lease ring, `deferred_jobs` is a plain scheduled/retryable backlog table promoted by delete-and-insert, and `dlq_entries` is an operator hold table with bounded retention cleanup. The ADR-019 validation artifact recorded 276 exact dead tuples across the entire schema after a 1000/s soak — `queue_lanes=19, ready=0, done=255, leases=2, attempt_state=0` — consistent with the design intent.
 
-The experimental receipt-backed short-job path introduced after that
-validation adds three tables:
+The experimental receipt-backed short-job path introduced after that validation adds three tables:
 
 - `lease_claims` — append-only claim receipts (durable claim history)
 - `lease_claim_closures` — append-only closure tombstones
-- `open_receipt_claims` — a bounded "currently live receipt-backed attempt"
-  frontier, introduced so rescue and queue-count queries would not degrade
-  into anti-joins against unbounded claim history
+- `open_receipt_claims` — a bounded "currently live receipt-backed attempt" frontier, introduced so rescue and queue-count queries would not degrade into anti-joins against unbounded claim history
 
-`lease_claims` and `lease_claim_closures` honour the ADR-019 contract:
-they are insert-only. `open_receipt_claims` does not. Its design is one
-`INSERT` per claim and one `DELETE` per completion, so every completion
-produces a dead tuple on that table.
+`lease_claims` and `lease_claim_closures` honour the ADR-019 contract: they are insert-only. `open_receipt_claims` does not. Its design is one `INSERT` per claim and one `DELETE` per completion, so every completion produces a dead tuple on that table.
 
-Measurements at the time the receipt ring landed confirmed this is the
-remaining MVCC source. In an internal long-horizon run from
-`custom-20260424T065828Z-227187` (since-extracted to
-[postgresql-job-queue-benchmarking](https://github.com/hardbyte/postgresql-job-queue-benchmarking),
-28-minute clean phase at ~800/s per replica, receipts on), the
-`open_receipt_claims` heap held a median of 28,390 dead tuples and a peak
-of 93,789 while every other hot table stayed under 100 dead tuples. The
-autovacuum floor is `autovacuum_naptime=60s`, which is global, so per-table
-thresholds do not move the median: a measured before/after run with
-per-table knobs on `open_receipt_claims` left that median unchanged.
-Knobs treat the symptom; they cannot remove the `DELETE` from the hot
-path.
+Measurements at the time the receipt ring landed confirmed this is the remaining MVCC source. In an internal long-horizon run from `custom-20260424T065828Z-227187` (since-extracted to [postgresql-job-queue-benchmarking](https://github.com/hardbyte/postgresql-job-queue-benchmarking), 28-minute clean phase at ~800/s per replica, receipts on), the `open_receipt_claims` heap held a median of 28,390 dead tuples and a peak of 93,789 while every other hot table stayed under 100 dead tuples. The autovacuum floor is `autovacuum_naptime=60s`, which is global, so per-table thresholds do not move the median: a measured before/after run with per-table knobs on `open_receipt_claims` left that median unchanged. Knobs treat the symptom; they cannot remove the `DELETE` from the hot path.
 
-The receipt-backed short-job path is the only way to retire
-per-claim mutable lease row churn on the common path, and making it the
-default is a 0.6 release goal. Delivering that goal without violating
-ADR-019 requires bringing `open_receipt_claims` onto the same rotation-and-
-prune discipline as the rest of the engine.
+The receipt-backed short-job path is the only way to retire per-claim mutable lease row churn on the common path, and making it the default is a 0.6 release goal. Delivering that goal without violating ADR-019 requires bringing `open_receipt_claims` onto the same rotation-and- prune discipline as the rest of the engine.
 
 ## Design goals and non-goals
 
 Guided by the 0.6 priorities from ADR-019:
 
-- Preserve at-least-once delivery. No claim may be lost across any crash,
-  restart, or partition-truncation boundary.
-- Preserve stale-writer protection by `(job_id, run_lease)`. Completion
-  must still lose cleanly against a rescue or cancel on the same attempt.
-- Keep the claim hot path at least as fast as the current receipt path,
-  not slower. The fix must reduce, not add, per-claim and per-completion
-  work.
-- Eliminate the remaining MVCC churn source. Steady-state dead tuples on
-  the receipt plane should be zero once rotation catches up.
-- Finish the vacuum-aware story before 0.6 ships; hold the quality bar
-  rather than the timeline.
+- Preserve at-least-once delivery. No claim may be lost across any crash, restart, or partition-truncation boundary.
+- Preserve stale-writer protection by `(job_id, run_lease)`. Completion must still lose cleanly against a rescue or cancel on the same attempt.
+- Keep the claim hot path at least as fast as the current receipt path, not slower. The fix must reduce, not add, per-claim and per-completion work.
+- Eliminate the remaining MVCC churn source. Steady-state dead tuples on the receipt plane should be zero once rotation catches up.
+- Finish the vacuum-aware story before 0.6 ships; hold the quality bar rather than the timeline.
 
 Non-goals:
 
-- Do not change the heartbeat / deadline / callback-timeout rescue
-  contract. Those continue to live on `attempt_state` and `active_leases`.
-- Do not change the external API or the `(job_id, run_lease)` stale-writer
-  guard.
-- Do not introduce any new reservation or pre-start state. The archived
-  [`lease-plane-redesign-spike`](../archive/0.6-storage-design/lease-plane-redesign-spike.md)
-  record shows that direction has been tried and rejected repeatedly on cost
-  grounds.
+- Do not change the heartbeat / deadline / callback-timeout rescue contract. Those continue to live on `attempt_state` and `active_leases`.
+- Do not change the external API or the `(job_id, run_lease)` stale-writer guard.
+- Do not introduce any new reservation or pre-start state. The archived [`lease-plane-redesign-spike`](../archive/0.6-storage-design/lease-plane-redesign-spike.md) record shows that direction has been tried and rejected repeatedly on cost grounds.
 
 ## Decision
 
-Apply ADR-019's rotation-and-prune pattern to the receipt plane. Remove
-`open_receipt_claims` as a distinct table.
+Apply ADR-019's rotation-and-prune pattern to the receipt plane. Remove `open_receipt_claims` as a distinct table.
 
 ### Physical layout
 
-1. `lease_claims` becomes `PARTITIONED BY LIST (claim_slot)` with a small
-   fixed set of child partitions (`lease_claims_0..N-1`).
-2. `lease_claim_closures` becomes `PARTITIONED BY LIST (claim_slot)` with
-   matching children. A closure row lives in the same `claim_slot` as its
-   originating claim.
-3. A new control-plane pair `claim_ring_state` and `claim_ring_slots`
-   coordinates rotation, mirroring the existing `lease_ring_state` and
-   `lease_ring_slots`.
-4. `open_receipt_claims` is deleted. Its indexes and the schema-install
-   backfill are dropped.
+1. `lease_claims` becomes `PARTITIONED BY LIST (claim_slot)` with a small fixed set of child partitions (`lease_claims_0..N-1`).
+2. `lease_claim_closures` becomes `PARTITIONED BY LIST (claim_slot)` with matching children. A closure row lives in the same `claim_slot` as its originating claim.
+3. A new control-plane pair `claim_ring_state` and `claim_ring_slots` coordinates rotation, mirroring the existing `lease_ring_state` and `lease_ring_slots`.
+4. `open_receipt_claims` is deleted. Its indexes and the schema-install backfill are dropped.
 
 ### Hot path
 
-- Claim: append to the current `lease_claims` child partition. No other
-  row is written on the receipt path. The claim result carries
-  `claim_slot` through to the worker so the completion path can target the
-  matching closure partition.
-- Complete: append a closure row to the `lease_claim_closures` child
-  partition for the same `claim_slot`, then append the terminal row to
-  `done_entries` / `dlq_entries` / `deferred_jobs` as today.
+- Claim: append to the current `lease_claims` child partition. No other row is written on the receipt path. The claim result carries `claim_slot` through to the worker so the completion path can target the matching closure partition.
+- Complete: append a closure row to the `lease_claim_closures` child partition for the same `claim_slot`, then append the terminal row to `done_entries` / `dlq_entries` / `deferred_jobs` as today.
 - Neither step performs any `UPDATE` or `DELETE` on the receipt plane.
-- Short-job fast path becomes strictly cheaper: one insert at claim
-  (previously two) and one insert at completion (previously one insert
-  and one delete).
-- Completion batches are ordered by `claim_slot` before `(job_id,
-  run_lease)` so a flusher presents partition-local closure rows to
-  Postgres. That ordering does not change the stale-writer guard; it
-  only improves locality for the append-only receipt plane.
-- Default successful completions avoid writing a terminal payload copy
-  when the runtime payload is empty or unchanged from `ready_entries`.
-  When an entire done batch has empty terminal payloads, completion also
-  skips the ready-payload lookup that would otherwise be needed to prove
-  unchanged non-empty payloads can be elided.
-- The receipt-backed completion SQL pipelines closure insert and
-  `attempt_state` cleanup in one data-modifying CTE. The terminal row
-  append remains a separate statement because it carries the public
-  terminal-history contract and unique-claim synchronization.
+- Short-job fast path becomes strictly cheaper: one insert at claim (previously two) and one insert at completion (previously one insert and one delete).
+- Completion batches are ordered by `claim_slot` before `(job_id, run_lease)` so a flusher presents partition-local closure rows to Postgres. That ordering does not change the stale-writer guard; it only improves locality for the append-only receipt plane.
+- Default successful completions avoid writing a terminal payload copy when the runtime payload is empty or unchanged from `ready_entries`. When an entire done batch has empty terminal payloads, completion also skips the ready-payload lookup that would otherwise be needed to prove unchanged non-empty payloads can be elided.
+- The receipt-backed completion SQL pipelines closure insert and `attempt_state` cleanup in one data-modifying CTE. The terminal row append remains a separate statement because it carries the public terminal-history contract and unique-claim synchronization.
 
 ### Open-claim queries
 
-Every read that currently targets `open_receipt_claims` becomes a bounded
-scan over the active `lease_claims` child partitions, anti-joined with the
-matching `lease_claim_closures` children:
+Every read that currently targets `open_receipt_claims` becomes a bounded scan over the active `lease_claims` child partitions, anti-joined with the matching `lease_claim_closures` children:
 
-- "Is `(job_id, run_lease)` still open?" — PK lookup into active claim
-  partitions, anti-join closures. Used by the completion guard and by
-  `load_job` on receipt-backed attempts.
-- "Scan stale receipt claims for rescue." — range scan on
-  `claimed_at < cutoff` in active claim partitions, anti-join closures.
-- "Count in-flight receipt-backed attempts." — count active-partition
-  rows minus matching closure rows.
+- "Is `(job_id, run_lease)` still open?" — PK lookup into active claim partitions, anti-join closures. Used by the completion guard and by `load_job` on receipt-backed attempts.
+- "Scan stale receipt claims for rescue." — range scan on `claimed_at < cutoff` in active claim partitions, anti-join closures.
+- "Count in-flight receipt-backed attempts." — count active-partition rows minus matching closure rows.
 
-Active partitions are bounded by the claim-ring rotation window, which is
-sized so that even worst-case throughput keeps the anti-join surface
-smaller than what `open_receipt_claims` used to hold dynamically.
+Active partitions are bounded by the claim-ring rotation window, which is sized so that even worst-case throughput keeps the anti-join surface smaller than what `open_receipt_claims` used to hold dynamically.
 
 ### Rotation and prune
 
-- The maintenance leader owns `claim_ring_state` rotation on a cadence
-  chosen to keep the active scan surface bounded. Initial target: rotate
-  at the same cadence as the queue ring so claim partitions age out
-  roughly in step with the ready / done partitions they reference.
-- A claim-slot partition may be truncated only when every claim in it is
-  represented by a closure row in the corresponding
-  `lease_claim_closures` partition. If open claims remain, prune skips the
-  partition until normal completion or the separate receipt-rescue scans close
-  those claims.
+- The maintenance leader owns `claim_ring_state` rotation on a cadence chosen to keep the active scan surface bounded. Initial target: rotate at the same cadence as the queue ring so claim partitions age out roughly in step with the ready / done partitions they reference.
+- A claim-slot partition may be truncated only when every claim in it is represented by a closure row in the corresponding `lease_claim_closures` partition. If open claims remain, prune skips the partition until normal completion or the separate receipt-rescue scans close those claims.
 - Prune order mirrors `prune_oldest` and `prune_oldest_leases`:
   1. `FOR UPDATE` on `claim_ring_state`.
   2. `FOR UPDATE` on the target `claim_ring_slots` row.
   3. `SET LOCAL lock_timeout = '50ms'`.
   4. `ACCESS EXCLUSIVE` on both partitions (claims and closures).
   5. Liveness recheck: every claim must have a closure, then `TRUNCATE`.
-- Partition truncation never races with claim because claim always writes
-  to the ring's current slot and rotation advances the current slot
-  atomically under the same lock order.
+- Partition truncation never races with claim because claim always writes to the ring's current slot and rotation advances the current slot atomically under the same lock order.
 
 ### Invariants preserved
 
-- At-least-once delivery: a partition cannot truncate while live claims
-  remain in it. Rescue is the gating step, not the prune itself.
-- `(job_id, run_lease)` stale-writer protection: the authoritative record
-  is still `lease_claims + lease_claim_closures`. Adding partitioning
-  changes where those rows live, not what they mean.
-- Heartbeat / deadline / callback-timeout rescue: unchanged. Those
-  continue to run against `attempt_state` and `active_leases`.
+- At-least-once delivery: a partition cannot truncate while live claims remain in it. Rescue is the gating step, not the prune itself.
+- `(job_id, run_lease)` stale-writer protection: the authoritative record is still `lease_claims + lease_claim_closures`. Adding partitioning changes where those rows live, not what they mean.
+- Heartbeat / deadline / callback-timeout rescue: unchanged. Those continue to run against `attempt_state` and `active_leases`.
 
 ### Migration
 
-This is a breaking schema change even though the external API does not
-change.
+This is a breaking schema change even though the external API does not change.
 
-1. A new migration creates `claim_ring_state`, `claim_ring_slots`, and the
-   partitioned `lease_claims` / `lease_claim_closures` shapes.
-2. Existing `lease_claims` and `lease_claim_closures` rows are rewritten
-   into the current slot of the new partitioned parents.
-3. The legacy `open_receipt_claims` table is not part of the live read path.
-   `prepare_schema()` drops it when empty, and refuses to proceed if it still
-   contains rows so an operator can drain or reverse-migrate those rows
-   deliberately.
-4. Subsequent claim, complete, rescue, and count paths target the partitioned
-   claim/closure tables; the live receipt set is derived as an anti-join over
-   the active claim-ring partitions.
+1. A new migration creates `claim_ring_state`, `claim_ring_slots`, and the partitioned `lease_claims` / `lease_claim_closures` shapes.
+2. Existing `lease_claims` and `lease_claim_closures` rows are rewritten into the current slot of the new partitioned parents.
+3. The legacy `open_receipt_claims` table is not part of the live read path. `prepare_schema()` drops it when empty, and refuses to proceed if it still contains rows so an operator can drain or reverse-migrate those rows deliberately.
+4. Subsequent claim, complete, rescue, and count paths target the partitioned claim/closure tables; the live receipt set is derived as an anti-join over the active claim-ring partitions.
 
-TLA+ coverage (`AwaSegmentedStorage`, `AwaStorageLockOrder`) is extended
-to model the claim-ring rotation and the rescue-before-truncate
-precondition, parallel to the existing lease-ring model.
+TLA+ coverage (`AwaSegmentedStorage`, `AwaStorageLockOrder`) is extended to model the claim-ring rotation and the rescue-before-truncate precondition, parallel to the existing lease-ring model.
 
 ## Validation
 
-Success criteria for this redesign, measured on the long-horizon portable
-harness used for the ADR-019 baseline:
+Success criteria for this redesign, measured on the long-horizon portable harness used for the ADR-019 baseline:
 
-- `open_receipt_claims` is absent from the schema. Steady-state dead
-  tuples across the queue-storage schema return to the ADR-019-validation
-  shape: low hundreds, concentrated in ring-state singletons.
-- Throughput on the `1x32`, `4x8`, and soak profiles is no worse than the
-  current branch and should improve slightly because claim and completion
-  each drop a table touch.
-- Crash-under-load recovers cleanly. The rescue-before-truncate path is
-  exercised by the existing crash-recovery scenarios and by a new test
-  that drives rescue concurrently with partition prune.
-- `lease_claim_receipts` is on by default for 0.6 with no dead-tuple
-  regression relative to the ADR-019 validation run.
+- `open_receipt_claims` is absent from the schema. Steady-state dead tuples across the queue-storage schema return to the ADR-019-validation shape: low hundreds, concentrated in ring-state singletons.
+- Throughput on the `1x32`, `4x8`, and soak profiles is no worse than the current branch and should improve slightly because claim and completion each drop a table touch.
+- Crash-under-load recovers cleanly. The rescue-before-truncate path is exercised by the existing crash-recovery scenarios and by a new test that drives rescue concurrently with partition prune.
+- `lease_claim_receipts` is on by default for 0.6 with no dead-tuple regression relative to the ADR-019 validation run.
 
 ## Consequences
 
 ### Positive
 
-- The 0.6 vacuum-aware story becomes complete: no hot table relies on
-  `DELETE` or `UPDATE` for reclamation.
-- The short-job hot path drops one `INSERT` at claim and one `DELETE` at
-  completion. Per-job database work is strictly reduced.
-- Autovacuum tuning on `open_receipt_claims` becomes dead code and is
-  removed. The per-table HOT tuning on the small ring-state and head
-  tables stays because it addresses a separate per-row UPDATE class that
-  this ADR does not change.
-- Receipts become the default short-job path for 0.6, retiring the
-  per-claim mutable lease row on the common path.
+- The 0.6 vacuum-aware story becomes complete: no hot table relies on `DELETE` or `UPDATE` for reclamation.
+- The short-job hot path drops one `INSERT` at claim and one `DELETE` at completion. Per-job database work is strictly reduced.
+- Autovacuum tuning on `open_receipt_claims` becomes dead code and is removed. The per-table HOT tuning on the small ring-state and head tables stays because it addresses a separate per-row UPDATE class that this ADR does not change.
+- Receipts become the default short-job path for 0.6, retiring the per-claim mutable lease row on the common path.
 
 ### Negative
 
 - This is a breaking schema migration.
-- "Currently open" queries move from a single bounded-frontier lookup to
-  a bounded anti-join across a small number of active partitions. Query
-  planning needs spot-checking once the partition count is chosen.
-- Rescue gains a partition-aware variant and must run before prune takes
-  `ACCESS EXCLUSIVE`. The interaction point is small but adds a
-  prune-path precondition not present for `ready` / `done`.
-- The default-success path still appends a `done_entries` row. ADR-026 later
-  narrowed that row by hydrating duplicated immutable body fields from the
-  retained ready row, but kept `done_entries` as the durable terminal record
-  used by queue counts, retention, `load_job`, and terminal inspection.
+- "Currently open" queries move from a single bounded-frontier lookup to a bounded anti-join across a small number of active partitions. Query planning needs spot-checking once the partition count is chosen.
+- Rescue gains a partition-aware variant and must run before prune takes `ACCESS EXCLUSIVE`. The interaction point is small but adds a prune-path precondition not present for `ready` / `done`.
+- The default-success path still appends a `done_entries` row. ADR-026 later narrowed that row by hydrating duplicated immutable body fields from the retained ready row, but kept `done_entries` as the durable terminal record used by queue counts, retention, `load_job`, and terminal inspection.
 
 ## Alternatives Considered
 
 ### Per-table autovacuum tuning on `open_receipt_claims`
 
-Rejected. A measured 28-minute soak with aggressive per-table thresholds
-and cost knobs left the median dead-tuple count on this table unchanged
-relative to the unmodified baseline (`custom-20260424T041700Z-278649`
-vs. `custom-20260424T065828Z-227187`). The rate-limiter is
-`autovacuum_naptime=60s`, which is global, and the table is already
-eligible for vacuum on every wake-up. Per-table knobs improve vacuum
-efficiency when it runs but do not change the steady-state floor.
+Rejected. A measured 28-minute soak with aggressive per-table thresholds and cost knobs left the median dead-tuple count on this table unchanged relative to the unmodified baseline (`custom-20260424T041700Z-278649` vs. `custom-20260424T065828Z-227187`). The rate-limiter is `autovacuum_naptime=60s`, which is global, and the table is already eligible for vacuum on every wake-up. Per-table knobs improve vacuum efficiency when it runs but do not change the steady-state floor.
 
 ### Documented operational `autovacuum_naptime` reduction
 
-Rejected as the primary fix. Lowering `autovacuum_naptime` globally
-improves reclamation cadence but pushes configuration requirements onto
-operators and applies to every table in their database. It contradicts
-the ADR-019 principle that vacuum-awareness is a property of the schema
-design, not of operator tuning.
+Rejected as the primary fix. Lowering `autovacuum_naptime` globally improves reclamation cadence but pushes configuration requirements onto operators and applies to every table in their database. It contradicts the ADR-019 principle that vacuum-awareness is a property of the schema design, not of operator tuning.
 
 ### Awa-owned periodic VACUUM on `open_receipt_claims`
 
-Rejected. A background `VACUUM` loop would mask the churn but keeps a hot
-`DELETE` on the common completion path and leaves the table as a
-permanent architectural outlier. The rest of the engine has no equivalent
-self-vacuum loop.
+Rejected. A background `VACUUM` loop would mask the churn but keeps a hot `DELETE` on the common completion path and leaves the table as a permanent architectural outlier. The rest of the engine has no equivalent self-vacuum loop.
 
 ### UPDATE-based soft close on `open_receipt_claims`
 
-Rejected. Marking a `closed_at` column and sweeping closed rows
-periodically keeps the table live-bounded, and a HOT-eligible `UPDATE`
-avoids a new heap tuple. But the sweep still performs `DELETE`s in batch,
-index bloat still tracks throughput, and the architectural outlier
-persists.
+Rejected. Marking a `closed_at` column and sweeping closed rows periodically keeps the table live-bounded, and a HOT-eligible `UPDATE` avoids a new heap tuple. But the sweep still performs `DELETE`s in batch, index bloat still tracks throughput, and the architectural outlier persists.
 
 ### Ship 0.6 with receipts off
 
-Rejected. Shipping with receipts off lets 0.6 hit the dead-tuple budget
-today, but it leaves the short-job path on the mutable `leases` ring and
-defers the work tracked in the archived
-[`lease-plane-redesign-spike`](../archive/0.6-storage-design/lease-plane-redesign-spike.md).
-ADR-019's vacuum-aware intent is only satisfied when receipts are on by
-default and do not regress the dead-tuple budget. This ADR is the path to
-that posture.
+Rejected. Shipping with receipts off lets 0.6 hit the dead-tuple budget today, but it leaves the short-job path on the mutable `leases` ring and defers the work tracked in the archived [`lease-plane-redesign-spike`](../archive/0.6-storage-design/lease-plane-redesign-spike.md). ADR-019's vacuum-aware intent is only satisfied when receipts are on by default and do not regress the dead-tuple budget. This ADR is the path to that posture.
 
 ## Relationship to Earlier ADRs
 
-- ADR-019 established the vacuum-aware discipline. This ADR applies that
-  discipline to the one remaining hot table that did not follow it.
-- ADR-013 (run-lease-guarded finalization) is unchanged. The
-  authoritative record for `(job_id, run_lease)` staleness moves from a
-  bounded mutable frontier to partitioned append-only tables; the
-  guarantee does not.
-- The archived
-  [`lease-plane-redesign-spike`](../archive/0.6-storage-design/lease-plane-redesign-spike.md)
-  identifies `open_receipt_claims` as the compromise that unblocked the
-  receipt-backed path. This ADR is the follow-through that the spike
-  anticipated.
+- ADR-019 established the vacuum-aware discipline. This ADR applies that discipline to the one remaining hot table that did not follow it.
+- ADR-013 (run-lease-guarded finalization) is unchanged. The authoritative record for `(job_id, run_lease)` staleness moves from a bounded mutable frontier to partitioned append-only tables; the guarantee does not.
+- The archived [`lease-plane-redesign-spike`](../archive/0.6-storage-design/lease-plane-redesign-spike.md) identifies `open_receipt_claims` as the compromise that unblocked the receipt-backed path. This ADR is the follow-through that the spike anticipated.
 
 ## Implementation and Validation Status
 
@@ -304,34 +155,14 @@ This ADR has been implemented for 0.6:
 
 - `lease_claims` and `lease_claim_closures` are partitioned by `claim_slot`.
 - `claim_ring_state` and `claim_ring_slots` control rotation and prune.
-- `open_receipt_claims` is removed from fresh installs and is no longer a hot
-  path table.
+- `open_receipt_claims` is removed from fresh installs and is no longer a hot path table.
 - `lease_claim_receipts` defaults to `true`.
-- Receipts mode supports per-claim deadlines. The claim path writes
-  `deadline_at` onto the `lease_claims` row when
-  `QueueConfig.deadline_duration > 0`, and a sibling rescue scan
-  (`rescue_expired_receipt_deadlines_tx`) force-closes claims whose
-  `deadline_at` has passed without a closure or materialized lease,
-  writing a `'deadline_expired'` closure. The maintenance entry point
-  (`rescue_expired_deadlines`) merges the lease-side and receipt-side
-  scans into one batch per tick, so receipts mode and the existing
-  hard-deadline behaviour compose without operator intervention.
+- Receipts mode supports per-claim deadlines. The claim path writes `deadline_at` onto the `lease_claims` row when `QueueConfig.deadline_duration > 0`, and a sibling rescue scan (`rescue_expired_receipt_deadlines_tx`) force-closes claims whose `deadline_at` has passed without a closure or materialized lease, writing a `'deadline_expired'` closure. The maintenance entry point (`rescue_expired_deadlines`) merges the lease-side and receipt-side scans into one batch per tick, so receipts mode and the existing hard-deadline behaviour compose without operator intervention.
 
 Validation evidence is split by purpose:
 
-- Runtime and long-horizon evidence lives in
-  [`bench/023-receipt-ring-validation-2026-04-26.md`](bench/023-receipt-ring-validation-2026-04-26.md).
-  The recorded runs include the 115-minute 4x8 receipts-on long-horizon run and
-  the 12-hour overnight run; receipt closure partitions stayed at 0 dead tuples
-  across every phase, and receipt claims remained bounded.
-- Spec and implementation mapping lives in
-  [`../../correctness/storage/MAPPING.md`](../../correctness/storage/MAPPING.md).
-  The storage TLA+ family models claim-ring rotation, partition prune safety,
-  receipt rescue, running cancel, and DLQ retry trace witnesses.
-- Operator-facing tuning and defaults live in
-  [`../configuration.md`](../configuration.md#queue-storage-tuning).
+- Runtime and long-horizon evidence lives in [`bench/023-receipt-ring-validation-2026-04-26.md`](bench/023-receipt-ring-validation-2026-04-26.md). The recorded runs include the 115-minute 4x8 receipts-on long-horizon run and the 12-hour overnight run; receipt closure partitions stayed at 0 dead tuples across every phase, and receipt claims remained bounded.
+- Spec and implementation mapping lives in [`../../correctness/storage/MAPPING.md`](../../correctness/storage/MAPPING.md). The storage TLA+ family models claim-ring rotation, partition prune safety, receipt rescue, running cancel, and DLQ retry trace witnesses.
+- Operator-facing tuning and defaults live in [`../configuration.md`](../configuration.md#queue-storage-tuning).
 
-The detailed phase-by-phase implementation notes were intentionally kept out of
-this ADR. ADRs record the decision and its consequences; dated build logs,
-benchmark output, and branch-era investigation notes belong in validation
-artifacts or the 0.6 storage-design archive.
+The detailed phase-by-phase implementation notes were intentionally kept out of this ADR. ADRs record the decision and its consequences; dated build logs, benchmark output, and branch-era investigation notes belong in validation artifacts or the 0.6 storage-design archive.

--- a/docs/adr/025-sharded-enqueue-heads.md
+++ b/docs/adr/025-sharded-enqueue-heads.md
@@ -2,16 +2,11 @@
 
 ## Status
 
-Accepted. The shard plane is operational; `awa.queue_meta.enqueue_shards`
-governs the per-queue shard count (default 1, range 1..=64), and every
-hot-path query — enqueue, claim, completion, receipt rescue, admin
-lookup, terminal storage — joins or filters on `enqueue_shard`.
+Accepted. The shard plane is operational; `awa.queue_meta.enqueue_shards` governs the per-queue shard count (default 1, range 1..=64), and every hot-path query — enqueue, claim, completion, receipt rescue, admin lookup, terminal storage — joins or filters on `enqueue_shard`.
 
 ## Context
 
-The queue-storage engine allocates each enqueue batch a contiguous
-`lane_seq` range by advancing a single counter per `(queue, priority)`
-lane:
+The queue-storage engine allocates each enqueue batch a contiguous `lane_seq` range by advancing a single counter per `(queue, priority)` lane:
 
 ```sql
 UPDATE queue_enqueue_heads
@@ -20,232 +15,100 @@ WHERE queue = $1 AND priority = $2
 RETURNING next_seq - $count;
 ```
 
-This is one row-level lock per producer transaction. Concurrent
-producers for the same lane serialise on that lock. The semantics are
-correct and the contract is strict FIFO within the lane; the cost is
-that producer throughput on a single hot lane is bounded by the
-end-to-end cost of touching that one row — commit, WAL flush, and the
-next producer's lock acquire.
+This is one row-level lock per producer transaction. Concurrent producers for the same lane serialise on that lock. The semantics are correct and the contract is strict FIFO within the lane; the cost is that producer throughput on a single hot lane is bounded by the end-to-end cost of touching that one row — commit, WAL flush, and the next producer's lock acquire.
 
-Wait-event sampling on a 16-producer same-queue workload attributes
-producer time as follows:
+Wait-event sampling on a 16-producer same-queue workload attributes producer time as follows:
 
-| Wait type | Wait event | % of producer time |
-|---|---|--:|
-| `Lock` | `transactionid` | 63.5% |
-| `Lock` | `tuple` | 29.6% |
-| running on CPU | — | 4.4% |
-| `IO` | `WalSync` | 1.1% |
-| `Client` | `ClientRead` | 1.1% |
-| `IO` | `DataFileExtend` | 0.3% |
+| Wait type      | Wait event       | % of producer time |
+| -------------- | ---------------- | -----------------: |
+| `Lock`         | `transactionid`  |              63.5% |
+| `Lock`         | `tuple`          |              29.6% |
+| running on CPU | —                |               4.4% |
+| `IO`           | `WalSync`        |               1.1% |
+| `Client`       | `ClientRead`     |               1.1% |
+| `IO`           | `DataFileExtend` |               0.3% |
 
-93% of producer wall-clock is row-lock wait, and 93% of that is on the
-single `UPDATE queue_enqueue_heads` query. The lock contention is
-structural: a single-counter scheme cannot amortise the lock across
-producers.
+93% of producer wall-clock is row-lock wait, and 93% of that is on the single `UPDATE queue_enqueue_heads` query. The lock contention is structural: a single-counter scheme cannot amortise the lock across producers.
 
-ADR-019 accepted the queue-storage engine as the vacuum-aware
-replacement for canonical `jobs_hot`. It inherits the single-row head
-pattern as the simplest correct mapping of a per-row state machine
-onto an append-only sequence space. The receipt plane (ADR-023) and
-the various rotation disciplines remove dead tuples but do not address
-producer-side contention on the live head row.
+ADR-019 accepted the queue-storage engine as the vacuum-aware replacement for canonical `jobs_hot`. It inherits the single-row head pattern as the simplest correct mapping of a per-row state machine onto an append-only sequence space. The receipt plane (ADR-023) and the various rotation disciplines remove dead tuples but do not address producer-side contention on the live head row.
 
-The two cheap producer-side mitigations that ship alongside this ADR
-do not address the head row directly:
+The two cheap producer-side mitigations that ship alongside this ADR do not address the head row directly:
 
-- A per-store in-process cache of `(queue, priority, shard)` lane
-  presence so subsequent enqueue batches skip the three
-  `INSERT ... ON CONFLICT DO NOTHING` round-trips for known lane rows.
-- Completion-batcher defaults of `(batch=512, flush=1ms)` plus the
-  queue-storage fused receipt completion statement, so the completion path
-  keeps worker permit latency low while still amortising per-batch SQL.
+- A per-store in-process cache of `(queue, priority, shard)` lane presence so subsequent enqueue batches skip the three `INSERT ... ON CONFLICT DO NOTHING` round-trips for known lane rows.
+- Completion-batcher defaults of `(batch=512, flush=1ms)` plus the queue-storage fused receipt completion statement, so the completion path keeps worker permit latency low while still amortising per-batch SQL.
 
 ## Decision
 
-Add an `enqueue_shard SMALLINT` column to every table in the active
-plane:
+Add an `enqueue_shard SMALLINT` column to every table in the active plane:
 
-- `queue_enqueue_heads` and `queue_claim_heads` extend their PK to
-  `(queue, priority, enqueue_shard)`.
-- `ready_entries` extends its PK to
-  `(ready_slot, queue, priority, enqueue_shard, lane_seq)`.
-- `leases` extends its PK to
-  `(lease_slot, queue, priority, enqueue_shard, lane_seq)`.
-- `done_entries` extends its PK to
-  `(ready_slot, queue, priority, enqueue_shard, lane_seq)`.
-- `lease_claims` carries `enqueue_shard` as a regular column; its PK
-  `(claim_slot, job_id, run_lease)` is unique through `job_id` and
-  stays as-is.
+- `queue_enqueue_heads` and `queue_claim_heads` extend their PK to `(queue, priority, enqueue_shard)`.
+- `ready_entries` extends its PK to `(ready_slot, queue, priority, enqueue_shard, lane_seq)`.
+- `leases` extends its PK to `(lease_slot, queue, priority, enqueue_shard, lane_seq)`.
+- `done_entries` extends its PK to `(ready_slot, queue, priority, enqueue_shard, lane_seq)`.
+- `lease_claims` carries `enqueue_shard` as a regular column; its PK `(claim_slot, job_id, run_lease)` is unique through `job_id` and stays as-is.
 
-Sharding is a per-queue tunable on `awa.queue_meta.enqueue_shards`
-(`SMALLINT NOT NULL DEFAULT 1 CHECK (BETWEEN 1 AND 64)`). With the
-default value of 1, only shard 0 exists and every code path reduces
-to the pre-shard behaviour observationally — single FIFO per lane,
-one head row per `(queue, priority)`, terminal keys colliding only
-on `job_id` (which is globally unique). Raising the value spreads
-producer writes across the configured shard count.
+Sharding is a per-queue tunable on `awa.queue_meta.enqueue_shards` (`SMALLINT NOT NULL DEFAULT 1 CHECK (BETWEEN 1 AND 64)`). With the default value of 1, only shard 0 exists and every code path reduces to the pre-shard behaviour observationally — single FIFO per lane, one head row per `(queue, priority)`, terminal keys colliding only on `job_id` (which is globally unique). Raising the value spreads producer writes across the configured shard count.
 
-The producer-side helper `shard_for_enqueue` reads the per-queue
-shard count once (cached in-process, invalidated on `reset()`) and
-selects a shard for each no-key `(queue, priority)` sub-batch by
-advancing a per-store `AtomicU16` counter modulo the shard count.
-Rows with an `ordering_key` bypass the rotor and route by the
-deterministic key hash.
+The producer-side helper `shard_for_enqueue` reads the per-queue shard count once (cached in-process, invalidated on `reset()`) and selects a shard for each no-key `(queue, priority)` sub-batch by advancing a per-store `AtomicU16` counter modulo the shard count. Rows with an `ordering_key` bypass the rotor and route by the deterministic key hash.
 
-The claim-side function `claim_ready_runtime` walks every shard row
-for a `(queue, priority)` via a `lane_candidates` CTE, picks one
-candidate (ordered by effective priority, `run_at`, and priority),
-locks that shard's `queue_claim_heads` row with `FOR UPDATE OF claims
-SKIP LOCKED`, and drains rows from that shard's `ready_entries` slice.
-Gap recovery is per-shard.
+The claim-side function `claim_ready_runtime` walks every shard row for a `(queue, priority)` via a `lane_candidates` CTE, picks one candidate (ordered by effective priority, `run_at`, and priority), locks that shard's `queue_claim_heads` row with `FOR UPDATE OF claims SKIP LOCKED`, and drains rows from that shard's `ready_entries` slice. Gap recovery is per-shard.
 
-Receipts and leases carry the shard end-to-end: the claim's
-`enqueue_shard` rides on `ClaimedEntry`, gets inserted into
-`lease_claims` (when receipts are on) and `leases` (when they
-materialise), is read back by the cancel-from-receipt path so the
-synthesized `done_entries` row lands on the correct shard, and is
-the join predicate for every admin lookup that joins
-`ready_entries` to `queue_claim_heads` (queue counts, cancel,
-priority aging). Without that predicate, a ready row from shard A
-could match shard B's `claim_seq` and an admin DELETE could remove
-or move rows from the wrong shard.
+Receipts and leases carry the shard end-to-end: the claim's `enqueue_shard` rides on `ClaimedEntry`, gets inserted into `lease_claims` (when receipts are on) and `leases` (when they materialise), is read back by the cancel-from-receipt path so the synthesized `done_entries` row lands on the correct shard, and is the join predicate for every admin lookup that joins `ready_entries` to `queue_claim_heads` (queue counts, cancel, priority aging). Without that predicate, a ready row from shard A could match shard B's `claim_seq` and an admin DELETE could remove or move rows from the wrong shard.
 
-`dlq_entries` is unsharded: its PK is `job_id`, which is globally
-unique.
+`dlq_entries` is unsharded: its PK is `job_id`, which is globally unique.
 
 ### Ordering contract: partitioned FIFO
 
-`enqueue_shards > 1` is a semantic mode switch, not a hidden
-performance optimization. It changes the ordering contract the queue
-offers and operators opt into it per queue. The peer comparison is
-SQS Standard vs FIFO, Kafka partitions, Pub/Sub ordering keys, and
-RabbitMQ sharded queues: a partition is the ordering scope, the
-operator picks how many partitions, and producers route into them.
+`enqueue_shards > 1` is a semantic mode switch, not a hidden performance optimization. It changes the ordering contract the queue offers and operators opt into it per queue. The peer comparison is SQS Standard vs FIFO, Kafka partitions, Pub/Sub ordering keys, and RabbitMQ sharded queues: a partition is the ordering scope, the operator picks how many partitions, and producers route into them.
 
-`lane_seq` is allocated by `UPDATE queue_enqueue_heads SET
-next_seq = ...` keyed by `(queue, priority, enqueue_shard)`. Each
-shard owns an independent strictly-increasing sequence. The contract:
+`lane_seq` is allocated by `UPDATE queue_enqueue_heads SET next_seq = ...` keyed by `(queue, priority, enqueue_shard)`. Each shard owns an independent strictly-increasing sequence. The contract:
 
-- **`enqueue_shards = 1` (default): strict FIFO per
-  `(queue, priority)`.** Identical to the pre-shard contract.
-  Workloads that depend on cross-producer FIFO at the lane level
-  stay here.
-- **`enqueue_shards > 1`: partitioned FIFO per
-  `(queue, priority, enqueue_shard)`.** Strict FIFO is preserved
-  within each shard. No ordering is promised across shards. Two
-  rows enqueued to different shards may be claimed in either order
-  depending on which shard the claim path visits first.
+- **`enqueue_shards = 1` (default): strict FIFO per `(queue, priority)`.** Identical to the pre-shard contract. Workloads that depend on cross-producer FIFO at the lane level stay here.
+- **`enqueue_shards > 1`: partitioned FIFO per `(queue, priority, enqueue_shard)`.** Strict FIFO is preserved within each shard. No ordering is promised across shards. Two rows enqueued to different shards may be claimed in either order depending on which shard the claim path visits first.
 
-Choosing `S > 1` is the same kind of decision as choosing SQS
-Standard over SQS FIFO: lock contention scales with the shard count
-and ordering scope shrinks to one shard. Choosing `S = 1` is the
-SQS-FIFO-equivalent contract.
+Choosing `S > 1` is the same kind of decision as choosing SQS Standard over SQS FIFO: lock contention scales with the shard count and ordering scope shrinks to one shard. Choosing `S = 1` is the SQS-FIFO-equivalent contract.
 
 ### Routing producers into shards
 
 Two modes share the `shard_for_enqueue` entry point:
 
-1. **Rotor (default).** When the caller does not supply an
-   `ordering_key`, the per-store `AtomicU16` rotor selects a shard
-   modulo the queue's shard count. Selection is **per
-   `(queue, priority)` sub-batch within a single `insert_*_tx`
-   call** — all rotor-routed rows that share a destination lane in
-   one batch collapse onto the same shard so a 500-row batch issues
-   one `advance_enqueue_head` UPDATE and one INSERT instead of
-   500. The rotor advances on each pick, so successive batches
-   spread across shards. This per-batch amortisation is what makes
-   `enqueue_shards > 1` net-faster than `S = 1` at moderate
-   producer concurrency; per-row pick was measured to invert the
-   curve (S>1 slower than S=1) because each batch fanned into S
-   sub-INSERTs.
+1. **Rotor (default).** When the caller does not supply an `ordering_key`, the per-store `AtomicU16` rotor selects a shard modulo the queue's shard count. Selection is **per `(queue, priority)` sub-batch within a single `insert_*_tx` call** — all rotor-routed rows that share a destination lane in one batch collapse onto the same shard so a 500-row batch issues one `advance_enqueue_head` UPDATE and one INSERT instead of 500. The rotor advances on each pick, so successive batches spread across shards. This per-batch amortisation is what makes `enqueue_shards > 1` net-faster than `S = 1` at moderate producer concurrency; per-row pick was measured to invert the curve (S>1 slower than S=1) because each batch fanned into S sub-INSERTs.
 
-2. **`InsertOpts::ordering_key` (hash-routed).** When the
-   caller pins a key, `shard_for_ordering_key` maps the key bytes
-   into `[0, shards)` deterministically. Awa uses a portable 64-bit
-   rolling hash implemented in Rust and in the SQL compatibility
-   function, so Rust, SQL, and Python producers route the same key
-   bytes to the same shard without relying on a PostgreSQL extension.
+2. **`InsertOpts::ordering_key` (hash-routed).** When the caller pins a key, `shard_for_ordering_key` maps the key bytes into `[0, shards)` deterministically. Awa uses a portable 64-bit rolling hash implemented in Rust and in the SQL compatibility function, so Rust, SQL, and Python producers route the same key bytes to the same shard without relying on a PostgreSQL extension.
 
-   `ordering_key` is the same primitive as Kafka partition keys or
-   Pub/Sub ordering keys: jobs that share a key share a shard, which
-   preserves partitioned FIFO for that key even across separate
-   `insert_*` calls. At `enqueue_shards = 1` the key is ignored
-   (every key collapses to shard 0).
+   `ordering_key` is the same primitive as Kafka partition keys or Pub/Sub ordering keys: jobs that share a key share a shard, which preserves partitioned FIFO for that key even across separate `insert_*` calls. At `enqueue_shards = 1` the key is ignored (every key collapses to shard 0).
 
-This trade is the point of the design: lifting the lock contention
-requires shrinking the ordering scope, and sharding lets each queue
-choose where on that trade-off it sits.
+This trade is the point of the design: lifting the lock contention requires shrinking the ordering scope, and sharding lets each queue choose where on that trade-off it sits.
 
 ## Validation
 
-Local A/B sweep on the in-tree `test_queue_storage_enqueue_contention`
-(16 producers × 15 k jobs each, same queue, post-cache, 3 runs per
-cell, with the full shard plane wired through claim, receipt, and
-admin paths):
+Local A/B sweep on the in-tree `test_queue_storage_enqueue_contention` (16 producers × 15 k jobs each, same queue, post-cache, 3 runs per cell, with the full shard plane wired through claim, receipt, and admin paths):
 
 | `enqueue_shards` | Mean throughput | vs S=1 |
-|---|--:|--:|
-| 1 (default) | 42,516 jobs/s | 1.00× |
-| 2 | 68,065 jobs/s | 1.60× |
-| 4 | 116,852 jobs/s | 2.75× |
-| 8 | 157,000 jobs/s | 3.69× |
+| ---------------- | --------------: | -----: |
+| 1 (default)      |   42,516 jobs/s |  1.00× |
+| 2                |   68,065 jobs/s |  1.60× |
+| 4                |  116,852 jobs/s |  2.75× |
+| 8                |  157,000 jobs/s |  3.69× |
 
-Scaling stays substantial up to `S=8` on a 2-producer-per-shard
-configuration. Per-shard claim-path work and WAL bandwidth set the
-diminishing-returns shape past S=8; the knee for this concurrency
-sits in the S=8..16 range. Combined with the in-process
-`ensure_lane` cache shipped alongside this work, the headline gain
-over the pre-cache, pre-shard baseline is ~5× (~30,000 jobs/s →
-157,000 jobs/s at S=8).
+Scaling stays substantial up to `S=8` on a 2-producer-per-shard configuration. Per-shard claim-path work and WAL bandwidth set the diminishing-returns shape past S=8; the knee for this concurrency sits in the S=8..16 range. Combined with the in-process `ensure_lane` cache shipped alongside this work, the headline gain over the pre-cache, pre-shard baseline is ~5× (~30,000 jobs/s → 157,000 jobs/s at S=8).
 
-`test_queue_storage_multi_shard_round_trip_through_completion`
-exercises the full plumbing at S=4: producers spread writes across
-four shards, workers drain them through completion, and terminal
-rows land in `done_entries` keyed by shard. The test asserts that
-every shard holds terminal rows and that at least one
-`(ready_slot, queue, priority, lane_seq)` tuple is reused across
-shards — i.e. the shard column is load-bearing in the PK and the
-end-to-end path correctly carries `enqueue_shard` from claim into
-the terminal write.
+`test_queue_storage_multi_shard_round_trip_through_completion` exercises the full plumbing at S=4: producers spread writes across four shards, workers drain them through completion, and terminal rows land in `done_entries` keyed by shard. The test asserts that every shard holds terminal rows and that at least one `(ready_slot, queue, priority, lane_seq)` tuple is reused across shards — i.e. the shard column is load-bearing in the PK and the end-to-end path correctly carries `enqueue_shard` from claim into the terminal write.
 
 ### What this ADR does not validate
 
-The validation here is the producer-side enqueue-contention story.
-It does not replicate the high-worker-count rescue-path regression
-that motivated the original perf investigation (1 replica × 256
-workers, receipts on, `LEASE_DEADLINE_MS=0` vs default A/B). That
-regression is on the claim / rescue side of the queue-storage
-engine; sharding the enqueue head row is a necessary but not
-sufficient fix. The A/B against the rescue-path workload is left
-for a follow-up so that the two effects can be measured
-independently.
+The validation here is the producer-side enqueue-contention story. It does not replicate the high-worker-count rescue-path regression that motivated the original perf investigation (1 replica × 256 workers, receipts on, `LEASE_DEADLINE_MS=0` vs default A/B). That regression is on the claim / rescue side of the queue-storage engine; sharding the enqueue head row is a necessary but not sufficient fix. The A/B against the rescue-path workload is left for a follow-up so that the two effects can be measured independently.
 
 ## Fairness and observability
 
-The claim-path SQL orders candidate shard heads by
-`(effective_priority, run_at, priority)` — `run_at` is the natural
-fairness mechanism. Under steady-state load every shard accumulates
-its own pending rows; the shard whose oldest waiting row has the
-earliest `run_at` wins the next claim, its lane head advances, and
-another shard's oldest row becomes the next pick. Concurrent claimers
-add a second fairness mechanism: `FOR UPDATE OF claims SKIP LOCKED`
-sends each claimer to a different shard's head.
+The claim-path SQL orders candidate shard heads by `(effective_priority, run_at, priority)` — `run_at` is the natural fairness mechanism. Under steady-state load every shard accumulates its own pending rows; the shard whose oldest waiting row has the earliest `run_at` wins the next claim, its lane head advances, and another shard's oldest row becomes the next pick. Concurrent claimers add a second fairness mechanism: `FOR UPDATE OF claims SKIP LOCKED` sends each claimer to a different shard's head.
 
-The audit is enforced by
-`test_queue_storage_multi_shard_claim_path_does_not_starve_shards`,
-which loads four shards equally and asserts every shard's
-`claim_seq` advanced to its `next_seq` after a worker drains the
-queue.
+The audit is enforced by `test_queue_storage_multi_shard_claim_path_does_not_starve_shards`, which loads four shards equally and asserts every shard's `claim_seq` advanced to its `next_seq` after a worker drains the queue.
 
 Per-shard observability:
 
-- `awa.job.claimed` (counter) carries an `awa.enqueue.shard`
-  attribute on the queue-storage path. Operators sum by that label
-  to see per-shard claim throughput and spot any shard that flatlines
-  while its peers are draining.
-- Ad-hoc inspection during incident response is a direct SQL query
-  against `queue_enqueue_heads` and `queue_claim_heads`:
+- `awa.job.claimed` (counter) carries an `awa.enqueue.shard` attribute on the queue-storage path. Operators sum by that label to see per-shard claim throughput and spot any shard that flatlines while its peers are draining.
+- Ad-hoc inspection during incident response is a direct SQL query against `queue_enqueue_heads` and `queue_claim_heads`:
 
   ```sql
   SELECT priority, enqueue_shard,
@@ -257,40 +120,18 @@ Per-shard observability:
   ORDER BY priority, enqueue_shard;
   ```
 
-  A non-zero `lag` that stays non-zero on one shard while peers
-  drain indicates a starved shard — but the in-tree fairness test
-  exercises the contract and the `awa.job.claimed` per-shard
-  counter is the live signal.
+  A non-zero `lag` that stays non-zero on one shard while peers drain indicates a starved shard — but the in-tree fairness test exercises the contract and the `awa.job.claimed` per-shard counter is the live signal.
 
 ## Lowering `enqueue_shards`
 
-Lowering is safe in the steady state because every claim, rescue,
-and admin path joins `queue_claim_heads` to `queue_enqueue_heads`
-on `(queue, priority, enqueue_shard)` without any `shard <
-current_count` predicate. Concretely:
+Lowering is safe in the steady state because every claim, rescue, and admin path joins `queue_claim_heads` to `queue_enqueue_heads` on `(queue, priority, enqueue_shard)` without any `shard < current_count` predicate. Concretely:
 
-- The claim function `claim_ready_runtime` walks every row in
-  `queue_claim_heads` for the queue. Rows for shards `>= newS`
-  continue to be picked up and drained as long as their
-  `claim_seq < next_seq`.
-- Heartbeat / deadline / callback rescue read the shard from the
-  in-flight `leases` or `lease_claims` row, so a rescued job
-  re-enters the lane it came from regardless of the current shard
-  count.
-- The promotion path (`deferred_jobs` → `ready_entries`) calls
-  `shard_for_enqueue` with the *current* shard count, so promoted
-  rows land on `[0, newS)`. They cannot leak onto out-of-range
-  shards.
+- The claim function `claim_ready_runtime` walks every row in `queue_claim_heads` for the queue. Rows for shards `>= newS` continue to be picked up and drained as long as their `claim_seq < next_seq`.
+- Heartbeat / deadline / callback rescue read the shard from the in-flight `leases` or `lease_claims` row, so a rescued job re-enters the lane it came from regardless of the current shard count.
+- The promotion path (`deferred_jobs` → `ready_entries`) calls `shard_for_enqueue` with the _current_ shard count, so promoted rows land on `[0, newS)`. They cannot leak onto out-of-range shards.
 - DLQ is unsharded; its PK is `job_id`.
 
-The in-process `enqueue_shards_cache` on `QueueStorage` is the only
-caveat: a running runtime that cached the old shard count keeps
-producing to shards `>= newS` until the cache is invalidated by
-`reset()` or process restart. That is operator-intent-stale but
-correctness-safe — the rows still claim, run, and finalise through
-the same code paths. Operators rolling out a `S` reduction restart
-runtimes (or trigger `reset()`) so producers immediately observe
-the new value.
+The in-process `enqueue_shards_cache` on `QueueStorage` is the only caveat: a running runtime that cached the old shard count keeps producing to shards `>= newS` until the cache is invalidated by `reset()` or process restart. That is operator-intent-stale but correctness-safe — the rows still claim, run, and finalise through the same code paths. Operators rolling out a `S` reduction restart runtimes (or trigger `reset()`) so producers immediately observe the new value.
 
 Operational procedure:
 
@@ -303,150 +144,51 @@ Operational procedure:
    DO UPDATE SET enqueue_shards = EXCLUDED.enqueue_shards;
    ```
 
-2. Restart runtime processes (or rely on natural restart cadence)
-   so the in-process cache observes the new value.
-3. Optionally watch the per-shard SQL above until `lag` reaches 0
-   on shards `>= newS`. The shards' `queue_*_heads` rows linger as
-   harmless empty heads — they cost a few small rows and have no
-   effect on throughput.
+2. Restart runtime processes (or rely on natural restart cadence) so the in-process cache observes the new value.
+3. Optionally watch the per-shard SQL above until `lag` reaches 0 on shards `>= newS`. The shards' `queue_*_heads` rows linger as harmless empty heads — they cost a few small rows and have no effect on throughput.
 
-The contract is enforced by
-`test_queue_storage_lowering_enqueue_shards_drains_existing_rows`,
-which seeds rows on every shard at `S = 4`, lowers to `S = 2`, and
-asserts every row drains to `done_entries`.
+The contract is enforced by `test_queue_storage_lowering_enqueue_shards_drains_existing_rows`, which seeds rows on every shard at `S = 4`, lowers to `S = 2`, and asserts every row drains to `done_entries`.
 
 ## Consequences
 
 ### Positive
 
-- **Row-lock contention on enqueue scales with the per-queue shard
-  count, not with producer concurrency.** Operators have a direct
-  lever for contended lanes without changing application code.
-- **Default unchanged.** `enqueue_shards = 1` is observationally
-  identical to the pre-shard layout. Existing tests, ADRs, and TLA+
-  models that index by `(queue, priority)` continue to describe
-  deployed behaviour at S=1.
-- **Cheap to revert.** Lowering `enqueue_shards` requires only that
-  the operator drain rows from the now-out-of-range shards; the
-  underlying tables continue to function during the drain. No schema
-  rollback required for `S>1 → S=1`.
-- **Co-located with the storage transition framework.** The
-  migration refuses to run mid-`mixed_transition`, where reshaping
-  the partitioned PKs would block the live engines. On `active`
-  installs the migration takes a brief `ACCESS EXCLUSIVE` during the
-  PK reshape; operators run it during a low-traffic window.
+- **Row-lock contention on enqueue scales with the per-queue shard count, not with producer concurrency.** Operators have a direct lever for contended lanes without changing application code.
+- **Default unchanged.** `enqueue_shards = 1` is observationally identical to the pre-shard layout. Existing tests, ADRs, and TLA+ models that index by `(queue, priority)` continue to describe deployed behaviour at S=1.
+- **Cheap to revert.** Lowering `enqueue_shards` requires only that the operator drain rows from the now-out-of-range shards; the underlying tables continue to function during the drain. No schema rollback required for `S>1 → S=1`.
+- **Co-located with the storage transition framework.** The migration refuses to run mid-`mixed_transition`, where reshaping the partitioned PKs would block the live engines. On `active` installs the migration takes a brief `ACCESS EXCLUSIVE` during the PK reshape; operators run it during a low-traffic window.
 
 ### Negative
 
-- **Ordering scope shrinks from the lane to the shard at
-  `enqueue_shards > 1`.** The contract becomes partitioned FIFO:
-  strict order within `(queue, priority, enqueue_shard)`, no order
-  promised across shards. Applications that document or rely on
-  strict cross-producer FIFO at the lane level pin `S = 1`.
-  Applications that need per-key FIFO (per customer, per order,
-  per account) pass `InsertOpts::ordering_key` so rows for that
-  key collapse onto one shard. Priority aging, deadline rescue,
-  callback resume, and DLQ semantics are unaffected.
-- **Claim-side cost is `O(S)` per claim call.** Each
-  `claim_ready_runtime` invocation scans up to S candidate shard
-  heads. With `S=64` and four priorities this is 256 candidate rows;
-  trivial at the current per-claim cost. The `BETWEEN 1 AND 64`
-  check constraint prevents pathological values.
-- **Producer-side fairness is statistical.** The `AtomicU16` rotor
-  spreads batches uniformly over time, but a producer that emits a
-  burst of single-row batches lands them on consecutive shards
-  rather than the same one. This is acceptable; the goal is
-  reducing per-row lock pressure, not strict round-robin balance.
+- **Ordering scope shrinks from the lane to the shard at `enqueue_shards > 1`.** The contract becomes partitioned FIFO: strict order within `(queue, priority, enqueue_shard)`, no order promised across shards. Applications that document or rely on strict cross-producer FIFO at the lane level pin `S = 1`. Applications that need per-key FIFO (per customer, per order, per account) pass `InsertOpts::ordering_key` so rows for that key collapse onto one shard. Priority aging, deadline rescue, callback resume, and DLQ semantics are unaffected.
+- **Claim-side cost is `O(S)` per claim call.** Each `claim_ready_runtime` invocation scans up to S candidate shard heads. With `S=64` and four priorities this is 256 candidate rows; trivial at the current per-claim cost. The `BETWEEN 1 AND 64` check constraint prevents pathological values.
+- **Producer-side fairness is statistical.** The `AtomicU16` rotor spreads batches uniformly over time, but a producer that emits a burst of single-row batches lands them on consecutive shards rather than the same one. This is acceptable; the goal is reducing per-row lock pressure, not strict round-robin balance.
 
 ## Alternatives Considered
 
-- **Separate `queue_enqueue_head_shards` table joined to
-  `queue_lanes`.** Adds a join on the claim hot path for no benefit
-  over an extended PK; co-locating shard rows inside the existing
-  head tables keeps the claim-side query plan identical at S=1 and
-  predictable at S>1.
-- **Hash-shard the queue name itself.** Distributes contention only
-  for cross-queue workloads; this ADR is about the single-queue
-  case where the producer set spans one logical queue.
-- **`CREATE SEQUENCE` per shard, `nextval`-based allocation.**
-  Avoids the row lock but loses the batched
-  `next_seq = next_seq + $count` allocation that lets one
-  round-trip reserve a contiguous range for a COPY batch. Per-row
-  `nextval` is strictly worse at high throughput.
-- **Global `lane_seq` per `(queue, priority)`, shards allocate from
-  it.** Reintroduces the single-counter contention this ADR exists
-  to remove.
+- **Separate `queue_enqueue_head_shards` table joined to `queue_lanes`.** Adds a join on the claim hot path for no benefit over an extended PK; co-locating shard rows inside the existing head tables keeps the claim-side query plan identical at S=1 and predictable at S>1.
+- **Hash-shard the queue name itself.** Distributes contention only for cross-queue workloads; this ADR is about the single-queue case where the producer set spans one logical queue.
+- **`CREATE SEQUENCE` per shard, `nextval`-based allocation.** Avoids the row lock but loses the batched `next_seq = next_seq + $count` allocation that lets one round-trip reserve a contiguous range for a COPY batch. Per-row `nextval` is strictly worse at high throughput.
+- **Global `lane_seq` per `(queue, priority)`, shards allocate from it.** Reintroduces the single-counter contention this ADR exists to remove.
 
 ## Relationship to other ADRs
 
-- **ADR-019 (queue-storage redesign).** This ADR refines the
-  segmented-storage hot path. The append-only / rotate / prune
-  discipline is unchanged; sharding lifts contention *within* that
-  discipline.
-- **ADR-023 (receipt plane ring partitioning).** Independent.
-  ADR-023 attacks dead-tuple density on the receipt plane; this ADR
-  attacks row-lock wait on the enqueue plane. Receipts carry
-  `enqueue_shard` so they route correctly through the cancel and
-  rescue paths at S>1.
-- **ADR-016 (priority aging).** Aging operates on `run_at` and the
-  effective priority. The `claim_ready_runtime` per-shard candidate
-  walk inherits the same aging clause; FIFO-within-shard does not
-  change the aging contract.
-- **ADR-002 (BLAKE3 uniqueness hashing).** `ordering_key` routing is
-  deliberately separate from ADR-002 unique-key fingerprints. Shard
-  routing needs a small, portable hash that can run identically in
-  Rust and inside `awa.insert_job_compat`; uniqueness keeps using the
-  BLAKE3 fingerprint contract from ADR-002.
+- **ADR-019 (queue-storage redesign).** This ADR refines the segmented-storage hot path. The append-only / rotate / prune discipline is unchanged; sharding lifts contention _within_ that discipline.
+- **ADR-023 (receipt plane ring partitioning).** Independent. ADR-023 attacks dead-tuple density on the receipt plane; this ADR attacks row-lock wait on the enqueue plane. Receipts carry `enqueue_shard` so they route correctly through the cancel and rescue paths at S>1.
+- **ADR-016 (priority aging).** Aging operates on `run_at` and the effective priority. The `claim_ready_runtime` per-shard candidate walk inherits the same aging clause; FIFO-within-shard does not change the aging contract.
+- **ADR-002 (BLAKE3 uniqueness hashing).** `ordering_key` routing is deliberately separate from ADR-002 unique-key fingerprints. Shard routing needs a small, portable hash that can run identically in Rust and inside `awa.insert_job_compat`; uniqueness keeps using the BLAKE3 fingerprint contract from ADR-002.
 
 ## Implementation
 
-- Migration `v017_shard_queue_enqueue_heads.sql` adds the column to
-  every table in the active plane and reshapes each PK. The
-  partitioned tables (`ready_entries`, `done_entries`, `leases`)
-  drop the parent PK first so the cascaded inherited PKs come with
-  it, then `ADD COLUMN` and `ADD PRIMARY KEY` on the parent —
-  operations on a partitioned parent propagate to every leaf. The
-  migration is gated on
-  `storage_transition_state.state != 'mixed_transition'` to avoid
-  reshaping under live cutover traffic.
-- `awa-model/src/queue_storage.rs` threads `enqueue_shard` through
-  the enqueue path (`ensure_lane`, `advance_enqueue_head`, the
-  three `insert_*_tx` variants), the claim function
-  `claim_ready_runtime`, the receipts path (the `claimed_cte`
-  INSERT into `lease_claims`, the non-receipts INSERT into
-  `leases`, the materialization helper, the cancel-from-receipt
-  hydration, the heartbeat and deadline receipt-rescue scans), the
-  admin lookups (`queue_counts_exact`, `cancel_job_tx`,
-  `age_waiting_priorities`), and the terminal storage path
-  (`done_entries` INSERT and the consumer SELECTs that hydrate
-  `DoneJobRow`).
-- The in-process lane cache is keyed on `(queue, priority,
-  enqueue_shard)`. The rollback-recovery retry path in
-  `advance_enqueue_head` invalidates by triple and calls
-  `ensure_lane_inserts` directly so a concurrent re-marker cannot
-  trick it into skipping the repair.
-- The in-tree A/B bench `test_queue_storage_enqueue_contention`
-  accepts `AWA_QS_CONTENTION_SHARDS` to seed
-  `queue_meta.enqueue_shards` before driving the producer fleet.
+- Migration `v017_shard_queue_enqueue_heads.sql` adds the column to every table in the active plane and reshapes each PK. The partitioned tables (`ready_entries`, `done_entries`, `leases`) drop the parent PK first so the cascaded inherited PKs come with it, then `ADD COLUMN` and `ADD PRIMARY KEY` on the parent — operations on a partitioned parent propagate to every leaf. The migration is gated on `storage_transition_state.state != 'mixed_transition'` to avoid reshaping under live cutover traffic.
+- `awa-model/src/queue_storage.rs` threads `enqueue_shard` through the enqueue path (`ensure_lane`, `advance_enqueue_head`, the three `insert_*_tx` variants), the claim function `claim_ready_runtime`, the receipts path (the `claimed_cte` INSERT into `lease_claims`, the non-receipts INSERT into `leases`, the materialization helper, the cancel-from-receipt hydration, the heartbeat and deadline receipt-rescue scans), the admin lookups (`queue_counts_exact`, `cancel_job_tx`, `age_waiting_priorities`), and the terminal storage path (`done_entries` INSERT and the consumer SELECTs that hydrate `DoneJobRow`).
+- The in-process lane cache is keyed on `(queue, priority, enqueue_shard)`. The rollback-recovery retry path in `advance_enqueue_head` invalidates by triple and calls `ensure_lane_inserts` directly so a concurrent re-marker cannot trick it into skipping the repair.
+- The in-tree A/B bench `test_queue_storage_enqueue_contention` accepts `AWA_QS_CONTENTION_SHARDS` to seed `queue_meta.enqueue_shards` before driving the producer fleet.
 
 ## TLA+
 
-`correctness/storage/AwaSegmentedStorage.tla` models one
-`(queue, priority, enqueue_shard)` lane. That keeps the lifecycle
-state-space small while still checking the per-shard FIFO, lease,
-receipt, terminal, DLQ, and rotate/prune invariants.
+`correctness/storage/AwaSegmentedStorage.tla` models one `(queue, priority, enqueue_shard)` lane. That keeps the lifecycle state-space small while still checking the per-shard FIFO, lease, receipt, terminal, DLQ, and rotate/prune invariants.
 
-The cross-shard invariant lives in
-`correctness/storage/AwaShardedPrune.tla`. It models two shards with
-independent sequence counters, so both shards can legitimately contain
-`lane_seq = 1`. The passing config requires queue-ring prune to match
-ready rows to done rows by `(enqueue_shard, lane_seq)`. The broken
-config intentionally drops `enqueue_shard` from that match and produces
-the counterexample where shard 0's completed row masks shard 1's
-pending ready row.
+The cross-shard invariant lives in `correctness/storage/AwaShardedPrune.tla`. It models two shards with independent sequence counters, so both shards can legitimately contain `lane_seq = 1`. The passing config requires queue-ring prune to match ready rows to done rows by `(enqueue_shard, lane_seq)`. The broken config intentionally drops `enqueue_shard` from that match and produces the counterexample where shard 0's completed row masks shard 1's pending ready row.
 
-`correctness/storage/AwaStorageLockOrder.tla` carries the lock-order
-side. At the lock abstraction level, each shard is a disjoint copy of
-the same row-level resources; enqueue touches one shard's head rows per
-transaction, and claim touches one physical claim row at a time, so the
-existing deadlock proof composes across shards.
+`correctness/storage/AwaStorageLockOrder.tla` carries the lock-order side. At the lock abstraction level, each shard is a disjoint copy of the same row-level resources; enqueue touches one shard's head rows per transaction, and claim touches one physical claim row at a time, so the existing deadlock proof composes across shards.

--- a/docs/adr/026-narrow-terminal-history.md
+++ b/docs/adr/026-narrow-terminal-history.md
@@ -6,71 +6,39 @@ Accepted.
 
 ## Context
 
-The queue-storage runtime intentionally keeps the runnable row immutable in
-`ready_entries` and writes a durable terminal fact to `done_entries` when an
-attempt completes, fails, or is cancelled. That shape is safe and easy to
-inspect, but it duplicates the immutable job body on the hottest successful
-completion path: `args`, `max_attempts`, `run_at`, `created_at`, uniqueness
-metadata, and often an unchanged runtime payload are written once in
-`ready_entries` and then again in `done_entries`.
+The queue-storage runtime intentionally keeps the runnable row immutable in `ready_entries` and writes a durable terminal fact to `done_entries` when an attempt completes, fails, or is cancelled. That shape is safe and easy to inspect, but it duplicates the immutable job body on the hottest successful completion path: `args`, `max_attempts`, `run_at`, `created_at`, uniqueness metadata, and often an unchanged runtime payload are written once in `ready_entries` and then again in `done_entries`.
 
-The duplication is visible in the WAL and row-size budget. Reference
-queue-storage runs showed this shape:
+The duplication is visible in the WAL and row-size budget. Reference queue-storage runs showed this shape:
 
-| Shape | Completed jobs/s | p99 e2e | WAL/job |
-|---|---:|---:|---:|
-| Tuned production queue storage | `7,885/s` | `203 ms` | `2,241 B` |
-| Narrow terminal history | `8,337/s` | `205 ms` | `1,932 B` |
-| Skip `done_entries` entirely | `8,402/s` | `230 ms` | `1,441 B` |
+| Shape                          | Completed jobs/s |  p99 e2e |   WAL/job |
+| ------------------------------ | ---------------: | -------: | --------: |
+| Tuned production queue storage |        `7,885/s` | `203 ms` | `2,241 B` |
+| Narrow terminal history        |        `8,337/s` | `205 ms` | `1,932 B` |
+| Skip `done_entries` entirely   |        `8,402/s` | `230 ms` | `1,441 B` |
 
-Skipping `done_entries` is not acceptable: it weakens the durable terminal
-history contract and removes the operator/API source of truth. The useful
-signal is that most of the safe gain comes from avoiding duplicated terminal
-body bytes, not from deleting the terminal fact.
+Skipping `done_entries` is not acceptable: it weakens the durable terminal history contract and removes the operator/API source of truth. The useful signal is that most of the safe gain comes from avoiding duplicated terminal body bytes, not from deleting the terminal fact.
 
 ## Decision
 
-For terminal rows whose source attempt still has a retained ready row, write a
-narrow `done_entries` row:
+For terminal rows whose source attempt still has a retained ready row, write a narrow `done_entries` row:
 
-- keep terminal identity and ordering fields:
-  `ready_slot`, `ready_generation`, `job_id`, `kind`, `queue`, `state`,
-  `priority`, `attempt`, `run_lease`, `lane_seq`, `enqueue_shard`,
-  `attempted_at`, and `finalized_at`
-- keep `payload` only when the terminal runtime payload differs from the
-  ready-row payload
-- leave duplicated immutable body fields nullable and normally `NULL`:
-  `args`, `max_attempts`, `run_at`, `created_at`, `unique_key`,
-  and `unique_states`
+- keep terminal identity and ordering fields: `ready_slot`, `ready_generation`, `job_id`, `kind`, `queue`, `state`, `priority`, `attempt`, `run_lease`, `lane_seq`, `enqueue_shard`, `attempted_at`, and `finalized_at`
+- keep `payload` only when the terminal runtime payload differs from the ready-row payload
+- leave duplicated immutable body fields nullable and normally `NULL`: `args`, `max_attempts`, `run_at`, `created_at`, `unique_key`, and `unique_states`
 
-Reads that materialize a `JobRow` or move a terminal row to another storage
-family hydrate through a left join from `done_entries` to the retained
-`ready_entries` row using the ready segment and lane key:
+Reads that materialize a `JobRow` or move a terminal row to another storage family hydrate through a left join from `done_entries` to the retained `ready_entries` row using the ready segment and lane key:
 
 ```text
 (ready_slot, ready_generation, queue, priority, enqueue_shard, lane_seq)
 ```
 
-Schema preparation also creates a read-only `{schema}.terminal_jobs` view with
-the hydrated terminal shape. It is the preferred SQL surface for inspection,
-reporting, and external read-only tooling. The physical `done_entries` table
-remains the write/transition surface because retry, DLQ move, and discard
-paths must delete the terminal fact and its retained ready backing row in one
-transaction.
+Schema preparation also creates a read-only `{schema}.terminal_jobs` view with the hydrated terminal shape. It is the preferred SQL surface for inspection, reporting, and external read-only tooling. The physical `done_entries` table remains the write/transition surface because retry, DLQ move, and discard paths must delete the terminal fact and its retained ready backing row in one transaction.
 
-Terminal rows are narrow only when the source state keeps the ready row:
-`running` and `waiting_external` attempts. Paths that delete the ready row
-before terminalizing, such as cancelling an unclaimed `available` job, still
-write a wide `done_entries` row. Scheduled/deferred cancellation also remains
-wide because there is no ready backing row.
+Terminal rows are narrow only when the source state keeps the ready row: `running` and `waiting_external` attempts. Paths that delete the ready row before terminalizing, such as cancelling an unclaimed `available` job, still write a wide `done_entries` row. Scheduled/deferred cancellation also remains wide because there is no ready backing row.
 
-When a terminal row is deleted, the retained ready backing row must be deleted
-in the same transaction before retry, DLQ move, or discard continues. Otherwise
-the backing row would become live again as soon as the terminal fact disappears.
+When a terminal row is deleted, the retained ready backing row must be deleted in the same transaction before retry, DLQ move, or discard continues. Otherwise the backing row would become live again as soon as the terminal fact disappears.
 
-Queue-ring prune reclaims the ready body and the terminal fact together. The
-TLA+ model records this as `TerminalHasRetainedReadyBody`: every modelled
-terminal row has a retained ready body until queue prune removes both.
+Queue-ring prune reclaims the ready body and the terminal fact together. The TLA+ model records this as `TerminalHasRetainedReadyBody`: every modelled terminal row has a retained ready body until queue prune removes both.
 
 ## Consequences
 
@@ -78,126 +46,68 @@ terminal row has a retained ready body until queue prune removes both.
 
 - Keeps the durable terminal fact and all existing public API semantics.
 - Reduces WAL and row bytes on the dominant completion path.
-- Preserves `attempted_at` and `finalized_at` in `done_entries`, so terminal
-  attempt timing remains directly inspectable without reconstructing it from a
-  ready row.
-- Keeps the ring-prune safety story unchanged: `ready_entries` and
-  `done_entries` are still reclaimed by queue-slot truncation.
+- Preserves `attempted_at` and `finalized_at` in `done_entries`, so terminal attempt timing remains directly inspectable without reconstructing it from a ready row.
+- Keeps the ring-prune safety story unchanged: `ready_entries` and `done_entries` are still reclaimed by queue-slot truncation.
 
 ### Negative
 
-- Direct SQL against `done_entries.args`, `max_attempts`, `run_at`,
-  `created_at`, `unique_key`, `unique_states`, or `payload` must tolerate
-  `NULL` on ready-backed terminal rows. Use `{schema}.terminal_jobs` unless
-  code intentionally needs the physical storage representation.
-- Terminal delete paths have one more responsibility: remove the retained
-  ready backing row before re-enqueuing, moving to DLQ, or discarding.
-- Queue-prune logic must continue treating ready and terminal rows as one
-  retention unit.
+- Direct SQL against `done_entries.args`, `max_attempts`, `run_at`, `created_at`, `unique_key`, `unique_states`, or `payload` must tolerate `NULL` on ready-backed terminal rows. Use `{schema}.terminal_jobs` unless code intentionally needs the physical storage representation.
+- Terminal delete paths have one more responsibility: remove the retained ready backing row before re-enqueuing, moving to DLQ, or discarding.
+- Queue-prune logic must continue treating ready and terminal rows as one retention unit.
 
 ## Alternatives Considered
 
 ### Keep fully materialized terminal rows
 
-This is the pre-ADR behavior. It is simple for direct SQL users but spends
-extra WAL and heap bytes on every terminal transition.
+This is the pre-ADR behavior. It is simple for direct SQL users but spends extra WAL and heap bytes on every terminal transition.
 
 ### Remove `done_entries` for successful completions
 
-This produced the lowest WAL/job result in experiment, but it removes the
-durable terminal fact that queue counts, `load_job`, admin inspection, and
-retention rely on. It is rejected.
+This produced the lowest WAL/job result in experiment, but it removes the durable terminal fact that queue counts, `load_job`, admin inspection, and retention rely on. It is rejected.
 
 ### Store a separate success-receipt table
 
-A success-receipt table would make successful completions even narrower, but it
-would add another terminal source for counts, admin reads, retry/replay tools,
-and prune. The retained-ready design gets most of the safe benefit while
-keeping one durable terminal family.
+A success-receipt table would make successful completions even narrower, but it would add another terminal source for counts, admin reads, retry/replay tools, and prune. The retained-ready design gets most of the safe benefit while keeping one durable terminal family.
 
 ## Defaults
 
-This ADR changes the batching defaults that determine whether lower WAL turns
-into durable throughput:
+This ADR changes the batching defaults that determine whether lower WAL turns into durable throughput:
 
-- `enqueue_shards = 1` remains the strict-FIFO default; use more shards only
-  when partitioned FIFO is acceptable.
+- `enqueue_shards = 1` remains the strict-FIFO default; use more shards only when partitioned FIFO is acceptable.
 - `claimers = 1` and `claim_batch_size = 512` remain the queue defaults.
-- `AWA_COMPLETION_BATCH_SIZE = 512`, `AWA_COMPLETION_FLUSH_MS = 1`, and
-  queue-storage `AWA_COMPLETION_SHARDS = 1` remain the completion defaults.
-- `queue_slot_count = 16`, `lease_slot_count = 8`, `claim_slot_count = 8`,
-  and `lease_claim_receipts = true` remain the queue-storage defaults.
+- `AWA_COMPLETION_BATCH_SIZE = 512`, `AWA_COMPLETION_FLUSH_MS = 1`, and queue-storage `AWA_COMPLETION_SHARDS = 1` remain the completion defaults.
+- `queue_slot_count = 16`, `lease_slot_count = 8`, `claim_slot_count = 8`, and `lease_claim_receipts = true` remain the queue-storage defaults.
 
-The queue-storage short-job completion path also uses one fused statement for
-the common receipt-backed, payload-empty terminal transition: close the receipt
-in `lease_claim_closures` and insert the narrow `done_entries` fact from the
-claimed runtime snapshot in the same SQL statement. Jobs with unique-key
-transitions, terminal payload metadata, materialized heartbeat/progress state,
-or missed receipt closures keep the general transaction path.
+The queue-storage short-job completion path also uses one fused statement for the common receipt-backed, payload-empty terminal transition: close the receipt in `lease_claim_closures` and insert the narrow `done_entries` fact from the claimed runtime snapshot in the same SQL statement. Jobs with unique-key transitions, terminal payload metadata, materialized heartbeat/progress state, or missed receipt closures keep the general transaction path.
 
-The offered-rate benchmark turns that lower write budget into an explicit
-capacity check. With one queue shard, one claimer, `claim_batch_size = 512`,
-queue-storage completion shards at `1`, and `max_workers = 1024`, a 10-second
-`10k/s` no-op workload keeps durable completions at the offered rate, drains to
-zero backlog, and writes `1.8 KiB` WAL per completed job. A `12k/s` offered
-workload exceeds that reference configuration and accumulates backlog during
-the offer window before draining afterward.
+The offered-rate benchmark turns that lower write budget into an explicit capacity check. With one queue shard, one claimer, `claim_batch_size = 512`, queue-storage completion shards at `1`, and `max_workers = 1024`, a 10-second `10k/s` no-op workload keeps durable completions at the offered rate, drains to zero backlog, and writes `1.8 KiB` WAL per completed job. A `12k/s` offered workload exceeds that reference configuration and accumulates backlog during the offer window before draining afterward.
 
 ## Relationship to Rejected ADR-024
 
-The relevant historical ADR-024 was **Deferred `done_entries`
-Materialisation**. It removed the `done_entries` insert from receipt completion
-entirely, treated
-`lease_claim_closures` as the immediate completion source of truth, and added a
-background materializer plus read-side synthetic projections and prune guards.
-Its A/B benchmark was worse than the synchronous path: `1,839/s` vs `2,803/s`,
-with higher p99 latency. It also added new moving
-parts: a materializer cadence, materializer lag monitoring, rotation catch-up,
-and temporary closure-without-terminal read semantics.
+The relevant historical ADR-024 was **Deferred `done_entries` Materialisation**. It removed the `done_entries` insert from receipt completion entirely, treated `lease_claim_closures` as the immediate completion source of truth, and added a background materializer plus read-side synthetic projections and prune guards. Its A/B benchmark was worse than the synchronous path: `1,839/s` vs `2,803/s`, with higher p99 latency. It also added new moving parts: a materializer cadence, materializer lag monitoring, rotation catch-up, and temporary closure-without-terminal read semantics.
 
 ADR-026 deliberately keeps the opposite contract:
 
 - completion still writes the durable terminal fact synchronously;
-- `done_entries` remains the terminal source of truth for counts, admin reads,
-  retries, DLQ moves, discard, and retention;
+- `done_entries` remains the terminal source of truth for counts, admin reads, retries, DLQ moves, discard, and retention;
 - there is no materializer, no lag window, and no extra prune precondition;
-- the fast path is an implementation detail of the same logical transition:
-  only claims that are successfully closed in `lease_claim_closures` are
-  inserted into `done_entries`.
+- the fast path is an implementation detail of the same logical transition: only claims that are successfully closed in `lease_claim_closures` are inserted into `done_entries`.
 
-The overlap with ADR-024 is the insight that duplicating ready-body JSONB is
-wasteful. The difference is where the system draws the safety boundary:
-ADR-024 deferred the terminal fact; ADR-026 keeps the terminal fact durable and
-only narrows its payload, then fuses the receipt-close and terminal-insert SQL
-so the synchronous contract is cheap enough to hit the throughput target.
+The overlap with ADR-024 is the insight that duplicating ready-body JSONB is wasteful. The difference is where the system draws the safety boundary: ADR-024 deferred the terminal fact; ADR-026 keeps the terminal fact durable and only narrows its payload, then fuses the receipt-close and terminal-insert SQL so the synchronous contract is cheap enough to hit the throughput target.
 
-The first tuning move for overload remains semantic enqueue sharding when the
-workload can accept partitioned FIFO. This ADR lowers the durable completion
-write budget underneath those defaults.
+The first tuning move for overload remains semantic enqueue sharding when the workload can accept partitioned FIFO. This ADR lowers the durable completion write budget underneath those defaults.
 
 ## Validation
 
-- Runtime tests assert that completed and failed ready-backed terminal rows are
-  narrow, hydrate correctly through `load_job`, and can retry without
-  resurrecting the retained ready backing row.
-- Runtime tests assert that the `{schema}.terminal_jobs` compatibility view
-  hydrates ready-backed terminal rows while the physical `done_entries` row
-  remains narrow.
-- Runtime tests assert that cancelling an unclaimed available job writes a wide
-  terminal row because no ready backing row survives that transition.
-- Existing DLQ move, bulk move, retry, and discard flows hydrate terminal rows
-  before moving them and delete retained backing rows when the terminal fact is
-  removed.
-- `correctness/storage/AwaSegmentedStorage.tla` models retained terminal ready
-  bodies, terminal-to-DLQ backing-row deletion, and queue prune reclaiming the
-  ready body and terminal fact together.
+- Runtime tests assert that completed and failed ready-backed terminal rows are narrow, hydrate correctly through `load_job`, and can retry without resurrecting the retained ready backing row.
+- Runtime tests assert that the `{schema}.terminal_jobs` compatibility view hydrates ready-backed terminal rows while the physical `done_entries` row remains narrow.
+- Runtime tests assert that cancelling an unclaimed available job writes a wide terminal row because no ready backing row survives that transition.
+- Existing DLQ move, bulk move, retry, and discard flows hydrate terminal rows before moving them and delete retained backing rows when the terminal fact is removed.
+- `correctness/storage/AwaSegmentedStorage.tla` models retained terminal ready bodies, terminal-to-DLQ backing-row deletion, and queue prune reclaiming the ready body and terminal fact together.
 
 ## Relationship to Other ADRs
 
 - Refines ADR-019's queue-storage terminal family.
-- Preserves ADR-023's receipt-plane safety: completion still closes the exact
-  claim and writes a durable terminal fact.
-- Complements ADR-025: enqueue sharding attacks producer head-row contention;
-  this ADR reduces completion-side WAL/row pressure.
-- Supersedes the useful part of the rejected ADR-024 deferred-materialisation
-  experiment without adopting its asynchronous terminal-history contract.
+- Preserves ADR-023's receipt-plane safety: completion still closes the exact claim and writes a durable terminal fact.
+- Complements ADR-025: enqueue sharding attacks producer head-row contention; this ADR reduces completion-side WAL/row pressure.
+- Supersedes the useful part of the rejected ADR-024 deferred-materialisation experiment without adopting its asynchronous terminal-history contract.

--- a/docs/adr/027-callback-ingress-surface.md
+++ b/docs/adr/027-callback-ingress-surface.md
@@ -6,38 +6,22 @@ Proposed
 
 ## Context
 
-Awa currently exposes HTTP-worker callback endpoints through `awa-ui`.
-`awa serve` builds one axum router that contains:
+Awa currently exposes HTTP-worker callback endpoints through `awa-ui`. `awa serve` builds one axum router that contains:
 
 - the operator UI static assets,
 - the admin REST API under `/api`,
 - the HTTP-worker callback receiver under `/api/callbacks`.
 
-That bundling is convenient for development, but it mixes surfaces with
-different exposure requirements.
+That bundling is convenient for development, but it mixes surfaces with different exposure requirements.
 
-The admin UI and REST API are an operator surface. They should normally be
-private, authenticated by deployment infrastructure, and reachable only from
-trusted networks. The callback receiver is different: when using
-`HttpWorker` async mode, the remote function must be able to reach it to
-complete, fail, or heartbeat a parked job. In many deployments that means the
-callback receiver is public or partner-facing, even when the admin UI is not.
+The admin UI and REST API are an operator surface. They should normally be private, authenticated by deployment infrastructure, and reachable only from trusted networks. The callback receiver is different: when using `HttpWorker` async mode, the remote function must be able to reach it to complete, fail, or heartbeat a parked job. In many deployments that means the callback receiver is public or partner-facing, even when the admin UI is not.
 
 Today users have two imperfect options:
 
-1. Run `awa serve` and expose only `/api/callbacks` through a reverse proxy.
-   This works, but the process still contains the whole admin/UI surface and
-   permissive UI CORS configuration.
-2. Implement their own callback endpoint around `admin::complete_external`,
-   `admin::fail_external`, and `admin::heartbeat_callback`. This gives them
-   control over FastAPI, axum, Django, or another framework, but forces them
-   to reimplement Awa's callback signature contract, payload parsing, error
-   mapping, and future compatibility rules.
+1. Run `awa serve` and expose only `/api/callbacks` through a reverse proxy. This works, but the process still contains the whole admin/UI surface and permissive UI CORS configuration.
+2. Implement their own callback endpoint around `admin::complete_external`, `admin::fail_external`, and `admin::heartbeat_callback`. This gives them control over FastAPI, axum, Django, or another framework, but forces them to reimplement Awa's callback signature contract, payload parsing, error mapping, and future compatibility rules.
 
-ADR-018 deliberately made HTTP workers possible without new storage
-primitives, and ADR-021 defines the callback semantics. This ADR narrows the
-HTTP deployment surface so those semantics can be exposed safely without
-requiring the admin UI.
+ADR-018 deliberately made HTTP workers possible without new storage primitives, and ADR-021 defines the callback semantics. This ADR narrows the HTTP deployment surface so those semantics can be exposed safely without requiring the admin UI.
 
 ## Decision
 
@@ -45,24 +29,20 @@ Make callback ingress a first-class Awa surface, separate from the admin UI.
 
 ### Surface split
 
-Awa's HTTP-facing pieces should be documented and structured as distinct
-surfaces:
+Awa's HTTP-facing pieces should be documented and structured as distinct surfaces:
 
 | Surface | Purpose | Expected exposure |
-|---|---|---|
+| --- | --- | --- |
 | Admin UI / admin REST API | Operator inspection and mutation | Private operator network |
 | Callback receiver | Complete, fail, and heartbeat callback waits | Public or partner-facing, signed |
 | Worker runtime | Claim and execute jobs | Internal |
 | Maintenance runtime | Promote, rescue, prune, and refresh runtime state | Internal |
 
-`awa serve` remains the admin/UI command. It may continue to mount callback
-routes for backward compatibility, but the callback receiver should no longer
-be treated as an incidental part of the UI crate.
+`awa serve` remains the admin/UI command. It may continue to mount callback routes for backward compatibility, but the callback receiver should no longer be treated as an incidental part of the UI crate.
 
 ### Shared callback contract and auth
 
-Extract the HTTP callback contract into a shared module or crate that is not
-owned by `awa-ui`:
+Extract the HTTP callback contract into a shared module or crate that is not owned by `awa-ui`:
 
 - request and response types for `complete`, `fail`, and `heartbeat`,
 - the `X-Awa-Signature` header name,
@@ -71,10 +51,7 @@ owned by `awa-ui`:
 - timeout validation and error mapping,
 - contract tests shared by every HTTP integration.
 
-The worker-side signer and receiver-side verifier must use the same
-implementation. The option name `hmac_secret` may remain for compatibility,
-but docs and new APIs should describe the algorithm precisely as BLAKE3 keyed
-hashing.
+The worker-side signer and receiver-side verifier must use the same implementation. The option name `hmac_secret` may remain for compatibility, but docs and new APIs should describe the algorithm precisely as BLAKE3 keyed hashing.
 
 ### Callback-only axum router
 
@@ -95,29 +72,21 @@ The callback-only router should:
 - expose no admin REST routes,
 - avoid permissive CORS by default,
 - require writable database access,
-- require a callback signing secret by default unless the caller explicitly
-  opts into unsigned callbacks.
+- require a callback signing secret by default unless the caller explicitly opts into unsigned callbacks.
 
-This router can be mounted by Awa's own CLI, by an existing axum application,
-or by users who want a minimal callback receiver binary.
+This router can be mounted by Awa's own CLI, by an existing axum application, or by users who want a minimal callback receiver binary.
 
 ### Framework-neutral service layer
 
-Provide lower-level callback receiver functions that can be used outside
-axum:
+Provide lower-level callback receiver functions that can be used outside axum:
 
 - `complete_callback(pool, callback_id, signature, payload)`,
 - `fail_callback(pool, callback_id, signature, error)`,
 - `heartbeat_callback(pool, callback_id, signature, timeout)`.
 
-The service layer should own validation and signature verification, then call
-the storage/admin APIs. This lets Rust frameworks share one implementation and
-gives the Python package a clear contract to mirror for FastAPI, Starlette,
-Django, or Flask examples.
+The service layer should own validation and signature verification, then call the storage/admin APIs. This lets Rust frameworks share one implementation and gives the Python package a clear contract to mirror for FastAPI, Starlette, Django, or Flask examples.
 
-Python helpers should at minimum expose signature verification and typed
-request parsing examples. If the Python admin/client API grows a callback
-receiver helper, it should preserve the same contract and tests.
+Python helpers should at minimum expose signature verification and typed request parsing examples. If the Python admin/client API grows a callback receiver helper, it should preserve the same contract and tests.
 
 ### CLI
 
@@ -127,16 +96,14 @@ Add a callback-only command:
 awa callbacks serve
 ```
 
-The command should accept the normal database/pool options plus callback
-receiver configuration:
+The command should accept the normal database/pool options plus callback receiver configuration:
 
 - host and port,
 - callback signing secret,
 - path prefix,
 - optional explicit unsigned mode for private-network deployments.
 
-It should not inherit `awa serve`'s admin routes, static file fallback, or UI
-CORS behavior.
+It should not inherit `awa serve`'s admin routes, static file fallback, or UI CORS behavior.
 
 ### Callback URL construction
 
@@ -146,98 +113,53 @@ CORS behavior.
 {callback_base_url}/api/callbacks/{callback_id}/complete
 ```
 
-Keep that as the compatibility default, but add configuration for a path
-prefix or URL template. That allows callback-only servers and user-owned API
-layers to expose framework-native routes without reverse-proxy rewriting.
+Keep that as the compatibility default, but add configuration for a path prefix or URL template. That allows callback-only servers and user-owned API layers to expose framework-native routes without reverse-proxy rewriting.
 
 ### Lifecycle hooks
 
-Callback ingress resolves callback state. It must not assume a co-located
-`Client` runtime or local in-process lifecycle hook registry.
+Callback ingress resolves callback state. It must not assume a co-located `Client` runtime or local in-process lifecycle hook registry.
 
-Durable side effects triggered by callback resolution are delivered
-through the transactional follow-up enqueue mechanism in ADR-029. A
-worker `Client` performing the resolution (the in-process worker
-case) commits the callback transition and the follow-up `INSERT` in a
-single transaction via the `admin::*_external_in_tx` /
-`store::*_external_in_tx` helpers — an INSERT failure rolls the
-transition back, so the external sender can retry. Once the follow-up
-commits an ordinary worker (anywhere) picks it up.
+Durable side effects triggered by callback resolution are delivered through the transactional follow-up enqueue mechanism in ADR-029. A worker `Client` performing the resolution (the in-process worker case) commits the callback transition and the follow-up `INSERT` in a single transaction via the `admin::*_external_in_tx` / `store::*_external_in_tx` helpers — an INSERT failure rolls the transition back, so the external sender can retry. Once the follow-up commits an ordinary worker (anywhere) picks it up.
 
-A callback-only ingress process (this ADR) does not yet own a worker
-registry, so it cannot dispatch user follow-up specs itself. When the
-callback-only surface lands, reusing the same `_in_tx` admin helpers
-plus a router-side registry hookup will give it the same atomic
-contract; until then, callback-only ingress runs the transition
-without follow-up dispatch. The callback receiver does not invoke
-process-local hooks directly; observation-only hooks (ADR-015)
-continue to fire only in processes that perform the resolution
-themselves via the worker `Client`.
+A callback-only ingress process (this ADR) does not yet own a worker registry, so it cannot dispatch user follow-up specs itself. When the callback-only surface lands, reusing the same `_in_tx` admin helpers plus a router-side registry hookup will give it the same atomic contract; until then, callback-only ingress runs the transition without follow-up dispatch. The callback receiver does not invoke process-local hooks directly; observation-only hooks (ADR-015) continue to fire only in processes that perform the resolution themselves via the worker `Client`.
 
 ## Consequences
 
 ### Positive
 
-- The recommended secure deployment becomes obvious: public callback ingress,
-  private admin UI, internal workers and maintenance.
-- Users can embed Awa callbacks in FastAPI, axum, or another application
-  without copying the signature algorithm and payload contract from docs.
-- Minimal callback deployments no longer carry the embedded frontend or admin
-  REST surface.
-- `HttpWorker` async mode becomes easier to operate behind real routing
-  schemes instead of relying on the UI path layout.
+- The recommended secure deployment becomes obvious: public callback ingress, private admin UI, internal workers and maintenance.
+- Users can embed Awa callbacks in FastAPI, axum, or another application without copying the signature algorithm and payload contract from docs.
+- Minimal callback deployments no longer carry the embedded frontend or admin REST surface.
+- `HttpWorker` async mode becomes easier to operate behind real routing schemes instead of relying on the UI path layout.
 
 ### Negative / Risks
 
 - There is one more public surface to version and test.
-- The split overlaps with, but does not replace, the broader `awa-api` /
-  `awa-ui` separation discussed elsewhere. Keeping this narrowly scoped is
-  important.
-- Tightening callback-only defaults to require signatures is safer but may
-  surprise users who expect the old `awa serve` behavior where missing secrets
-  disable verification. Compatibility docs and explicit opt-out flags are
-  required.
-- Lifecycle hook behavior around externally resolved jobs must be stated
-  precisely so users do not assume the callback receiver runs in the same
-  process as their worker hooks.
+- The split overlaps with, but does not replace, the broader `awa-api` / `awa-ui` separation discussed elsewhere. Keeping this narrowly scoped is important.
+- Tightening callback-only defaults to require signatures is safer but may surprise users who expect the old `awa serve` behavior where missing secrets disable verification. Compatibility docs and explicit opt-out flags are required.
+- Lifecycle hook behavior around externally resolved jobs must be stated precisely so users do not assume the callback receiver runs in the same process as their worker hooks.
 
 ## Alternatives considered
 
 ### Keep callback routes inside `awa serve`
 
-This is the smallest implementation, and it works when deployments can rely on
-private networking or a reverse proxy. It keeps the security guidance awkward:
-the process users need to expose for callbacks also contains admin mutation
-routes and UI concerns.
+This is the smallest implementation, and it works when deployments can rely on private networking or a reverse proxy. It keeps the security guidance awkward: the process users need to expose for callbacks also contains admin mutation routes and UI concerns.
 
 ### Split all API handlers into a new `awa-api` crate first
 
-A broader API/UI split may still be useful, especially if Awa ships an
-API-only image. It is more work than the callback problem requires. Callback
-ingress has a distinct security boundary and should be separable even if the
-admin API remains in `awa-ui` for now.
+A broader API/UI split may still be useful, especially if Awa ships an API-only image. It is more work than the callback problem requires. Callback ingress has a distinct security boundary and should be separable even if the admin API remains in `awa-ui` for now.
 
 ### Require every application to implement callbacks itself
 
-This gives maximum framework flexibility, but makes every integration
-responsible for reproducing auth, parsing, and compatibility behavior. That is
-exactly the glue ADR-018 tried to remove for HTTP workers.
+This gives maximum framework flexibility, but makes every integration responsible for reproducing auth, parsing, and compatibility behavior. That is exactly the glue ADR-018 tried to remove for HTTP workers.
 
 ### Rely on reverse-proxy path filtering
 
-Path filtering is still useful defense-in-depth, but it should not be the only
-way to avoid exposing the admin UI. A callback-only router gives the proxy a
-smaller upstream to protect.
+Path filtering is still useful defense-in-depth, but it should not be the only way to avoid exposing the admin UI. A callback-only router gives the proxy a smaller upstream to protect.
 
 ## Relationship to other ADRs
 
-- ADR-018 introduced `HttpWorker` and the callback receiver contract this ADR
-  narrows into its own deployable surface.
-- ADR-021 defines callback completion, sequential waits, and heartbeats. This
-  ADR changes HTTP exposure, not callback semantics.
-- ADR-015 defines builder-side lifecycle hooks. Callback ingress does not
-  depend on process-local hook registries; observation hooks stay in the
-  worker process.
-- ADR-029 defines transactional follow-up jobs, the runtime-independent
-  mechanism callback ingress uses for durable side effects triggered by a
-  resolution.
+- ADR-018 introduced `HttpWorker` and the callback receiver contract this ADR narrows into its own deployable surface.
+- ADR-021 defines callback completion, sequential waits, and heartbeats. This ADR changes HTTP exposure, not callback semantics.
+- ADR-015 defines builder-side lifecycle hooks. Callback ingress does not depend on process-local hook registries; observation hooks stay in the worker process.
+- ADR-029 defines transactional follow-up jobs, the runtime-independent mechanism callback ingress uses for durable side effects triggered by a resolution.

--- a/docs/adr/028-maintenance-only-runtime-role.md
+++ b/docs/adr/028-maintenance-only-runtime-role.md
@@ -16,8 +16,7 @@ Awa's normal runtime process does several jobs:
 - rotates and prunes queue-storage structures,
 - refreshes admin metadata and runtime snapshots.
 
-That composition is sensible for a traditional worker deployment: if a worker
-process is running, it can also own the maintenance leader duties.
+That composition is sensible for a traditional worker deployment: if a worker process is running, it can also own the maintenance leader duties.
 
 Callback-only ingress changes the deployment shape. A team may want:
 
@@ -28,11 +27,7 @@ Callback-only ingress changes the deployment shape. A team may want:
 - no public `awa serve` process,
 - maintenance duties running somewhere predictable.
 
-The callback receiver cannot replace the worker runtime or maintenance
-runtime. It only resolves external waits. If no runtime performs maintenance,
-scheduled jobs may not promote, retryable jobs may not become available,
-stale heartbeats may not rescue, expired callbacks may remain parked, and
-storage hygiene may drift.
+The callback receiver cannot replace the worker runtime or maintenance runtime. It only resolves external waits. If no runtime performs maintenance, scheduled jobs may not promote, retryable jobs may not become available, stale heartbeats may not rescue, expired callbacks may remain parked, and storage hygiene may drift.
 
 There are related but distinct efforts:
 
@@ -40,13 +35,11 @@ There are related but distinct efforts:
 - serverless-friendly bounded `tick()` execution,
 - splitting callback ingress away from the UI.
 
-This ADR defines a persistent maintenance-only role that composes with those
-efforts without requiring it to claim user jobs.
+This ADR defines a persistent maintenance-only role that composes with those efforts without requiring it to claim user jobs.
 
 ## Decision
 
-Add a maintenance-only runtime role. It runs Awa maintenance loops and leader
-election but does not claim or execute ordinary jobs.
+Add a maintenance-only runtime role. It runs Awa maintenance loops and leader election but does not claim or execute ordinary jobs.
 
 ### Public shape
 
@@ -68,15 +61,11 @@ CLI:
 awa maintenance run
 ```
 
-The library API is for applications that declare cron jobs, queue
-descriptors, job-kind descriptors, or other code-owned runtime metadata. The
-CLI command is for pool-only maintenance where no application-specific
-handlers or declarations are needed.
+The library API is for applications that declare cron jobs, queue descriptors, job-kind descriptors, or other code-owned runtime metadata. The CLI command is for pool-only maintenance where no application-specific handlers or declarations are needed.
 
 ### What maintenance-only runs
 
-The maintenance-only role should run internal state maintenance that does not
-require executing user handler code:
+The maintenance-only role should run internal state maintenance that does not require executing user handler code:
 
 - scheduled and retryable promotion,
 - stale heartbeat rescue,
@@ -87,15 +76,12 @@ require executing user handler code:
 - admin metadata refresh,
 - runtime liveness publication for the maintenance process itself.
 
-When constructed from `ClientBuilder`, it may also run configured
-declaration-owned work:
+When constructed from `ClientBuilder`, it may also run configured declaration-owned work:
 
 - cron scheduling for cron definitions registered on that builder,
 - descriptor publication for queues and job kinds declared by that builder.
 
-The pool-only CLI form must not invent application declarations. It should not
-publish descriptors or schedule cron jobs unless those definitions are
-provided through a future explicit config format.
+The pool-only CLI form must not invent application declarations. It should not publish descriptors or schedule cron jobs unless those definitions are provided through a future explicit config format.
 
 ### What maintenance-only does not run
 
@@ -105,44 +91,32 @@ Maintenance-only mode must not:
 - invoke Rust or Python user handlers,
 - dispatch `HttpWorker` function calls,
 - expose HTTP callback or admin routes by itself,
-- hide the fact that a separate dispatcher is still required for normal job
-  execution.
+- hide the fact that a separate dispatcher is still required for normal job execution.
 
-For HTTP-worker deployments, a dispatcher process is still needed to claim jobs
-and POST to the remote function URL. Maintenance-only keeps time-based and
-hygiene guarantees moving; it is not a serverless dispatcher.
+For HTTP-worker deployments, a dispatcher process is still needed to claim jobs and POST to the remote function URL. Maintenance-only keeps time-based and hygiene guarantees moving; it is not a serverless dispatcher.
 
 ### Composition with callback ingress
 
-Callback-only servers may optionally run maintenance in the same process for
-small deployments:
+Callback-only servers may optionally run maintenance in the same process for small deployments:
 
 ```text
 awa callbacks serve --with-maintenance
 ```
 
-That option should be implemented by composing the same maintenance runtime,
-not by embedding a separate maintenance loop in the callback server. Larger
-deployments should run callback ingress and maintenance as separate roles.
+That option should be implemented by composing the same maintenance runtime, not by embedding a separate maintenance loop in the callback server. Larger deployments should run callback ingress and maintenance as separate roles.
 
 ### Leadership and cancellation
 
-Maintenance-only mode uses the same leader-election semantics as the normal
-runtime. Maintenance tasks start only while the process owns the maintenance
-lock and stop promptly when leadership is lost or the process shuts down.
+Maintenance-only mode uses the same leader-election semantics as the normal runtime. Maintenance tasks start only while the process owns the maintenance lock and stop promptly when leadership is lost or the process shuts down.
 
-The internal lane isolation work should still apply: user-visible maintenance
-such as promotion and rescue should not be blocked by slower admin hygiene or
-cleanup branches.
+The internal lane isolation work should still apply: user-visible maintenance such as promotion and rescue should not be blocked by slower admin hygiene or cleanup branches.
 
 ### Relationship to bounded tick execution
 
-The persistent maintenance-only role does not replace a future bounded
-`tick()` API. They serve different deployment models:
+The persistent maintenance-only role does not replace a future bounded `tick()` API. They serve different deployment models:
 
 - `maintenance run`: persistent, leader-elected, predictable internal role,
-- `tick()`: bounded, externally invoked, useful for scale-to-zero or very
-  low-traffic deployments.
+- `tick()`: bounded, externally invoked, useful for scale-to-zero or very low-traffic deployments.
 
 Both should share the same underlying maintenance steps where possible.
 
@@ -150,72 +124,40 @@ Both should share the same underlying maintenance steps where possible.
 
 ### Positive
 
-- Deployments can keep maintenance guarantees without running a job-executing
-  worker in the same process.
-- Callback-only ingress has an obvious companion role for time-based rescue
-  and storage hygiene.
-- The role split makes operational docs clearer: admin UI, callback ingress,
-  workers, and maintenance can be scaled and exposed independently.
-- Library users with code-declared cron jobs or descriptors can still publish
-  those declarations without registering handlers.
+- Deployments can keep maintenance guarantees without running a job-executing worker in the same process.
+- Callback-only ingress has an obvious companion role for time-based rescue and storage hygiene.
+- The role split makes operational docs clearer: admin UI, callback ingress, workers, and maintenance can be scaled and exposed independently.
+- Library users with code-declared cron jobs or descriptors can still publish those declarations without registering handlers.
 
 ### Negative / Risks
 
-- Operators may confuse maintenance-only with a full worker. The CLI and docs
-  must be explicit that it does not dispatch or execute user jobs.
-- Pool-only CLI maintenance cannot know application-defined cron jobs or
-  descriptors. That limitation must be documented.
-- More runtime modes increase test matrix size around shutdown, leadership
-  loss, and task cancellation.
-- Running maintenance alongside callback ingress is convenient but can blur
-  deployment boundaries if presented as the default.
+- Operators may confuse maintenance-only with a full worker. The CLI and docs must be explicit that it does not dispatch or execute user jobs.
+- Pool-only CLI maintenance cannot know application-defined cron jobs or descriptors. That limitation must be documented.
+- More runtime modes increase test matrix size around shutdown, leadership loss, and task cancellation.
+- Running maintenance alongside callback ingress is convenient but can blur deployment boundaries if presented as the default.
 
 ## Alternatives considered
 
 ### Keep maintenance only inside normal workers
 
-This is simple and works for traditional deployments. It forces users who only
-need maintenance to run a process that is also capable of claiming and
-executing jobs, which is unnecessarily broad for callback/API-heavy
-deployments.
+This is simple and works for traditional deployments. It forces users who only need maintenance to run a process that is also capable of claiming and executing jobs, which is unnecessarily broad for callback/API-heavy deployments.
 
 ### Put maintenance inside the callback receiver
 
-This is convenient for the callback-only story but creates the wrong
-ownership. HTTP routing and database maintenance are separate concerns. The
-callback server may compose maintenance, but it should not own the
-implementation.
+This is convenient for the callback-only story but creates the wrong ownership. HTTP routing and database maintenance are separate concerns. The callback server may compose maintenance, but it should not own the implementation.
 
 ### Only build bounded `tick()`
 
-`tick()` is attractive for low-traffic and scale-to-zero deployments, but it
-depends on an external caller and has tick-interval latency. A persistent
-maintenance role is still useful for production systems that want timely
-promotion and rescue without job execution in that process.
+`tick()` is attractive for low-traffic and scale-to-zero deployments, but it depends on an external caller and has tick-interval latency. A persistent maintenance role is still useful for production systems that want timely promotion and rescue without job execution in that process.
 
 ### Use database-native scheduling only
 
-Database schedulers such as `pg_cron` can trigger maintenance calls, but they
-do not solve application-defined cron descriptors, runtime metadata, or
-portable deployment across Postgres providers. They may be a driver for
-bounded `tick()`, not a replacement for the runtime role.
+Database schedulers such as `pg_cron` can trigger maintenance calls, but they do not solve application-defined cron descriptors, runtime metadata, or portable deployment across Postgres providers. They may be a driver for bounded `tick()`, not a replacement for the runtime role.
 
 ## Relationship to other ADRs
 
-- ADR-027 separates callback ingress from the admin UI. This ADR defines the
-  internal maintenance role that may accompany that deployment.
-- ADR-018 explains that HTTP-worker async mode still requires an always-on
-  dispatcher. Maintenance-only does not change that requirement.
-- ADR-021 relies on expired callback rescue. This ADR gives deployments a way
-  to run that rescue without also executing handlers in the same process.
-- ADR-019 owns queue-storage maintenance concerns such as rotation and
-  pruning. Maintenance-only runs those existing storage tasks; it does not
-  redefine the storage engine.
-- ADR-029 defines transactional follow-up jobs. Maintenance-only uses that
-  mechanism to dispatch durable lifecycle effects for rescues (expired
-  callback, stale heartbeat, exceeded deadline). The dispatch is
-  best-effort (in a separate transaction after the rescue UPDATE
-  commits — see ADR-029's atomicity matrix); once the follow-up
-  `INSERT` lands, the row is a regular Awa job. This closes the
-  rescue/timeout event gap without requiring a handler registry in the
-  maintenance process.
+- ADR-027 separates callback ingress from the admin UI. This ADR defines the internal maintenance role that may accompany that deployment.
+- ADR-018 explains that HTTP-worker async mode still requires an always-on dispatcher. Maintenance-only does not change that requirement.
+- ADR-021 relies on expired callback rescue. This ADR gives deployments a way to run that rescue without also executing handlers in the same process.
+- ADR-019 owns queue-storage maintenance concerns such as rotation and pruning. Maintenance-only runs those existing storage tasks; it does not redefine the storage engine.
+- ADR-029 defines transactional follow-up jobs. Maintenance-only uses that mechanism to dispatch durable lifecycle effects for rescues (expired callback, stale heartbeat, exceeded deadline). The dispatch is best-effort (in a separate transaction after the rescue UPDATE commits — see ADR-029's atomicity matrix); once the follow-up `INSERT` lands, the row is a regular Awa job. This closes the rescue/timeout event gap without requiring a handler registry in the maintenance process.

--- a/docs/adr/029-transactional-followup-jobs.md
+++ b/docs/adr/029-transactional-followup-jobs.md
@@ -2,49 +2,26 @@
 
 ## Status
 
-Accepted. Worker-driven outcomes and callback resolution via the worker
-`Client` commit follow-ups atomically with the state transition;
-maintenance rescue dispatches follow-ups best-effort in a separate
-transaction (see [Atomicity matrix](#atomicity-matrix)).
+Accepted. Worker-driven outcomes and callback resolution via the worker `Client` commit follow-ups atomically with the state transition; maintenance rescue dispatches follow-ups best-effort in a separate transaction (see [Atomicity matrix](#atomicity-matrix)).
 
 ## Context
 
 Awa exposes two ways for application code to react to a job's lifecycle:
 
-- **Builder-side lifecycle hooks** (ADR-015). Closures registered on
-  `ClientBuilder::on_event` fire after the state commit, in-process,
-  best-effort. They are explicitly not durable: a process crash between the
-  state commit and the hook dispatch loses the event. ADR-015 states the
-  guidance: *"If a hook side effect must be durable or retried, that logic
-  should enqueue another job instead."* That guidance lives in prose, not in
-  the API.
-- **Tracing spans and structured logs** (PRD §15). Useful for observability,
-  but not a delivery mechanism for side effects.
+- **Builder-side lifecycle hooks** (ADR-015). Closures registered on `ClientBuilder::on_event` fire after the state commit, in-process, best-effort. They are explicitly not durable: a process crash between the state commit and the hook dispatch loses the event. ADR-015 states the guidance: _"If a hook side effect must be durable or retried, that logic should enqueue another job instead."_ That guidance lives in prose, not in the API.
+- **Tracing spans and structured logs** (PRD §15). Useful for observability, but not a delivery mechanism for side effects.
 
 Two adjacent design tracks make the gap acute:
 
-- **Callback ingress as a separate surface** (ADR-027, proposed). A
-  callback-only receiver has no `Client` and no in-process hook registry, so
-  resolving a callback there fires no hook. ADR-027 punts: *"If callback
-  completion should produce lifecycle notifications beyond the storage
-  transition itself, that mechanism needs to be durable or otherwise
-  runtime-independent."*
-- **Maintenance-only runtime role** (ADR-028, proposed). Rescue paths
-  (expired callback, stale heartbeat, exceeded deadline) commit state
-  transitions from the maintenance worker, with no notion of a per-kind hook
-  registry. Today an attempt that times out emits a `Started` and then goes
-  silent; the rescue itself produces no lifecycle event.
+- **Callback ingress as a separate surface** (ADR-027, proposed). A callback-only receiver has no `Client` and no in-process hook registry, so resolving a callback there fires no hook. ADR-027 punts: _"If callback completion should produce lifecycle notifications beyond the storage transition itself, that mechanism needs to be durable or otherwise runtime-independent."_
+- **Maintenance-only runtime role** (ADR-028, proposed). Rescue paths (expired callback, stale heartbeat, exceeded deadline) commit state transitions from the maintenance worker, with no notion of a per-kind hook registry. Today an attempt that times out emits a `Started` and then goes silent; the rescue itself produces no lifecycle event.
 
-Users routinely ask for "reliable events" for things like "send a welcome
-email when this signup completes." They reach for hooks — the only event
-surface that exists — and ship code that quietly drops events on a deploy or
-when the resolving process changes. The naming and ergonomics of the current
-hooks API encourage this mistake.
+Users routinely ask for "reliable events" for things like "send a welcome email when this signup completes." They reach for hooks — the only event surface that exists — and ship code that quietly drops events on a deploy or when the resolving process changes. The naming and ergonomics of the current hooks API encourage this mistake.
 
 Two distinct needs are being conflated:
 
 | Need | Examples | Acceptable loss | Latency budget |
-|---|---|---|---|
+| --- | --- | --- | --- |
 | Observation | metrics, traces, logs, alerting | low single-digit % | sub-second |
 | Side effects | send email, kick off workflow, persist record | zero | seconds to minutes |
 
@@ -52,30 +29,15 @@ A single mechanism cannot honestly serve both.
 
 ## Decision
 
-Treat observation and side effects as separate mechanisms with separate APIs.
-Keep ADR-015's in-process hooks unchanged for observation. Add a first-class
-**transactional follow-up enqueue** API for durable side effects.
+Treat observation and side effects as separate mechanisms with separate APIs. Keep ADR-015's in-process hooks unchanged for observation. Add a first-class **transactional follow-up enqueue** API for durable side effects.
 
 ### Principle
 
-A side effect that must survive process crash, deployment, or a split
-deployment topology (per ADR-027) is delivered as an Awa job. For
-worker-driven outcomes that follow-up `INSERT`s **in the same database
-transaction** as the triggering state transition — both commit together
-or both roll back. Callback resolution and maintenance rescue dispatch
-their follow-ups in a separate transaction (best-effort, see
-[Atomicity matrix](#atomicity-matrix)) because the resolution / rescue
-transition has already committed by the time the dispatcher sees it.
-Either way the follow-up inherits Awa's existing durability properties:
-at-least-once delivery, retries, dead-letter (ADR-020), DLQ replay,
-observability through the admin UI, and crash recovery via run-lease
-guarded finalization (ADR-013).
+A side effect that must survive process crash, deployment, or a split deployment topology (per ADR-027) is delivered as an Awa job. For worker-driven outcomes that follow-up `INSERT`s **in the same database transaction** as the triggering state transition — both commit together or both roll back. Callback resolution and maintenance rescue dispatch their follow-ups in a separate transaction (best-effort, see [Atomicity matrix](#atomicity-matrix)) because the resolution / rescue transition has already committed by the time the dispatcher sees it. Either way the follow-up inherits Awa's existing durability properties: at-least-once delivery, retries, dead-letter (ADR-020), DLQ replay, observability through the admin UI, and crash recovery via run-lease guarded finalization (ADR-013).
 
 ### Builder API
 
-`ClientBuilder` gains transactional enqueue counterparts to `on_event`. The
-naming mirrors the existing hook surface so the choice between observation
-and side effect is explicit at the registration site:
+`ClientBuilder` gains transactional enqueue counterparts to `on_event`. The naming mirrors the existing hook surface so the choice between observation and side effect is explicit at the registration site:
 
 ```rust
 Client::builder(pool)
@@ -94,337 +56,137 @@ Client::builder(pool)
     });
 ```
 
-The closure returns a follow-up `JobArgs` value (default `InsertOpts`) or
-an `EnqueueRequest<F>` with `InsertOpts` overrides. For worker-driven
-outcomes and callback resolution via the worker `Client`, the engine
-`INSERT`s the follow-up in the same transaction as the triggering state
-change; the follow-up commits with the trigger or rolls back with it
-(a spec INSERT failure or a panic in the user-supplied closure rolls the
-trigger transition back as well). For maintenance rescue the engine
-`INSERT`s the follow-up in a separate transaction opened *after* the
-rescue commits (see [Atomicity matrix](#atomicity-matrix)). In either
-case, once the follow-up `INSERT` commits the row is durably visible and
-rides Awa's existing retry / DLQ machinery.
+The closure returns a follow-up `JobArgs` value (default `InsertOpts`) or an `EnqueueRequest<F>` with `InsertOpts` overrides. For worker-driven outcomes and callback resolution via the worker `Client`, the engine `INSERT`s the follow-up in the same transaction as the triggering state change; the follow-up commits with the trigger or rolls back with it (a spec INSERT failure or a panic in the user-supplied closure rolls the trigger transition back as well). For maintenance rescue the engine `INSERT`s the follow-up in a separate transaction opened _after_ the rescue commits (see [Atomicity matrix](#atomicity-matrix)). In either case, once the follow-up `INSERT` commits the row is durably visible and rides Awa's existing retry / DLQ machinery.
 
-Counterparts cover the outcomes that benefit most from durable delivery:
-`on_completed_enqueue`, `on_retried_enqueue`, `on_exhausted_enqueue`,
-`on_cancelled_enqueue`, `on_waiting_for_callback_enqueue`, and
-`on_rescued_enqueue`. `Started` is intentionally excluded — claim-time
-enqueue would join the dispatcher's hot path and the use case for
-"job started" is observation, which `on_event` already covers.
-`Snooze` continues to emit nothing on either surface.
+Counterparts cover the outcomes that benefit most from durable delivery: `on_completed_enqueue`, `on_retried_enqueue`, `on_exhausted_enqueue`, `on_cancelled_enqueue`, `on_waiting_for_callback_enqueue`, and `on_rescued_enqueue`. `Started` is intentionally excluded — claim-time enqueue would join the dispatcher's hot path and the use case for "job started" is observation, which `on_event` already covers. `Snooze` continues to emit nothing on either surface.
 
 ### Where the enqueue runs
 
-The enqueue is performed by whatever process performs the state
-transition:
+The enqueue is performed by whatever process performs the state transition:
 
 | Transition | Performed by | Follow-up enqueued by | Atomic? |
-|---|---|---|---|
+| --- | --- | --- | --- |
 | Inline outcomes (Completed, Retried, Exhausted, Cancelled, WaitingForCallback) | Worker executor | Worker executor, in the finalization transaction | yes |
 | Callback resolution via worker `Client` | The resolving process | That process, in the resolution transaction (via `admin::*_external_in_tx` / `store::*_external_in_tx`) | yes |
 | Callback resolution via callback-only ingress (ADR-027) | Callback receiver | Pending: callback-only ingress does not yet own a worker registry. When that surface lands it can reuse the same `_in_tx` admin / store helpers used by the worker `Client`. | pending |
 | Expired-callback / stale-heartbeat / deadline rescue (ADR-028) | Maintenance runtime | Maintenance runtime, in a separate transaction after the rescue commits | no — best-effort |
 
-Why rescue stays best-effort: a panic in a user-supplied
-`on_rescued_enqueue` closure would otherwise roll the rescue UPDATE
-back, coupling rescue liveness (the maintenance loop's job recovery
-guarantee) to the correctness of user follow-up code. A zero-loss
-rescue-notification story is better served by an outbox/sweeper than
-by inlining user code into the rescue tx. The current best-effort
-behaviour means the trigger has already committed, so the worst case
-is a missing follow-up — not a phantom follow-up. See
-[Atomicity matrix](#atomicity-matrix) for the call sites involved.
+Why rescue stays best-effort: a panic in a user-supplied `on_rescued_enqueue` closure would otherwise roll the rescue UPDATE back, coupling rescue liveness (the maintenance loop's job recovery guarantee) to the correctness of user follow-up code. A zero-loss rescue-notification story is better served by an outbox/sweeper than by inlining user code into the rescue tx. The current best-effort behaviour means the trigger has already committed, so the worst case is a missing follow-up — not a phantom follow-up. See [Atomicity matrix](#atomicity-matrix) for the call sites involved.
 
 ### Registry lives in process — for now
 
-The mapping from "trigger kind + outcome" to "make follow-up args" is a Rust
-closure (or a Python callable, when the Python API gains parity). Closures
-cannot be portably stored in the database, so each process that performs a
-state transition must have the spec registered locally:
+The mapping from "trigger kind + outcome" to "make follow-up args" is a Rust closure (or a Python callable, when the Python API gains parity). Closures cannot be portably stored in the database, so each process that performs a state transition must have the spec registered locally:
 
 - A worker process: registers via its own `ClientBuilder`.
-- A callback-only ingress process (ADR-027): registers via the callback
-  router's config (planned in #279).
-- A maintenance-only process (ADR-028): registers via its own
-  `ClientBuilder` in the library form, or via a future config file for the
-  pool-only CLI form.
+- A callback-only ingress process (ADR-027): registers via the callback router's config (planned in #279).
+- A maintenance-only process (ADR-028): registers via its own `ClientBuilder` in the library form, or via a future config file for the pool-only CLI form.
 
-In normal deployments every process is built from the same code, so the
-registries agree. When they disagree — a worker on a new build registers a
-new follow-up that an older callback-receiver doesn't know about — the
-emitter that *doesn't* know the spec simply doesn't enqueue; the trigger
-still commits. This is the same drift behavior as in-process hooks today and
-is acceptable for v1.
+In normal deployments every process is built from the same code, so the registries agree. When they disagree — a worker on a new build registers a new follow-up that an older callback-receiver doesn't know about — the emitter that _doesn't_ know the spec simply doesn't enqueue; the trigger still commits. This is the same drift behavior as in-process hooks today and is acceptable for v1.
 
-A future ADR may introduce a database-stored registry (mapping trigger →
-follow-up kind, with the args transformation expressed declaratively — for
-example, JSONata-style mapping or a CEL expression like ADR-021's callback
-filters use). That option is deferred until the in-process surface is in
-use and the missing mapping in another process becomes a real operational
-problem.
+A future ADR may introduce a database-stored registry (mapping trigger → follow-up kind, with the args transformation expressed declaratively — for example, JSONata-style mapping or a CEL expression like ADR-021's callback filters use). That option is deferred until the in-process surface is in use and the missing mapping in another process becomes a real operational problem.
 
 ### NOTIFY is a wakeup hint, not the delivery channel
 
-Postgres `LISTEN` / `NOTIFY` is suitable for low-latency wakeup but not for
-delivery: payloads are capped, undelivered notifications are dropped, and
-a process not currently listening misses the event. The follow-up enqueue
-already provides durability; pairing it with a `pg_notify` of the follow-up
-job's queue (in the same transaction) is a useful latency optimisation —
-listening workers can claim immediately rather than waiting for the next
-poll interval — but the notification carries no payload and no event
-semantics. It is purely a wakeup signal layered on top of a durable
-INSERT.
+Postgres `LISTEN` / `NOTIFY` is suitable for low-latency wakeup but not for delivery: payloads are capped, undelivered notifications are dropped, and a process not currently listening misses the event. The follow-up enqueue already provides durability; pairing it with a `pg_notify` of the follow-up job's queue (in the same transaction) is a useful latency optimisation — listening workers can claim immediately rather than waiting for the next poll interval — but the notification carries no payload and no event semantics. It is purely a wakeup signal layered on top of a durable INSERT.
 
 ### Boundary with hooks
 
 The two APIs are deliberately separate and orthogonal:
 
-- A user may register `on_event` and `on_*_enqueue` for the same trigger.
-  Both fire; the hook is observation, the enqueue is delivery.
-- An `on_*_enqueue` registration on a process that does *not* perform the
-  relevant state transition is dormant; the engine has nothing to insert for
-  that process. This is consistent with the registry being per-process.
-- Snooze and rescue produce no hooks today; only the enqueue path covers
-  them. This is intentional — rescues happen in the maintenance process,
-  which has no user handler registry, but can still insert a follow-up job
-  from its transaction. Cancellation has both: `Cancelled` is a hook event in
-  ADR-015 and gains an `on_cancelled_enqueue` counterpart here.
+- A user may register `on_event` and `on_*_enqueue` for the same trigger. Both fire; the hook is observation, the enqueue is delivery.
+- An `on_*_enqueue` registration on a process that does _not_ perform the relevant state transition is dormant; the engine has nothing to insert for that process. This is consistent with the registry being per-process.
+- Snooze and rescue produce no hooks today; only the enqueue path covers them. This is intentional — rescues happen in the maintenance process, which has no user handler registry, but can still insert a follow-up job from its transaction. Cancellation has both: `Cancelled` is a hook event in ADR-015 and gains an `on_cancelled_enqueue` counterpart here.
 
-`docs/lifecycle-hooks.md` describes the hook path. The follow-up enqueue
-path gets its own section that names the trade-off explicitly: pick the API
-whose guarantees match the side effect.
+`docs/lifecycle-hooks.md` describes the hook path. The follow-up enqueue path gets its own section that names the trade-off explicitly: pick the API whose guarantees match the side effect.
 
 ### What this is not
 
-- Not a generic event bus. The mechanism is one Awa job per follow-up
-  registration per transition. Fan-out across application components happens
-  by registering multiple follow-ups, each its own job.
-- Not a replacement for tracing spans or logs (PRD §15). Those continue to
-  describe execution; this describes deliberate downstream work.
-- Not a CDC stream. WAL-level change capture is out of scope (alternative
-  E below).
-- Not a sub-millisecond reactor. Follow-up latency is bounded by claim
-  cadence (helped, but not eliminated, by the NOTIFY-as-wakeup hint).
+- Not a generic event bus. The mechanism is one Awa job per follow-up registration per transition. Fan-out across application components happens by registering multiple follow-ups, each its own job.
+- Not a replacement for tracing spans or logs (PRD §15). Those continue to describe execution; this describes deliberate downstream work.
+- Not a CDC stream. WAL-level change capture is out of scope (alternative E below).
+- Not a sub-millisecond reactor. Follow-up latency is bounded by claim cadence (helped, but not eliminated, by the NOTIFY-as-wakeup hint).
 
 ## Consequences
 
 ### Positive
 
-- A single durable mechanism covers every state transition Awa makes,
-  across every deployment role ADR-027 and ADR-028 introduce: inline
-  outcomes, callback resolution (worker-`Client` or callback-only), rescue,
-  and any future transition.
-- The rescue / timeout event gap closes: a rescue can dispatch
-  `job_failed_rescue` (or any user-defined follow-up) — best-effort,
-  in a separate transaction after the rescue commits, but the
-  follow-up itself is then a durable Awa job with full retry / DLQ
-  semantics. Closing this gap fully atomically is tracked as an open
-  extension.
-- The "what should be in a hook?" mistake disappears at the API level —
-  observation and delivery have different names and obviously different
-  guarantees.
-- No new event log table, no new subscriber protocol, no separate retention
-  policy. The follow-up is a job, with all of Awa's existing operator and
-  developer affordances.
-- Composes with the bridge adapters (ADR-016, ADR-017): a user resolving a
-  callback from their own application can pass their own transaction to
-  the resolution path, and the follow-up enqueues in *their* transaction
-  with the app rows.
+- A single durable mechanism covers every state transition Awa makes, across every deployment role ADR-027 and ADR-028 introduce: inline outcomes, callback resolution (worker-`Client` or callback-only), rescue, and any future transition.
+- The rescue / timeout event gap closes: a rescue can dispatch `job_failed_rescue` (or any user-defined follow-up) — best-effort, in a separate transaction after the rescue commits, but the follow-up itself is then a durable Awa job with full retry / DLQ semantics. Closing this gap fully atomically is tracked as an open extension.
+- The "what should be in a hook?" mistake disappears at the API level — observation and delivery have different names and obviously different guarantees.
+- No new event log table, no new subscriber protocol, no separate retention policy. The follow-up is a job, with all of Awa's existing operator and developer affordances.
+- Composes with the bridge adapters (ADR-016, ADR-017): a user resolving a callback from their own application can pass their own transaction to the resolution path, and the follow-up enqueues in _their_ transaction with the app rows.
 
 ### Negative / Risks
 
-- The cost of a "durable event" equals the cost of an Awa job: a row in
-  storage, a claim cycle, a worker pass. That is correctly more expensive
-  than a hook. Users who reach for the durable path for what is really
-  observation will pay that cost without benefit; docs and naming have to
-  make the cheaper option obvious for metrics-style use cases.
-- Latency for downstream work is bounded by Awa's poll cadence rather than
-  by an in-process callback. The NOTIFY-as-wakeup hint reduces but does not
-  eliminate this.
-- More API surface to teach. The split into two APIs is the design's whole
-  point, but the difference between `on_event` and `on_*_enqueue` must be
-  unmistakable in docs and examples; otherwise users will pick the wrong
-  one and observe one of the two failure modes (lost reliable side effect
-  or expensive metrics counter).
-- Cross-process registry drift is possible. The in-process registry choice
-  trades portability for simplicity; future work may have to harden it
-  with a database-stored spec if real deployments hit drift.
-- The maintenance runtime now has a way to insert user-defined jobs from
-  its rescue transactions. That is a deliberate broadening of what
-  maintenance writes and must be documented alongside ADR-028.
+- The cost of a "durable event" equals the cost of an Awa job: a row in storage, a claim cycle, a worker pass. That is correctly more expensive than a hook. Users who reach for the durable path for what is really observation will pay that cost without benefit; docs and naming have to make the cheaper option obvious for metrics-style use cases.
+- Latency for downstream work is bounded by Awa's poll cadence rather than by an in-process callback. The NOTIFY-as-wakeup hint reduces but does not eliminate this.
+- More API surface to teach. The split into two APIs is the design's whole point, but the difference between `on_event` and `on_*_enqueue` must be unmistakable in docs and examples; otherwise users will pick the wrong one and observe one of the two failure modes (lost reliable side effect or expensive metrics counter).
+- Cross-process registry drift is possible. The in-process registry choice trades portability for simplicity; future work may have to harden it with a database-stored spec if real deployments hit drift.
+- The maintenance runtime now has a way to insert user-defined jobs from its rescue transactions. That is a deliberate broadening of what maintenance writes and must be documented alongside ADR-028.
 
 ## Alternatives considered
 
 ### A. Stay with in-process hooks only
 
-Status quo. Loses on every cross-process and crash scenario above. The
-prose-only guidance from ADR-015 does not survive contact with real
-deployments where the resolver process is different from the worker
-process. Rejected as the long-term answer.
+Status quo. Loses on every cross-process and crash scenario above. The prose-only guidance from ADR-015 does not survive contact with real deployments where the resolver process is different from the worker process. Rejected as the long-term answer.
 
 ### B. Postgres NOTIFY / LISTEN fan-out as the event channel
 
-Tempting because `awa:cancel` is precedent. NOTIFY is at-most-once delivery
-to *currently-connected* listeners, with an ~8 KB payload cap, and dropped
-notifications are not replayed. It is a viable wakeup primitive but cannot
-provide durability on its own. Using NOTIFY as the substrate would
-re-introduce the same losses this ADR exists to fix; using it as a wakeup
-hint on top of a durable enqueue is the right role.
+Tempting because `awa:cancel` is precedent. NOTIFY is at-most-once delivery to _currently-connected_ listeners, with an ~8 KB payload cap, and dropped notifications are not replayed. It is a viable wakeup primitive but cannot provide durability on its own. Using NOTIFY as the substrate would re-introduce the same losses this ADR exists to fix; using it as a wakeup hint on top of a durable enqueue is the right role.
 
 ### C. Dedicated `awa.events` outbox table
 
-A standard transactional-outbox pattern. Considered seriously. The decision
-weighed:
+A standard transactional-outbox pattern. Considered seriously. The decision weighed:
 
-- A dedicated events table is durable and replayable and supports cursor-
-  based subscribers.
-- But Awa is *already* a durable, retry-capable, dead-letter-aware queue.
-  Building an events log next to it duplicates the engine: a new subscriber
-  protocol, cursor management, retention policy, admin UI surface, and
-  test matrix.
-- "Queryable event history" — the main argument for an events table — is
-  addressable with tagged follow-up jobs and the existing completed/failed
-  history (ADR-026).
-- The follow-up-job pattern is composable: a follow-up may itself emit
-  follow-ups, may fan out across kinds, and is observable in the existing
-  UI.
+- A dedicated events table is durable and replayable and supports cursor- based subscribers.
+- But Awa is _already_ a durable, retry-capable, dead-letter-aware queue. Building an events log next to it duplicates the engine: a new subscriber protocol, cursor management, retention policy, admin UI surface, and test matrix.
+- "Queryable event history" — the main argument for an events table — is addressable with tagged follow-up jobs and the existing completed/failed history (ADR-026).
+- The follow-up-job pattern is composable: a follow-up may itself emit follow-ups, may fan out across kinds, and is observable in the existing UI.
 
-Rejected because the engine for it already exists; building another would
-trade familiarity for parallel infrastructure.
+Rejected because the engine for it already exists; building another would trade familiarity for parallel infrastructure.
 
 ### D. (Chosen) Transactional follow-up jobs
 
-Described above. Reuses Awa's existing primitives; needs only an API on
-`ClientBuilder` and an enqueue hook in each state-transition path.
+Described above. Reuses Awa's existing primitives; needs only an API on `ClientBuilder` and an enqueue hook in each state-transition path.
 
 ### E. Postgres logical decoding / WAL CDC
 
-Powerful and durable but heavy infra (logical replication slot,
-Debezium-class consumer), inconsistent support across managed Postgres
-providers, and contrary to Awa's "self-contained queue in Postgres"
-positioning (ADR-001). Out of scope.
+Powerful and durable but heavy infra (logical replication slot, Debezium-class consumer), inconsistent support across managed Postgres providers, and contrary to Awa's "self-contained queue in Postgres" positioning (ADR-001). Out of scope.
 
 ## Relationship to other ADRs
 
-- **ADR-015** (lifecycle hooks). This ADR codifies ADR-015's prose advice
-  ("enqueue another job") into a first-class API. ADR-015's hooks remain
-  the correct mechanism for observation; this ADR adds the mechanism for
-  delivery.
-- **ADR-027** (callback ingress, proposed). Addresses the open question
-  ADR-027 punts on: durable callback notifications. The worker `Client`
-  drives resolution + follow-up dispatch in a single transaction via
-  `admin::*_external_in_tx`. A callback-only ingress process built per
-  ADR-027 will need its own registry hookup to reuse the same
-  `_in_tx` admin path; until that hookup lands, callback ingress
-  outside the worker `Client` is a separate transition with no
-  follow-up dispatch. See the "Open extensions" section below for the
-  current implementation boundary.
-- **ADR-028** (maintenance-only runtime, proposed). Gives rescue paths
-  a way to dispatch durable lifecycle work without owning a handler
-  registry. The dispatch is best-effort (separate transaction); the
-  follow-up itself is a regular Awa job once enqueued.
-- **ADR-013** (run-lease, guarded finalization). For worker-driven
-  outcomes the follow-up enqueue joins the same transaction as the
-  guarded-finalization UPDATE; if the UPDATE matches zero rows (stale
-  outcome), the transaction rolls back and the follow-up is not
-  enqueued, preserving the at-most-once finalization contract.
-- **ADR-020** (DLQ). Follow-up jobs participate in the DLQ family
-  unchanged; a side effect that exhausts retries lands in the DLQ with
-  full args and history.
-- **ADR-021** (sequential callbacks, callback heartbeats). The
-  callback resolution surface is unchanged; this ADR adds a follow-up
-  dispatch that runs in a separate transaction after the resolution
-  commits.
-- **ADR-006** (insert-only transaction bridge) and **ADR-016/017**
-  (Postgres adapter / Python transaction bridge). The same transactional
-  insert primitive is reused; nothing new is added to the bridge contract.
+- **ADR-015** (lifecycle hooks). This ADR codifies ADR-015's prose advice ("enqueue another job") into a first-class API. ADR-015's hooks remain the correct mechanism for observation; this ADR adds the mechanism for delivery.
+- **ADR-027** (callback ingress, proposed). Addresses the open question ADR-027 punts on: durable callback notifications. The worker `Client` drives resolution + follow-up dispatch in a single transaction via `admin::*_external_in_tx`. A callback-only ingress process built per ADR-027 will need its own registry hookup to reuse the same `_in_tx` admin path; until that hookup lands, callback ingress outside the worker `Client` is a separate transition with no follow-up dispatch. See the "Open extensions" section below for the current implementation boundary.
+- **ADR-028** (maintenance-only runtime, proposed). Gives rescue paths a way to dispatch durable lifecycle work without owning a handler registry. The dispatch is best-effort (separate transaction); the follow-up itself is a regular Awa job once enqueued.
+- **ADR-013** (run-lease, guarded finalization). For worker-driven outcomes the follow-up enqueue joins the same transaction as the guarded-finalization UPDATE; if the UPDATE matches zero rows (stale outcome), the transaction rolls back and the follow-up is not enqueued, preserving the at-most-once finalization contract.
+- **ADR-020** (DLQ). Follow-up jobs participate in the DLQ family unchanged; a side effect that exhausts retries lands in the DLQ with full args and history.
+- **ADR-021** (sequential callbacks, callback heartbeats). The callback resolution surface is unchanged; this ADR adds a follow-up dispatch that runs in a separate transaction after the resolution commits.
+- **ADR-006** (insert-only transaction bridge) and **ADR-016/017** (Postgres adapter / Python transaction bridge). The same transactional insert primitive is reused; nothing new is added to the bridge contract.
 
 ## Implementation
 
-- **Outcome surface.** `Outcome::{Completed, Retried, Exhausted,
-  Cancelled, WaitingForCallback, Rescued}`. `Started` is intentionally
-  excluded — claim-time enqueue would join the dispatcher's hot path,
-  and the durable-side-effect use case for "job started" is uncommon.
-  Observation belongs to `on_event`. `on_started_enqueue` is not
-  blocked by anything in this design; whether to add it is left as an
-  open question rather than a v1 commitment.
-- **Builder API.** Each outcome has a pair of builders:
-  `on_<outcome>_enqueue` (closure returns `JobArgs`) and
-  `on_<outcome>_enqueue_with` (closure returns
-  `EnqueueRequest<F>` for `InsertOpts` overrides —
-  queue, priority, max_attempts, metadata, tags, unique, run_at,
-  deadline_duration, ordering_key).
-- **Closure signatures** carry the per-outcome context:
-  Completed/WaitingForCallback: `(args, &job_row)`;
-  Cancelled: `(args, &job_row, &reason)`;
-  Retried: `(args, &job_row, &error, attempt, next_run_at)`;
-  Exhausted: `(args, &job_row, &error, attempt)`;
-  Rescued: `(args, &job_row, RescueReason)`.
-- **Rescued event variant.** Maintenance rescues fire
-  `JobEvent::Rescued { args, job, reason: RescueReason }` alongside the
-  follow-up spec dispatch, keeping rescue context distinct from
-  Retried/Exhausted rather than overloading either.
+- **Outcome surface.** `Outcome::{Completed, Retried, Exhausted, Cancelled, WaitingForCallback, Rescued}`. `Started` is intentionally excluded — claim-time enqueue would join the dispatcher's hot path, and the durable-side-effect use case for "job started" is uncommon. Observation belongs to `on_event`. `on_started_enqueue` is not blocked by anything in this design; whether to add it is left as an open question rather than a v1 commitment.
+- **Builder API.** Each outcome has a pair of builders: `on_<outcome>_enqueue` (closure returns `JobArgs`) and `on_<outcome>_enqueue_with` (closure returns `EnqueueRequest<F>` for `InsertOpts` overrides — queue, priority, max_attempts, metadata, tags, unique, run_at, deadline_duration, ordering_key).
+- **Closure signatures** carry the per-outcome context: Completed/WaitingForCallback: `(args, &job_row)`; Cancelled: `(args, &job_row, &reason)`; Retried: `(args, &job_row, &error, attempt, next_run_at)`; Exhausted: `(args, &job_row, &error, attempt)`; Rescued: `(args, &job_row, RescueReason)`.
+- **Rescued event variant.** Maintenance rescues fire `JobEvent::Rescued { args, job, reason: RescueReason }` alongside the follow-up spec dispatch, keeping rescue context distinct from Retried/Exhausted rather than overloading either.
 
 ### Atomicity matrix
 
 | Emission site | Atomic with state commit? |
-|---|---|
+| --- | --- |
 | Worker-driven outcomes on canonical storage | yes — `*_canonical_with_followups` helpers open one tx, run the state UPDATE (UPDATE...RETURNING on `awa.jobs_hot`; for `retryable` the DELETE+INSERT move into `awa.scheduled_jobs` is in a CTE), dispatch specs, commit |
 | Worker-driven outcomes on queue storage | yes — `*_queue_storage_with_followups` helpers run inside `complete_runtime_batch_slow_in_tx` / `cancel_running_in_tx` / `fail_*_in_tx` / `retry_*_in_tx` / `enter_callback_wait_in_tx` |
 | Callback resolution on `Client` (`complete_external`, `fail_external`, `retry_external`, `resolve_callback`) on either storage engine | yes — `Client::*_external` opens one tx, drives the transition via `admin::*_external_in_tx` / `store::*_external_in_tx`, dispatches specs via `dispatch_specs_in_tx`, commits. A spec failure rolls the resolution back so the external sender can retry. |
 | Maintenance rescue (stale heartbeat, deadline exceeded, expired callback) | **no — best-effort.** Spec dispatch runs in a separate tx after the rescue commits. A spec failure leaves the rescue applied and is logged. Kept best-effort by design (see [Open extensions](#open-extensions)). |
 
-Worker-driven outcomes inherit ADR-013's run-lease guard (zero rows
-matched → tx rollback → no follow-up); callback resolution inherits a
-matching guard from the `SELECT ... FOR UPDATE` lookup on `awa.jobs_hot`
-or `FOR UPDATE OF lease` on the queue-storage leases table. The
-trigger transition and the follow-up `INSERT` either both commit or
-neither does, so each committed worker-driven outcome or callback
-resolution enqueues each registered follow-up exactly once. *Delivery*
-of the follow-up itself is at-least-once — once enqueued the row rides
-Awa's normal claim/retry semantics, and the follow-up handler must
-remain safe under re-execution. The maintenance rescue path remains
-best-effort because coupling rescue liveness to the correctness of user
-follow-up code (a panic in `on_rescued_enqueue`) would be a worse
-trade than a missed Rescued follow-up; the rescue UPDATE has already
-committed when the dispatch runs, so the worst case is a missing
-follow-up — not a phantom follow-up.
+Worker-driven outcomes inherit ADR-013's run-lease guard (zero rows matched → tx rollback → no follow-up); callback resolution inherits a matching guard from the `SELECT ... FOR UPDATE` lookup on `awa.jobs_hot` or `FOR UPDATE OF lease` on the queue-storage leases table. The trigger transition and the follow-up `INSERT` either both commit or neither does, so each committed worker-driven outcome or callback resolution enqueues each registered follow-up exactly once. _Delivery_ of the follow-up itself is at-least-once — once enqueued the row rides Awa's normal claim/retry semantics, and the follow-up handler must remain safe under re-execution. The maintenance rescue path remains best-effort because coupling rescue liveness to the correctness of user follow-up code (a panic in `on_rescued_enqueue`) would be a worse trade than a missed Rescued follow-up; the rescue UPDATE has already committed when the dispatch runs, so the worst case is a missing follow-up — not a phantom follow-up.
 
 ### Open extensions
 
-- **Python parity.** The Python binding does not yet expose
-  `on_*_enqueue` or `on_event`. The implementation path mirrors
-  `register_worker` in `awa-python/src/worker.rs`: a `PythonFollowUp`
-  type that wraps a Python callable, takes the GIL inside
-  `dispatch_specs_in_tx`, serialises `JobRow + OutcomeContext` to
-  Python, invokes the callable, and decodes the returned dict to
-  (`JobArgs`, `InsertOpts`) before the underlying `insert_with` fires.
-  ADR-015's hook surface (`@on_event`) needs the same scaffold first.
-- **Atomic callback-resolution for callback-only ingress (ADR-027).**
-  The worker `Client::*_external` paths now drive the resolution and
-  spec dispatch in a single tx via `admin::*_external_in_tx` and the
-  matching `store::*_external_in_tx` helpers. The callback-only
-  ingress process landed by ADR-027 will need its own registry hookup
-  to reuse the same `_in_tx` admin path; until then, callback ingress
-  outside the worker `Client` remains a separate transition with no
-  follow-up dispatch.
-- **Atomic rescue + follow-up enqueue: deliberately not pursued.**
-  Threading `&mut tx` through `maintenance::rescue_*` would couple
-  rescue liveness to the correctness of user follow-up code — a panic
-  in `on_rescued_enqueue` could roll back a rescue UPDATE and prevent
-  maintenance from recovering stale jobs. A future zero-loss
-  rescue-notification design should use an outbox/sweeper rather than
-  inlining user code into the rescue tx.
-- **`on_started_enqueue`.** Not blocked by the design; deliberately
-  out of scope to keep the claim/dispatch hot path uncontended. The
-  observation use case is already covered by `on_event`.
-- **Conditional spec dispatch.** Skipping enqueue based on a predicate
-  over the triggering row is not part of the API; conditioning belongs
-  inside the follow-up handler instead.
-- **In-DB spec registry.** Not part of the design; the in-process
-  registry is sufficient while specs are declared in one place per
-  deployment.
-- **NOTIFY-as-wakeup-hint for follow-up queue poll cadence.** An
-  implementation-level tuning lever rather than an architectural
-  concern.
+- **Python parity.** The Python binding does not yet expose `on_*_enqueue` or `on_event`. The implementation path mirrors `register_worker` in `awa-python/src/worker.rs`: a `PythonFollowUp` type that wraps a Python callable, takes the GIL inside `dispatch_specs_in_tx`, serialises `JobRow + OutcomeContext` to Python, invokes the callable, and decodes the returned dict to (`JobArgs`, `InsertOpts`) before the underlying `insert_with` fires. ADR-015's hook surface (`@on_event`) needs the same scaffold first.
+- **Atomic callback-resolution for callback-only ingress (ADR-027).** The worker `Client::*_external` paths now drive the resolution and spec dispatch in a single tx via `admin::*_external_in_tx` and the matching `store::*_external_in_tx` helpers. The callback-only ingress process landed by ADR-027 will need its own registry hookup to reuse the same `_in_tx` admin path; until then, callback ingress outside the worker `Client` remains a separate transition with no follow-up dispatch.
+- **Atomic rescue + follow-up enqueue: deliberately not pursued.** Threading `&mut tx` through `maintenance::rescue_*` would couple rescue liveness to the correctness of user follow-up code — a panic in `on_rescued_enqueue` could roll back a rescue UPDATE and prevent maintenance from recovering stale jobs. A future zero-loss rescue-notification design should use an outbox/sweeper rather than inlining user code into the rescue tx.
+- **`on_started_enqueue`.** Not blocked by the design; deliberately out of scope to keep the claim/dispatch hot path uncontended. The observation use case is already covered by `on_event`.
+- **Conditional spec dispatch.** Skipping enqueue based on a predicate over the triggering row is not part of the API; conditioning belongs inside the follow-up handler instead.
+- **In-DB spec registry.** Not part of the design; the in-process registry is sufficient while specs are declared in one place per deployment.
+- **NOTIFY-as-wakeup-hint for follow-up queue poll cadence.** An implementation-level tuning lever rather than an architectural concern.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,18 +1,13 @@
 # Architecture Decision Records
 
-Each file in this directory captures a single architectural decision —
-its context, the decision itself, the alternatives considered, and the
-consequences. ADRs are written when a decision has a non-obvious
-rationale, trades off across concerns, or will be hard to change later.
+Each file in this directory captures a single architectural decision — its context, the decision itself, the alternatives considered, and the consequences. ADRs are written when a decision has a non-obvious rationale, trades off across concerns, or will be hard to change later.
 
-Template: `Status / Context / Decision / Consequences (positive, negative) /
-Alternatives Considered / Relationship to other ADRs`. Superseded ADRs stay
-in-place as historical context.
+Template: `Status / Context / Decision / Consequences (positive, negative) / Alternatives Considered / Relationship to other ADRs`. Superseded ADRs stay in-place as historical context.
 
 ## Index
 
 | # | Title | Status | Summary | Relationship |
-|---:|---|---|---|---|
+| --: | --- | --- | --- | --- |
 | 001 | [Postgres-only](001-postgres-only.md) | Accepted | Single storage backend, no pluggable adapter layer | Current layout per ADR-019 |
 | 002 | [BLAKE3 uniqueness](002-blake3-uniqueness.md) | Accepted | Uniqueness keys hashed with BLAKE3, claims in `awa.job_unique_claims` | — |
 | 003 | [Heartbeat + deadline hybrid](003-heartbeat-deadline-hybrid.md) | Accepted | Two independent rescue paths cover crash and runaway failure modes | Fields moved to `active_leases` per ADR-019 |
@@ -45,34 +40,15 @@ in-place as historical context.
 
 ## Validation artifacts
 
-Runtime validation for ADR-019 is recorded in
-[`bench/019-queue-storage-validation-2026-04-19.md`](bench/019-queue-storage-validation-2026-04-19.md)
-(exact commands, raw output, measured numbers).
+Runtime validation for ADR-019 is recorded in [`bench/019-queue-storage-validation-2026-04-19.md`](bench/019-queue-storage-validation-2026-04-19.md) (exact commands, raw output, measured numbers).
 
-Runtime validation for ADR-023 is recorded in
-[`bench/023-receipt-ring-validation-2026-04-26.md`](bench/023-receipt-ring-validation-2026-04-26.md)
-(receipt-ring long-horizon and overnight evidence).
+Runtime validation for ADR-023 is recorded in [`bench/023-receipt-ring-validation-2026-04-26.md`](bench/023-receipt-ring-validation-2026-04-26.md) (receipt-ring long-horizon and overnight evidence).
 
-TLA+ correctness models that pin spec-level invariants are under
-[`../../correctness/`](../../correctness/) — the segmented-storage family
-(`AwaSegmentedStorage`, `AwaSegmentedStorageRaces`, `AwaStorageLockOrder`,
-`AwaSegmentedStorageTrace`) maps to ADR-019 and ADR-020; the
-worker-runtime family (`AwaCore`, `AwaExtended`, `AwaBatcher`, `AwaCbk`,
-`AwaDispatchClaim`, `AwaViewTrigger`, `AwaCron`) covers rescue, batcher,
-callback race, dispatcher claim, view-trigger concurrency, and cron
-double-fire.
+TLA+ correctness models that pin spec-level invariants are under [`../../correctness/`](../../correctness/) — the segmented-storage family (`AwaSegmentedStorage`, `AwaSegmentedStorageRaces`, `AwaStorageLockOrder`, `AwaSegmentedStorageTrace`) maps to ADR-019 and ADR-020; the worker-runtime family (`AwaCore`, `AwaExtended`, `AwaBatcher`, `AwaCbk`, `AwaDispatchClaim`, `AwaViewTrigger`, `AwaCron`) covers rescue, batcher, callback race, dispatcher claim, view-trigger concurrency, and cron double-fire.
 
 ## Conventions
 
-- Status is one of: **Accepted**, **Proposed**, **Superseded by ADR-XXX**,
-  **Deprecated**, **Rejected**. Superseded ADRs stay in the directory as
-  historical context.
-- Relationships to later ADRs that change implementation but not
-  decision are recorded in a bottom-of-doc `## Relationship to ADR-XXX`
-  section rather than a top-of-doc `## Note`.
-- ADRs should be narrative: context, rationale, what-was-considered.
-  Deep implementation detail belongs in
-  [`../architecture.md`](../architecture.md) or a companion design
-  doc, with the ADR holding the decision and its alternatives.
-- New ADRs claim the next number in a small placeholder PR before
-  writing to avoid collisions.
+- Status is one of: **Accepted**, **Proposed**, **Superseded by ADR-XXX**, **Deprecated**, **Rejected**. Superseded ADRs stay in the directory as historical context.
+- Relationships to later ADRs that change implementation but not decision are recorded in a bottom-of-doc `## Relationship to ADR-XXX` section rather than a top-of-doc `## Note`.
+- ADRs should be narrative: context, rationale, what-was-considered. Deep implementation detail belongs in [`../architecture.md`](../architecture.md) or a companion design doc, with the ADR holding the decision and its alternatives.
+- New ADRs claim the next number in a small placeholder PR before writing to avoid collisions.

--- a/docs/adr/bench/019-queue-storage-validation-2026-04-19.md
+++ b/docs/adr/bench/019-queue-storage-validation-2026-04-19.md
@@ -1,10 +1,8 @@
 # ADR-019 Validation Artifact (2026-04-19)
 
-This file records the exact commands and raw output used for the current
-validation numbers in ADR-019.
+This file records the exact commands and raw output used for the current validation numbers in ADR-019.
 
-All commands were run from the repository root on branch
-`feature/vacuum-aware-storage-redesign` with:
+All commands were run from the repository root on branch `feature/vacuum-aware-storage-redesign` with:
 
 ```text
 DATABASE_URL=postgres://postgres:test@localhost:15432/awa_test
@@ -139,8 +137,7 @@ ok
 
 One failed experiment is worth preserving because it changed the design:
 
-When `queue_lanes` was updated on every hot-path completion to maintain live
-`running` and `completed` counters, queue-storage throughput collapsed.
+When `queue_lanes` was updated on every hot-path completion to maintain live `running` and `completed` counters, queue-storage throughput collapsed.
 
 Command:
 
@@ -165,6 +162,4 @@ and after a partial rollback:
 [bench-va] Throughput: 628 jobs/sec
 ```
 
-The recovered design keeps only claim/enqueue control in `lane_state`, derives
-`running` from `active_leases`, and derives terminal counts from live
-`terminal_entries` plus a prune-time rollup.
+The recovered design keeps only claim/enqueue control in `lane_state`, derives `running` from `active_leases`, and derives terminal counts from live `terminal_entries` plus a prune-time rollup.

--- a/docs/adr/bench/023-completion-write-amplification-2026-05-02.md
+++ b/docs/adr/bench/023-completion-write-amplification-2026-05-02.md
@@ -1,8 +1,6 @@
 # ADR-023 Completion Write-Amplification Follow-Up (2026-05-02)
 
-This note records a focused completion-path follow-up to
-[ADR-023](../023-receipt-plane-ring-partitioning.md). The experiment
-targeted three costs visible in the portable harness:
+This note records a focused completion-path follow-up to [ADR-023](../023-receipt-plane-ring-partitioning.md). The experiment targeted three costs visible in the portable harness:
 
 - terminal write amplification for default successful completions
 - round trips inside receipt-backed completion transactions
@@ -10,26 +8,16 @@ targeted three costs visible in the portable harness:
 
 ## Changes Tested
 
-- Keep `done_entries.payload` `NULL` when the terminal runtime payload is
-  empty or unchanged from the corresponding ready row.
-- Skip the ready-payload lookup entirely when every row in a done batch
-  has an empty terminal payload.
-- Merge receipt closure insertion and `attempt_state` cleanup into one
-  data-modifying CTE.
-- Sort completion batches by `claim_slot`, then `(job_id, run_lease)`,
-  before dispatching them to queue storage.
+- Keep `done_entries.payload` `NULL` when the terminal runtime payload is empty or unchanged from the corresponding ready row.
+- Skip the ready-payload lookup entirely when every row in a done batch has an empty terminal payload.
+- Merge receipt closure insertion and `attempt_state` cleanup into one data-modifying CTE.
+- Sort completion batches by `claim_slot`, then `(job_id, run_lease)`, before dispatching them to queue storage.
 
-The changes preserve ADR-023's correctness shape: receipt-backed
-completion still closes the exact `(claim_slot, job_id, run_lease)` claim
-and stale writers still lose via the closure conflict / materialized
-lease fallback. The default successful path still appends a
-`done_entries` row, so terminal history, retention, and queue-count
-semantics do not change.
+The changes preserve ADR-023's correctness shape: receipt-backed completion still closes the exact `(claim_slot, job_id, run_lease)` claim and stale writers still lose via the closure conflict / materialized lease fallback. The default successful path still appends a `done_entries` row, so terminal history, retention, and queue-count semantics do not change.
 
 ## Focused Harness Runs
 
-All runs used the extracted portable harness from
-`hardbyte/postgresql-job-queue-benchmarking` with:
+All runs used the extracted portable harness from `hardbyte/postgresql-job-queue-benchmarking` with:
 
 ```text
 PRODUCER_BATCH_MAX=128 PRODUCER_BATCH_MS=25 \
@@ -37,37 +25,23 @@ uv run bench run --systems awa --producer-rate 5000 --worker-count 64 \
   --phase warmup=warmup:10s --phase clean=clean:75s --sample-every 5
 ```
 
-The earlier comparison run used the same Awa adapter settings as part of
-an `awa,pgque` comparison. Systems are run independently with a fresh
-Postgres container, so the Awa phase is comparable for a directional
-signal.
+The earlier comparison run used the same Awa adapter settings as part of an `awa,pgque` comparison. Systems are run independently with a fresh Postgres container, so the Awa phase is comparable for a directional signal.
 
 | run id | median completion/s | peak completion/s | median backlog | peak backlog | median e2e p99 |
-|--------|---------------------:|------------------:|---------------:|-------------:|---------------:|
+| --- | --: | --: | --: | --: | --: |
 | `custom-20260502T022357Z-14b91e` | 3,251 | 4,002 | 57,005 | 116,812 | 11.6 s |
 | `custom-20260502T024341Z-674839` | 4,272 | 5,204 | 7,315 | 28,098 | 2.0 s |
 | `custom-20260502T024606Z-6a2d02` | 4,621 | 5,861 | 3,780 | 31,988 | 1.9 s |
 
-The patched repeats were both above the comparison run by 31-42% on
-median completion throughput. The backlog and end-to-end p99 reductions
-are larger because the producer target was 5,000/s: once completion gets
-closer to the offered rate, the queue stops running away during the
-short clean phase.
+The patched repeats were both above the comparison run by 31-42% on median completion throughput. The backlog and end-to-end p99 reductions are larger because the producer target was 5,000/s: once completion gets closer to the offered rate, the queue stops running away during the short clean phase.
 
 ## Wait Profile
 
-The wait profile did not move to relation or transaction locks. It
-remained dominated by CPU, `WALWriteLock`, `ClientRead`, and `WalSync`,
-which matches the write-amplification model from issue #207: fewer
-completion statements and less terminal payload work improve throughput,
-but the binding resource is still the WAL/fsync plane.
+The wait profile did not move to relation or transaction locks. It remained dominated by CPU, `WALWriteLock`, `ClientRead`, and `WalSync`, which matches the write-amplification model from issue #207: fewer completion statements and less terminal payload work improve throughput, but the binding resource is still the WAL/fsync plane.
 
 ## Later Follow-Up: ADR-026
 
-ADR-026 shipped the safe version of the narrower terminal-history idea. It
-does not remove `done_entries`; it keeps a durable terminal fact and hydrates
-duplicated immutable body fields from the retained `ready_entries` row for
-ready-backed terminal transitions.
+ADR-026 shipped the safe version of the narrower terminal-history idea. It does not remove `done_entries`; it keeps a durable terminal fact and hydrates duplicated immutable body fields from the retained `ready_entries` row for ready-backed terminal transitions.
 
 The design keeps enough information for:
 
@@ -76,5 +50,4 @@ The design keeps enough information for:
 - `load_job` / admin inspection of completed jobs
 - retry/replay tooling that expects terminal job identity and timing
 
-Transitions without a retained ready row, such as cancelling an unclaimed
-available job, still write a wide `done_entries` row.
+Transitions without a retained ready row, such as cancelling an unclaimed available job, still write a wide `done_entries` row.

--- a/docs/adr/bench/023-receipt-ring-validation-2026-04-26.md
+++ b/docs/adr/bench/023-receipt-ring-validation-2026-04-26.md
@@ -1,39 +1,23 @@
 # ADR-023 Receipt-Ring Validation Artifact (2026-04-26)
 
-This file records the exact commands, configuration, and raw results
-backing the validation numbers in ADR-023. The run exercises the
-post-Phase-6 system: `lease_claim_receipts` defaulted on, the legacy
-`open_receipt_claims` table deleted, and `lease_claims` /
-`lease_claim_closures` partitioned by `claim_slot` with the claim ring
-rotating in lockstep with the lease ring.
+This file records the exact commands, configuration, and raw results backing the validation numbers in ADR-023. The run exercises the post-Phase-6 system: `lease_claim_receipts` defaulted on, the legacy `open_receipt_claims` table deleted, and `lease_claims` / `lease_claim_closures` partitioned by `claim_slot` with the claim ring rotating in lockstep with the lease ring.
 
-> **Note on paths.** This validation artefact pre-dates the extraction
-> of the long-horizon harness into its own repository. References to
-> `benchmarks/portable/...` below describe the in-tree layout at the
-> time of the run; the harness now lives at
-> [hardbyte/postgresql-job-queue-benchmarking](https://github.com/hardbyte/postgresql-job-queue-benchmarking).
-> The data files referenced by run-id (`custom-20260426...`) are
-> retained on the host that produced the run; they are not in the new
-> public repo.
+> **Note on paths.** This validation artefact pre-dates the extraction of the long-horizon harness into its own repository. References to `benchmarks/portable/...` below describe the in-tree layout at the time of the run; the harness now lives at [hardbyte/postgresql-job-queue-benchmarking](https://github.com/hardbyte/postgresql-job-queue-benchmarking). The data files referenced by run-id (`custom-20260426...`) are retained on the host that produced the run; they are not in the new public repo.
 
 ## Run identity
 
 - Run id: `custom-20260426T032000Z-839ddc`
 - Branch: `feature/vacuum-aware-storage-redesign` at `7b688e4`
 - Started: 2026-04-26 05:15:45Z (15:15 NZST), finished ~17:14 NZST
-- Duration: 115 min (5m warmup + 25m clean + 30m idle-in-tx + 30m
-  recovery + 25m clean)
+- Duration: 115 min (5m warmup + 25m clean + 30m idle-in-tx + 30m recovery + 25m clean)
 
 ## Host
 
 - 24-core x86_64, 91 GiB RAM
 - Linux 6.18.21, glibc 2.42
 - Postgres 17.2-alpine in compose
-- `max_connections = 400` (raised from default 200 — see
-  `benchmarks/portable/postgres.conf` for the reasoning; smaller
-  ceilings caused pool exhaustion on the 4×8 profile)
-- `shared_buffers = 256MB`, `autovacuum = on`,
-  `autovacuum_naptime = 1min`, `autovacuum_vacuum_scale_factor = 0.2`
+- `max_connections = 400` (raised from default 200 — see `benchmarks/portable/postgres.conf` for the reasoning; smaller ceilings caused pool exhaustion on the 4×8 profile)
+- `shared_buffers = 256MB`, `autovacuum = on`, `autovacuum_naptime = 1min`, `autovacuum_vacuum_scale_factor = 0.2`
 
 ## CLI
 
@@ -53,155 +37,89 @@ Per-replica producer rate is 200/s, so aggregate offered load is 800/s.
 
 ## Headline result
 
-> Receipt-plane peak dead tuples stayed at **≤49** across **all** phases
-> — including a 30-min `idle-in-tx` phase that holds open transactions
-> to block autovacuum. The `lease_claim_closures_<0..7>` partitions
-> stayed at exactly **0** dead tuples in every phase, confirming the
-> append-only-then-truncate property the partitioning was designed to
-> preserve.
+> Receipt-plane peak dead tuples stayed at **≤49** across **all** phases — including a 30-min `idle-in-tx` phase that holds open transactions to block autovacuum. The `lease_claim_closures_<0..7>` partitions stayed at exactly **0** dead tuples in every phase, confirming the append-only-then-truncate property the partitioning was designed to preserve.
 
-`open_receipt_claims` is absent from the schema and from
-`manifest.adapters.awa.event_tables`. The receipt control table no
-longer exists.
+`open_receipt_claims` is absent from the schema and from `manifest.adapters.awa.event_tables`. The receipt control table no longer exists.
 
 ## Throughput by phase
 
-Aggregate completion / enqueue rates summed across the 4 replicas
-(median over the 5s sample window of each phase):
+Aggregate completion / enqueue rates summed across the 4 replicas (median over the 5s sample window of each phase):
 
-| phase      | type        | aggregate completion/s | aggregate enqueue/s | p99 e2e median (ms) | p99 e2e peak (ms) |
-|------------|-------------|------------------------|---------------------|---------------------|-------------------|
-| clean_1    | clean       | 769.8                  | 791.9               | 92.0                | 244.1             |
-| idle_1     | idle-in-tx  | 359.2                  | 640.5               | n/a (no clean drain)| 67 076            |
-| recovery_1 | recovery    | 744.3                  | 752.0               | n/a                 | n/a               |
-| clean_2    | clean       | 614.0                  | 736.0               | n/a                 | n/a               |
+| phase | type | aggregate completion/s | aggregate enqueue/s | p99 e2e median (ms) | p99 e2e peak (ms) |
+| --- | --- | --- | --- | --- | --- |
+| clean_1 | clean | 769.8 | 791.9 | 92.0 | 244.1 |
+| idle_1 | idle-in-tx | 359.2 | 640.5 | n/a (no clean drain) | 67 076 |
+| recovery_1 | recovery | 744.3 | 752.0 | n/a | n/a |
+| clean_2 | clean | 614.0 | 736.0 | n/a | n/a |
 
-The e2e p99 spike of 67 s during `idle_1` is the expected blocked-vacuum
-latency: held-open transactions prevent claim-ring partitions from being
-truncated and the steady-state pipeline backs up. The recovery and
-following clean phases drained without losing any claims (see receipt
-plane numbers below).
+The e2e p99 spike of 67 s during `idle_1` is the expected blocked-vacuum latency: held-open transactions prevent claim-ring partitions from being truncated and the steady-state pipeline backs up. The recovery and following clean phases drained without losing any claims (see receipt plane numbers below).
 
 ## Receipt plane — peak `n_dead_tup` per partition per phase
 
-| table                               | clean_1 | idle_1 | recovery_1 | clean_2 |
-|-------------------------------------|--------:|-------:|-----------:|--------:|
-| awa_exp.lease_claims_0              | 7       | 8      | 1          | 6       |
-| awa_exp.lease_claims_1              | 0       | 0      | 3          | 2       |
-| awa_exp.lease_claims_2              | 3       | 0      | 0          | 8       |
-| awa_exp.lease_claims_3              | 0       | 0      | 8          | 1       |
-| awa_exp.lease_claims_4              | 4       | 0      | 0          | 8       |
-| awa_exp.lease_claims_5              | 2       | 0      | 8          | 8       |
-| awa_exp.lease_claims_6              | 7       | 2      | 8          | 11      |
-| awa_exp.lease_claims_7              | 8       | 0      | 0          | 5       |
-| awa_exp.lease_claim_closures_0..7   | 0       | 0      | 0          | 0       |
-| **receipt-plane total**             | **31**  | **10** | **28**     | **49**  |
+| table                             | clean_1 | idle_1 | recovery_1 | clean_2 |
+| --------------------------------- | ------: | -----: | ---------: | ------: |
+| awa_exp.lease_claims_0            |       7 |      8 |          1 |       6 |
+| awa_exp.lease_claims_1            |       0 |      0 |          3 |       2 |
+| awa_exp.lease_claims_2            |       3 |      0 |          0 |       8 |
+| awa_exp.lease_claims_3            |       0 |      0 |          8 |       1 |
+| awa_exp.lease_claims_4            |       4 |      0 |          0 |       8 |
+| awa_exp.lease_claims_5            |       2 |      0 |          8 |       8 |
+| awa_exp.lease_claims_6            |       7 |      2 |          8 |      11 |
+| awa_exp.lease_claims_7            |       8 |      0 |          0 |       5 |
+| awa_exp.lease_claim_closures_0..7 |       0 |      0 |          0 |       0 |
+| **receipt-plane total**           |  **31** | **10** |     **28** |  **49** |
 
-Closure partitions are append-only between rotations; their truncate
-runs under `ACCESS EXCLUSIVE` on a partition that the rotate path has
-already moved off. Zero-dead-tuple steady state is the designed shape.
+Closure partitions are append-only between rotations; their truncate runs under `ACCESS EXCLUSIVE` on a partition that the rotate path has already moved off. Zero-dead-tuple steady state is the designed shape.
 
 ## Receipt plane — peak `total_relation_size_mb`
 
-Largest single partition during `clean_2` was
-`lease_claims_1` at **1.26 MB**. Aggregate across all 16 receipt-plane
-partitions stayed **< 12 MB** through the entire run.
+Largest single partition during `clean_2` was `lease_claims_1` at **1.26 MB**. Aggregate across all 16 receipt-plane partitions stayed **< 12 MB** through the entire run.
 
 ## Warm tables — peak `n_dead_tup` per phase
 
-| table                          | clean_1 | idle_1 | recovery_1 | clean_2 |
-|--------------------------------|--------:|-------:|-----------:|--------:|
-| awa_exp.attempt_state          | 0       | 0      | 0          | 0       |
-| awa_exp.queue_lanes            | 0       | 0      | 0          | 0       |
-| awa_exp.queue_claim_heads      | 0       | 0      | 0          | 0       |
-| awa_exp.queue_enqueue_heads    | 0       | 0      | 0          | 0       |
-| awa_exp.queue_ring_state       | 76      | 665    | 40         | 40      |
-| awa_exp.queue_ring_slots       | 95      | 665    | 158        | 0       |
-| awa_exp.lease_ring_state       | 103     | 28 503 | 232        | 104     |
-| awa_exp.lease_ring_slots       | 0       | 0      | 0          | 0       |
-| awa_exp.claim_ring_state       | 78      | 1 631  | 84         | 76      |
-| awa_exp.claim_ring_slots       | 0       | 0      | 0          | 0       |
+| table                       | clean_1 | idle_1 | recovery_1 | clean_2 |
+| --------------------------- | ------: | -----: | ---------: | ------: |
+| awa_exp.attempt_state       |       0 |      0 |          0 |       0 |
+| awa_exp.queue_lanes         |       0 |      0 |          0 |       0 |
+| awa_exp.queue_claim_heads   |       0 |      0 |          0 |       0 |
+| awa_exp.queue_enqueue_heads |       0 |      0 |          0 |       0 |
+| awa_exp.queue_ring_state    |      76 |    665 |         40 |      40 |
+| awa_exp.queue_ring_slots    |      95 |    665 |        158 |       0 |
+| awa_exp.lease_ring_state    |     103 | 28 503 |        232 |     104 |
+| awa_exp.lease_ring_slots    |       0 |      0 |          0 |       0 |
+| awa_exp.claim_ring_state    |      78 |  1 631 |         84 |      76 |
+| awa_exp.claim_ring_slots    |       0 |      0 |          0 |       0 |
 
-The `*_ring_state` tables are singletons (one row each); their dead
-tuples are HOT-update churn that recovers within one autovacuum pass
-once held-open transactions release. The 28 503 spike on
-`lease_ring_state` during `idle_1` collapses back to 232 in
-`recovery_1` and 104 by `clean_2`. This matches the architectural
-contract in `correctness/storage/AwaDeadTupleContract.tla`: ring-state
-rows are `Warm` (bounded by row count, churn-prone but reclaim-fast).
+The `*_ring_state` tables are singletons (one row each); their dead tuples are HOT-update churn that recovers within one autovacuum pass once held-open transactions release. The 28 503 spike on `lease_ring_state` during `idle_1` collapses back to 232 in `recovery_1` and 104 by `clean_2`. This matches the architectural contract in `correctness/storage/AwaDeadTupleContract.tla`: ring-state rows are `Warm` (bounded by row count, churn-prone but reclaim-fast).
 
 ## ADR-019 baseline comparison
 
-ADR-019 (`docs/adr/bench/019-queue-storage-validation-2026-04-19.md`)
-is dominated by short throughput tests against a single-replica DB.
-The closest comparable number is the mixed-workload soak's
-`exact_dead_total = 276` after a 10s, 1000 jobs/s drain. The Phase 6
-multi-replica long-horizon equivalent is the **49** receipt-plane peak
-in `clean_2` — a different shape (longer, multi-replica, includes an
-idle-in-tx phase), but the order-of-magnitude reduction confirms the
-prediction in ADR-023: by removing the `open_receipt_claims` row from
-the receipt path, receipt-plane MVCC churn drops from "low hundreds"
-to "low tens" and is fully partition-truncate-reclaimed instead of
-autovacuum-reclaimed.
+ADR-019 (`docs/adr/bench/019-queue-storage-validation-2026-04-19.md`) is dominated by short throughput tests against a single-replica DB. The closest comparable number is the mixed-workload soak's `exact_dead_total = 276` after a 10s, 1000 jobs/s drain. The Phase 6 multi-replica long-horizon equivalent is the **49** receipt-plane peak in `clean_2` — a different shape (longer, multi-replica, includes an idle-in-tx phase), but the order-of-magnitude reduction confirms the prediction in ADR-023: by removing the `open_receipt_claims` row from the receipt path, receipt-plane MVCC churn drops from "low hundreds" to "low tens" and is fully partition-truncate-reclaimed instead of autovacuum-reclaimed.
 
 ## Validation status
 
-- All four TLA+ specs in `correctness/storage/` pass under TLC
-  (`AwaSegmentedStorage`, `AwaSegmentedStorageRaces`,
-  `AwaStorageLockOrder`, `AwaSegmentedStorageTrace`,
-  `AwaDeadTupleContract`). TLC is wired into
-  `.github/workflows/nightly-chaos.yml`.
+- All four TLA+ specs in `correctness/storage/` pass under TLC (`AwaSegmentedStorage`, `AwaSegmentedStorageRaces`, `AwaStorageLockOrder`, `AwaSegmentedStorageTrace`, `AwaDeadTupleContract`). TLC is wired into `.github/workflows/nightly-chaos.yml`.
 - `cargo test --workspace` green at `7b688e4`.
-- 4 receipt-plane chaos scenarios in
-  `awa/tests/receipt_plane_chaos_test.rs` pass (`#[ignore]` group,
-  exercised in `nightly-chaos.yml`).
-- `open_receipt_claims` is absent from `prepare_schema()` and from
-  the live schema after install (test
-  `test_open_receipt_claims_is_absent_after_install`).
+- 4 receipt-plane chaos scenarios in `awa/tests/receipt_plane_chaos_test.rs` pass (`#[ignore]` group, exercised in `nightly-chaos.yml`).
+- `open_receipt_claims` is absent from `prepare_schema()` and from the live schema after install (test `test_open_receipt_claims_is_absent_after_install`).
 
 ## Known limitations / follow-ups
 
 ### Residual ~2.4 GB/h/replica RSS growth (resolved 2026-04-27)
 
-The 115-min run saw per-replica RSS climb from ~zero at start to 3.9–
-4.6 GB at T+95m. Initial investigation traced this to glibc malloc
-arena fragmentation and applied `MALLOC_ARENA_MAX=2` in
-`bench_harness/adapters.py:_base_env`. That capped arena *count* (1-2
-distinct arenas) but a 12h validation attempt at T+1h still showed
-2.7-3.6 GB/replica (~3.2 GB/h/replica), with the 1-2 capped arenas
-growing via repeated 64 MB chunk allocations.
+The 115-min run saw per-replica RSS climb from ~zero at start to 3.9– 4.6 GB at T+95m. Initial investigation traced this to glibc malloc arena fragmentation and applied `MALLOC_ARENA_MAX=2` in `bench_harness/adapters.py:_base_env`. That capped arena _count_ (1-2 distinct arenas) but a 12h validation attempt at T+1h still showed 2.7-3.6 GB/replica (~3.2 GB/h/replica), with the 1-2 capped arenas growing via repeated 64 MB chunk allocations.
 
-A jemalloc heap profile (and a parallel code audit) traced 99.1% of
-allocations to `tokio::runtime::task::core::Cell::new` from
-`awa-worker/src/dispatcher.rs:662`: the `Dispatcher::drain_ready` path
-spawns every job-runner future into a shared
-`Arc<Mutex<JoinSet<()>>>`, but `JoinSet::join_next()` was only called
-during shutdown drain. Completed `JoinHandle`s — and the task `Cell`
-each one keeps alive (which captures the entire `execute_task`
-closure: cloned `Arc`s of pool/storage/metrics, the job payload,
-the dispatch permit) — accumulated indefinitely under steady-state
-load.
+A jemalloc heap profile (and a parallel code audit) traced 99.1% of allocations to `tokio::runtime::task::core::Cell::new` from `awa-worker/src/dispatcher.rs:662`: the `Dispatcher::drain_ready` path spawns every job-runner future into a shared `Arc<Mutex<JoinSet<()>>>`, but `JoinSet::join_next()` was only called during shutdown drain. Completed `JoinHandle`s — and the task `Cell` each one keeps alive (which captures the entire `execute_task` closure: cloned `Arc`s of pool/storage/metrics, the job payload, the dispatch permit) — accumulated indefinitely under steady-state load.
 
-Fixed in commit `c0df1df` by reaping completed handles via
-`set.try_join_next()` before each spawn batch. Validated end-to-end
-with the 12h overnight run below; per-replica RSS held at **17-18 MB
-for the entire 11.6h** (vs 3.6 GB at T+1h pre-fix).
+Fixed in commit `c0df1df` by reaping completed handles via `set.try_join_next()` before each spawn batch. Validated end-to-end with the 12h overnight run below; per-replica RSS held at **17-18 MB for the entire 11.6h** (vs 3.6 GB at T+1h pre-fix).
 
 ### Pool sizing
 
-The pre-fix `max_connections = 200` ceiling caused pool-timeout errors
-on the 4×8 profile because each replica's bench pool defaults to 80
-connections (worker_count × 4 + 48), and 4 × 80 = 320 exceeds the
-ceiling. The new defaults — `max_connections = 400` in
-`benchmarks/portable/postgres.conf` and per-replica pool size in
-`benchmarks/portable/awa-bench/src/long_horizon.rs` — are pinned and
-captured in the manifest for cross-run comparability.
+The pre-fix `max_connections = 200` ceiling caused pool-timeout errors on the 4×8 profile because each replica's bench pool defaults to 80 connections (worker_count × 4 + 48), and 4 × 80 = 320 exceeds the ceiling. The new defaults — `max_connections = 400` in `benchmarks/portable/postgres.conf` and per-replica pool size in `benchmarks/portable/awa-bench/src/long_horizon.rs` — are pinned and captured in the manifest for cross-run comparability.
 
 ## 12-hour overnight run (2026-04-27, after JoinSet leak fix)
 
-Run id: `custom-20260426T101003Z-ba9cb4`. Started 2026-04-26 22:10 NZST,
-completed 2026-04-27 09:46 NZST (11.6 h wall time). Same branch +
-commit `c0df1df` (JoinSet drain fix). Profile:
+Run id: `custom-20260426T101003Z-ba9cb4`. Started 2026-04-26 22:10 NZST, completed 2026-04-27 09:46 NZST (11.6 h wall time). Same branch + commit `c0df1df` (JoinSet drain fix). Profile:
 
 ```text
 --phase warmup=warmup:5m
@@ -216,148 +134,112 @@ commit `c0df1df` (JoinSet drain fix). Profile:
 
 ### Receipt plane — 7-phase summary
 
-| phase      | type        | claims peak dead | closures peak dead | claims peak MB | closures peak MB |
-|------------|-------------|-----------------:|-------------------:|---------------:|-----------------:|
-| clean_1    | clean       | 85               | **0**              | 3.58           | 3.37             |
-| idle_1     | idle-in-tx  | 38               | **0**              | 4.35           | 3.19             |
-| recovery_1 | recovery    | 42               | **0**              | 6.50           | 4.55             |
-| clean_2    | clean       | 68               | **0**              | 57.57          | 36.45            |
-| idle_2     | idle-in-tx  | 33               | **0**              | 59.67          | 37.56            |
-| recovery_2 | recovery    | 37               | **0**              | 101.63         | 63.73            |
-| clean_3    | clean       | 42               | **0**              | 98.18          | 61.55            |
+| phase | type | claims peak dead | closures peak dead | claims peak MB | closures peak MB |
+| --- | --- | --: | --: | --: | --: |
+| clean_1 | clean | 85 | **0** | 3.58 | 3.37 |
+| idle_1 | idle-in-tx | 38 | **0** | 4.35 | 3.19 |
+| recovery_1 | recovery | 42 | **0** | 6.50 | 4.55 |
+| clean_2 | clean | 68 | **0** | 57.57 | 36.45 |
+| idle_2 | idle-in-tx | 33 | **0** | 59.67 | 37.56 |
+| recovery_2 | recovery | 37 | **0** | 101.63 | 63.73 |
+| clean_3 | clean | 42 | **0** | 98.18 | 61.55 |
 
-Closure partitions stayed at **0 dead tuples through every phase**
-across two full idle-in-tx stress cycles — the architectural property
-ADR-023 set out to deliver. Receipt-plane peak dead-tuple count over
-the entire 11.6 h was ≤85.
+Closure partitions stayed at **0 dead tuples through every phase** across two full idle-in-tx stress cycles — the architectural property ADR-023 set out to deliver. Receipt-plane peak dead-tuple count over the entire 11.6 h was ≤85.
 
 ### Warm singletons — peak `n_dead_tup` per phase
 
-| table                       | clean_1 | idle_1 | recovery_1 | clean_2 | idle_2 | recovery_2 | clean_3 |
-|-----------------------------|--------:|-------:|-----------:|--------:|-------:|-----------:|--------:|
-| awa_exp.queue_ring_state    | 78      | 668    | 668        | 44      | 44     | 44         | 44      |
-| awa_exp.lease_ring_state    | 108     | 28 541 | 28 584     | 148     | 23 563 | 237        | 2 505   |
-| awa_exp.claim_ring_state    | 78      | 1 635  | 1 635      | 79      | 186    | 77         | 76      |
-| awa_exp.attempt_state       | 0       | 0      | 0          | 0       | 0      | 0          | 0       |
-| awa_exp.queue_lanes         | 0       | 0      | 0          | 0       | 0      | 0          | 0       |
-| awa_exp.queue_claim_heads   | 0       | 0      | 0          | 0       | 0      | 0          | 0       |
+| table | clean_1 | idle_1 | recovery_1 | clean_2 | idle_2 | recovery_2 | clean_3 |
+| --- | --: | --: | --: | --: | --: | --: | --: |
+| awa_exp.queue_ring_state | 78 | 668 | 668 | 44 | 44 | 44 | 44 |
+| awa_exp.lease_ring_state | 108 | 28 541 | 28 584 | 148 | 23 563 | 237 | 2 505 |
+| awa_exp.claim_ring_state | 78 | 1 635 | 1 635 | 79 | 186 | 77 | 76 |
+| awa_exp.attempt_state | 0 | 0 | 0 | 0 | 0 | 0 | 0 |
+| awa_exp.queue_lanes | 0 | 0 | 0 | 0 | 0 | 0 | 0 |
+| awa_exp.queue_claim_heads | 0 | 0 | 0 | 0 | 0 | 0 | 0 |
 
-Ring-state row counts spike under blocked vacuum and recover within an
-autovacuum pass once held-open transactions release — exactly the
-`Warm` reclaim shape in the dead-tuple contract spec.
+Ring-state row counts spike under blocked vacuum and recover within an autovacuum pass once held-open transactions release — exactly the `Warm` reclaim shape in the dead-tuple contract spec.
 
 ### Per-replica RSS
 
 Hourly samples taken from `/proc/<pid>/status`:
 
-| sample      | replica 0 | replica 1 | replica 2 | replica 3 |
-|-------------|----------:|----------:|----------:|----------:|
-| T+1h        | 18 080 kB | 17 240 kB | 17 176 kB | 17 308 kB |
-| T+5h        | 18 284 kB | 17 376 kB | 17 232 kB | 17 396 kB |
+| sample        | replica 0 | replica 1 | replica 2 | replica 3 |
+| ------------- | --------: | --------: | --------: | --------: |
+| T+1h          | 18 080 kB | 17 240 kB | 17 176 kB | 17 308 kB |
+| T+5h          | 18 284 kB | 17 376 kB | 17 232 kB | 17 396 kB |
 | T+9h (idle_2) | 18 404 kB | 17 428 kB | 17 260 kB | 17 396 kB |
-| T+11h       | 18 436 kB | 17 448 kB | 17 260 kB | 17 396 kB |
+| T+11h         | 18 436 kB | 17 448 kB | 17 260 kB | 17 396 kB |
 
-Net per-replica drift over 11 h: **< 400 kB**. Total allocator-arena
-mappings stayed at 16-18 anonymous regions, ~16 MB total per replica.
-Compare pre-fix: 2.7-3.6 GB at T+1h, projecting to ~150 GB at T+12h.
+Net per-replica drift over 11 h: **< 400 kB**. Total allocator-arena mappings stayed at 16-18 anonymous regions, ~16 MB total per replica. Compare pre-fix: 2.7-3.6 GB at T+1h, projecting to ~150 GB at T+12h.
 
 ### Throughput regression — out of scope for ADR-023
 
-| phase      | aggregate completion/s | aggregate enqueue/s | total backlog peak |
-|------------|-----------------------:|--------------------:|-------------------:|
-| clean_1    | 759                    | 776                 | 95                 |
-| idle_1     | 365                    | 645                 | 354 878            |
-| recovery_1 | 747                    | 746                 | 360 925            |
-| clean_2    | 344                    | 704                 | 4 956 477          |
-| idle_2    | 167                    | 596                 | 5 732 775          |
-| recovery_2 | 221                    | 707                 | 6 591 795          |
-| clean_3    | 200                    | 700                 | 9 229 258          |
+| phase | aggregate completion/s | aggregate enqueue/s | total backlog peak |
+| --- | --: | --: | --: |
+| clean_1 | 759 | 776 | 95 |
+| idle_1 | 365 | 645 | 354 878 |
+| recovery_1 | 747 | 746 | 360 925 |
+| clean_2 | 344 | 704 | 4 956 477 |
+| idle_2 | 167 | 596 | 5 732 775 |
+| recovery_2 | 221 | 707 | 6 591 795 |
+| clean_3 | 200 | 700 | 9 229 258 |
 
-After idle_1 leaves a ~360k-job backlog, recovery_1's drain rate just
-matches the steady enqueue rate — it does not actually drain the
-backlog. From clean_2 onward completion rate falls to 200-350/s while
-enqueue holds at ~700/s, so the backlog grows monotonically to 9.2 M
-jobs / 12 GB `ready_entries` by the end. **This is not an ADR-023
-issue** — the receipt plane stayed clean throughout (closures
-stayed at 0 dead tuples; claim partitions reclaimed each rotation).
-The slowdown is a separate scaling characteristic exposed by holding a
-~Million-row `ready_entries` accumulation, tracked separately.
+After idle_1 leaves a ~360k-job backlog, recovery_1's drain rate just matches the steady enqueue rate — it does not actually drain the backlog. From clean_2 onward completion rate falls to 200-350/s while enqueue holds at ~700/s, so the backlog grows monotonically to 9.2 M jobs / 12 GB `ready_entries` by the end. **This is not an ADR-023 issue** — the receipt plane stayed clean throughout (closures stayed at 0 dead tuples; claim partitions reclaimed each rotation). The slowdown is a separate scaling characteristic exposed by holding a ~Million-row `ready_entries` accumulation, tracked separately.
 
 ## Three 30-minute regression-confirmation runs (2026-04-27)
 
-After the 12 h validation surfaced the post-idle throughput regression
-fixed in `c0df1df` / `ab99a31` / `d21e5db`, three short bench runs
-were taken at the same 4×8×200/s topology to confirm the regression
-stays gone under different pressure shapes. All three runs stream
-metrics through the OTel side-stack at `docker/observability/`
-(commit `7905c74`), so the dashboard is the canonical operator view
-and these tables are the textual record.
+After the 12 h validation surfaced the post-idle throughput regression fixed in `c0df1df` / `ab99a31` / `d21e5db`, three short bench runs were taken at the same 4×8×200/s topology to confirm the regression stays gone under different pressure shapes. All three runs stream metrics through the OTel side-stack at `docker/observability/` (commit `7905c74`), so the dashboard is the canonical operator view and these tables are the textual record.
 
 ### Run 1 — clean baseline
 
-`custom-20260427T043422Z-ab7901`. 4×8×200/s, warmup 2m + clean 28m.
-Headline: completion 783/s vs enqueue 792/s, claim peak 25, closures
-**0**. Steady-state shape; no surprises.
+`custom-20260427T043422Z-ab7901`. 4×8×200/s, warmup 2m + clean 28m. Headline: completion 783/s vs enqueue 792/s, claim peak 25, closures **0**. Steady-state shape; no surprises.
 
 ### Run 2 — single-cycle idle-in-tx stress (the original regression scenario)
 
-`custom-20260427T051026Z-5bc479`. warmup 2m + clean_pre 8m +
-idle-in-tx 5m + clean_post 15m.
+`custom-20260427T051026Z-5bc479`. warmup 2m + clean_pre 8m + idle-in-tx 5m + clean_post 15m.
 
 | phase      | comp/s | enq/s | claim peak | closure peak |
-|------------|-------:|------:|-----------:|-------------:|
-| clean_pre  | 787    | 800   | 16         | **0**        |
-| idle_1     | 779    | 781   | 3          | **0**        |
-| clean_post | 784    | 792   | 36         | **0**        |
+| ---------- | -----: | ----: | ---------: | -----------: |
+| clean_pre  |    787 |   800 |         16 |        **0** |
+| idle_1     |    779 |   781 |          3 |        **0** |
+| clean_post |    784 |   792 |         36 |        **0** |
 
-The original 12 h regression had clean_pre 759 → idle_1 365 →
-clean_post 344. This run is the post-fix shape: clean_post within
-3/s of clean_pre, and within 8/s of enqueue. The post-idle drop is
-gone.
+The original 12 h regression had clean_pre 759 → idle_1 365 → clean_post 344. This run is the post-fix shape: clean_post within 3/s of clean_pre, and within 8/s of enqueue. The post-idle drop is gone.
 
 ### Run 3 — two-cycle stress (most informative)
 
-`custom-20260427T054607Z-6a8f52`. warmup 2m + clean_1 5m + idle_1
-5m + recovery_1 5m + clean_2 5m + idle_2 3m + recovery_2 3m + clean_3
-2m. Two full stress cycles in 30 minutes.
+`custom-20260427T054607Z-6a8f52`. warmup 2m + clean_1 5m + idle_1 5m + recovery_1 5m + clean_2 5m + idle_2 3m + recovery_2 3m + clean_3 2m. Two full stress cycles in 30 minutes.
 
 | phase      | comp/s | enq/s | gap | claim peak | closure peak |
-|------------|-------:|------:|----:|-----------:|-------------:|
-| clean_1    | 783    | 800   | 17  | 15         | **0**        |
-| idle_1     | 755    | 757   | 3   | 15         | **0**        |
-| recovery_1 | 798    | 800   | 2   | 1          | **0**        |
-| clean_2    | 790    | 792   | 2   | 21         | **0**        |
-| idle_2     | 773    | 785   | 12  | 3          | **0**        |
-| recovery_2 | 773    | 787   | 14  | 8          | **0**        |
-| clean_3    | 774    | 788   | 14  | 13         | **0**        |
+| ---------- | -----: | ----: | --: | ---------: | -----------: |
+| clean_1    |    783 |   800 |  17 |         15 |        **0** |
+| idle_1     |    755 |   757 |   3 |         15 |        **0** |
+| recovery_1 |    798 |   800 |   2 |          1 |        **0** |
+| clean_2    |    790 |   792 |   2 |         21 |        **0** |
+| idle_2     |    773 |   785 |  12 |          3 |        **0** |
+| recovery_2 |    773 |   787 |  14 |          8 |        **0** |
+| clean_3    |    774 |   788 |  14 |         13 |        **0** |
 
-Receipt-plane closure peak: **0** across every one of the seven
-phases, including two full idle-in-tx stress cycles. Claim peak
-≤21 across the entire run. Throughput keeps within 2% of the
-producer rate in all phases — the post-idle regression does not
-re-emerge across repeated stress cycles.
+Receipt-plane closure peak: **0** across every one of the seven phases, including two full idle-in-tx stress cycles. Claim peak ≤21 across the entire run. Throughput keeps within 2% of the producer rate in all phases — the post-idle regression does not re-emerge across repeated stress cycles.
 
-Warm singleton (`lease_ring_state`) dead-tuple peaks per phase, for
-the dead-tuple contract spec's `Warm` reclaim shape:
+Warm singleton (`lease_ring_state`) dead-tuple peaks per phase, for the dead-tuple contract spec's `Warm` reclaim shape:
 
 | phase      | lease_ring_state | queue_ring_state | claim_ring_state |
-|------------|-----------------:|-----------------:|-----------------:|
-| clean_1    | 101              | 68               | 69               |
-| idle_1     | 5 909            | 296              | 296              |
-| recovery_1 | 6 010            | 75               | 301              |
-| clean_2    | 93               | 72               | 79               |
-| idle_2     | 3 510            | 176              | 175              |
-| recovery_2 | 3 608            | 181              | 181              |
-| clean_3    | 93               | 65               | 66               |
+| ---------- | ---------------: | ---------------: | ---------------: |
+| clean_1    |              101 |               68 |               69 |
+| idle_1     |            5 909 |              296 |              296 |
+| recovery_1 |            6 010 |               75 |              301 |
+| clean_2    |               93 |               72 |               79 |
+| idle_2     |            3 510 |              176 |              175 |
+| recovery_2 |            3 608 |              181 |              181 |
+| clean_3    |               93 |               65 |               66 |
 
-Spikes under held-tx, full recovery within one clean phase. Exactly
-the `Warm`/`bounded-by-row-count` shape declared in
-`correctness/storage/AwaDeadTupleContract.tla`.
+Spikes under held-tx, full recovery within one clean phase. Exactly the `Warm`/`bounded-by-row-count` shape declared in `correctness/storage/AwaDeadTupleContract.tla`.
 
 ## Files
 
 - 115-min run: `benchmarks/portable/results/custom-20260426T032000Z-839ddc/`
-- 12-hour run:  `benchmarks/portable/results/custom-20260426T101003Z-ba9cb4/`
+- 12-hour run: `benchmarks/portable/results/custom-20260426T101003Z-ba9cb4/`
 - Run 1 (clean baseline): `benchmarks/portable/results/custom-20260427T043422Z-ab7901/`
 - Run 2 (single-cycle stress): `benchmarks/portable/results/custom-20260427T051026Z-5bc479/`
 - Run 3 (two-cycle stress): `benchmarks/portable/results/custom-20260427T054607Z-6a8f52/`
@@ -365,155 +247,95 @@ the `Warm`/`bounded-by-row-count` shape declared in
 
 ## Second 12-hour overnight run (2026-04-27 → 2026-04-28)
 
-Run id: `custom-20260427T081444Z-2471c6`. Started 2026-04-27 20:14 NZST,
-completed 2026-04-28 07:56 NZST (11h 35m wall). Branch tip
-`a45dca6` (post-doc-consolidation). Same 7-phase profile as the prior
-12h run (4 replicas × 8 workers × 200/s producer = 800/s aggregate;
-`warmup:5m → clean_1:4h → idle_1:30m → recovery_1:30m → clean_2:4h
-→ idle_2:30m → recovery_2:30m → clean_3:90m`).
+Run id: `custom-20260427T081444Z-2471c6`. Started 2026-04-27 20:14 NZST, completed 2026-04-28 07:56 NZST (11h 35m wall). Branch tip `a45dca6` (post-doc-consolidation). Same 7-phase profile as the prior 12h run (4 replicas × 8 workers × 200/s producer = 800/s aggregate; `warmup:5m → clean_1:4h → idle_1:30m → recovery_1:30m → clean_2:4h → idle_2:30m → recovery_2:30m → clean_3:90m`).
 
 ### Headline
 
-Receipt-plane invariant **held across the entire 11.6 h** including
-two full idle-in-tx stress cycles:
+Receipt-plane invariant **held across the entire 11.6 h** including two full idle-in-tx stress cycles:
 
 - `lease_claim_closures_0..7` peak `n_dead_tup` = **0** in **every** phase.
-- `lease_claims_0..7` peak `n_dead_tup` = **24** across the run
-  (well under the 200 threshold).
+- `lease_claims_0..7` peak `n_dead_tup` = **24** across the run (well under the 200 threshold).
 
-Per-replica RSS: held at **17184–17552 kB** across 5 sampled checkpoints
-spanning 8 hours of the run. Net drift ~150 kB. The JoinSet leak fix
-from `c0df1df` continues to hold.
+Per-replica RSS: held at **17184–17552 kB** across 5 sampled checkpoints spanning 8 hours of the run. Net drift ~150 kB. The JoinSet leak fix from `c0df1df` continues to hold.
 
-Run log: 0 ERROR/FATAL/panic. 474 sqlx WARN slow-statement events,
-all on the queue_counts query during high-backlog phases — see
-"queue_counts perf characterisation" below.
+Run log: 0 ERROR/FATAL/panic. 474 sqlx WARN slow-statement events, all on the queue_counts query during high-backlog phases — see "queue_counts perf characterisation" below.
 
 ### Receipt plane — 8-phase summary
 
-Peak `n_dead_tup` per partition family per phase. Dashes mean the
-metric was not sampled in that phase (no events fell within the
-sample window).
+Peak `n_dead_tup` per partition family per phase. Dashes mean the metric was not sampled in that phase (no events fell within the sample window).
 
 | phase      | claims peak | closures peak |
-|------------|------------:|--------------:|
-| warmup     | 0           | 0             |
-| clean_1    | 16          | 0             |
-| idle_1     | 14          | 0             |
-| recovery_1 | 8           | 0             |
-| clean_2    | 9           | 0             |
-| idle_2     | 4           | 0             |
-| recovery_2 | 8           | 0             |
-| clean_3    | 0           | 0             |
+| ---------- | ----------: | ------------: |
+| warmup     |           0 |             0 |
+| clean_1    |          16 |             0 |
+| idle_1     |          14 |             0 |
+| recovery_1 |           8 |             0 |
+| clean_2    |           9 |             0 |
+| idle_2     |           4 |             0 |
+| recovery_2 |           8 |             0 |
+| clean_3    |           0 |             0 |
 
 ### Warm singletons — peak `n_dead_tup` per phase
 
-| table             | clean_1 | idle_1 | recovery_1 | clean_2 | idle_2 | recovery_2 | clean_3 |
-|-------------------|--------:|-------:|-----------:|--------:|-------:|-----------:|--------:|
-| lease_ring_state  | 105     | 28 563 | (≤ 132)    | 132     | 26 686 | (≤ 88)     | 88      |
-| claim_ring_state  | 78      | 1 616  | (≤ 79)     | 79      | 323    | (≤ 76)     | 76      |
-| queue_ring_state  | 78      | 633    | (≤ 9)      | 9       | 9      | (≤ 9)      | 9       |
+| table | clean_1 | idle_1 | recovery_1 | clean_2 | idle_2 | recovery_2 | clean_3 |
+| --- | --: | --: | --: | --: | --: | --: | --: |
+| lease_ring_state | 105 | 28 563 | (≤ 132) | 132 | 26 686 | (≤ 88) | 88 |
+| claim_ring_state | 78 | 1 616 | (≤ 79) | 79 | 323 | (≤ 76) | 76 |
+| queue_ring_state | 78 | 633 | (≤ 9) | 9 | 9 | (≤ 9) | 9 |
 
-Same `Warm`/`bounded-by-row-count` reclaim shape as the first 12h
-run. Spike under held-tx, full reclaim within one clean phase.
+Same `Warm`/`bounded-by-row-count` reclaim shape as the first 12h run. Spike under held-tx, full reclaim within one clean phase.
 
 ### Throughput by phase
 
-Per-replica completion / enqueue rates (median over the 5s sample
-window). Multiply by 4 for aggregate.
+Per-replica completion / enqueue rates (median over the 5s sample window). Multiply by 4 for aggregate.
 
 | phase      | completion/s | enqueue/s |
-|------------|-------------:|----------:|
-| warmup     | 198.5        | 198.5     |
-| clean_1    | 190.2        | 190.2     |
-| idle_1     | 118.1        | 164.9     |
-| recovery_1 | 184.5        | 183.4     |
-| clean_2    |  95.7        | 174.0     |
-| idle_2    |  42.8        | 158.3     |
-| recovery_2 |  52.0        | 175.4     |
-| clean_3    |  31.5        | 175.8     |
+| ---------- | -----------: | --------: |
+| warmup     |        198.5 |     198.5 |
+| clean_1    |        190.2 |     190.2 |
+| idle_1     |        118.1 |     164.9 |
+| recovery_1 |        184.5 |     183.4 |
+| clean_2    |         95.7 |     174.0 |
+| idle_2     |         42.8 |     158.3 |
+| recovery_2 |         52.0 |     175.4 |
+| clean_3    |         31.5 |     175.8 |
 
-Same post-idle backlog-growth shape as the first 12h run. Receipt
-plane stayed clean throughout, so the slowdown is not an ADR-023
-property — it is the queue_counts hot-path described next.
+Same post-idle backlog-growth shape as the first 12h run. Receipt plane stayed clean throughout, so the slowdown is not an ADR-023 property — it is the queue_counts hot-path described next.
 
 ### queue_counts perf characterisation (targeted bench, off-pool)
 
-Driven by a fresh-postgres microbench
-(`artifacts/queue_counts_bench/run.sh`) that seeds N rows into a
-single `ready_entries` partition for one queue and runs
-`EXPLAIN (ANALYZE, BUFFERS)` on the exact-count CTE used by
-`QueueStorage::queue_counts_exact`. Three repeats per size; the run
-isolates the count from concurrent enqueue/claim traffic.
+Driven by a fresh-postgres microbench (`artifacts/queue_counts_bench/run.sh`) that seeds N rows into a single `ready_entries` partition for one queue and runs `EXPLAIN (ANALYZE, BUFFERS)` on the exact-count CTE used by `QueueStorage::queue_counts_exact`. Three repeats per size; the run isolates the count from concurrent enqueue/claim traffic.
 
 | backlog rows | execution_ms (median) | total_ms (median) |
-|-------------:|----------------------:|------------------:|
+| -----------: | --------------------: | ----------------: |
 |      100 000 |                  14.1 |              29.6 |
 |    1 000 000 |                 116.1 |             134.7 |
 |    5 000 000 |                 460.2 |             475.1 |
 |   10 000 000 |                 845.9 |             860.9 |
 
-Linear in the backlog. The cost is dominated by a single sub-CTE,
-`lane_counts`, which scans every row in `ready_entries` and joins
-against `queue_claim_heads` to filter by `lane_seq >= claim_seq`.
-At 10 M rows the EXPLAIN plan reports 877 ms in `Finalize Aggregate`
-over a Parallel Seq Scan + Hash Join across `ready_entries_0`
-partition, with the parallel workers each reading ~55 k buffer
-pages (3 × 8 GB residency across the partition heap).
+Linear in the backlog. The cost is dominated by a single sub-CTE, `lane_counts`, which scans every row in `ready_entries` and joins against `queue_claim_heads` to filter by `lane_seq >= claim_seq`. At 10 M rows the EXPLAIN plan reports 877 ms in `Finalize Aggregate` over a Parallel Seq Scan + Hash Join across `ready_entries_0` partition, with the parallel workers each reading ~55 k buffer pages (3 × 8 GB residency across the partition heap).
 
 Every other sub-CTE finishes in under a millisecond:
 
-| sub-CTE          | actual time (10 M backlog) |
-|------------------|----------------------------|
-| `lane_counts`    | **877 ms** (full ready_entries scan) |
+| sub-CTE | actual time (10 M backlog) |
+| --- | --- |
+| `lane_counts` | **877 ms** (full ready_entries scan) |
 | `live_running` (leases) | 0.04 ms (8 partitions, all empty) |
 | `live_running` (lease_claims anti-join) | 0.04 ms (claim ring TRUNCATE'd hot) |
 | `live_terminal` (done_entries) | 0.08 ms |
 | `pruned_terminal` (queue_lanes ⨝ rollups) | 0.13 ms |
 
-The dispatcher caches `queue_counts` for `CLAIMER_QUEUE_COUNTS_MAX_AGE
-= 250 ms` (`awa-worker/src/dispatcher.rs:20`). Once the backlog
-crosses ~3 M rows the exact query takes longer than the cache
-window, so every replica's claim batch ends up waiting on a fresh
-exact count. Across 4 replicas this saturates one connection per
-replica with the count query alone, which is why throughput
-collapses from ~750/s aggregate in `clean_1` to ~125/s in `clean_3`.
+The dispatcher caches `queue_counts` for `CLAIMER_QUEUE_COUNTS_MAX_AGE = 250 ms` (`awa-worker/src/dispatcher.rs:20`). Once the backlog crosses ~3 M rows the exact query takes longer than the cache window, so every replica's claim batch ends up waiting on a fresh exact count. Across 4 replicas this saturates one connection per replica with the count query alone, which is why throughput collapses from ~750/s aggregate in `clean_1` to ~125/s in `clean_3`.
 
 ### Fix direction (not landed in this branch)
 
-The receipt-plane numbers tell us this is **not** an ADR-023 issue;
-the partitioned receipt tables are doing exactly what they were
-designed to do. The fix space is:
+The receipt-plane numbers tell us this is **not** an ADR-023 issue; the partitioned receipt tables are doing exactly what they were designed to do. The fix space is:
 
-1. **Replace the ready_entries scan with a counter read.**
-   `queue_lanes.available_count` already tracks per-(queue, priority)
-   available entries and is updated transactionally by
-   enqueue/claim/rotate. Summing that column over the matching
-   logical-queue physical stripes is O(few rows) regardless of
-   backlog size and gives the same semantic answer as the current
-   row-count scan.
-2. **Lift queue_counts out of the dispatcher claim hot path.** The
-   dispatcher only uses queue_counts to size `target_claimers`. That
-   is a slow-moving control-loop input — a 1–5 second cache window
-   would be safe and would absorb the worst-case query cost without
-   visible impact.
-**Resolution:** both directions landed before the 0.6 cut. The
-queue_counts_exact `lane_counts` CTE now reads
-`sum(queue_lanes.available_count)`; the dispatcher's claimer-target
-loop uses an `AvailableSignal` from the same lane-head counter; the
-legacy `queue_counts_cached` method, the `queue_count_snapshots`
-cache table, and the dispatcher's `CLAIMER_QUEUE_COUNTS_MAX_AGE`
-constant are gone. The receipt-plane validation in this artifact
-holds independently of those throughput-side changes.
+1. **Replace the ready_entries scan with a counter read.** `queue_lanes.available_count` already tracks per-(queue, priority) available entries and is updated transactionally by enqueue/claim/rotate. Summing that column over the matching logical-queue physical stripes is O(few rows) regardless of backlog size and gives the same semantic answer as the current row-count scan.
+2. **Lift queue_counts out of the dispatcher claim hot path.** The dispatcher only uses queue_counts to size `target_claimers`. That is a slow-moving control-loop input — a 1–5 second cache window would be safe and would absorb the worst-case query cost without visible impact. **Resolution:** both directions landed before the 0.6 cut. The queue_counts_exact `lane_counts` CTE now reads `sum(queue_lanes.available_count)`; the dispatcher's claimer-target loop uses an `AvailableSignal` from the same lane-head counter; the legacy `queue_counts_cached` method, the `queue_count_snapshots` cache table, and the dispatcher's `CLAIMER_QUEUE_COUNTS_MAX_AGE` constant are gone. The receipt-plane validation in this artifact holds independently of those throughput-side changes.
 
 ### Files
 
-- Long-horizon results bundle:
-  `benchmarks/portable/results/custom-20260427T081444Z-2471c6/`
-  (`summary.json`, `manifest.json`, `raw.csv`, `index.html`, `plots/`).
-  `raw.csv` is 529 MB and is gitignored — the bundle is local-only
-  archive evidence; this artifact captures the derived numbers.
-- Overnight check log: `artifacts/overnight/checks.log`
-  (5 sampled health checkpoints from the autonomous cron).
-- queue_counts microbench: `artifacts/queue_counts_bench/`
-  (`run.sh`, `timings.csv`, four `explain_<N>_<r>.txt` per repeat).
+- Long-horizon results bundle: `benchmarks/portable/results/custom-20260427T081444Z-2471c6/` (`summary.json`, `manifest.json`, `raw.csv`, `index.html`, `plots/`). `raw.csv` is 529 MB and is gitignored — the bundle is local-only archive evidence; this artifact captures the derived numbers.
+- Overnight check log: `artifacts/overnight/checks.log` (5 sampled health checkpoints from the autonomous cron).
+- queue*counts microbench: `artifacts/queue_counts_bench/` (`run.sh`, `timings.csv`, four `explain*<N>\_<r>.txt` per repeat).

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,13 +1,8 @@
 # Awa Architecture Overview
 
-Awa (Māori: river) is a Postgres-native background job queue for Rust and
-Python. Postgres is the sole infrastructure dependency: there is no Redis,
-RabbitMQ, sidecar scheduler, or separate lease store. Producers enqueue inside
-ordinary Postgres transactions, workers claim and complete jobs through the
-same database, and one elected worker runs cluster-wide maintenance.
+Awa (Māori: river) is a Postgres-native background job queue for Rust and Python. Postgres is the sole infrastructure dependency: there is no Redis, RabbitMQ, sidecar scheduler, or separate lease store. Producers enqueue inside ordinary Postgres transactions, workers claim and complete jobs through the same database, and one elected worker runs cluster-wide maintenance.
 
-This document is ordered by the questions operators and contributors usually
-need answered first:
+This document is ordered by the questions operators and contributors usually need answered first:
 
 - What owns the runtime?
 - What deployment assumptions shape that runtime?
@@ -17,65 +12,44 @@ need answered first:
 - How are partitions rotated and reclaimed?
 - Which surfaces are operational rather than hot-path?
 
-For migration details see [migrations.md](migrations.md). For user-facing
-knobs see [configuration.md](configuration.md).
+For migration details see [migrations.md](migrations.md). For user-facing knobs see [configuration.md](configuration.md).
 
 ## Terms
 
-- A **claim** is the storage transition that makes a ready job belong to one
-  attempt. It increments `run_lease`; later completion, retry, rescue, and
-  cancellation must match that lease number.
-- A **deferred** job is not claimable yet. Future `run_at` jobs are
-  `scheduled`; retry backoff and snooze rows are `retryable`. Maintenance
-  promotes due deferred rows into the ready ring.
-- A **lane** is one ordered `(queue, priority, enqueue_shard)` stream. Raising
-  the shard count creates more lanes for the same logical queue.
-- A **lease** is the durable live-attempt row used when an attempt needs mutable
-  execution state such as heartbeat, progress, callbacks, or deadlines.
-- A **receipt** is the lighter claim record used for short attempts. A closure
-  row records how the receipt ended; open receipts are derived by anti-joining
-  claims and closures.
-- A **segment** is a ring partition. Awa rotates segments and truncates whole
-  old segments instead of vacuuming hot history row by row.
-- A **ready tombstone** is an append-only marker that excludes an immutable
-  ready row from future claims.
+- A **claim** is the storage transition that makes a ready job belong to one attempt. It increments `run_lease`; later completion, retry, rescue, and cancellation must match that lease number.
+- A **deferred** job is not claimable yet. Future `run_at` jobs are `scheduled`; retry backoff and snooze rows are `retryable`. Maintenance promotes due deferred rows into the ready ring.
+- A **lane** is one ordered `(queue, priority, enqueue_shard)` stream. Raising the shard count creates more lanes for the same logical queue.
+- A **lease** is the durable live-attempt row used when an attempt needs mutable execution state such as heartbeat, progress, callbacks, or deadlines.
+- A **receipt** is the lighter claim record used for short attempts. A closure row records how the receipt ended; open receipts are derived by anti-joining claims and closures.
+- A **segment** is a ring partition. Awa rotates segments and truncates whole old segments instead of vacuuming hot history row by row.
+- A **ready tombstone** is an append-only marker that excludes an immutable ready row from future claims.
 
 ## Runtime Shape
 
 The runtime is three cooperating layers:
 
 | Layer | Owns | Notes |
-|---|---|---|
+| --- | --- | --- |
 | Application code | Producer transactions, Rust handlers, Python handlers, optional HTTP worker targets | Enqueue can commit or roll back with the application's own writes. Rust and Python workers share the same storage engine. |
 | Worker runtime | Dispatchers, executor tasks, guarded completion, per-process heartbeat refresh, maintenance leader election | Every worker process runs these services. Only one process wins the maintenance lock at a time. |
 | Postgres | Queue state, execution state, control metadata, uniqueness, cron rows, runtime snapshots | Postgres is the coordination point for visibility, claim ownership, recovery, callbacks, and operator state. |
 
-The important ownership split is simple: every worker can dispatch and
-heartbeat its own attempts, but exactly one elected maintenance leader runs
-cluster-wide promotion, rescue, queue/lease/claim ring rotation and prune, DLQ
-cleanup, descriptor cleanup, cron evaluation, metadata refresh, and
-queue-health publication.
+The important ownership split is simple: every worker can dispatch and heartbeat its own attempts, but exactly one elected maintenance leader runs cluster-wide promotion, rescue, queue/lease/claim ring rotation and prune, DLQ cleanup, descriptor cleanup, cron evaluation, metadata refresh, and queue-health publication.
 
 ## Deployment Model
 
-- Awa assumes one shared Postgres database and any number of Rust or Python
-  worker processes.
+- Awa assumes one shared Postgres database and any number of Rust or Python worker processes.
 - Each process registers the queues and job kinds it can execute.
 - Queue work is awakened by `LISTEN/NOTIFY` with polling as the fallback.
-- The maintenance leader is elected inside the same worker fleet; no `pg_cron`
-  or external scheduler is required.
-- Long analytical reads should run on replicas or with disciplined timeouts,
-  because long-lived primary transactions can delay best-effort partition
-  prune.
+- The maintenance leader is elected inside the same worker fleet; no `pg_cron` or external scheduler is required.
+- Long analytical reads should run on replicas or with disciplined timeouts, because long-lived primary transactions can delay best-effort partition prune.
 
 ## Storage Planes
 
-Queue storage is the worker engine in 0.6. It is not one mutable jobs heap; it
-is split into queue, execution, and control planes so each plane carries the
-right kind of churn.
+Queue storage is the worker engine in 0.6. It is not one mutable jobs heap; it is split into queue, execution, and control planes so each plane carries the right kind of churn.
 
 | Plane | Tables | Shape | Why it matters |
-|---|---|---|---|
+| --- | --- | --- | --- |
 | Queue | `ready_entries_*`, `ready_tombstones_*`, `done_entries_*` | Ring partitions by `ready_slot` | Runnable and terminal rows stay append-first; rare ready mutations append tombstones instead of deleting ready rows; the whole segment is reclaimed by queue-ring prune. |
 | Queue backlog | `deferred_jobs` | Plain table | Scheduled and retryable work stays out of the hot claim path until promotion. |
 | Operator hold | `dlq_entries` | Plain table | DLQ rows are explicit operator backlog with retry, purge, and retention cleanup. |
@@ -83,21 +57,14 @@ right kind of churn.
 | Materialized execution | `leases_*`, `attempt_state` | Lease ring plus mutable state table | Attempts escalate here when they need callback waiting, progress, or other mutable attempt state. |
 | Control | `queue_lanes`, heads, ring-state tables, `queue_meta`, descriptors, runtimes, cron, uniqueness | Narrow metadata tables | Claim cursors, queue state, operator metadata, uniqueness, and liveness are kept separate from payload history. |
 
-The asymmetry is intentional. Ready/done, lease, and receipt tables are
-ring-pruned because they are hot. Deferred and DLQ rows are backlog/hold tables
-with their own promotion, retry, purge, and retention paths. Control tables
-stay narrow because they are the coordination surface dispatchers and
-maintenance touch most often.
+The asymmetry is intentional. Ready/done, lease, and receipt tables are ring-pruned because they are hot. Deferred and DLQ rows are backlog/hold tables with their own promotion, retry, purge, and retention paths. Control tables stay narrow because they are the coordination surface dispatchers and maintenance touch most often.
 
 ## Storage Surfaces
 
-Most applications should use the Rust, Python, CLI, or UI APIs rather than
-querying queue-storage tables directly. The SQL objects still matter for
-operators, adapters, and incident read-outs, so Awa separates read surfaces from
-physical transition surfaces:
+Most applications should use the Rust, Python, CLI, or UI APIs rather than querying queue-storage tables directly. The SQL objects still matter for operators, adapters, and incident read-outs, so Awa separates read surfaces from physical transition surfaces:
 
 | Surface | Role | Consumer contract |
-|---|---|---|
+| --- | --- | --- |
 | `awa.jobs` / `awa.insert_job_compat()` | Canonical compatibility surface used during the storage transition and by SQL adapters that need the public job shape. When queue storage is active, the runtime does not claim or complete from `awa.jobs`; compatibility inserts route into the active backend, and SQL deletes of ready rows append ready tombstones. | Public compatibility surface. Prefer Rust/Python/adapter APIs for ordinary writes. For high-volume queue-storage producers, prefer configured direct COPY through `QueueStorage::enqueue_params_copy()` or Python `enqueue_many_copy()` rather than the compat COPY path. |
 | `{schema}.terminal_jobs` | Read-only hydrated view over queue-storage terminal history. It joins narrow `done_entries_*` rows back to retained `ready_entries_*` bodies. | Public read surface for SQL inspection and reporting of terminal queue-storage rows. It is not a write or transition surface. |
 | `ready_entries_*` | Physical runnable queue ring. | Internal storage. Read only for low-level debugging; writes must go through Awa enqueue, claim, retry, cancel, or maintenance paths. |
@@ -110,27 +77,20 @@ physical transition surfaces:
 | `queue_lanes`, queue heads, ring-state tables, `queue_meta` | Claim cursors, enqueue heads, rotation/prune state, and queue storage configuration. | Internal control surface except documented configuration fields such as `queue_meta.enqueue_shards`. If no `queue_meta` row exists for a queue, enqueue defaults to one shard; operators should configure shard counts with an UPSERT before load tests or production traffic. |
 | descriptors, runtime snapshots, cron tables | Operator metadata and scheduler declarations. | Public through Awa APIs and UI; SQL reads are acceptable for reporting. Writes should go through the corresponding Awa APIs. |
 
-ADR-019 is the storage-engine source of truth; ADR-023 supersedes it for the
-receipt plane, and ADR-026 refines terminal history:
+ADR-019 is the storage-engine source of truth; ADR-023 supersedes it for the receipt plane, and ADR-026 refines terminal history:
 
 - [ADR-019: Queue Storage Engine](adr/019-queue-storage-redesign.md)
 - [ADR-023: Receipt Plane Ring Partitioning](adr/023-receipt-plane-ring-partitioning.md)
 - [ADR-026: Narrow Terminal History](adr/026-narrow-terminal-history.md)
 
-For how the per-schema substrate is installed and who owns which
-objects, see [Queue-storage substrate](queue-storage-substrate.md).
-The default `awa.*` substrate is materialised by `awa migrate`; custom
-queue-storage schemas are installed via the
-`awa.install_queue_storage_substrate()` SQL helper that
-`prepare_schema()` and `awa storage prepare-queue-storage-schema`
-both call into.
+For how the per-schema substrate is installed and who owns which objects, see [Queue-storage substrate](queue-storage-substrate.md). The default `awa.*` substrate is materialised by `awa migrate`; custom queue-storage schemas are installed via the `awa.install_queue_storage_substrate()` SQL helper that `prepare_schema()` and `awa storage prepare-queue-storage-schema` both call into.
 
 ## Job Lifecycle
 
 Core transitions:
 
 | From | To | Trigger |
-|---|---|---|
+| --- | --- | --- |
 | insert | `available` | Immediate enqueue. |
 | insert | `scheduled` | Future `run_at`. |
 | `scheduled` / `retryable` | `available` | Maintenance promotion when `run_at <= now()`. |
@@ -143,32 +103,15 @@ Core transitions:
 | `running` / `waiting_external` | `failed` | Attempts exhausted, terminal error, or callback timeout exhaustion. |
 | `failed` | `dlq_entries` | Optional per-queue DLQ routing. |
 
-`run_lease` increments at claim time. Runtime mutations carry
-`(job_id, run_lease)`, so stale completions, retries, snoozes, cancels, and
-callback resumes lose after rescue, admin cancellation, or re-claim.
+`run_lease` increments at claim time. Runtime mutations carry `(job_id, run_lease)`, so stale completions, retries, snoozes, cancels, and callback resumes lose after rescue, admin cancellation, or re-claim.
 
 Terminal rows differ by storage backend:
 
-- In queue storage, `completed`, ordinary `failed`, and `cancelled` snapshots
-  live in `done_entries_*` and are reclaimed by queue-ring prune. Ready-backed
-  terminal rows are narrow: immutable job-body fields stay in the retained
-  `ready_entries_*` row and public/admin reads hydrate through the storage
-  surfaces described above. Unclaimed ready cancellation and priority aging do
-  not delete ready rows; they append `ready_tombstones_*` rows so claim and
-  exact-count paths skip the old lane until queue prune reclaims the segment.
-- DLQ-enabled terminal failures are routed or moved into `dlq_entries`
-  instead of ordinary terminal history; that table has explicit retention
-  cleanup plus operator retry/purge.
-- In the canonical compatibility path, terminal rows in `awa.jobs_hot` use
-  row-by-row retention cleanup.
+- In queue storage, `completed`, ordinary `failed`, and `cancelled` snapshots live in `done_entries_*` and are reclaimed by queue-ring prune. Ready-backed terminal rows are narrow: immutable job-body fields stay in the retained `ready_entries_*` row and public/admin reads hydrate through the storage surfaces described above. Unclaimed ready cancellation and priority aging do not delete ready rows; they append `ready_tombstones_*` rows so claim and exact-count paths skip the old lane until queue prune reclaims the segment.
+- DLQ-enabled terminal failures are routed or moved into `dlq_entries` instead of ordinary terminal history; that table has explicit retention cleanup plus operator retry/purge.
+- In the canonical compatibility path, terminal rows in `awa.jobs_hot` use row-by-row retention cleanup.
 
-Progress is cleared on successful completion and preserved across retry,
-snooze, cancel, fail, and rescue. On queue storage, mutable progress snapshots
-live in `attempt_state` once an attempt first needs that mutable state; they
-are not rewrites of the immutable ready row. Cancellation is cooperative for
-live handlers: Rust handlers can poll `ctx.is_cancelled()`, Python handlers can
-poll `job.is_cancelled()`, and stale storage writes are still rejected by the
-`run_lease` guard if a handler misses the signal.
+Progress is cleared on successful completion and preserved across retry, snooze, cancel, fail, and rescue. On queue storage, mutable progress snapshots live in `attempt_state` once an attempt first needs that mutable state; they are not rewrites of the immutable ready row. Cancellation is cooperative for live handlers: Rust handlers can poll `ctx.is_cancelled()`, Python handlers can poll `job.is_cancelled()`, and stale storage writes are still rejected by the `run_lease` guard if a handler misses the signal.
 
 ## Enqueue And Claim
 
@@ -193,54 +136,24 @@ sequenceDiagram
     D->>E: execute handlers
 ```
 
-Enqueue is transactional: if the producer's outer transaction rolls back, the
-job never becomes visible. Immediate jobs append to `ready_entries_*`; future
-scheduled or retryable jobs append to `deferred_jobs`.
+Enqueue is transactional: if the producer's outer transaction rolls back, the job never becomes visible. Immediate jobs append to `ready_entries_*`; future scheduled or retryable jobs append to `deferred_jobs`.
 
-`deferred_jobs` is deliberately outside the claim path. The maintenance leader
-promotes due `scheduled` and `retryable` rows into `ready_entries_*` in batches
-and notifies the target queues. Cron schedules are just producers for ordinary
-jobs: when a schedule fires, the cron transaction records the fire and enqueues
-the job atomically, using `ready_entries_*` for immediate fires or
-`deferred_jobs` when the enqueue carries a future `run_at`.
+`deferred_jobs` is deliberately outside the claim path. The maintenance leader promotes due `scheduled` and `retryable` rows into `ready_entries_*` in batches and notifies the target queues. Cron schedules are just producers for ordinary jobs: when a schedule fires, the cron transaction records the fire and enqueues the job atomically, using `ready_entries_*` for immediate fires or `deferred_jobs` when the enqueue carries a future `run_at`.
 
 There are two COPY-shaped producer paths:
 
-- Direct queue-storage COPY is the high-throughput path: Rust producers use a
-  configured `QueueStorage::enqueue_params_copy()`, and Python producers use
-  `enqueue_many_copy()`. Direct-copy producers must use the same queue-storage
-  configuration as the worker fleet, especially `queue_stripe_count` /
-  `queue_storage_queue_stripe_count`.
-- `insert_many_copy()` is the compatibility path. It stages rows with COPY but
-  then routes each row through `awa.insert_job_compat()`, so it preserves the
-  public compatibility surface rather than bypassing to the direct producer
-  path.
+- Direct queue-storage COPY is the high-throughput path: Rust producers use a configured `QueueStorage::enqueue_params_copy()`, and Python producers use `enqueue_many_copy()`. Direct-copy producers must use the same queue-storage configuration as the worker fleet, especially `queue_stripe_count` / `queue_storage_queue_stripe_count`.
+- `insert_many_copy()` is the compatibility path. It stages rows with COPY but then routes each row through `awa.insert_job_compat()`, so it preserves the public compatibility surface rather than bypassing to the direct producer path.
 
 Claim is cursor-based rather than heap-scan based:
 
-- `queue_meta.enqueue_shards` controls how many independent enqueue/claim head
-  rows a queue has. The default is one shard. Raising it changes the ordering
-  contract to FIFO within `(queue, priority, enqueue_shard)`, with no global
-  ordering promise across shards.
-- `queue_enqueue_heads` allocates lane sequence ranges at enqueue time per
-  `(physical queue, priority, enqueue_shard)`.
-- `queue_claim_heads` advances monotonically during claim and is the authority
-  for the next claimable lane position on the same shard-qualified lane.
-- The dispatcher pre-acquires execution permits before claiming, so every
-  claimed `running` job has reserved local capacity.
-- Queue striping and bounded claimers reduce contention on very hot logical
-  queues. Per-queue `claimers` can add dispatcher/claimer loops inside one
-  runtime, but those loops share the queue's worker permits and rate limiter;
-  they do not own jobs. Recovery still follows the receipt/lease state in
-  Postgres.
+- `queue_meta.enqueue_shards` controls how many independent enqueue/claim head rows a queue has. The default is one shard. Raising it changes the ordering contract to FIFO within `(queue, priority, enqueue_shard)`, with no global ordering promise across shards.
+- `queue_enqueue_heads` allocates lane sequence ranges at enqueue time per `(physical queue, priority, enqueue_shard)`.
+- `queue_claim_heads` advances monotonically during claim and is the authority for the next claimable lane position on the same shard-qualified lane.
+- The dispatcher pre-acquires execution permits before claiming, so every claimed `running` job has reserved local capacity.
+- Queue striping and bounded claimers reduce contention on very hot logical queues. Per-queue `claimers` can add dispatcher/claimer loops inside one runtime, but those loops share the queue's worker permits and rate limiter; they do not own jobs. Recovery still follows the receipt/lease state in Postgres.
 
-Priority ordering is by effective priority first. Within one enqueue shard the
-lane sequence is FIFO; across enqueue shards, strict global lane order is not
-promised. With queue storage, priority aging is applied at claim time rather
-than by physically rewriting ready rows. The ready/done/lease partitions carry
-shard-aware lane indexes on `(queue, priority, enqueue_shard, lane_seq)` so
-deep backlog claim probes do not scan a non-shard-selective lane index and
-post-filter most rows.
+Priority ordering is by effective priority first. Within one enqueue shard the lane sequence is FIFO; across enqueue shards, strict global lane order is not promised. With queue storage, priority aging is applied at claim time rather than by physically rewriting ready rows. The ready/done/lease partitions carry shard-aware lane indexes on `(queue, priority, enqueue_shard, lane_seq)` so deep backlog claim probes do not scan a non-shard-selective lane index and post-filter most rows.
 
 ## Completion And Callbacks
 
@@ -258,68 +171,42 @@ handler result
 
 Two callback modes share the same attempt guard:
 
-- **Parked callback.** The handler registers a callback token and returns
-  `WaitForCallback`; the runtime frees the task slot and moves the attempt to
-  `waiting_external` until a signed callback completes, fails, retries, or
-  resumes it.
-- **Sequential wait.** The handler calls `wait_for_callback()` and stays
-  suspended; `resume_external` writes the callback result and returns the same
-  attempt to `running` so the handler can continue.
+- **Parked callback.** The handler registers a callback token and returns `WaitForCallback`; the runtime frees the task slot and moves the attempt to `waiting_external` until a signed callback completes, fails, retries, or resumes it.
+- **Sequential wait.** The handler calls `wait_for_callback()` and stays suspended; `resume_external` writes the callback result and returns the same attempt to `running` so the handler can continue.
 
-Callback tokens are attempt-specific. Stale tokens and stale completions are
-rejected after a newer claim or terminal transition. The `awa-ui` HTTP callback
-receiver verifies `X-Awa-Signature` when `AWA_CALLBACK_HMAC_SECRET` is set;
-custom callback receivers must provide equivalent authentication. See
-[HTTP workers and callback signatures](http-callbacks.md) for the concrete
-endpoint and signing contract.
+Callback tokens are attempt-specific. Stale tokens and stale completions are rejected after a newer claim or terminal transition. The `awa-ui` HTTP callback receiver verifies `X-Awa-Signature` when `AWA_CALLBACK_HMAC_SECRET` is set; custom callback receivers must provide equivalent authentication. See [HTTP workers and callback signatures](http-callbacks.md) for the concrete endpoint and signing contract.
 
 ## Recovery Model
 
 Awa has three rescue paths:
 
-- **Stale heartbeat rescue.** Each worker heartbeats the attempts it owns.
-  The maintenance leader rescues attempts whose heartbeat is older than
-  `heartbeat_staleness` (default 90s).
-- **Hard deadline rescue.** Per-queue deadlines write `deadline_at` onto
-  receipt or lease rows. The maintenance leader closes expired attempts and
-  routes them through the normal retry/fail/DLQ path.
-- **Callback-timeout rescue.** Waiting attempts with expired callback timeouts
-  are moved back through the same guarded finalization machinery.
+- **Stale heartbeat rescue.** Each worker heartbeats the attempts it owns. The maintenance leader rescues attempts whose heartbeat is older than `heartbeat_staleness` (default 90s).
+- **Hard deadline rescue.** Per-queue deadlines write `deadline_at` onto receipt or lease rows. The maintenance leader closes expired attempts and routes them through the normal retry/fail/DLQ path.
+- **Callback-timeout rescue.** Waiting attempts with expired callback timeouts are moved back through the same guarded finalization machinery.
 
-Rescue closes the old attempt before making work available again. If the old
-handler later writes a completion, the `run_lease` guard rejects it as stale.
-When rescue happens in a process that still has the handler registered, the
-runtime also flips the in-memory cancellation flag.
+Rescue closes the old attempt before making work available again. If the old handler later writes a completion, the `run_lease` guard rejects it as stale. When rescue happens in a process that still has the handler registered, the runtime also flips the in-memory cancellation flag.
 
 ## Partition Rotation And Reclamation
 
-Queue storage has three independent rings, each advanced by the elected
-maintenance leader:
+Queue storage has three independent rings, each advanced by the elected maintenance leader:
 
 | Ring | Partitions | Default cadence | Rotate requires | Prune requires |
-|---|---|---:|---|---|
+| --- | --- | --: | --- | --- |
 | Queue | `ready_entries_*`, `ready_tombstones_*`, `done_entries_*` | `1000ms` | incoming ready/done/tombstone slot is empty | oldest non-current slot has no active leases and no pending ready rows; terminal rows and tombstones in that ready segment are reclaimed with their retained ready bodies |
 | Lease | `leases_*` | `250ms` | incoming lease slot is empty | oldest initialized non-current lease slot is empty |
 | Claim | `lease_claims_*`, `lease_claim_closures_*` | matches queue ring | incoming claims/closures slot is empty | every claim in the oldest non-current slot has a matching closure |
 
-The maintenance tick for each ring is deliberately small: attempt one rotate,
-then attempt one prune. If a partition is busy, blocked by a lock, current, or
-still live, the tick records a skipped/blocked outcome and tries again on a
-future interval.
+The maintenance tick for each ring is deliberately small: attempt one rotate, then attempt one prune. If a partition is busy, blocked by a lock, current, or still live, the tick records a skipped/blocked outcome and tries again on a future interval.
 
 The common safety pattern is:
 
 1. Lock the ring-state row with `FOR UPDATE`.
 2. Choose the incoming or oldest initialized slot.
-3. Use a short `SET LOCAL lock_timeout = '50ms'` before child-table
-   `ACCESS EXCLUSIVE` locks in prune paths.
+3. Use a short `SET LOCAL lock_timeout = '50ms'` before child-table `ACCESS EXCLUSIVE` locks in prune paths.
 4. Recheck liveness after acquiring the partition lock.
 5. `TRUNCATE` only partitions that are proven inactive.
 
-This is why queue storage's hot-path reclamation is a rotation-and-prune
-discipline, not ordinary row-by-row vacuum cleanup. Ordinary retention cleanup
-still exists for DLQ rows, stale descriptors, stale runtime snapshots, and the
-canonical compatibility path.
+This is why queue storage's hot-path reclamation is a rotation-and-prune discipline, not ordinary row-by-row vacuum cleanup. Ordinary retention cleanup still exists for DLQ rows, stale descriptors, stale runtime snapshots, and the canonical compatibility path.
 
 ## Maintenance Leader
 
@@ -341,10 +228,7 @@ flowchart TB
     Leader --> Tasks["promotion<br/>heartbeat/deadline/callback rescue<br/>queue/lease/claim rotate + prune<br/>DLQ cleanup<br/>descriptor cleanup<br/>cron eval<br/>metadata refresh<br/>queue health"]
 ```
 
-The advisory lock is session-scoped. If the leader process or database
-connection dies, Postgres releases the lock and another worker can win the next
-election. Heartbeat refresh is not leader-elected; only cluster-wide rescue and
-maintenance scans are.
+The advisory lock is session-scoped. If the leader process or database connection dies, Postgres releases the lock and another worker can win the next election. Heartbeat refresh is not leader-elected; only cluster-wide rescue and maintenance scans are.
 
 ## Operator Surfaces
 
@@ -356,49 +240,34 @@ Awa keeps operator-facing descriptor catalogs separate from per-job metadata:
 - `awa.job_kind_descriptors` labels and documents job kinds.
 - `awa.runtime_instances` reports live runtimes and descriptor hashes.
 
-Descriptors are code-declared by Rust `ClientBuilder` or Python `AsyncClient`.
-Workers upsert their declared descriptors at startup and on runtime snapshot
-ticks. Admin APIs derive:
+Descriptors are code-declared by Rust `ClientBuilder` or Python `AsyncClient`. Workers upsert their declared descriptors at startup and on runtime snapshot ticks. Admin APIs derive:
 
 - **stale**: no live runtime has refreshed the descriptor recently.
 - **drift**: live runtimes report conflicting descriptor hashes.
 
-The maintenance leader deletes descriptor rows whose `last_seen_at` is older
-than `descriptor_retention` (default 30 days). Runtime liveness rows are
-garbage-collected on a shorter horizon.
+The maintenance leader deletes descriptor rows whose `last_seen_at` is older than `descriptor_retention` (default 30 days). Runtime liveness rows are garbage-collected on a shorter horizon.
 
 ### DLQ
 
-The Dead Letter Queue is not a dispatchable `job_state`; it is a separate hold
-table for failed snapshots that need operator action.
+The Dead Letter Queue is not a dispatchable `job_state`; it is a separate hold table for failed snapshots that need operator action.
 
 - DLQ policy is per queue.
-- Retry deletes the DLQ row and inserts a fresh ready/deferred entry with
-  `attempt = 0` and `run_lease = 0`.
+- Retry deletes the DLQ row and inserts a fresh ready/deferred entry with `attempt = 0` and `run_lease = 0`.
 - Purge deletes the DLQ row permanently.
 - DLQ retention is independent of ordinary terminal history.
 
 ### Cron
 
-Periodic jobs are declared by worker code and synchronized to `cron_jobs`.
-Only the maintenance leader evaluates due schedules. Enqueue is atomic, so a
-crash between evaluation and insert cannot create half-visible work.
-Schedules carry a `paused_at` flag; the evaluator skips paused rows and the
-atomic enqueue CTE re-checks the flag inside the same UPDATE, so a pause
-asserted between the leader's read and its enqueue still takes effect.
+Periodic jobs are declared by worker code and synchronized to `cron_jobs`. Only the maintenance leader evaluates due schedules. Enqueue is atomic, so a crash between evaluation and insert cannot create half-visible work. Schedules carry a `paused_at` flag; the evaluator skips paused rows and the atomic enqueue CTE re-checks the flag inside the same UPDATE, so a pause asserted between the leader's read and its enqueue still takes effect.
 
 ## Observability And Correctness
 
-Awa emits tracing spans and OpenTelemetry metrics for enqueue, claim,
-execution, completion, rescue, rotation, prune, DLQ, queue depth, runtime
-health, and callback flows. The Grafana dashboards in
-[`docs/grafana`](grafana/README.md) use those metrics plus SQL panels for
-storage-level inspection.
+Awa emits tracing spans and OpenTelemetry metrics for enqueue, claim, execution, completion, rescue, rotation, prune, DLQ, queue depth, runtime health, and callback flows. The Grafana dashboards in [`docs/grafana`](grafana/README.md) use those metrics plus SQL panels for storage-level inspection.
 
 Core safety invariants are modeled in TLA+:
 
 | Model | Focus |
-|---|---|
+| --- | --- |
 | [`AwaCore`](../correctness/core/AwaCore.tla) | job lifecycle, retry/fail/cancel transitions, callback states |
 | [`AwaBatcher`](../correctness/core/AwaBatcher.tla) | guarded completion batching and stale-result rejection |
 | [`AwaExtended`](../correctness/protocol/AwaExtended.tla) | multi-instance shutdown, rescue, permit, leadership, and bounded fairness protocol |
@@ -414,13 +283,7 @@ Core safety invariants are modeled in TLA+:
 | [`AwaViewTrigger`](../correctness/races/AwaViewTrigger.tla) | `awa.jobs` view trigger concurrency and version checks |
 | [`AwaCron`](../correctness/races/AwaCron.tla) | cron double-fire prevention under leader failover |
 
-The storage model-to-code correspondence is maintained in
-[`correctness/storage/MAPPING.md`](../correctness/storage/MAPPING.md). Runtime
-tests replay representative storage traces against these models, and the
-benchmark notes document long-horizon partition and dead-tuple validation for
-ADR-019 and ADR-023. Public SQL projections such as `awa.jobs` and admin
-counts are treated as refinements over the modeled storage state; they need
-code-level regression tests as well as TLA+ lifecycle coverage.
+The storage model-to-code correspondence is maintained in [`correctness/storage/MAPPING.md`](../correctness/storage/MAPPING.md). Runtime tests replay representative storage traces against these models, and the benchmark notes document long-horizon partition and dead-tuple validation for ADR-019 and ADR-023. Public SQL projections such as `awa.jobs` and admin counts are treated as refinements over the modeled storage state; they need code-level regression tests as well as TLA+ lifecycle coverage.
 
 ## Crate Structure
 
@@ -436,6 +299,4 @@ awa (workspace)
 └── awa-python        PyO3 Python bindings
 ```
 
-`awa-model` owns schema and storage APIs. `awa-worker` owns runtime behavior.
-`awa` is the normal Rust facade. `awa-python` embeds the same worker runtime
-behind Python bindings, so mixed Rust/Python fleets share storage semantics.
+`awa-model` owns schema and storage APIs. `awa-worker` owns runtime behavior. `awa` is the normal Rust facade. `awa-python` embeds the same worker runtime behind Python bindings, so mixed Rust/Python fleets share storage semantics.

--- a/docs/archive/0.6-storage-design/README.md
+++ b/docs/archive/0.6-storage-design/README.md
@@ -1,10 +1,8 @@
 # 0.6 Storage Design Archive
 
-This directory keeps branch-era design notes, reverted experiments, and dated
-performance reviews from the 0.6 queue-storage redesign.
+This directory keeps branch-era design notes, reverted experiments, and dated performance reviews from the 0.6 queue-storage redesign.
 
-These documents are useful design history, but they are not operator guidance.
-For the shipping 0.6 shape, prefer:
+These documents are useful design history, but they are not operator guidance. For the shipping 0.6 shape, prefer:
 
 - [Architecture](../../architecture.md)
 - [Configuration](../../configuration.md)
@@ -15,5 +13,4 @@ For the shipping 0.6 shape, prefer:
 
 Included archived notes:
 
-- [Issue 169 storage redesign spike](issue-169-storage-spike.md) — early
-  segment/claim-ledger exploration kept for issue-thread continuity.
+- [Issue 169 storage redesign spike](issue-169-storage-spike.md) — early segment/claim-ledger exploration kept for issue-thread continuity.

--- a/docs/archive/0.6-storage-design/bounded-claimers-plan.md
+++ b/docs/archive/0.6-storage-design/bounded-claimers-plan.md
@@ -1,32 +1,18 @@
 # Bounded Claimers Per Queue
 
-> **Status: shipped as internal 0.6 queue-storage claim control.** The
-> release shape uses `queue_claimer_state` / `queue_claimer_leases` inside
-> the queue-storage engine to bound and adapt the number of active claimers
-> per hot queue. There is no public `QueueConfig::max_claimers` knob in the
-> 0.6 API; the dispatcher currently uses internal constants
-> (`MAX_CLAIMERS_PER_QUEUE = 4`, short lease/idle windows) and tests exercise
-> the storage-level lease behavior. The planning notes below are retained as
-> rationale and experiment history.
+> **Status: shipped as internal 0.6 queue-storage claim control.** The release shape uses `queue_claimer_state` / `queue_claimer_leases` inside the queue-storage engine to bound and adapt the number of active claimers per hot queue. There is no public `QueueConfig::max_claimers` knob in the 0.6 API; the dispatcher currently uses internal constants (`MAX_CLAIMERS_PER_QUEUE = 4`, short lease/idle windows) and tests exercise the storage-level lease behavior. The planning notes below are retained as rationale and experiment history.
 
 ## Release shape
 
 Bounded claimers are a queue-level claim-authority control plane:
 
-- Jobs still move directly from `ready_entries` to the existing receipt/lease
-  execution path; there is no reservation or pre-start job state.
-- At most a bounded number of runtime instances actively hit a hot queue's
-  claim path at one time.
+- Jobs still move directly from `ready_entries` to the existing receipt/lease execution path; there is no reservation or pre-start job state.
+- At most a bounded number of runtime instances actively hit a hot queue's claim path at one time.
 - Claim authority is time-bounded and can be reacquired or stolen when idle.
-- A shared `queue_claimer_state` target lets the runtime expand active claimers
-  when queue pressure proves one claimer is not enough, then contract toward
-  the cheap path when pressure falls.
-- Claimer ownership never owns jobs. If a claimer process dies, already-claimed
-  attempts are recovered by the existing receipt / lease rescue paths.
+- A shared `queue_claimer_state` target lets the runtime expand active claimers when queue pressure proves one claimer is not enough, then contract toward the cheap path when pressure falls.
+- Claimer ownership never owns jobs. If a claimer process dies, already-claimed attempts are recovered by the existing receipt / lease rescue paths.
 
-This mechanism is complementary to queue striping. Bounded claimers reduce
-cross-replica contention; striping reduces the amount of work funneled through
-one physical queue coordination path.
+This mechanism is complementary to queue striping. Bounded claimers reduce cross-replica contention; striping reduces the amount of work funneled through one physical queue coordination path.
 
 ## Why this exists
 
@@ -38,8 +24,7 @@ The queue-storage engine is now in a good place for:
 - low hot-path dead tuples
 - single large runtime shapes like `1x32`
 
-The investigation focused on the realistic many-small-replica shape on one
-hot queue:
+The investigation focused on the realistic many-small-replica shape on one hot queue:
 
 - `2x16`
 - `4x8`
@@ -57,12 +42,9 @@ The common failure mode is now clear:
 
 - any design that adds a second effective hot-path start transaction loses
 - any design that lets every replica contend on the same hot queue loses
-- any design that lies about `running_depth` or starts rescue semantics early
-  is unacceptable even if it benchmarks well
+- any design that lies about `running_depth` or starts rescue semantics early is unacceptable even if it benchmarks well
 
-The proposal that shipped in simplified/internal form reduces
-many-small-replica contention by limiting **how many replicas are allowed to
-claim from a queue at once**, while keeping job lifecycle semantics unchanged.
+The proposal that shipped in simplified/internal form reduces many-small-replica contention by limiting **how many replicas are allowed to claim from a queue at once**, while keeping job lifecycle semantics unchanged.
 
 ## Design summary
 
@@ -95,8 +77,7 @@ If a queue currently allows `2` or `4` active claimers:
 - they still claim from the same logical queue
 - they do **not** each receive a fixed `1/N` share of jobs
 
-So the design is about bounding and rotating **claim authority**, not dividing
-jobs into quotas.
+So the design is about bounding and rotating **claim authority**, not dividing jobs into quotas.
 
 That preserves:
 
@@ -112,8 +93,7 @@ This design should:
 - keep `1x32` roughly where it is now
 - preserve current short-job and long-running job semantics
 - keep hot-path dead tuples low
-- prefer strong fairness over time, not globally optimal fairness on every
-  single claim
+- prefer strong fairness over time, not globally optimal fairness on every single claim
 
 ## Historical Non-goals
 
@@ -319,8 +299,7 @@ with exits to:
 - waiting
 - dlq
 
-This is intentional. Bounded claimers change queue-level claim authority, not
-job execution semantics.
+This is intentional. Bounded claimers change queue-level claim authority, not job execution semantics.
 
 ## Fairness model
 
@@ -355,24 +334,19 @@ This is the intended trade:
 
 ## Adaptive bounded-claimers v2
 
-The fixed-cap experiment established that the claimer idea itself is useful,
-but a hard cap is too blunt:
+The fixed-cap experiment established that the claimer idea itself is useful, but a hard cap is too blunt:
 
 - it helps calm phases
 - it preserves the good `1x32` shape
-- but it can starve a hot queue during `pressure_1` and especially
-  `recovery_1`
+- but it can starve a hot queue during `pressure_1` and especially `recovery_1`
 
-So the next real design is **queue-global adaptive bounded claimers with
-anti-hoarding**, not fixed bounded claimers and not per-replica local
-adaptation.
+So the next real design is **queue-global adaptive bounded claimers with anti-hoarding**, not fixed bounded claimers and not per-replica local adaptation.
 
 That means:
 
 - the queue has one shared active-claimer target
 - replicas do not each privately decide their own target
-- one replica should not be allowed to monopolize all claimer slots while
-  others are healthy and interested
+- one replica should not be allowed to monopolize all claimer slots while others are healthy and interested
 
 ### Controller states
 
@@ -398,8 +372,7 @@ The queue-level controller should be modeled explicitly:
 [calm]
 ```
 
-This is still not a new job state machine. It is only a queue-level control
-loop over how many replicas are allowed to claim from that queue.
+This is still not a new job state machine. It is only a queue-level control loop over how many replicas are allowed to claim from that queue.
 
 ### Queue-global target
 
@@ -418,20 +391,16 @@ steady hot      -> target = 4
 backlog drains  -> target = 1
 ```
 
-That target should be derived from queue-level signals, not one replica's
-private claim streak.
+That target should be derived from queue-level signals, not one replica's private claim streak.
 
 ### Anti-hoarding
 
-The fixed-cap experiment showed that throughput can look healthy while one
-replica still does essentially all the useful claiming/completing work.
+The fixed-cap experiment showed that throughput can look healthy while one replica still does essentially all the useful claiming/completing work.
 
 So the next version needs an explicit anti-hoarding rule:
 
-- until the queue reaches its current target, prefer assigning claimer slots to
-  replicas that do not already own one for that queue
-- in the first adaptive version, cap ownership at **one claimer slot per
-  instance per queue**
+- until the queue reaches its current target, prefer assigning claimer slots to replicas that do not already own one for that queue
+- in the first adaptive version, cap ownership at **one claimer slot per instance per queue**
 
 This is still not a `1/N` job split. It only limits who may claim.
 
@@ -447,8 +416,7 @@ The queue should maintain:
 - `idle_threshold`
 - `lease_ttl`
 
-The first version should keep `min_claimers_per_queue = 1` and `max_claimers`
-small, likely `4`.
+The first version should keep `min_claimers_per_queue = 1` and `max_claimers` small, likely `4`.
 
 ### Inputs to the controller
 
@@ -543,12 +511,9 @@ These are the non-negotiables.
 6. Crash after claim:
    - existing receipt / attempt / lease rescue handles it
 7. Stale claimers cannot renew or continue owning once epoch changes.
-8. Idle claimers cannot block progress indefinitely because idle slots are
-   stealable.
-9. Changing the active claimer target changes only claim authority, not job
-   state.
-10. Contraction is safe because allowing a claimer lease to expire does not
-    revoke already-claimed jobs.
+8. Idle claimers cannot block progress indefinitely because idle slots are stealable.
+9. Changing the active claimer target changes only claim authority, not job state.
+10. Contraction is safe because allowing a claimer lease to expire does not revoke already-claimed jobs.
 
 ## Historical Measurement Plan
 
@@ -627,7 +592,7 @@ The minimum confidence plan should be:
 7. **Per-replica distribution**
    - confirm `4x8` does not collapse into one effective claimer after warmup
 
-Only keep it if the *pattern* is stable across repeats.
+Only keep it if the _pattern_ is stable across repeats.
 
 ### Success thresholds
 
@@ -641,15 +606,13 @@ The minimum bar to keep the design:
   - `recovery_1` no longer stalls or collapses
 - `8x4`
   - should improve in the same direction, even if it remains worse than `4x8`
-- dead tuples remain in the current low-hundreds regime, not canonical-style
-  tens of thousands
+- dead tuples remain in the current low-hundreds regime, not canonical-style tens of thousands
 - `running_depth` remains honest
 - crash-under-load remains correct
 
 ### Comparison against canonical
 
-Once the queue-storage shape looks good enough, rerun the realistic
-single-producer comparison against:
+Once the queue-storage shape looks good enough, rerun the realistic single-producer comparison against:
 
 - `awa`
 - `awa-canonical`
@@ -659,8 +622,7 @@ Especially for:
 - `1x32`
 - `4x8`
 
-That will tell us whether the new engine is now good enough in the deployment
-shape that still blocks shipping confidence.
+That will tell us whether the new engine is now good enough in the deployment shape that still blocks shipping confidence.
 
 ## Historical Implementation Phases
 
@@ -677,8 +639,7 @@ shape that still blocks shipping confidence.
 1. track owned claimer slots per queue
 2. renew only on successful claims
 3. compute a queue-local target claimer count from observed saturation
-4. attempt idle/expired steal only when the active claimer set is below the
-   adaptive target
+4. attempt idle/expired steal only when the active claimer set is below the adaptive target
 5. let excess claimers expire or relinquish during contraction
 
 ### Phase 3: claim path integration
@@ -703,17 +664,14 @@ These are not the next implementation, but they are worth preserving.
 
 This is the most important future escape hatch.
 
-For very hot logical queues, support mapping one logical queue to a fixed set of
-physical stripes / subqueues.
+For very hot logical queues, support mapping one logical queue to a fixed set of physical stripes / subqueues.
 
 That would give us:
 
 - a better default engine for normal queues
 - an explicit escape hatch for extreme single-queue workloads
 
-This should remain a real option even if bounded claimers work, because some
-production workloads will still want an operationally explicit way to spread a
-very hot queue across more coordination points.
+This should remain a real option even if bounded claimers work, because some production workloads will still want an operationally explicit way to spread a very hot queue across more coordination points.
 
 ### 2. Bounded active claimers plus striping
 
@@ -736,8 +694,7 @@ over:
 
 - perfect global ordering on every claim
 
-That principle has repeatedly matched the measurements better than globally
-optimal hot-path fairness.
+That principle has repeatedly matched the measurements better than globally optimal hot-path fairness.
 
 ## Current status after the first implementation pass
 
@@ -749,8 +706,7 @@ That version was informative but reverted:
   - `clean_1 800/s`
   - `pressure_1 1199/s`
   - `recovery_1 800/s`
-- after fixing the multi-replica report aggregation, it became clear that the
-  `4x8` shape did **not** collapse to zero throughput:
+- after fixing the multi-replica report aggregation, it became clear that the `4x8` shape did **not** collapse to zero throughput:
   - `clean_1 778/s`
   - `pressure_1 829/s`
   - `recovery_1 754/s`
@@ -762,8 +718,7 @@ That version was informative but reverted:
     - `pressure_1 5583 ms`
     - `recovery_1 17023 ms`
 
-So the next bounded-claimers iteration should **not** keep a rigid cap under
-all conditions.
+So the next bounded-claimers iteration should **not** keep a rigid cap under all conditions.
 
 The next variant should be:
 
@@ -771,8 +726,7 @@ The next variant should be:
 - locality-first when the queue is calm
 - able to expand active claimers during sustained saturation / recovery
 
-That keeps the same semantic model, but makes the claimer limit part of the
-runtime control loop rather than a hard static ceiling.
+That keeps the same semantic model, but makes the claimer limit part of the runtime control loop rather than a hard static ceiling.
 
 ## Current status after the adaptive MVP
 
@@ -793,8 +747,7 @@ What held up:
 What failed:
 
 - the realistic `4x8` gate collapsed
-- phase summaries showed effectively `0/s` useful throughput across
-  `clean_1`, `pressure_1`, and `recovery_1`
+- phase summaries showed effectively `0/s` useful throughput across `clean_1`, `pressure_1`, and `recovery_1`
 - the run emitted:
   - multi-second `COMMIT`s
   - blocked `queue_claimer_leases` updates
@@ -804,23 +757,18 @@ What failed:
 So the useful conclusion is:
 
 - **adaptive bounded claimers is not enough in its naïve form**
-- the claimer-lease control plane itself becomes a bottleneck in the hot queue
-  shape
+- the claimer-lease control plane itself becomes a bottleneck in the hot queue shape
 
-That means the next direction should not be “keep tuning the same adaptive
-controller.” It should be a broader control-plane rethink, likely one of:
+That means the next direction should not be “keep tuning the same adaptive controller.” It should be a broader control-plane rethink, likely one of:
 
 - a cheaper claimer-authority mechanism
 - or queue striping as an explicit hot-queue mode
 
-The latter should stay on the table even if a better bounded-claimers variant
-is found, because it remains the clearest operational escape hatch for extreme
-single-queue workloads.
+The latter should stay on the table even if a better bounded-claimers variant is found, because it remains the clearest operational escape hatch for extreme single-queue workloads.
 
 ## Current status after controller tuning
 
-The next adaptive tuning pass kept the same semantic model but moved target
-calculation off the hot claim round:
+The next adaptive tuning pass kept the same semantic model but moved target calculation off the hot claim round:
 
 - shared `queue_claimer_state`
 - queue-wide target refresh at most every `500ms`
@@ -834,8 +782,7 @@ Why it is being kept:
 
 - `1x32` remained healthy
 - `4x8` stayed genuinely multi-replica after warmup
-- `pressure_1` and `recovery_1` both improved relative to the earlier adaptive
-  pass
+- `pressure_1` and `recovery_1` both improved relative to the earlier adaptive pass
 
 Why it is not done yet:
 
@@ -848,17 +795,13 @@ After the crash-under-load rerun, that last point is now concrete:
 - the tuned controller still shows recovery-path maintenance errors
 - backlog and tails remain too high during restart/recovery
 
-So bounded claimers are still an active line of investigation, but no longer
-look like a complete hot-queue answer by themselves.
+So bounded claimers are still an active line of investigation, but no longer look like a complete hot-queue answer by themselves.
 
-This strengthens the case that **queue striping should move up from “future
-idea” to “real hot-queue mode”** if the next controller pass still cannot make
-the realistic and crash gates boring.
+This strengthens the case that **queue striping should move up from “future idea” to “real hot-queue mode”** if the next controller pass still cannot make the realistic and crash gates boring.
 
 ## Why this is the next design
 
-This design is attractive because it keeps the good properties of the current
-branch:
+This design is attractive because it keeps the good properties of the current branch:
 
 - direct short-job starts
 - honest running state
@@ -869,5 +812,4 @@ while attacking the measured remaining problem directly:
 
 - too many small replicas all trying to be claimers on one hot queue
 
-If it works, it is likely the cleanest path left to make the realistic `4x8`
-shape good enough to ship with confidence.
+If it works, it is likely the cleanest path left to make the realistic `4x8` shape good enough to ship with confidence.

--- a/docs/archive/0.6-storage-design/issue-169-storage-spike.md
+++ b/docs/archive/0.6-storage-design/issue-169-storage-spike.md
@@ -1,32 +1,23 @@
 # Issue 169 Storage Redesign Spike
 
-This is an archived design spike from the 0.6 storage investigation, kept for
-context because public issue threads refer to it. It is not the current 0.6
-implementation guide.
+This is an archived design spike from the 0.6 storage investigation, kept for context because public issue threads refer to it. It is not the current 0.6 implementation guide.
 
-For the queue-storage design that shipped in the 0.6 line, see
-[ADR-019](../../adr/019-queue-storage-redesign.md). Follow-up work on a
-future segment/cursor storage engine is tracked in the public issue tracker.
+For the queue-storage design that shipped in the 0.6 line, see [ADR-019](../../adr/019-queue-storage-redesign.md). Follow-up work on a future segment/cursor storage engine is tracked in the public issue tracker.
 
 ## Question
 
-Can Awa close the Issue 169 gap with **one** new storage model, rather than
-shipping two user-facing modes?
+Can Awa close the Issue 169 gap with **one** new storage model, rather than shipping two user-facing modes?
 
-The specific question in this follow-up was whether Awa could adopt a
-`pgq`/`pgque`-style rotation scheme, let maintenance own pruning, and avoid
-the earlier dual-mode recommendation.
+The specific question in this follow-up was whether Awa could adopt a `pgq`/`pgque`-style rotation scheme, let maintenance own pruning, and avoid the earlier dual-mode recommendation.
 
 ## Short answer
 
-Yes, one public model is credible, but only if we are willing to replace the
-current `jobs_hot` row-state machine with a new storage engine.
+Yes, one public model is credible, but only if we are willing to replace the current `jobs_hot` row-state machine with a new storage engine.
 
 What does **not** work:
 
 - rotating the current mutable rows across buckets/tables
-- moving payload/history into rotated tables while keeping the same mutable
-  `available -> running -> done` lifecycle in one hot table
+- moving payload/history into rotated tables while keeping the same mutable `available -> running -> done` lifecycle in one hot table
 
 What does look credible:
 
@@ -36,8 +27,7 @@ What does look credible:
 - maintenance-led best-effort rotation and prune
 - cached queue stats so long-running readers do not scan the prunable segments
 
-The spike results strongly suggest that **rotation only pays off once the queue
-row stops being the lifecycle state machine**.
+The spike results strongly suggest that **rotation only pays off once the queue row stops being the lifecycle state machine**.
 
 ## Why the earlier 2-mode idea existed
 
@@ -46,8 +36,7 @@ The previous 2-mode recommendation was a risk hedge:
 - the current per-row model maps cleanly to Awa's rich job semantics
 - the rotated append-only model maps cleanly to low-bloat queue storage
 
-Given the updated constraint that a big migration is acceptable for `0.6`, I
-do **not** think we need two public modes. I think we need one new engine.
+Given the updated constraint that a big migration is acceptable for `0.6`, I do **not** think we need two public modes. I think we need one new engine.
 
 ## What `pgq` is really buying
 
@@ -59,14 +48,11 @@ The useful `pgq` property is not "partitioning" by itself. It is this:
 - retry handling is separate from the main queue tables
 - maintenance owns the rotation/prune loop
 
-That is very different from Awa's current model, where the main queue row is
-mutated repeatedly as it moves through claim, heartbeat, retry, callback,
-completion, failure, and cleanup.
+That is very different from Awa's current model, where the main queue row is mutated repeatedly as it moves through claim, heartbeat, retry, callback, completion, failure, and cleanup.
 
 ## Experiments
 
-These were database spikes against local Postgres 17, not drop-in Awa
-implementations.
+These were database spikes against local Postgres 17, not drop-in Awa implementations.
 
 Common setup:
 
@@ -88,7 +74,7 @@ Model:
 Result:
 
 | Scenario | TPS | Avg latency | Prune ok | Prune blocked | Dead tuples |
-|---|---:|---:|---:|---:|---:|
+| --- | --: | --: | --: | --: | --: |
 | Mutable ring + history reader | 2157.0 | 1.854 ms | 0 | 10 | 25,890 |
 
 Dead tuples by bucket:
@@ -115,7 +101,7 @@ Model:
 #### 2a. Reader hits runtime only
 
 | Scenario | TPS | Avg latency | Prune ok | Prune blocked | Event dead | Runtime dead |
-|---|---:|---:|---:|---:|---:|---:|
+| --- | --: | --: | --: | --: | --: | --: |
 | Append ring + runtime reader | 2779.7 | 1.439 ms | 11 | 0 | 0 | 33,356 |
 
 Interpretation:
@@ -127,7 +113,7 @@ Interpretation:
 #### 2b. Reader hits history ring
 
 | Scenario | TPS | Avg latency | Prune ok | Prune blocked | Event dead | Runtime dead |
-|---|---:|---:|---:|---:|---:|---:|
+| --- | --: | --: | --: | --: | --: | --: |
 | Append ring + history reader | 2710.6 | 1.476 ms | 0 | 10 | 0 | 32,542 |
 
 Interpretation:
@@ -149,7 +135,7 @@ Model:
 #### 3a. Reader hits running claims only
 
 | Scenario | TPS | Avg latency | Prune ok | Prune blocked | Event dead | Done dead | Running dead |
-|---|---:|---:|---:|---:|---:|---:|---:|
+| --- | --: | --: | --: | --: | --: | --: | --: |
 | Claim ledger + running reader | 590.9 | 6.770 ms | 11 | 0 | 0 | 0 | 250 |
 
 Interpretation:
@@ -161,7 +147,7 @@ Interpretation:
 #### 3b. Reader hits event ring
 
 | Scenario | TPS | Avg latency | Prune ok | Prune blocked | Running dead |
-|---|---:|---:|---:|---:|---:|
+| --- | --: | --: | --: | --: | --: |
 | Claim ledger + history reader | 294.3 | 13.593 ms | 0 | 10 | 1,766 |
 
 Interpretation:
@@ -173,8 +159,7 @@ Interpretation:
 
 ### 1. Rotation is necessary but not sufficient
 
-If the hot lifecycle still lives in a mutable state table, dead tuples stay
-high even when payload/history is append-only.
+If the hot lifecycle still lives in a mutable state table, dead tuples stay high even when payload/history is append-only.
 
 ### 2. Maintenance can own pruning, but only under strict rules
 
@@ -186,30 +171,24 @@ However, pruning must be:
 - short lock timeout
 - retry later on conflict
 
-And the design must guarantee that long readers are **not** routinely touching
-the prunable segments.
+And the design must guarantee that long readers are **not** routinely touching the prunable segments.
 
 ### 3. The real break point is the claim model
 
-The dead tuple collapse only happened when I stopped treating the queue row as
-the mutable lifecycle record and turned the mutable part into a small claim
-ledger.
+The dead tuple collapse only happened when I stopped treating the queue row as the mutable lifecycle record and turned the mutable part into a small claim ledger.
 
 That is the important result from this spike.
 
 ### 4. A naive claim-ledger implementation is too slow
 
-The spike used anti-joins over event/done/running views to find the next
-claimable job. That cut dead tuples sharply, but it also cut throughput
-sharply.
+The spike used anti-joins over event/done/running views to find the next claimable job. That cut dead tuples sharply, but it also cut throughput sharply.
 
 So the right conclusion is **not** "ship the spike". The conclusion is:
 
 - the storage direction is right
 - the claim algorithm is wrong
 
-The real implementation needs a queue-local cursor/tick/range allocator, not a
-global anti-join over all history.
+The real implementation needs a queue-local cursor/tick/range allocator, not a global anti-join over all history.
 
 ## Revised recommendation for `0.6`
 
@@ -226,8 +205,7 @@ Ship **one** new storage engine, not two public modes.
 2. `in-flight leases`
 
 - small mutable table for active claims only
-- heartbeat / deadline / callback waiting live here or in adjacent small
-  control tables
+- heartbeat / deadline / callback waiting live here or in adjacent small control tables
 
 3. `done / retry / callback segments`
 
@@ -236,8 +214,7 @@ Ship **one** new storage engine, not two public modes.
 4. `queue stats cache`
 
 - maintenance-updated or event-updated counters
-- admin/UI reads queue depth and state from cache tables, not by scanning the
-  prunable segment ring in long transactions
+- admin/UI reads queue depth and state from cache tables, not by scanning the prunable segment ring in long transactions
 
 5. `claim allocator metadata`
 
@@ -249,12 +226,9 @@ Ship **one** new storage engine, not two public modes.
 The following current assumptions likely need to change:
 
 - `jobs_hot` stops being the canonical lifecycle table
-- `completed`, `failed`, and `cancelled` stop living as long-retained rows in
-  the claim table
-- `count(*) FROM jobs_hot` style analytics queries stop being the source of
-  truth for queue visibility
-- callback / retry / rescue flows need their own control-plane rows rather
-  than repeated rewrites of the queue row itself
+- `completed`, `failed`, and `cancelled` stop living as long-retained rows in the claim table
+- `count(*) FROM jobs_hot` style analytics queries stop being the source of truth for queue visibility
+- callback / retry / rescue flows need their own control-plane rows rather than repeated rewrites of the queue row itself
 
 ## What I would not do
 
@@ -262,8 +236,7 @@ I would **not** spend `0.6` on any of these as the headline answer:
 
 - declarative partitioning of the current `jobs_hot`
 - rotating mutable `jobs_hot` buckets without changing the lifecycle model
-- moving only payload/history to rotated tables while keeping the same mutable
-  runtime state machine
+- moving only payload/history to rotated tables while keeping the same mutable runtime state machine
 
 Those may help around the edges, but the spike says they do not close the gap.
 
@@ -276,14 +249,12 @@ Those may help around the edges, but the spike says they do not close the gap.
    - cold-segment eligibility checks
    - queue stats refresh / reconciliation
 3. Design the new claim allocator before writing schema migrations.
-4. Benchmark the new allocator under the same idle-in-tx reader harness before
-   merging the storage redesign.
+4. Benchmark the new allocator under the same idle-in-tx reader harness before merging the storage redesign.
 5. Keep admin/history queries off the prunable ring, or pruning will stall.
 
 ## Bottom line
 
-If the goal is to entirely close the gap, I no longer think the right answer is
-"two modes".
+If the goal is to entirely close the gap, I no longer think the right answer is "two modes".
 
 I think the right answer is:
 
@@ -294,6 +265,4 @@ I think the right answer is:
 - cached admin visibility
 - a non-naive claim allocator
 
-That is a bigger migration than the earlier dual-mode idea, but it is the
-first direction from the spike that looks capable of attacking the real
-problem instead of reshuffling the same row churn.
+That is a bigger migration than the earlier dual-mode idea, but it is the first direction from the spike that looks capable of attacking the real problem instead of reshuffling the same row churn.

--- a/docs/archive/0.6-storage-design/lease-plane-redesign-spike.md
+++ b/docs/archive/0.6-storage-design/lease-plane-redesign-spike.md
@@ -1,22 +1,10 @@
 # Lease Plane Redesign Spike
 
-> **Status: superseded for the receipt plane by [ADR-023](../../adr/023-receipt-plane-ring-partitioning.md).**
-> The narrow-implementation-spike portion of this doc that proposed
-> `open_receipt_claims` as a bounded live-frontier table has been
-> replaced by the partitioned `lease_claims` / `lease_claim_closures`
-> ring; the table no longer exists in the schema (`prepare_schema`
-> drops it on every install). Read the rest of this doc as a snapshot
-> of the lease-plane investigation that triggered ADR-023; the
-> sections on the long-running lease plane (heartbeat, callback,
-> `attempt_state`) are unchanged. References to `open_receipt_claims`
-> in the body below are kept verbatim as historical context — they
-> describe the design that motivated ADR-023, not the shipping
-> architecture.
+> **Status: superseded for the receipt plane by [ADR-023](../../adr/023-receipt-plane-ring-partitioning.md).** The narrow-implementation-spike portion of this doc that proposed `open_receipt_claims` as a bounded live-frontier table has been replaced by the partitioned `lease_claims` / `lease_claim_closures` ring; the table no longer exists in the schema (`prepare_schema` drops it on every install). Read the rest of this doc as a snapshot of the lease-plane investigation that triggered ADR-023; the sections on the long-running lease plane (heartbeat, callback, `attempt_state`) are unchanged. References to `open_receipt_claims` in the body below are kept verbatim as historical context — they describe the design that motivated ADR-023, not the shipping architecture.
 
 ## Why this exists
 
-The split-head change removed `queue_lanes` as the dominant MVCC hotspot. The
-remaining steady-state churn is now concentrated in the lease plane:
+The split-head change removed `queue_lanes` as the dominant MVCC hotspot. The remaining steady-state churn is now concentrated in the lease plane:
 
 - `leases_*` partitions
 - `lease_ring_state`
@@ -24,13 +12,9 @@ remaining steady-state churn is now concentrated in the lease plane:
 
 Small tuning experiments were not enough:
 
-- slower lease rotation reduced ring-state churn but moved much more dead
-  tuples into `leases_*`
+- slower lease rotation reduced ring-state churn but moved much more dead tuples into `leases_*`
 - higher `lease_slot_count` spread churn around but increased total dead tuples
-- the current implementation keeps `lease_ring_slots` only as transitional
-  compatibility/inspection state; lease prune order is now derived from
-  `lease_ring_state`, and the remaining work is about making the lease plane
-  colder without trading away delivery latency
+- the current implementation keeps `lease_ring_slots` only as transitional compatibility/inspection state; lease prune order is now derived from `lease_ring_state`, and the remaining work is about making the lease plane colder without trading away delivery latency
 
 So the next change has to be architectural rather than another timing tweak.
 
@@ -81,8 +65,7 @@ The remaining pressure is specifically:
 - repeated updates for heartbeat / callback wait
 - delete churn when attempts leave `running`
 
-In other words, the queue plane is now mostly event-log shaped, but the lease
-plane is still a mutable state table.
+In other words, the queue plane is now mostly event-log shaped, but the lease plane is still a mutable state table.
 
 ## Redesign goal
 
@@ -94,8 +77,7 @@ Move the lease plane closer to the same shape as the queue plane:
 The desired steady state is:
 
 - short jobs do not create or update a mutable lease row
-- long-running / waiting jobs create a mutable per-attempt row only when
-  heartbeat, callback wait, or progress needs it
+- long-running / waiting jobs create a mutable per-attempt row only when heartbeat, callback wait, or progress needs it
 - rescue logic still has a bounded, checkable source of truth
 
 ## Reservation-plane spike
@@ -123,24 +105,21 @@ But the first implementation was not good enough to keep.
 
 ### What the measurements showed
 
-The reservation plane improved backlog and latency at very low worker counts,
-but it regressed throughput once the worker pool got larger.
+The reservation plane improved backlog and latency at very low worker counts, but it regressed throughput once the worker pool got larger.
 
 The core reason was cost shape:
 
 - reservation requires one DB round-trip
 - start promotion required a second DB round-trip per actually-started job
 
-So the design reduced claim-roundtrip pressure at small worker counts but paid
-for it with an extra per-job start transaction.
+So the design reduced claim-roundtrip pressure at small worker counts but paid for it with an extra per-job start transaction.
 
 The buffered-reservation variant was worse:
 
 - it preserved the safety boundary better than the earlier naive prefetch spike
 - but it still reduced throughput, including at `1` worker in the benchmark
 
-We also tried a batched reservation/start frontier aimed specifically at the
-realistic many-small-replica case:
+We also tried a batched reservation/start frontier aimed specifically at the realistic many-small-replica case:
 
 - bounded `open_dispatch_reservations`
 - batched dispatcher reservation
@@ -162,16 +141,12 @@ So even the batched frontier did not clear the bar for `0.6`. It was reverted.
 
 ### Current conclusion
 
-The reservation plane is still a plausible long-term direction, but only if
-promotion is much cheaper than the spikes we tried:
+The reservation plane is still a plausible long-term direction, but only if promotion is much cheaper than the spikes we tried:
 
 - batched reservation promotion
-- or another design that separates reservation from attempt start without
-  introducing one extra transaction per job
+- or another design that separates reservation from attempt start without introducing one extra transaction per job
 
-For the `0.6` branch, every reservation-plane implementation was reverted.
-The design note remains because it explains the right safety boundary if we
-return to this later:
+For the `0.6` branch, every reservation-plane implementation was reverted. The design note remains because it explains the right safety boundary if we return to this later:
 
 - `reserved but not started`
 - `active attempt`
@@ -194,22 +169,19 @@ Each claim appends one immutable row containing:
 - `claimed_at`
 - static attempt metadata (`attempt`, `max_attempts`)
 
-This row replaces the current use of `leases` as the durable "claim happened"
-record.
+This row replaces the current use of `leases` as the durable "claim happened" record.
 
 #### `open_receipt_claims`
 
 Bounded live frontier for currently-open receipt-backed attempts.
 
-This table duplicates only the metadata the runtime needs to answer hot-path
-questions without scanning append-only history:
+This table duplicates only the metadata the runtime needs to answer hot-path questions without scanning append-only history:
 
 - queue / priority / lane ordering for counts and lookup
 - ready reference for hydration and rescue
 - `claimed_at` for the short-attempt grace window
 
-`lease_claims` remains the durable claim history; `open_receipt_claims`
-exists only while the attempt is still live on the receipt path.
+`lease_claims` remains the durable claim history; `open_receipt_claims` exists only while the attempt is still live on the receipt path.
 
 #### `attempt_state`
 
@@ -235,8 +207,7 @@ The closure of an attempt is already visible in immutable storage:
 
 Those rows already carry `job_id` and `run_lease`.
 
-So for the short-job path, we do not need a mutable lease delete to say
-"running has ended". The closure is the next immutable append.
+So for the short-job path, we do not need a mutable lease delete to say "running has ended". The closure is the next immutable append.
 
 ### 3. Rescue becomes two-tiered
 
@@ -246,19 +217,16 @@ For attempts with a `lease_claims` row but **no** `attempt_state` row:
 
 - treat them as short, recently claimed attempts
 - do not rescue them immediately
-- once `claimed_at` exceeds a configured grace/staleness window and there is
-  still no closure row, rescue them
+- once `claimed_at` exceeds a configured grace/staleness window and there is still no closure row, rescue them
 
-This covers workers that crash before the first heartbeat or before any
-callback wait registration.
+This covers workers that crash before the first heartbeat or before any callback wait registration.
 
 #### Tier B: explicit long-running attempt state
 
 For attempts with `attempt_state`:
 
 - use current heartbeat / deadline / callback-timeout rescue semantics
-- all mutable rescue scanning happens against `attempt_state`, not the claim
-  receipts
+- all mutable rescue scanning happens against `attempt_state`, not the claim receipts
 
 That keeps rescue correctness while avoiding mutable rows for short jobs.
 
@@ -291,20 +259,16 @@ Proposed:
 - immutable claim receipt at claim time
 - mutable `attempt_state` row only after the job actually needs runtime state
 
-That makes mutable churn track "active long-running attempts" rather than
-"every claim".
+That makes mutable churn track "active long-running attempts" rather than "every claim".
 
 ### Control-plane simplification
 
-If `lease_claims` is append-only, the lease ring / prune machinery becomes
-closer to the queue ring:
+If `lease_claims` is append-only, the lease ring / prune machinery becomes closer to the queue ring:
 
 - rotation is about sealing append-only claim segments
-- prune no longer needs to wait for every short completion to delete its live
-  row
+- prune no longer needs to wait for every short completion to delete its live row
 
-The mutable control plane shrinks to `attempt_state` plus small rotation
-metadata.
+The mutable control plane shrinks to `attempt_state` plus small rotation metadata.
 
 ## Invariants to preserve
 
@@ -314,8 +278,7 @@ Any implementation of this redesign must preserve:
 - exactly-once terminalization per attempt
 - no rescue before the short-attempt grace window expires
 - heartbeat / deadline / callback rescue tied only to `attempt_state`
-- completion path must still be able to return "already rescued/cancelled" for
-  stale workers
+- completion path must still be able to return "already rescued/cancelled" for stale workers
 
 ## Likely implementation shape
 
@@ -325,8 +288,7 @@ Add:
 
 - `{schema}.lease_claims`
 - rotating `lease_claims_<slot>` partitions
-- maybe `{schema}.lease_claim_ring_state` if we keep the current lease ring
-  separate from ready segments
+- maybe `{schema}.lease_claim_ring_state` if we keep the current lease ring separate from ready segments
 
 Retain and narrow:
 
@@ -384,12 +346,9 @@ Long-path rescue scans:
 
 ## Risks
 
-- Rescue logic becomes more subtle because "currently running" is no longer
-  represented by one mutable row family.
-- Short-attempt rescue must be carefully bounded so we do not rescue healthy
-  jobs before they have a chance to heartbeat or complete.
-- Admin/state inspection will need a clear view of "claimed but not yet
-  materialized into attempt_state".
+- Rescue logic becomes more subtle because "currently running" is no longer represented by one mutable row family.
+- Short-attempt rescue must be carefully bounded so we do not rescue healthy jobs before they have a chance to heartbeat or complete.
+- Admin/state inspection will need a clear view of "claimed but not yet materialized into attempt_state".
 - TLA+ coverage will need to model the short-attempt grace window explicitly.
 
 ## Recommendation
@@ -405,31 +364,23 @@ The next real storage redesign should be:
    - claim-age based for short attempts
    - heartbeat/deadline/callback based for long attempts
 
-That is the design most likely to remove the remaining lease-plane dead-tuple
-pressure without giving up Awa's dispatch, rescue, callback, and stale-writer
-guarantees.
+That is the design most likely to remove the remaining lease-plane dead-tuple pressure without giving up Awa's dispatch, rescue, callback, and stale-writer guarantees.
 
 ## Narrow implementation spike
 
-There is now a narrow experimental path in the branch for **short successful
-jobs only**:
+There is now a narrow experimental path in the branch for **short successful jobs only**:
 
 - append-only `lease_claims`
 - bounded `open_receipt_claims`
 - append-only `lease_claim_closures`
 - no mutable `leases` row on the common short path
 - lazy materialization into `attempt_state` on first heartbeat / progress
-- lazy materialization into `leases` on callback registration or rarer
-  lease-specific mutation paths
-- stale short claims that never materialize are rescued append-only after the
-  grace window by writing a rescue closure and requeueing the attempt
-- no `attempt_state` row unless the attempt actually needs mutable callback or
-  progress state
+- lazy materialization into `leases` on callback registration or rarer lease-specific mutation paths
+- stale short claims that never materialize are rescued append-only after the grace window by writing a rescue closure and requeueing the attempt
+- no `attempt_state` row unless the attempt actually needs mutable callback or progress state
 - guarded so it only activates when queue `deadline_duration = 0`
 
-That spike is deliberately not the full redesign above. It exists to answer one
-question: does removing the insert/delete churn on short claims materially help
-steady-state MVCC behavior?
+That spike is deliberately not the full redesign above. It exists to answer one question: does removing the insert/delete churn on short claims materially help steady-state MVCC behavior?
 
 ### Measured result
 
@@ -449,16 +400,11 @@ Throughput stayed effectively flat in the same profile:
 
 The trade-off in the current spike is latency:
 
-- subscriber / end-to-end p99 got worse, especially in `pressure_1` and
-  `recovery_1`
+- subscriber / end-to-end p99 got worse, especially in `pressure_1` and `recovery_1`
 
 So the spike validates the direction:
 
 - append-only short-claim receipts dramatically reduce steady-state dead tuples
-- heartbeat/progress-only receipt-backed attempts can stay off the mutable
-  lease heap while still getting stale-heartbeat rescue
-- long-horizon runs still need a bounded live frontier; otherwise queue counts
-  and receipt rescue degrade into append-only history scans
-- the next work is making the materialized long-running path cheaper on the
-  delivery path, and then extending the same model further across more of the
-  long-running rescue surface
+- heartbeat/progress-only receipt-backed attempts can stay off the mutable lease heap while still getting stale-heartbeat rescue
+- long-horizon runs still need a bounded live frontier; otherwise queue counts and receipt rescue degrade into append-only history scans
+- the next work is making the materialized long-running path cheaper on the delivery path, and then extending the same model further across more of the long-running rescue surface

--- a/docs/archive/0.6-storage-design/perf-review-2026-04-22.md
+++ b/docs/archive/0.6-storage-design/perf-review-2026-04-22.md
@@ -1,17 +1,8 @@
 ## Queue Storage Performance And Design Review
 
-> **Status: pre-ADR-023 snapshot.** The `open_receipt_claims` finding
-> in this review triggered the receipt-plane redesign that became
-> [ADR-023](../../adr/023-receipt-plane-ring-partitioning.md). The dead-tuple
-> shape described below for that table no longer applies; the
-> partitioned `lease_claims` / `lease_claim_closures` ring reclaims
-> the same data via `TRUNCATE` rather than row-level vacuum. The rest
-> of the review (queue plane, lease ring, observation methodology)
-> still describes the current architecture.
+> **Status: pre-ADR-023 snapshot.** The `open_receipt_claims` finding in this review triggered the receipt-plane redesign that became [ADR-023](../../adr/023-receipt-plane-ring-partitioning.md). The dead-tuple shape described below for that table no longer applies; the partitioned `lease_claims` / `lease_claim_closures` ring reclaims the same data via `TRUNCATE` rather than row-level vacuum. The rest of the review (queue plane, lease ring, observation methodology) still describes the current architecture.
 
-Date: 2026-04-22
-Branch: `feature/vacuum-aware-storage-redesign`
-Baseline commit for this review: `3919b05`
+Date: 2026-04-22 Branch: `feature/vacuum-aware-storage-redesign` Baseline commit for this review: `3919b05`
 
 ### Scope
 
@@ -31,20 +22,17 @@ It is intended to answer two questions:
 
 ### Evaluation rubric
 
-The `0.6` branch should be judged against these priorities, not just the
-headline benchmark:
+The `0.6` branch should be judged against these priorities, not just the headline benchmark:
 
 - transactional enqueue remains a first-class Postgres-native property
 - no lost work under failure beats a faster but weaker design
-- at-least-once delivery is stated honestly; retries and idempotency are part
-  of the contract
+- at-least-once delivery is stated honestly; retries and idempotency are part of the contract
 - perf work should keep prioritizing:
   - claim path under contention
   - recovery path
   - retry storm behavior
   - observability of saturation and backlog
-- any optimization that weakens crash/restart safety or makes retries amplify
-  outages should be rejected, even if it wins a microbenchmark
+- any optimization that weakens crash/restart safety or makes retries amplify outages should be rejected, even if it wins a microbenchmark
 
 ### High-level conclusion
 
@@ -62,16 +50,11 @@ The remaining problems are **not** signs that the overall storage direction is w
 - latency tails during recovery or retry-heavy workloads
 - low-worker underfill from claim/start amortization
 
-So the current question is no longer "was the redesign a good idea?".
-It was.
+So the current question is no longer "was the redesign a good idea?". It was.
 
 The question is now "how much more of the lease/control plane should be made cold before `0.6` lands?".
 
-One concrete outcome after this review: low-worker underfill was not another
-queue-storage MVCC hotspot. The strongest fix so far is releasing local worker
-capacity when handler execution ends, while keeping durable completion on the
-existing `run_lease`-guarded finalization path. That improves `1/4/8/16`
-worker throughput without changing the underlying storage state machine.
+One concrete outcome after this review: low-worker underfill was not another queue-storage MVCC hotspot. The strongest fix so far is releasing local worker capacity when handler execution ends, while keeping durable completion on the existing `run_lease`-guarded finalization path. That improves `1/4/8/16` worker throughput without changing the underlying storage state machine.
 
 We also tested a reservation-plane spike for low-worker underfill:
 
@@ -79,14 +62,9 @@ We also tested a reservation-plane spike for low-worker underfill:
 - promote reservation -> active attempt only when a worker actually starts
 - expire stale reservations back to ready work if the worker dies before start
 
-The safety boundary was good, but the implementation was reverted. The first
-version added too much per-job start cost, and the buffered-reservation
-follow-up regressed throughput further. So the current branch does **not**
-carry the reservation plane; it only carries the design learning from that
-spike.
+The safety boundary was good, but the implementation was reverted. The first version added too much per-job start cost, and the buffered-reservation follow-up regressed throughput further. So the current branch does **not** carry the reservation plane; it only carries the design learning from that spike.
 
-A later batched reservation/start frontier pass also kept the safety boundary
-sound:
+A later batched reservation/start frontier pass also kept the safety boundary sound:
 
 - direct promotion from reservation -> receipt-backed attempt was validated
 - reserve -> expire -> re-enqueue -> late promotion loses was validated
@@ -96,14 +74,9 @@ But the realistic single-producer replica check was still not good enough:
 - `1x32`: `clean_1 397/s`, `pressure_1 576/s`, `recovery_1 730/s`
 - `4x8`: `clean_1 157/s`, `pressure_1 92/s`, `recovery_1 12/s`
 
-That means the frontier did **not** solve the many-small-replica deployment
-shape without introducing large throughput and latency regressions. It was
-reverted as well.
+That means the frontier did **not** solve the many-small-replica deployment shape without introducing large throughput and latency regressions. It was reverted as well.
 
-After adding the dedicated `awa-canonical` adapter and fixing the
-single-producer observer artifact, we tried one more explicit
-reserved-but-not-started frontier on the same gate (`1x32` and `4x8`,
-single-producer only). That version was also reverted.
+After adding the dedicated `awa-canonical` adapter and fixing the single-producer observer artifact, we tried one more explicit reserved-but-not-started frontier on the same gate (`1x32` and `4x8`, single-producer only). That version was also reverted.
 
 - `1x32`: `clean_1 511/s`, `pressure_1 486/s`, `recovery_1 531/s`
 - `4x8`: `clean_1 86/s`, `pressure_1 82/s`, `recovery_1 85/s`
@@ -111,30 +84,21 @@ single-producer only). That version was also reverted.
 So the first-principles conclusion is now stronger:
 
 - a distinct reservation state is still the right conceptual fix
-- but the current explicit frontier implementation shape adds too much
-  transactional overhead to the hot start path
-- the remaining blocker is still many-small-replica claim/start coordination,
-  but it will not be solved by this frontier shape without another batching
-  step or a cheaper promotion mechanism
+- but the current explicit frontier implementation shape adds too much transactional overhead to the hot start path
+- the remaining blocker is still many-small-replica claim/start coordination, but it will not be solved by this frontier shape without another batching step or a cheaper promotion mechanism
 
 ### Next design pass: striped claim heads instead of explicit reservations
 
-After the reverted frontier passes, the next recommended direction is **not**
-another reserve/promote control plane. The stronger candidate is to reduce
-multi-replica contention at the source by **striping the claim cursor itself**.
+After the reverted frontier passes, the next recommended direction is **not** another reserve/promote control plane. The stronger candidate is to reduce multi-replica contention at the source by **striping the claim cursor itself**.
 
-The current queue-storage design still serializes all claimers for one
-`(queue, priority)` through a single `queue_claim_heads` row. That scales
-acceptably for one large worker process (`1x32`) but collapses when many small
-replicas (`4x8`, `8x4`) all contend on the same hot queue.
+The current queue-storage design still serializes all claimers for one `(queue, priority)` through a single `queue_claim_heads` row. That scales acceptably for one large worker process (`1x32`) but collapses when many small replicas (`4x8`, `8x4`) all contend on the same hot queue.
 
 The proposed next shape is:
 
 - keep the current direct `ready -> active attempt` transition
 - keep `running_depth` honest
 - keep crash/retry/rescue semantics unchanged
-- replace one `queue_claim_heads(queue, priority)` row with a small fixed set of
-  `queue_claim_heads(queue, priority, claim_shard)` rows
+- replace one `queue_claim_heads(queue, priority)` row with a small fixed set of `queue_claim_heads(queue, priority, claim_shard)` rows
 
 Conceptually:
 
@@ -145,34 +109,25 @@ Conceptually:
 - no new reserved-but-not-started state is needed
 - no extra promotion transaction is added to the short-job hot path
 
-This is a better fit for the current evidence because it targets the measured
-serialization point directly:
+This is a better fit for the current evidence because it targets the measured serialization point directly:
 
-- `1x32` already shows that the current start/completion path can work when
-  claim contention is low
-- `4x8` shows that many small replicas are coordinating badly even with one
-  producer and low dead tuples
-- explicit reservations improved coordination but paid too much extra hot-path
-  transaction cost
+- `1x32` already shows that the current start/completion path can work when claim contention is low
+- `4x8` shows that many small replicas are coordinating badly even with one producer and low dead tuples
+- explicit reservations improved coordination but paid too much extra hot-path transaction cost
 
 Key design constraints for a striped claim-head pass:
 
 - preserve no-lost-work semantics under crash/restart
 - keep claim and start in one hot-path transaction for short jobs
 - preserve honest `running_depth`
-- avoid reintroducing a hot mutable jobs table or a long-lived reservation
-  frontier
-- keep fairness good enough that low-priority or older work does not starve
-  behind shard-local skew
+- avoid reintroducing a hot mutable jobs table or a long-lived reservation frontier
+- keep fairness good enough that low-priority or older work does not starve behind shard-local skew
 
-The likely trade-off is that strict per-priority FIFO becomes **approximate**
-across shards rather than globally serialized through one lane head. That is
-acceptable only if:
+The likely trade-off is that strict per-priority FIFO becomes **approximate** across shards rather than globally serialized through one lane head. That is acceptable only if:
 
 - ordering skew is bounded by the shard count
 - claim-time effective priority aging still works across shards
-- real fairness/backlog behavior improves materially in the realistic
-  `4x8`/`8x4` deployment shape
+- real fairness/backlog behavior improves materially in the realistic `4x8`/`8x4` deployment shape
 
 Acceptance bar for a striped-claim pass:
 
@@ -182,8 +137,7 @@ Acceptance bar for a striped-claim pass:
 - dead tuples remain low
 - no new hidden control-plane state is needed to explain `running_depth`
 
-We implemented and measured the first striped-claim-head version, then
-reverted it.
+We implemented and measured the first striped-claim-head version, then reverted it.
 
 Results on the same single-producer gate:
 
@@ -198,24 +152,15 @@ Results on the same single-producer gate:
 
 That means:
 
-- the striped claim heads did reduce the single-row claim-head serialization
-  point
+- the striped claim heads did reduce the single-row claim-head serialization point
 - `1x32` stayed healthy
-- `4x8` improved one pressure phase versus the prior queue-storage baseline,
-  but recovery still collapsed badly and the overall shape was not good enough
-  to keep
+- `4x8` improved one pressure phase versus the prior queue-storage baseline, but recovery still collapsed badly and the overall shape was not good enough to keep
 
-So the next many-small-replica fix still needs to do more than split one claim
-cursor into shards. The remaining cost is not just the single-row cursor lock;
-it is still the amount of per-start coordination each small replica pays on the
-hot queue.
+So the next many-small-replica fix still needs to do more than split one claim cursor into shards. The remaining cost is not just the single-row cursor lock; it is still the amount of per-start coordination each small replica pays on the hot queue.
 
 ### Reverted stateful receipt-frontier pass
 
-We then tried the next more integrated design: keep a distinct
-`reserved-but-not-started` state, but make it live inside the receipt frontier
-so batched worker start becomes an in-place state transition instead of a
-second insert/delete promotion into another hot table.
+We then tried the next more integrated design: keep a distinct `reserved-but-not-started` state, but make it live inside the receipt frontier so batched worker start becomes an in-place state transition instead of a second insert/delete promotion into another hot table.
 
 That version was safe enough to test:
 
@@ -240,18 +185,15 @@ Single-producer results on the same short gate:
 
 That means:
 
-- folding reservation state into the receipt frontier still adds too much hot
-  path cost
-- the problem is not just *where* the state lives
-- the remaining blocker is still the extra coordination work many small
-  replicas pay before actual execution starts
+- folding reservation state into the receipt frontier still adds too much hot path cost
+- the problem is not just _where_ the state lives
+- the remaining blocker is still the extra coordination work many small replicas pay before actual execution starts
 
 So the current first-principles picture is:
 
 ### Queue striping first pass
 
-We also moved queue striping up from a future escape hatch into a real measured track.
-The first implementation used:
+We also moved queue striping up from a future escape hatch into a real measured track. The first implementation used:
 
 - logical queue -> physical stripes (`queue#0..N-1`)
 - deterministic stripe selection on enqueue
@@ -260,35 +202,31 @@ The first implementation used:
 
 Measured with `QUEUE_STRIPE_COUNT=4` on the same single-producer realistic gate:
 
-The first striping readout looked promising on throughput, but alarming on
-dead tuples and `running_depth`. A follow-up root-cause pass showed the
-regression signal was mostly a benchmark artifact:
+The first striping readout looked promising on throughput, but alarming on dead tuples and `running_depth`. A follow-up root-cause pass showed the regression signal was mostly a benchmark artifact:
 
-- the portable event-table set was **not sampling `open_receipt_claims`**, which
-  is the real short-job churn hotspot
-- the observer was using a hard `15s` queue-count cache TTL against very short
-  phases, which overstated logical `running_depth`
+- the portable event-table set was **not sampling `open_receipt_claims`**, which is the real short-job churn hotspot
+- the observer was using a hard `15s` queue-count cache TTL against very short phases, which overstated logical `running_depth`
 
 After fixing the benchmark path:
 
 - `open_receipt_claims` is now part of the sampled queue-storage event tables
-- queue-count sampling uses a short, configurable max age (`QUEUE_COUNT_MAX_AGE_MS`)
-  tied to the sample interval by default
+- queue-count sampling uses a short, configurable max age (`QUEUE_COUNT_MAX_AGE_MS`) tied to the sample interval by default
 
 Fresh `4x8` comparisons after that fix show:
 
 Striped (`QUEUE_STRIPE_COUNT=4`)
+
 - `clean_1`: throughput `797.7/s`, subscriber p99 `32 ms`, median dead tuples `8817`
 - `pressure_1`: throughput `1198.0/s`, subscriber p99 `34 ms`, median dead tuples `3646`
 - `recovery_1`: throughput `798.8/s`, subscriber p99 `36 ms`, median dead tuples `14033`
 
 Unstriped (`QUEUE_STRIPE_COUNT=1`)
+
 - `clean_1`: throughput `792.8/s`, subscriber p99 `21 ms`, median dead tuples `8771`
 - `pressure_1`: throughput `1183.3/s`, subscriber p99 `24 ms`, median dead tuples `3683`
 - `recovery_1`: throughput `786.0/s`, subscriber p99 `33 ms`, median dead tuples `13838`
 
-And direct live-table inspection during a fresh striped `800 -> 1200 -> 800`
-repro showed:
+And direct live-table inspection during a fresh striped `800 -> 1200 -> 800` repro showed:
 
 - `open_receipt_claims` carries the real dead-tuple churn
 - `lease_claim_closures` dead tuples remain `0`
@@ -297,27 +235,20 @@ repro showed:
 
 So the corrected conclusion is:
 
-- striping did **not** introduce a special `lease_claim_closures` or
-  `done_entries_*` regression
-- the earlier “striping regression” mostly reflected a benchmark blind spot and
-  stale observer counts
-- the real hot table under both striped and unstriped short-job pressure is
-  `open_receipt_claims`
+- striping did **not** introduce a special `lease_claim_closures` or `done_entries_*` regression
+- the earlier “striping regression” mostly reflected a benchmark blind spot and stale observer counts
+- the real hot table under both striped and unstriped short-job pressure is `open_receipt_claims`
 
-That means queue striping is still experimental, but it is now being judged on
-the right thing:
+That means queue striping is still experimental, but it is now being judged on the right thing:
 
-- does it improve realistic hot-queue distribution/tails enough to justify the
-  added complexity?
-- and does it avoid making the existing `open_receipt_claims` churn materially
-  worse than the unstriped baseline?
+- does it improve realistic hot-queue distribution/tails enough to justify the added complexity?
+- and does it avoid making the existing `open_receipt_claims` churn materially worse than the unstriped baseline?
 
 A follow-up stripe-count sweep on the corrected path gave a clearer answer:
 
 - `QUEUE_STRIPE_COUNT=8` was too much
 - `QUEUE_STRIPE_COUNT=4` helped the hot phase but hurt the `1x32` shape
-- `QUEUE_STRIPE_COUNT=2` is the first candidate that looks plausibly worth
-  keeping
+- `QUEUE_STRIPE_COUNT=2` is the first candidate that looks plausibly worth keeping
 
 Short `4x8` sweep (`15s` warmup, `30s` phases):
 
@@ -326,8 +257,7 @@ Short `4x8` sweep (`15s` warmup, `30s` phases):
 - `4` stripes: `762 / 1092 / 761/s` with subscriber p99 `142 / 439 / 713 ms`
 - `8` stripes: `729 / 957 / 627/s` with subscriber p99 `562 / 558 / 1729 ms`
 
-That sweep was still noisy, so a longer `4x8` confirmation pair (`30s`
-warmup, `60s` phases) was run comparing `1` vs `2` stripes:
+That sweep was still noisy, so a longer `4x8` confirmation pair (`30s` warmup, `60s` phases) was run comparing `1` vs `2` stripes:
 
 - unstriped:
   - `clean_1 446/s`, subscriber p99 `7823 ms`, queue depth `5537`
@@ -343,8 +273,7 @@ So the current striping conclusion is:
 - a real `4x8` win does seem possible
 - the promising candidate is specifically **2 stripes**
 - the remaining problem is no longer “does striping help at all?”
-- it is “can a 2-stripe hot-queue mode make tails boring enough without
-  worsening `open_receipt_claims` churn?”
+- it is “can a 2-stripe hot-queue mode make tails boring enough without worsening `open_receipt_claims` churn?”
 
 We also built and measured a first dynamic striping controller:
 
@@ -381,22 +310,17 @@ So the updated striping recommendation is:
 
 - static `2` stripes remains the leading candidate
 - the current dynamic-striping controller should be reverted
-- if dynamic striping is revisited later, it needs a substantially cheaper
-  control path than queue-global state consulted from both enqueue and claim
+- if dynamic striping is revisited later, it needs a substantially cheaper control path than queue-global state consulted from both enqueue and claim
 
 One measurement caveat from this pass:
 
-- the portable `awa-bench` adapter currently emits `claim_p99_ms` as the same
-  value as `subscriber_p99_ms`
-- so it should **not** be treated as an independent database-claim latency
-  signal in these striping investigations
-- the reliable striping signals here are throughput, queue depth/backlog
-  growth, per-replica completion spread, and dead-tuple sources
+- the portable `awa-bench` adapter currently emits `claim_p99_ms` as the same value as `subscriber_p99_ms`
+- so it should **not** be treated as an independent database-claim latency signal in these striping investigations
+- the reliable striping signals here are throughput, queue depth/backlog growth, per-replica completion spread, and dead-tuple sources
 
 ### Reverted sticky shard leasing v1
 
-We then tried the next design shift: make claim authority sticky at the shard
-level instead of introducing another per-job pre-start state transition.
+We then tried the next design shift: make claim authority sticky at the shard level instead of introducing another per-job pre-start state transition.
 
 The v1 sticky-shard pass did this:
 
@@ -405,11 +329,9 @@ The v1 sticky-shard pass did this:
 - added `lane_shard_leases(queue, priority, claim_shard, owner_instance_id, expires_at)`
 - kept the direct short-job path:
   - `ready -> active_receipt`
-- had claimers prefer owned or expired shards, with no explicit reservation or
-  promotion step
+- had claimers prefer owned or expired shards, with no explicit reservation or promotion step
 
-That version compiled cleanly, passed targeted queue-storage runtime tests, and
-was benchmarked on the same realistic single-producer gate.
+That version compiled cleanly, passed targeted queue-storage runtime tests, and was benchmarked on the same realistic single-producer gate.
 
 Results:
 
@@ -431,17 +353,13 @@ This tells us:
 - sticky shard ownership is promising for the `1x32` shape
 - it keeps churn low and does not need a second start-phase transaction
 - but the naïve ownership/renewal rules over-localize work in the `4x8` shape
-- recovery can stall entirely because shards are not being rebalanced or stolen
-  aggressively enough once ownership goes stale or uneven
+- recovery can stall entirely because shards are not being rebalanced or stolen aggressively enough once ownership goes stale or uneven
 
-So sticky shard leasing as a concept is still alive, but **v1 is not
-keepable**. Any next pass has to add a real rebalance / steal policy rather
-than just sticky ownership over expired or unowned shards.
+So sticky shard leasing as a concept is still alive, but **v1 is not keepable**. Any next pass has to add a real rebalance / steal policy rather than just sticky ownership over expired or unowned shards.
 
 ### Reverted sticky shard leasing v2
 
-We then tried the next obvious refinement: keep the direct short-job path, but
-make shard ownership **decay and rebalance** instead of staying sticky.
+We then tried the next obvious refinement: keep the direct short-job path, but make shard ownership **decay and rebalance** instead of staying sticky.
 
 The v2 pass added:
 
@@ -452,8 +370,7 @@ The v2 pass added:
   - `owned-idle`
 - renewals only on successful claims
 - idle-shard steal eligibility based on recent inactivity
-- per-instance queue-storage claiming, so shard ownership could be tied to the
-  live runtime instance
+- per-instance queue-storage claiming, so shard ownership could be tied to the live runtime instance
 
 The important part is that v2 still preserved the good short-job invariant:
 
@@ -461,8 +378,7 @@ The important part is that v2 still preserved the good short-job invariant:
 - no reserved-but-not-started job state
 - no second start-phase promotion transaction
 
-That version also compiled cleanly and passed the focused queue-storage runtime
-tests we use as the fast gate:
+That version also compiled cleanly and passed the focused queue-storage runtime tests we use as the fast gate:
 
 - `test_queue_storage_claim_runtime_applies_priority_aging_dynamically`
 - `test_queue_storage_short_jobs_complete_via_lease_claim_receipts`
@@ -487,10 +403,8 @@ This is not keepable.
 What it tells us:
 
 - the direct short-job path remains healthy in the `1x32` shape
-- shard leasing with idle-aware rebalance does **not** by itself solve the
-  many-small-replica problem
-- `4x8` is still collapsing hard enough that the remaining coordination cost is
-  deeper than “one hot claim-head row with overly sticky ownership”
+- shard leasing with idle-aware rebalance does **not** by itself solve the many-small-replica problem
+- `4x8` is still collapsing hard enough that the remaining coordination cost is deeper than “one hot claim-head row with overly sticky ownership”
 
 So sticky shard leasing is now in the same bucket as striped claim heads:
 
@@ -513,8 +427,7 @@ But the search space is now tighter:
 
 The next direction to try is **bounded claimers per queue**.
 
-The idea is to stop treating every replica with free workers as an active
-claimer for one hot queue. Instead:
+The idea is to stop treating every replica with free workers as an active claimer for one hot queue. Instead:
 
 - only a small bounded set of replicas may claim from that queue at once
 - all other replicas remain executor-only for that queue
@@ -531,15 +444,11 @@ This is different from a fragile leader:
 
 Why this direction is promising:
 
-- repeated experiments now suggest the main remaining cost is **how many
-  independent small replicas are trying to coordinate on one hot queue**
-- several reservation/frontier variants improved coordination but paid too much
-  extra hot-path state-transition cost
-- bounded claimers attacks the measured blocker directly while preserving the
-  current job lifecycle semantics
+- repeated experiments now suggest the main remaining cost is **how many independent small replicas are trying to coordinate on one hot queue**
+- several reservation/frontier variants improved coordination but paid too much extra hot-path state-transition cost
+- bounded claimers attacks the measured blocker directly while preserving the current job lifecycle semantics
 
-The concrete design package for this next pass is tracked in
-[`bounded-claimers-plan.md`](bounded-claimers-plan.md).
+The concrete design package for this next pass is tracked in [`bounded-claimers-plan.md`](bounded-claimers-plan.md).
 
 That plan also records a future escape hatch worth keeping on the table:
 
@@ -566,8 +475,7 @@ That version was safe enough to test and it preserved the good `1x32` shape:
   - `pressure_1 1197/s`
   - `recovery_1 800/s`
 
-But it was **not** keepable, because the realistic hot-queue `4x8` shape still
-collapsed once the workload moved beyond the calm phase:
+But it was **not** keepable, because the realistic hot-queue `4x8` shape still collapsed once the workload moved beyond the calm phase:
 
 - `4x8`
   - `clean_1 250/s`
@@ -578,8 +486,7 @@ collapsed once the workload moved beyond the calm phase:
 
 Interpretation:
 
-- the fixed claimer cap does reduce contention enough to help the calm
-  `4x8 clean_1` phase
+- the fixed claimer cap does reduce contention enough to help the calm `4x8 clean_1` phase
 - but it starves the hot queue under `pressure_1` and especially `recovery_1`
 - so a **hard fixed cap is too blunt**
 
@@ -593,14 +500,12 @@ The next bounded-claimers pass should therefore be:
 The target is no longer “choose the right fixed cap.” It is:
 
 - keep the calm path cheap
-- raise claim parallelism only when measured signals say the queue is genuinely
-  saturated
+- raise claim parallelism only when measured signals say the queue is genuinely saturated
 
 In other words, the repeated lesson still holds:
 
 - strong fairness over time is the right target
-- but the runtime must still be able to raise claim parallelism when one hot
-  queue is genuinely saturated
+- but the runtime must still be able to raise claim parallelism when one hot queue is genuinely saturated
 
 #### Adaptive bounded claimers MVP (reverted)
 
@@ -653,15 +558,12 @@ The useful learning is narrower than before:
 
 - bounded claim authority is still directionally right
 - but the naïve adaptive control loop is not enough
-- once the queue enters the hot/recovery regime, the claimer-lease update path
-  itself becomes part of the problem
+- once the queue enters the hot/recovery regime, the claimer-lease update path itself becomes part of the problem
 
-That means the next design should not be “adaptive bounded claimers, but tuned
-better.” It should reconsider the control plane itself:
+That means the next design should not be “adaptive bounded claimers, but tuned better.” It should reconsider the control plane itself:
 
 - either a cheaper queue-level claimer authority mechanism
-- or an explicit hot-queue mode such as queue striping that reduces
-  cross-replica coordination at the source
+- or an explicit hot-queue mode such as queue striping that reduces cross-replica coordination at the source
 
 ### What now looks solid
 
@@ -669,15 +571,13 @@ better.” It should reconsider the control plane itself:
 
 Append-only queue storage is the right foundation.
 
-`ready_entries` / `done_entries` are no longer the dominant MVCC problem.
-The old `jobs_hot` failure mode is not coming back.
+`ready_entries` / `done_entries` are no longer the dominant MVCC problem. The old `jobs_hot` failure mode is not coming back.
 
 #### 2. Lane/control plane
 
 The `queue_lanes` hotspot is solved.
 
-The split-head design removed the last "single hot metadata row per `(queue, priority)`" problem.
-In the newer runs, `queue_lanes` contributes effectively zero dead tuples.
+The split-head design removed the last "single hot metadata row per `(queue, priority)`" problem. In the newer runs, `queue_lanes` contributes effectively zero dead tuples.
 
 That means the current control-plane split is the right one:
 
@@ -754,11 +654,9 @@ The direct Rust runtime benchmark now prints both:
 - **post-insert throughput**: drain rate after the insert phase finishes
 - **end-to-end throughput**: total jobs divided by total elapsed time from first insert to final completion
 
-That distinction matters because the old single throughput number over-weighted the
-drain phase and made very fast inserters look artificially better.
+That distinction matters because the old single throughput number over-weighted the drain phase and made very fast inserters look artificially better.
 
-Current local Docker PG rerun (`postgres://bench:bench@localhost:15555/awa_bench`,
-`5000` jobs):
+Current local Docker PG rerun (`postgres://bench:bench@localhost:15555/awa_bench`, `5000` jobs):
 
 - canonical
   - post-insert throughput: `46827 jobs/s`
@@ -781,9 +679,7 @@ Interpretation:
 
 - canonical still drains a short preloaded burst faster on this microjob benchmark
 - queue storage still has the much cleaner hot-path churn profile
-- the direct runtime benchmark is useful as a smoke check, but the longer portable
-  phase-driven scenarios remain the more trustworthy picture for sustained behavior
-  under readers, pressure, and recovery
+- the direct runtime benchmark is useful as a smoke check, but the longer portable phase-driven scenarios remain the more trustworthy picture for sustained behavior under readers, pressure, and recovery
 
 #### Table-level dead tuples in the current Awa baseline
 
@@ -970,11 +866,9 @@ Likely directions:
 
 ##### 2. Retry-heavy overload behavior
 
-This is no longer a correctness red flag, but it is still a throughput/backlog
-weakness.
+This is no longer a correctness red flag, but it is still a throughput/backlog weakness.
 
-After switching queue storage to claim-time effective priority aging and fixing
-the receipt-backed retry close path:
+After switching queue storage to claim-time effective priority aging and fixing the receipt-backed retry close path:
 
 - retryable failures are retried correctly
 - aged lower-priority work is now visibly completing during recovery
@@ -984,8 +878,7 @@ The newest semantics run is:
 
 - `benchmarks/portable/results/awa_semantics_retry_priority_mix_20260422_045458.json`
 
-That run shows a materially healthier shape than the earlier benchmark-only
-aging pass:
+That run shows a materially healthier shape than the earlier benchmark-only aging pass:
 
 - `clean_1`: completion `642/s`, subscriber p99 `2.9s`, total backlog `247.5`
 - `pressure_1`: completion `651/s`, subscriber p99 `23.8s`, total backlog `14.2k`
@@ -1000,8 +893,7 @@ So the remaining problem is not "retries are stuck in the wrong state". It is:
 
 ##### 3. Recovery latency tails
 
-Recovery remains the weakest phase in both the main Awa-only runs and the
-explicit crash-under-load scenario.
+Recovery remains the weakest phase in both the main Awa-only runs and the explicit crash-under-load scenario.
 
 The newest crash-under-load run is:
 
@@ -1020,8 +912,7 @@ Observed shape:
 - `restart`: completion `780/s`, subscriber p99 `58.1s`, total backlog `41.5k`
 - `recovery_1`: completion `727/s`, subscriber p99 `30.0s`, total backlog `32.7k`
 
-This is now clearly a performance issue, not a lock-safety issue. The system
-recovers, but the recovery path is still too expensive under load.
+This is now clearly a performance issue, not a lock-safety issue. The system recovers, but the recovery path is still too expensive under load.
 
 ##### 4. Counts/admin read model
 
@@ -1034,9 +925,7 @@ With the cached queue-count snapshot path used by the portable benchmark adapter
 - crash recovery rerun:
   - `benchmarks/portable/results/awa_semantics_crash_recovery_under_load_20260422_025919.json`
 
-At low to mid worker counts, the old `queue_counts()` warning largely
-disappears. At higher worker counts it still appears occasionally, but it is no
-longer the main bottleneck.
+At low to mid worker counts, the old `queue_counts()` warning largely disappears. At higher worker counts it still appears occasionally, but it is no longer the main bottleneck.
 
 That means the next target has shifted to:
 
@@ -1074,8 +963,7 @@ So the scaling story is now:
 
 - the high-worker regime is strong
 - the low-worker regime is still bad enough that we should not ignore it
-- the current bottleneck is likely in the claim / completion pipeline shape,
-  not the old storage-MVCC hotspot class
+- the current bottleneck is likely in the claim / completion pipeline shape, not the old storage-MVCC hotspot class
 
 ### Cross-system position
 
@@ -1089,8 +977,7 @@ That run shows:
 
 - Awa leading on throughput in every presented phase
 - Awa showing lower dead tuples than pgque in the same short profile
-- but Awa also showing very large subscriber and end-to-end tails once the
-  short run carries backlog
+- but Awa also showing very large subscriber and end-to-end tails once the short run carries backlog
 
 Representative medians:
 
@@ -1101,15 +988,11 @@ Representative medians:
   - `awa`: `705/s`, subscriber p99 `32.9s`, dead tuples `215`
   - `pgque`: `456/s`, subscriber p99 `126 ms`, dead tuples `726`
 
-So the cross-system narrative is still not "Awa wins everything". The real
-position is:
+So the cross-system narrative is still not "Awa wins everything". The real position is:
 
-- Awa's storage design is now strong enough to compete on throughput and dead
-  tuples
-- but the runtime still has tail-latency problems under short overloaded
-  profiles
-- those tails need to be understood before we use these short compare runs as
-  release messaging
+- Awa's storage design is now strong enough to compete on throughput and dead tuples
+- but the runtime still has tail-latency problems under short overloaded profiles
+- those tails need to be understood before we use these short compare runs as release messaging
 
 ### Overall judgement
 
@@ -1143,87 +1026,54 @@ In order:
 
 2. Investigate low-worker underfill
    - the `1/4/8/16` worker scaling results are still too weak
-   - a direct `claim_ready_runtime(...)` broadening spike was tried and reverted:
-     claiming across multiple ready slots for the chosen lane did help the
-     higher-concurrency backlog case, but it regressed `1/4` worker throughput
-     enough that it was not worth keeping
-   - a later claim-function cleanup spike was also reverted:
-     reusing the first candidate lookup to avoid the second ready-slot query,
-     and reusing one captured timestamp across the batch, made the SQL look
-     cleaner but regressed plugged-in `1/4` worker throughput enough that it
-     was not worth keeping
-   - so the next low-worker work should focus on fixed per-claim/start cost on
-     the current design, not broader ready-slot selection
+   - a direct `claim_ready_runtime(...)` broadening spike was tried and reverted: claiming across multiple ready slots for the chosen lane did help the higher-concurrency backlog case, but it regressed `1/4` worker throughput enough that it was not worth keeping
+   - a later claim-function cleanup spike was also reverted: reusing the first candidate lookup to avoid the second ready-slot query, and reusing one captured timestamp across the batch, made the SQL look cleaner but regressed plugged-in `1/4` worker throughput enough that it was not worth keeping
+   - so the next low-worker work should focus on fixed per-claim/start cost on the current design, not broader ready-slot selection
 
 3. Investigate realistic multi-replica deployment shape
-   - holding total workers constant but splitting them across many replicas is
-     now clearly a major remaining weakness
-   - the portable harness now has a true `awa-canonical` variant using the
-     same `awa-bench` binary, so we can compare canonical and queue storage
-     under the same replica matrix instead of relying only on the direct
-     single-process benchmark
+   - holding total workers constant but splitting them across many replicas is now clearly a major remaining weakness
+   - the portable harness now has a true `awa-canonical` variant using the same `awa-bench` binary, so we can compare canonical and queue storage under the same replica matrix instead of relying only on the direct single-process benchmark
    - one benchmark artifact was identified and fixed here:
-     - the long-horizon Awa adapter was previously polling queue depth from
-       every replica
-     - only replica `0` now performs that observer work, which removes the
-       artificial "every pod runs queue_counts() every second" load
+     - the long-horizon Awa adapter was previously polling queue depth from every replica
+     - only replica `0` now performs that observer work, which removes the artificial "every pod runs queue_counts() every second" load
    - that fix did **not** remove the core multi-replica problem
    - fixed-load replica-shape runs showed:
      - `1x32` remained healthy
      - `2x16` degraded badly
      - `4x8` and `8x4` collapsed
-   - a single-producer variant (`PRODUCER_ONLY_INSTANCE_ZERO=1`) still showed
-     the same degradation, so this is **not** just queue-enqueue-head
-     contention from many producers
+   - a single-producer variant (`PRODUCER_ONLY_INSTANCE_ZERO=1`) still showed the same degradation, so this is **not** just queue-enqueue-head contention from many producers
    - after the observer fix, the single-producer matrix still looked like:
      - `1x32`: `clean_1 662/s`, `pressure_1 896/s`, `recovery_1 676/s`
      - `2x16`: `clean_1 180/s`, `pressure_1 39/s`, `recovery_1 300/s`
      - `4x8`: `clean_1 76/s`, `pressure_1 25/s`, `recovery_1 77/s`
      - `8x4`: `clean_1 18/s`, `pressure_1 23/s`, `recovery_1 16/s`
-   - apples-to-apples canonical vs queue-storage checkpoints now show the
-     remaining bar much more clearly:
+   - apples-to-apples canonical vs queue-storage checkpoints now show the remaining bar much more clearly:
      - `1x32`
-       - `queue_storage`: `clean_1 692/s`, `pressure_1 1140/s`, `recovery_1 741/s`,
-         median dead tuples `130.5 / 92.0 / 109.0`
-       - `canonical`: `clean_1 712/s`, `pressure_1 981/s`, `recovery_1 700/s`,
-         median dead tuples `43429 / 43940 / 54645`
+       - `queue_storage`: `clean_1 692/s`, `pressure_1 1140/s`, `recovery_1 741/s`, median dead tuples `130.5 / 92.0 / 109.0`
+       - `canonical`: `clean_1 712/s`, `pressure_1 981/s`, `recovery_1 700/s`, median dead tuples `43429 / 43940 / 54645`
      - `4x8`
-       - `queue_storage`: `clean_1 181/s`, `pressure_1 143/s`, `recovery_1 148/s`,
-         subscriber p99 `8962 / 23429 / 53658 ms`, median dead tuples
-         `158.5 / 133.0 / 175.0`
-       - `canonical`: `clean_1 163/s`, `pressure_1 217/s`, `recovery_1 155/s`,
-         subscriber p99 `234 / 292 / 315 ms`, median dead tuples
-         `39599.5 / 42828.5 / 55371.0`
+       - `queue_storage`: `clean_1 181/s`, `pressure_1 143/s`, `recovery_1 148/s`, subscriber p99 `8962 / 23429 / 53658 ms`, median dead tuples `158.5 / 133.0 / 175.0`
+       - `canonical`: `clean_1 163/s`, `pressure_1 217/s`, `recovery_1 155/s`, subscriber p99 `234 / 292 / 315 ms`, median dead tuples `39599.5 / 42828.5 / 55371.0`
    - interpretation:
      - queue storage already gives the intended churn profile under both shapes
-     - at `1x32`, queue storage is competitive with canonical and better in
-       `pressure` / `recovery` throughput
-     - at `4x8`, canonical currently wins on latency and pressure/recovery
-       throughput despite its huge dead-tuple cost
-   - the remaining blocker is now best understood as multi-process
-     claim/start coordination on one queue, not one-big-process underfill alone
-   - one later spike reused the receipt-backed live frontier as a local
-     prefetch buffer so each replica could claim ahead and dispatch from memory
-   - that spike was the first thing that materially improved the realistic
-     `4x8` shape:
+     - at `1x32`, queue storage is competitive with canonical and better in `pressure` / `recovery` throughput
+     - at `4x8`, canonical currently wins on latency and pressure/recovery throughput despite its huge dead-tuple cost
+   - the remaining blocker is now best understood as multi-process claim/start coordination on one queue, not one-big-process underfill alone
+   - one later spike reused the receipt-backed live frontier as a local prefetch buffer so each replica could claim ahead and dispatch from memory
+   - that spike was the first thing that materially improved the realistic `4x8` shape:
      - `clean_1 174.8/s`
      - `pressure_1 208.0/s`
      - `recovery_1 161.2/s`
      - subscriber p99 about `140 / 269 / 237 ms`
    - but it was reverted because it crossed the safety/observability boundary:
-     - prefetched receipt claims were indistinguishable from active attempts, so
-       `running_depth` was inflated badly
+     - prefetched receipt claims were indistinguishable from active attempts, so `running_depth` was inflated badly
      - crash-under-load runs surfaced stale rescue errors:
        - `queue storage ready row missing for deleted lease job ...`
    - the lesson is now stronger than before:
-     - a buffered frontier probably **is** required to clear the many-small-
-       replica blocker
-     - but it cannot safely reuse `open_receipt_claims` as both
-       reservation-state and active-attempt state
-     - the proper remaining fix is an explicit reserved-but-not-started
-       frontier with separate promotion into the active receipt/attempt plane
-   - after fixing the multi-replica reporting bug, we ran a fixed bounded-
-     claimers pass and learned something more precise:
+     - a buffered frontier probably **is** required to clear the many-small- replica blocker
+     - but it cannot safely reuse `open_receipt_claims` as both reservation-state and active-attempt state
+     - the proper remaining fix is an explicit reserved-but-not-started frontier with separate promotion into the active receipt/attempt plane
+   - after fixing the multi-replica reporting bug, we ran a fixed bounded- claimers pass and learned something more precise:
      - `1x32` stayed healthy:
        - `clean_1 800/s`
        - `pressure_1 1199/s`
@@ -1236,24 +1086,20 @@ In order:
      - the per-replica summary made the actual failure mode obvious:
        - replica `0` did essentially all the work
        - replicas `1-3` stayed idle
-       - backlog and running depth were effectively localized to the incumbent
-         claimer
+       - backlog and running depth were effectively localized to the incumbent claimer
    - so fixed bounded claimers is not keepable as-is:
      - it reduces contention
      - but it over-localizes claim authority to one replica
-     - the next bounded-claimers iteration needs queue-global adaptation and
-       explicit anti-hoarding rather than a fixed small cap
+     - the next bounded-claimers iteration needs queue-global adaptation and explicit anti-hoarding rather than a fixed small cap
 
 #### Queue-global adaptive bounded claimers (current experiment)
 
-The next bounded-claimers pass moved from a fixed small cap to a queue-depth
-driven target while keeping the same core semantic boundary:
+The next bounded-claimers pass moved from a fixed small cap to a queue-depth driven target while keeping the same core semantic boundary:
 
 - no per-job reservation/start state
 - direct `ready -> active_receipt`
 - one claimer slot per instance per queue
-- queue-global-ish target derived from shared queue depth / running depth,
-  rather than replica-local streaks
+- queue-global-ish target derived from shared queue depth / running depth, rather than replica-local streaks
 
 The realistic single-producer gate on commit `a7043fb` produced:
 
@@ -1270,9 +1116,7 @@ The realistic single-producer gate on commit `a7043fb` produced:
   - subscriber p99 `671 / 11420 / 31441 ms`
   - median dead tuples `129 / 152 / 147`
 
-The important improvement over the earlier fixed-cap pass is that the corrected
-per-replica raw adapter metrics now show real work spread across multiple
-replicas after warmup, rather than replica `0` doing almost everything:
+The important improvement over the earlier fixed-cap pass is that the corrected per-replica raw adapter metrics now show real work spread across multiple replicas after warmup, rather than replica `0` doing almost everything:
 
 - `clean_1`
   - replica `0`: median nonzero completion rate `334.6/s`
@@ -1284,37 +1128,29 @@ replicas after warmup, rather than replica `0` doing almost everything:
 - `recovery_1`
   - replicas `0..3`: roughly `167–191/s` median nonzero completion rate
 
-So this version appears to address the worst over-localization problem that
-made fixed bounded claimers unattractive.
+So this version appears to address the worst over-localization problem that made fixed bounded claimers unattractive.
 
 However, it is not yet a shipping answer because:
 
-- `4x8` subscriber tails are still far too high under `pressure_1` and
-  `recovery_1`
-- the adaptive controller is still likely too eager or too sticky under hot
-  queue conditions
+- `4x8` subscriber tails are still far too high under `pressure_1` and `recovery_1`
+- the adaptive controller is still likely too eager or too sticky under hot queue conditions
 - we have not yet rerun crash-under-load on this version
 
 Current conclusion:
 
-- this is the first bounded-claimers variant worth keeping in the branch as an
-  active candidate
-- it improves realistic multi-replica throughput materially relative to the
-  unbounded baseline
+- this is the first bounded-claimers variant worth keeping in the branch as an active candidate
+- it improves realistic multi-replica throughput materially relative to the unbounded baseline
 - but it still needs controller tuning before it clears the shipping bar
 
 #### First investigation of the adaptive claimer result
 
-Before discarding the adaptive claimer direction, the first follow-up check was
-to look at the corrected per-replica adapter metrics from the realistic `4x8`
-run rather than only the aggregate phase summary.
+Before discarding the adaptive claimer direction, the first follow-up check was to look at the corrected per-replica adapter metrics from the realistic `4x8` run rather than only the aggregate phase summary.
 
 That investigation changes the diagnosis:
 
 - this version does **not** collapse to `0/s`
 - it does **not** over-localize to one replica the way the fixed-cap pass did
-- under `pressure_1` and `recovery_1`, all four replicas show sustained nonzero
-  completion rates
+- under `pressure_1` and `recovery_1`, all four replicas show sustained nonzero completion rates
 
 From `custom-20260423T123737Z-b7c2f9`:
 
@@ -1327,8 +1163,7 @@ From `custom-20260423T123737Z-b7c2f9`:
 - `recovery_1`
   - replicas `0..3` roughly `167–191/s` median nonzero completion rate
 
-So the remaining problem is not “only one replica is active.” The remaining
-problem is:
+So the remaining problem is not “only one replica is active.” The remaining problem is:
 
 - throughput under `4x8` is still below producer rate
 - queue depth builds materially:
@@ -1339,18 +1174,13 @@ problem is:
 
 One caveat from this investigation:
 
-- `running_depth` in the current portable harness is still effectively an
-  observer-instance metric, not a true cluster-wide aggregate, so it should not
-  be over-interpreted in this multi-replica analysis
+- `running_depth` in the current portable harness is still effectively an observer-instance metric, not a true cluster-wide aggregate, so it should not be over-interpreted in this multi-replica analysis
 
 Working interpretation after this first investigation:
 
 - the adaptive claimer idea is still alive
-- the current queue-depth controller is likely too conservative or too
-  expensive, so the queue accumulates backlog early and never regains latency
-  control
-- the next tuning pass should focus on the controller and claimer-lease
-  overhead rather than discarding the design immediately
+- the current queue-depth controller is likely too conservative or too expensive, so the queue accumulates backlog early and never regains latency control
+- the next tuning pass should focus on the controller and claimer-lease overhead rather than discarding the design immediately
 
 #### Adaptive bounded claimers after controller tuning
 
@@ -1361,8 +1191,7 @@ The next tuning pass moved the target calculation off the hot claim round:
 - used more aggressive expansion and slower contraction heuristics
 - added jittered claimer slot probe order
 
-This reduced the amount of `queue_counts_cached(...)` work paid directly on
-every claim attempt and made the controller materially less replica-local.
+This reduced the amount of `queue_counts_cached(...)` work paid directly on every claim attempt and made the controller materially less replica-local.
 
 Results on commit `84483bc`:
 
@@ -1381,8 +1210,7 @@ Results on commit `84483bc`:
   - median queue depth `375 / 7489 / 18639`
   - median dead tuples `155 / 185 / 181`
 
-Compared with the first adaptive claimer run (`a7043fb`), the tuned controller
-shows:
+Compared with the first adaptive claimer run (`a7043fb`), the tuned controller shows:
 
 - `1x32`
   - still healthy overall, though with somewhat worse tails
@@ -1393,8 +1221,7 @@ shows:
   - much lower `pressure_1` and `recovery_1` queue depth
   - substantially better `pressure_1` and `recovery_1` subscriber tails
 
-Per-replica completion medians remain distributed across all four replicas
-after warmup:
+Per-replica completion medians remain distributed across all four replicas after warmup:
 
 - `clean_1`
   - replicas `0..3`: `136–197/s`
@@ -1403,26 +1230,21 @@ after warmup:
 - `recovery_1`
   - replicas `0..3`: `179–193/s`
 
-So this tuning pass does not solve the realistic `4x8` tail problem yet, but
-it is the first adaptive claimer version that is both:
+So this tuning pass does not solve the realistic `4x8` tail problem yet, but it is the first adaptive claimer version that is both:
 
 - clearly multi-replica, not over-localized to one owner
-- and measurably better than the earlier adaptive controller in the hot
-  backlog phases
+- and measurably better than the earlier adaptive controller in the hot backlog phases
 
 Current conclusion:
 
 - keep this version in the branch as the active bounded-claimers candidate
-- next work should focus on further controller tuning and crash/recovery
-  validation, not discarding the design
+- next work should focus on further controller tuning and crash/recovery validation, not discarding the design
 
 #### Crash-under-load on the tuned controller
 
-The tuned adaptive controller was also exercised through the existing
-`crash_recovery_under_load` semantics scenario at `2x8`.
+The tuned adaptive controller was also exercised through the existing `crash_recovery_under_load` semantics scenario at `2x8`.
 
-That run completed, but it is not operationally clean enough to count as a
-shipping answer yet.
+That run completed, but it is not operationally clean enough to count as a shipping answer yet.
 
 Observed behavior:
 
@@ -1453,24 +1275,14 @@ So the tuned adaptive claimer controller remains:
 - viable enough to keep in-branch for further study
 - not yet safe/boring enough to call production-ready
 
-Most importantly, this means the remaining blocker is no longer just a `4x8`
-throughput/tail issue. There is still at least one recovery-path correctness or
-control-plane interaction issue to resolve before the design can be considered
-ready.
+Most importantly, this means the remaining blocker is no longer just a `4x8` throughput/tail issue. There is still at least one recovery-path correctness or control-plane interaction issue to resolve before the design can be considered ready.
 
-Because the tuned adaptive claimer controller is now good enough to keep in the
-branch, but still not boring enough to ship on hot queues, queue striping has
-been promoted from "future escape hatch" to the next serious design track. See
-[`queue-striping-plan.md`](queue-striping-plan.md) for the proposed logical
-queue -> physical stripe model and the measurement plan against the current
-`4x8` blocker.
+Because the tuned adaptive claimer controller is now good enough to keep in the branch, but still not boring enough to ship on hot queues, queue striping has been promoted from "future escape hatch" to the next serious design track. See [`queue-striping-plan.md`](queue-striping-plan.md) for the proposed logical queue -> physical stripe model and the measurement plan against the current `4x8` blocker.
 
 4. Investigate retry-heavy overload behavior
    - especially completion throughput vs queue depth growth
    - but now on the corrected claim-time aging baseline
-   - note: a quick `PRIORITY_AGING_MS=0` probe was attempted and is not a valid
-     comparison yet; it currently panics the maintenance timer because the
-     queue-storage runtime still requires a non-zero aging interval
+   - note: a quick `PRIORITY_AGING_MS=0` probe was attempted and is not a valid comparison yet; it currently panics the maintenance timer because the queue-storage runtime still requires a non-zero aging interval
 
 5. Re-run a longer settled `awa` vs `pgque` comparison after those fixes
    - avoid using very short cross-system runs as the main narrative

--- a/docs/archive/0.6-storage-design/queue-striping-plan.md
+++ b/docs/archive/0.6-storage-design/queue-striping-plan.md
@@ -1,34 +1,20 @@
 # Queue Striping
 
-> **Status: shipped as an optional 0.6 queue-storage mode.** The release
-> shape is static striping via `QueueStorageConfig::queue_stripe_count`
-> (default `1`, disabled). Physical stripe queues use the internal
-> `queue#N` naming convention; users still configure and observe the
-> logical queue. The dynamic striping controller experiments below were
-> not kept for 0.6.
+> **Status: shipped as an optional 0.6 queue-storage mode.** The release shape is static striping via `QueueStorageConfig::queue_stripe_count` (default `1`, disabled). Physical stripe queues use the internal `queue#N` naming convention; users still configure and observe the logical queue. The dynamic striping controller experiments below were not kept for 0.6.
 
 ## Release shape
 
 Queue striping is now a queue-storage tuning knob, not a separate engine.
 
 - Default: `queue_stripe_count = 1`, preserving the unstriped path.
-- Hot-queue candidate: `queue_stripe_count = 2` based on the best measured
-  `4x8` results in this investigation.
-- Higher stripe counts are not generally recommended from the current data:
-  `4` helped some pressure phases but hurt other shapes, and `8` regressed.
-- Enqueue chooses one physical stripe deterministically. Unique-keyed jobs hash
-  by `unique_key`; otherwise the insert sequence/salt spreads work.
-- Claim probes the physical stripes cyclically from a per-runtime round-robin
-  hint.
-- Stats aggregate back to the logical queue; stripe names are an internal
-  diagnostic surface.
-- Maintenance rotates/prunes the existing queue-storage table families; striping
-  does not add a new job lifecycle state.
+- Hot-queue candidate: `queue_stripe_count = 2` based on the best measured `4x8` results in this investigation.
+- Higher stripe counts are not generally recommended from the current data: `4` helped some pressure phases but hurt other shapes, and `8` regressed.
+- Enqueue chooses one physical stripe deterministically. Unique-keyed jobs hash by `unique_key`; otherwise the insert sequence/salt spreads work.
+- Claim probes the physical stripes cyclically from a per-runtime round-robin hint.
+- Stats aggregate back to the logical queue; stripe names are an internal diagnostic surface.
+- Maintenance rotates/prunes the existing queue-storage table families; striping does not add a new job lifecycle state.
 
-The implementation lives in `awa-model/src/queue_storage.rs` (search for
-`queue_stripe_count`). Operator-facing configuration is documented in
-[`configuration.md`](../../configuration.md#queue-storage-tuning), and the runtime
-architecture is summarized in [`architecture.md`](../../architecture.md#queue-striping-and-claim-authority).
+The implementation lives in `awa-model/src/queue_storage.rs` (search for `queue_stripe_count`). Operator-facing configuration is documented in [`configuration.md`](../../configuration.md#queue-storage-tuning), and the runtime architecture is summarized in [`architecture.md`](../../architecture.md#queue-striping-and-claim-authority).
 
 ## Why this exists
 
@@ -94,8 +80,7 @@ Workers continue to subscribe to one logical queue, but internally:
 - claims probe multiple stripes
 - observability aggregates stripes back to one logical queue
 
-This does **not** add a new per-job execution state.
-Jobs still use the current lifecycle:
+This does **not** add a new per-job execution state. Jobs still use the current lifecycle:
 
 ```text
 ready -> active_receipt -> attempt_state -> active_lease
@@ -109,8 +94,7 @@ Queue striping should:
 
 - materially improve `4x8` and `8x4` hot-queue behavior
 - preserve the current good `1x32` shape
-- avoid making hot-path churn materially worse than the current unstriped
-  short-job baseline once `open_receipt_claims` is measured explicitly
+- avoid making hot-path churn materially worse than the current unstriped short-job baseline once `open_receipt_claims` is measured explicitly
 - preserve current short-job and long-running job semantics
 - preserve honest `running_depth`
 - avoid a second start transaction
@@ -138,11 +122,9 @@ This should be treated as:
 
 - an implementation/proof step first
 - a product-shape decision later
-- an **experimental / investigation-only** engine mode until the churn and
-  counting regressions are understood
+- an **experimental / investigation-only** engine mode until the churn and counting regressions are understood
 
-So the first implementation can still use an explicit stripe count internally.
-Whether striping becomes automatic or always-on can be decided after measurement.
+So the first implementation can still use an explicit stripe count internally. Whether striping becomes automatic or always-on can be decided after measurement.
 
 ## Logical queue -> physical stripes
 
@@ -218,8 +200,7 @@ This keeps the hot path simple while avoiding global contention on one queue hea
 
 We already know that over-sticky ownership can underutilize capacity.
 
-The first striping pass should reduce coordination pressure without also
-introducing another ownership control plane.
+The first striping pass should reduce coordination pressure without also introducing another ownership control plane.
 
 So v1 should prefer:
 
@@ -250,14 +231,11 @@ The round-robin start hint gives a simple first approximation of this.
 
 ### Across priorities
 
-Priorities still apply within stripes.
-Global fairness is approximate, but claim-time aging should still guarantee eventual progress for low-priority work.
+Priorities still apply within stripes. Global fairness is approximate, but claim-time aging should still guarantee eventual progress for low-priority work.
 
 ## Operational model
 
-The first implementation treated striping as an internal engine mode for
-experimentation. In the release shape, static striping remains optional and
-off by default.
+The first implementation treated striping as an internal engine mode for experimentation. In the release shape, static striping remains optional and off by default.
 
 That means:
 
@@ -271,8 +249,7 @@ The investigated product shapes were:
 - automatic striping for hot queues
 - or a visible queue-level policy
 
-Measurement selected static optional striping for 0.6; the dynamic controller
-experiment below was not kept.
+Measurement selected static optional striping for 0.6; the dynamic controller experiment below was not kept.
 
 ## Observability
 
@@ -348,10 +325,8 @@ We keep striping only if:
 - `1x32` stays roughly where the current good branch is
 - `4x8` materially improves over the current unstriped adaptive claimer result
 - `4x8` tails are much lower than the current unstriped adaptive claimer result
-- dead tuples do not materially exceed the current unstriped short-job baseline
-  once `open_receipt_claims` is included in the sampled event tables
-- logical `running_depth` remains plausible for the offered load and queue
-  depth, rather than inflating into thousands of apparently-running jobs
+- dead tuples do not materially exceed the current unstriped short-job baseline once `open_receipt_claims` is included in the sampled event tables
+- logical `running_depth` remains plausible for the offered load and queue depth, rather than inflating into thousands of apparently-running jobs
 - crash-under-load remains correct
 
 ## Comparison targets
@@ -398,9 +373,7 @@ What we expect, based on the experiments so far:
 
 - `1x32` may stay about the same or regress slightly
 - `4x8` should benefit substantially because the hot queue is no longer one shared coordination point
-- dead tuples should stay in roughly the same range as the current unstriped
-  short-job path, because striping changes the coordination shape, not the
-  receipt-claim lifecycle itself
+- dead tuples should stay in roughly the same range as the current unstriped short-job path, because striping changes the coordination shape, not the receipt-claim lifecycle itself
 - fairness should remain good enough if stripes are probed cyclically and priority aging remains active
 
 The biggest risk is:
@@ -409,11 +382,9 @@ The biggest risk is:
 
 The first version should measure that explicitly rather than trying to solve it prematurely.
 
-
 ## First experiment results
 
-The first implementation pass was built and measured with `QUEUE_STRIPE_COUNT=4` on the
-same single-producer realistic gate used for the bounded-claimer work.
+The first implementation pass was built and measured with `QUEUE_STRIPE_COUNT=4` on the same single-producer realistic gate used for the bounded-claimer work.
 
 ### `1x32`
 
@@ -435,25 +406,19 @@ same single-producer realistic gate used for the bounded-claimer work.
 
 ### Investigation result: the first regression signal was misleading
 
-The first write-up treated striping as if it had caused a new dead-tuple and
-counting regression. A focused root-cause pass showed that conclusion was too
-strong.
+The first write-up treated striping as if it had caused a new dead-tuple and counting regression. A focused root-cause pass showed that conclusion was too strong.
 
 What was actually happening:
 
-- the portable benchmark was **not sampling `open_receipt_claims`**, which is
-  the real short-job churn hotspot under sustained load
-- the observer was using a hard `15s` queue-count cache TTL against `10–15s`
-  phases, which overstated logical `running_depth`
+- the portable benchmark was **not sampling `open_receipt_claims`**, which is the real short-job churn hotspot under sustained load
+- the observer was using a hard `15s` queue-count cache TTL against `10–15s` phases, which overstated logical `running_depth`
 
 After fixing the benchmark:
 
 - `open_receipt_claims` is included in the sampled event tables
-- queue-count sampling is tied to the sample interval by default (and can be
-  overridden via `QUEUE_COUNT_MAX_AGE_MS`)
+- queue-count sampling is tied to the sample interval by default (and can be overridden via `QUEUE_COUNT_MAX_AGE_MS`)
 
-On a fresh manual `4x8` striped repro with phase transitions (`800 -> 1200 ->
-800`), the live database state was:
+On a fresh manual `4x8` striped repro with phase transitions (`800 -> 1200 -> 800`), the live database state was:
 
 - `open_receipt_claims` carried the dead tuples (`n_dead_tup ~= 11611`)
 - `lease_claim_closures` had `0` dead tuples
@@ -467,25 +432,23 @@ And a matched unstriped repro showed essentially the same shape:
 
 So the corrected conclusion is:
 
-- striping did **not** introduce a special `lease_claim_closures` or
-  `done_entries_*` churn regression
-- the dead-tuple hotspot is the existing `open_receipt_claims` insert/delete
-  cycle
-- striping should now be judged on whether it improves realistic `4x8`
-  throughput/tails **without making that existing hotspot materially worse**
+- striping did **not** introduce a special `lease_claim_closures` or `done_entries_*` churn regression
+- the dead-tuple hotspot is the existing `open_receipt_claims` insert/delete cycle
+- striping should now be judged on whether it improves realistic `4x8` throughput/tails **without making that existing hotspot materially worse**
 
 ### Corrected comparison
 
-With the corrected benchmark path, a short `4x8` single-producer comparison
-looks like this:
+With the corrected benchmark path, a short `4x8` single-producer comparison looks like this:
 
 Striped (`QUEUE_STRIPE_COUNT=4`)
+
 - `clean_1`: throughput about `798/s`, subscriber p99 about `32 ms`
 - `pressure_1`: throughput about `1198/s`, subscriber p99 about `34 ms`
 - `recovery_1`: throughput about `799/s`, subscriber p99 about `36 ms`
 - median dead tuples about `8817 / 3646 / 14033`
 
 Unstriped (`QUEUE_STRIPE_COUNT=1`)
+
 - `clean_1`: throughput about `793/s`, subscriber p99 about `21 ms`
 - `pressure_1`: throughput about `1183/s`, subscriber p99 about `24 ms`
 - `recovery_1`: throughput about `786/s`, subscriber p99 about `33 ms`
@@ -495,13 +458,11 @@ So the first striping pass is now best understood as:
 
 - **not** a clear regression
 - **not yet** a clear win
-- still an investigation-only implementation until it shows a stronger
-  `4x8` benefit than the unstriped baseline
+- still an investigation-only implementation until it shows a stronger `4x8` benefit than the unstriped baseline
 
 ### Stripe-count sweep
 
-With the corrected benchmark path in place, the next question was whether a
-different stripe count could produce a real `4x8` win.
+With the corrected benchmark path in place, the next question was whether a different stripe count could produce a real `4x8` win.
 
 Short `4x8` sweep (`15s` warmup, `30s` phases):
 
@@ -531,8 +492,7 @@ What this suggests:
 The hot dead-tuple source remains unchanged across the sweep:
 
 - `open_receipt_claims` is still the dominant dead-tuple table
-- striping is changing queueing behavior, not introducing a new closure/done
-  regression
+- striping is changing queueing behavior, not introducing a new closure/done regression
 
 ### Longer `4x8` confirmation: `1` vs `2` stripes
 
@@ -546,23 +506,18 @@ To reduce the noise in the short sweep, we then reran a longer pair:
 Results:
 
 Unstriped (`QUEUE_STRIPE_COUNT=1`)
-- `clean_1`: throughput about `446/s`, subscriber p99 about `7823 ms`,
-  queue depth about `5537`
-- `pressure_1`: throughput about `465/s`, subscriber p99 about `33579 ms`,
-  queue depth about `34286`
-- `recovery_1`: throughput about `520/s`, subscriber p99 about `64455 ms`,
-  queue depth about `59008`
+
+- `clean_1`: throughput about `446/s`, subscriber p99 about `7823 ms`, queue depth about `5537`
+- `pressure_1`: throughput about `465/s`, subscriber p99 about `33579 ms`, queue depth about `34286`
+- `recovery_1`: throughput about `520/s`, subscriber p99 about `64455 ms`, queue depth about `59008`
 
 Two stripes (`QUEUE_STRIPE_COUNT=2`)
-- `clean_1`: throughput about `667/s`, subscriber p99 about `1728 ms`,
-  queue depth about `1070`
-- `pressure_1`: throughput about `553/s`, subscriber p99 about `15630 ms`,
-  queue depth about `14150`
-- `recovery_1`: throughput about `762/s`, subscriber p99 about `36340 ms`,
-  queue depth about `26252`
 
-This longer pair is the strongest evidence so far that striping can produce a
-real `4x8` win:
+- `clean_1`: throughput about `667/s`, subscriber p99 about `1728 ms`, queue depth about `1070`
+- `pressure_1`: throughput about `553/s`, subscriber p99 about `15630 ms`, queue depth about `14150`
+- `recovery_1`: throughput about `762/s`, subscriber p99 about `36340 ms`, queue depth about `26252`
+
+This longer pair is the strongest evidence so far that striping can produce a real `4x8` win:
 
 - lower backlog growth
 - materially lower tails
@@ -570,17 +525,14 @@ real `4x8` win:
 
 Measurement caveat:
 
-- the portable `awa-bench` adapter currently reports `claim_p99_ms` using the
-  same windowed value as `subscriber_p99_ms`
-- so `claim_p99_ms` should not be used as an independent diagnosis signal for
-  striping until the adapter emits a true claim-latency metric
+- the portable `awa-bench` adapter currently reports `claim_p99_ms` using the same windowed value as `subscriber_p99_ms`
+- so `claim_p99_ms` should not be used as an independent diagnosis signal for striping until the adapter emits a true claim-latency metric
 
 But it is still not yet “boring” enough to call done:
 
 - tails remain high in absolute terms
 - `open_receipt_claims` churn remains the limiting table family
-- the best candidate so far is specifically `QUEUE_STRIPE_COUNT=2`, not
-  striping in general
+- the best candidate so far is specifically `QUEUE_STRIPE_COUNT=2`, not striping in general
 
 ### Dynamic striping controller experiment
 
@@ -592,8 +544,7 @@ We then tested the first dynamic controller for striping:
 - initial target `1`, widening toward `2`
 - enqueue and claim both limited to the currently active stripe set
 
-The intent was to preserve the proven `2`-stripe hot-queue win without paying
-the steady-state cost of always-on striping.
+The intent was to preserve the proven `2`-stripe hot-queue win without paying the steady-state cost of always-on striping.
 
 That implementation was benchmarked twice:
 
@@ -623,13 +574,11 @@ The controller is therefore **not** the current answer:
 
 - both versions regressed relative to the static `2`-stripe candidate
 - the retuned version regressed relative to the initial dynamic version
-- the failure is not a special new dead-tuple hotspot; `open_receipt_claims`
-  remains the dominant table family
+- the failure is not a special new dead-tuple hotspot; `open_receipt_claims` remains the dominant table family
 - the problem is the dynamic control path itself, not the basic striping idea
 
 Current conclusion:
 
 - keep static `2` stripes as the leading striping candidate
 - do **not** keep the current dynamic-striping controller
-- if dynamic striping is revisited, it needs a much cheaper control model than
-  “queue-global state consulted on both enqueue and claim”
+- if dynamic striping is revisited, it needs a much cheaper control model than “queue-global state consulted on both enqueue and claim”

--- a/docs/archive/0.6-storage-design/sticky-shard-leasing-plan.md
+++ b/docs/archive/0.6-storage-design/sticky-shard-leasing-plan.md
@@ -1,11 +1,6 @@
 # Sticky Shard Leasing Plan
 
-> **Status: reverted experiment, kept as design context.** Sticky shard
-> leasing was prototyped during the 0.6 redesign but not adopted —
-> bounded claimers + queue striping (both shipped) cover the same
-> coordination pressure with simpler operational semantics. This doc is
-> kept for historical context on the design space; do not implement
-> from it without revisiting the trade-off against the shipped path.
+> **Status: reverted experiment, kept as design context.** Sticky shard leasing was prototyped during the 0.6 redesign but not adopted — bounded claimers + queue striping (both shipped) cover the same coordination pressure with simpler operational semantics. This doc is kept for historical context on the design space; do not implement from it without revisiting the trade-off against the shipped path.
 
 ## Why this exists
 
@@ -13,11 +8,9 @@ The queue-storage engine is now in a good place for:
 
 - single large runtime shapes like `1x32`
 - dead-tuple behavior on the hot queue plane
-- receipt/attempt/lease correctness for the common short-job and long-running
-  paths
+- receipt/attempt/lease correctness for the common short-job and long-running paths
 
-The remaining blocker for `0.6` is the realistic many-small-replica shape on
-one hot queue:
+The remaining blocker for `0.6` is the realistic many-small-replica shape on one hot queue:
 
 - `2x16`
 - `4x8`
@@ -40,13 +33,11 @@ This document is the implementation plan for that next design.
 
 It now describes **v2** of sticky shard leasing.
 
-v1 proved that shard-local ownership is compatible with the hot path and keeps
-dead tuples low, but it was too sticky:
+v1 proved that shard-local ownership is compatible with the hot path and keeps dead tuples low, but it was too sticky:
 
 - `1x32` stayed healthy
 - `4x8` still underutilized workers
-- `recovery_1` could stall because shard ownership was not redistributed fast
-  enough
+- `recovery_1` could stall because shard ownership was not redistributed fast enough
 
 So v2 keeps direct starts, but changes the ownership model to be:
 
@@ -58,10 +49,7 @@ So v2 keeps direct starts, but changes the ownership model to be:
 
 Use **sticky shard leasing** for the claim plane.
 
-Instead of one global claim cursor per `(queue, priority)`, split each hot lane
-into a small fixed set of claim shards. Replicas lease claim authority over
-those shards for a short period and claim directly from owned shards into the
-existing active-attempt path.
+Instead of one global claim cursor per `(queue, priority)`, split each hot lane into a small fixed set of claim shards. Replicas lease claim authority over those shards for a short period and claim directly from owned shards into the existing active-attempt path.
 
 The resulting shape is:
 
@@ -140,15 +128,13 @@ with exits to:
 - waiting
 - dlq
 
-That is intentional. Sticky shard leasing changes **claim authority**, not job
-lifecycle semantics.
+That is intentional. Sticky shard leasing changes **claim authority**, not job lifecycle semantics.
 
 ## Schema sketch
 
 ### 1. Shard-local claim heads
 
-Replace one row per `(queue, priority)` with one row per
-`(queue, priority, claim_shard)`:
+Replace one row per `(queue, priority)` with one row per `(queue, priority, claim_shard)`:
 
 ```sql
 CREATE TABLE {schema}.queue_claim_heads (
@@ -197,8 +183,7 @@ That can be:
 - stored physically as a column on `ready_entries`, or
 - derived in queries
 
-For the implementation pass, prefer a stored column because it simplifies
-indexing and avoids repeated modulo work in the hot claim query.
+For the implementation pass, prefer a stored column because it simplifies indexing and avoids repeated modulo work in the hot claim query.
 
 Suggested index:
 
@@ -252,8 +237,7 @@ Important v2 rule:
 
 - **do not** renew just because the dispatcher wakes
 - **do not** renew just because the replica exists
-- renew only on successful claim (or a very short post-claim grace window if we
-  later need one)
+- renew only on successful claim (or a very short post-claim grace window if we later need one)
 
 ### Steal / reclaim policy (v2)
 
@@ -306,8 +290,7 @@ Fairness comes from:
 
 Recommended first cap:
 
-- a replica may own at most `1-2` shards per `(queue, priority)` lane in the
-  initial implementation
+- a replica may own at most `1-2` shards per `(queue, priority)` lane in the initial implementation
 
 ## Safety invariants
 
@@ -323,8 +306,7 @@ These are the non-negotiable ones:
 6. Crash after claim:
    - existing receipt/attempt/lease rescue applies
 7. Stale owners cannot renew or continue claiming after `lease_epoch` changes.
-8. Idle owners do not block progress indefinitely because `owned-idle` shards
-   are stealable.
+8. Idle owners do not block progress indefinitely because `owned-idle` shards are stealable.
 
 ## Dead-tuple expectations
 
@@ -379,8 +361,7 @@ That is acceptable if lease rows remain:
 1. add cleanup of expired `lane_shard_leases`
 2. ensure stale owners naturally lose claim authority
 3. no job recovery path is needed for shard expiry, because jobs remain ready
-4. no shard should remain non-stealable indefinitely if it is not producing
-   successful claims
+4. no shard should remain non-stealable indefinitely if it is not producing successful claims
 
 ### Phase 5: metrics
 
@@ -422,7 +403,7 @@ We keep the change only if:
 3. `recovery_1` no longer stalls under `4x8`
 4. dead tuples stay low
 5. crash-under-load remains correct
-5. no new misleading control-plane state is required to explain `running_depth`
+6. no new misleading control-plane state is required to explain `running_depth`
 
 ## Non-goals for v1
 

--- a/docs/archive/prd.md
+++ b/docs/archive/prd.md
@@ -1,13 +1,8 @@
 # AWA — Product Requirements Document (archived)
 
-> **Historical product brief — archived.** This document captures the
-> 0.x design intent at the time it was written (early 2026) and is
-> retained for context. It is **not** a description of current behavior;
-> for that, see [`docs/architecture.md`](../architecture.md),
-> [`docs/configuration.md`](../configuration.md), and the ADRs under
-> [`docs/adr/`](../adr/).
+> **Historical product brief — archived.** This document captures the 0.x design intent at the time it was written (early 2026) and is retained for context. It is **not** a description of current behavior; for that, see [`docs/architecture.md`](../architecture.md), [`docs/configuration.md`](../configuration.md), and the ADRs under [`docs/adr/`](../adr/).
 
-*Version: 1.0 — March 2026 (archived)*
+_Version: 1.0 — March 2026 (archived)_
 
 ---
 
@@ -19,7 +14,7 @@ The Rust runtime handles all queue machinery — polling, heartbeating, crash re
 
 **Positioning:** Postgres-native job execution for Rust and Python. One queue engine, two first-class languages.
 
-**Inspirations:** River (Go), Oban (Elixir), GoodJob (Ruby). All three converged on the same core design — Postgres as the only dependency, `SKIP LOCKED` for dispatch, transactional enqueue as the killer feature. None of them provide first-class multi-language *worker execution* — River's Python/Ruby clients are insert-only, Oban has a Python insert library but no workers. Awa's Python workers are full participants backed by a Rust runtime.
+**Inspirations:** River (Go), Oban (Elixir), GoodJob (Ruby). All three converged on the same core design — Postgres as the only dependency, `SKIP LOCKED` for dispatch, transactional enqueue as the killer feature. None of them provide first-class multi-language _worker execution_ — River's Python/Ruby clients are insert-only, Oban has a Python insert library but no workers. Awa's Python workers are full participants backed by a Rust runtime.
 
 ---
 
@@ -30,7 +25,7 @@ The Rust runtime handles all queue machinery — polling, heartbeating, crash re
 Existing Rust Postgres job queues are fragmented and incomplete:
 
 | Library | Status | Weakness |
-|---|---|---|
+| --- | --- | --- |
 | **sqlxmq** | Low activity (sqlx 0.8 update 2024, no new features since) | Best API design but stagnant |
 | **fang** | Active | Multi-backend dilutes PG depth, `typetag` dynamic dispatch |
 | **graphile_worker_rs** | Active | Port of Node.js system, inherits non-Rust conventions |
@@ -42,7 +37,7 @@ Existing Rust Postgres job queues are fragmented and incomplete:
 Python's most popular job queues (Celery, RQ, Dramatiq, ARQ) require Redis or RabbitMQ. Postgres-native alternatives exist but are pure Python — their queue engine performance is bounded by CPython:
 
 | Library | Status | Weakness |
-|---|---|---|
+| --- | --- | --- |
 | **Procrastinate** | Active, mature (v3.7) | Pure Python queue engine. Heartbeats compete with handler for event loop. No cross-language interop. |
 | **PgQueuer** | Active | Newer, less battle-tested. Pure Python. LISTEN/NOTIFY + SKIP LOCKED. |
 | **django-postgres-queue** | Active | Django-only. |
@@ -194,7 +189,7 @@ awa/
 ### Which Crate/Package Do I Depend On?
 
 | I want to… | Language | Depend on |
-|---|---|---|
+| --- | --- | --- |
 | Insert jobs from a Rust service (no worker) | Rust | `awa-model` |
 | Insert AND process jobs | Rust | `awa` (or `awa-model` + `awa-worker`) |
 | Insert and/or process jobs | Python | `pip install awa` |
@@ -226,7 +221,7 @@ scheduled ──(time passes)──▶ available ──(worker claims)──▶ 
 ```
 
 | State | Meaning |
-|---|---|
+| --- | --- |
 | `scheduled` | Enqueued with a future `run_at`. Not yet eligible. |
 | `available` | Ready to be claimed by a worker. |
 | `running` | Claimed. Being heartbeated. Has a hard `deadline_at`. |
@@ -242,7 +237,7 @@ scheduled ──(time passes)──▶ available ──(worker claims)──▶ 
 Five handler outcomes, identical semantics across Rust and Python:
 
 | Category | Rust | Python | Effect |
-|---|---|---|---|
+| --- | --- | --- | --- |
 | **Completed** | `Ok(Completed)` | return `None` | → `completed` |
 | **Retryable error** | `Err(e)` | raise `Exception` | → `retryable` if attempts remain, else `failed`. Increments `attempt`. |
 | **Retry after** | `Ok(RetryAfter(d))` | return `awa.RetryAfter(seconds=N)` | → `retryable` with explicit backoff. Increments `attempt`. |
@@ -252,7 +247,7 @@ Five handler outcomes, identical semantics across Rust and Python:
 **Terminal errors (automatic):**
 
 | Failure | Cause | Behaviour |
-|---|---|---|
+| --- | --- | --- |
 | Args don't match schema | serde failure (Rust), `TypeError`/`ValidationError` (Python) | → `failed` immediately. No retry. Attempt incremented to record the error. |
 | Unknown `kind` | No handler registered | → `failed` immediately or skipped (configurable). |
 | Explicit terminal | `raise awa.TerminalError(...)` (Python) | → `failed` immediately regardless of remaining attempts. |
@@ -402,7 +397,7 @@ CREATE TRIGGER trg_awa_notify
 ## 8. Operational Limits
 
 | Parameter | Limit | Enforcement | Rationale |
-|---|---|---|---|
+| --- | --- | --- | --- |
 | `args` size | 500 KB | Advisory | Dequeue CTE reads full rows. Large args = slow claims. Store large data externally, pass a reference. |
 | `tags` count | 20 | CHECK constraint | Tags are for filtering, not free-form metadata. Use `metadata` JSONB for unbounded data. |
 | `tags` element length | 200 chars | CHECK constraint | Tags should be short labels. |
@@ -495,17 +490,17 @@ The `kind` string is the cross-language contract. Algorithm: CamelCase → snake
 
 **Golden test cases (must pass in both Rust and Python CI):**
 
-| Input | Kind |
-|---|---|
-| `SendEmail` | `send_email` |
+| Input                   | Kind                      |
+| ----------------------- | ------------------------- |
+| `SendEmail`             | `send_email`              |
 | `SendConfirmationEmail` | `send_confirmation_email` |
-| `SMTPEmail` | `smtp_email` |
-| `OAuthRefresh` | `o_auth_refresh` |
-| `PDFRenderJob` | `pdf_render_job` |
-| `ProcessV2Import` | `process_v2_import` |
-| `ReconcileQ3Revenue` | `reconcile_q3_revenue` |
-| `HTMLToPDF` | `html_to_pdf` |
-| `IOError` | `io_error` |
+| `SMTPEmail`             | `smtp_email`              |
+| `OAuthRefresh`          | `o_auth_refresh`          |
+| `PDFRenderJob`          | `pdf_render_job`          |
+| `ProcessV2Import`       | `process_v2_import`       |
+| `ReconcileQ3Revenue`    | `reconcile_q3_revenue`    |
+| `HTMLToPDF`             | `html_to_pdf`             |
+| `IOError`               | `io_error`                |
 
 Override always available: `#[awa(kind = "custom")]` (Rust), `@client.worker(T, kind="custom")` (Python).
 
@@ -625,11 +620,11 @@ RETURNING awa.jobs.*;
 **Priority aging** prevents starvation. A priority-4 job waiting 3× the aging interval becomes effectively priority-1. Default aging interval: 60s. Configurable per queue. Set to `MAX` to disable (strict priority, starvation possible).
 
 | Job priority | Wait time (60s interval) | Effective priority |
-|---|---|---|
-| 4 (low) | 0s | 4 |
-| 4 (low) | 60s | 3 |
-| 4 (low) | 120s | 2 |
-| 4 (low) | 180s+ | 1 (highest) |
+| ------------ | ------------------------ | ------------------ |
+| 4 (low)      | 0s                       | 4                  |
+| 4 (low)      | 60s                      | 3                  |
+| 4 (low)      | 120s                     | 2                  |
+| 4 (low)      | 180s+                    | 1 (highest)        |
 
 **Poll interval:** Default 200ms. LISTEN/NOTIFY wakeup reduces latency to <10ms. LISTEN requires a dedicated connection (one per worker process).
 
@@ -639,12 +634,12 @@ RETURNING awa.jobs.*;
 
 **Signal 2: Hard deadline (runaway protection).** Even healthy-heartbeating jobs are killed at `deadline_at`. Default: 5 minutes from claim. Override at insert time.
 
-| Failure mode | Heartbeat catches it? | Deadline catches it? |
-|---|---|---|
-| Worker killed (OOM, SIGKILL) | Yes | Eventually |
-| Network partition | Yes | Eventually |
-| Infinite loop in handler | No | **Yes** |
-| Deadlocked external call | No | **Yes** |
+| Failure mode                 | Heartbeat catches it? | Deadline catches it? |
+| ---------------------------- | --------------------- | -------------------- |
+| Worker killed (OOM, SIGKILL) | Yes                   | Eventually           |
+| Network partition            | Yes                   | Eventually           |
+| Infinite loop in handler     | No                    | **Yes**              |
+| Deadlocked external call     | No                    | **Yes**              |
 
 **Python advantage (assuming async workers — see Phase 0):** Heartbeat runs on the Rust tokio runtime, not the Python event loop. If Python handler code blocks the event loop, heartbeats continue. Awa preserves queue liveness even when Python handlers misbehave. This does NOT solve bad handler throughput or CPU-bound Python code.
 
@@ -717,15 +712,15 @@ Cross-language golden tests required. JSON canonicalization: UTF-8, sorted keys,
 
 **Unique states bitmask** (bits 0–4 set by default = scheduled, available, running, completed, retryable):
 
-| Bit | State |
-|-----|-------|
-| 0 | scheduled |
-| 1 | available |
-| 2 | running |
-| 3 | completed |
-| 4 | retryable |
-| 5 | failed |
-| 6 | cancelled |
+| Bit | State     |
+| --- | --------- |
+| 0   | scheduled |
+| 1   | available |
+| 2   | running   |
+| 3   | completed |
+| 4   | retryable |
+| 5   | failed    |
+| 6   | cancelled |
 
 Insert uses `ON CONFLICT (unique_key) WHERE ... DO NOTHING`.
 
@@ -747,7 +742,7 @@ Exponential backoff + jitter: `min(2^attempt + jitter, 24h)`. Produces: ~1s, ~2s
 Operators get day-one tools through CLI, Python, Rust, and documented SQL.
 
 | Operation | CLI | Python | Rust |
-|---|---|---|---|
+| --- | --- | --- | --- |
 | Retry one job | `awa job retry <id>` | `await client.retry(id)` | `awa_model::admin::retry(exec, id)` |
 | Cancel one job | `awa job cancel <id>` | `await client.cancel(id)` | `awa_model::admin::cancel(exec, id)` |
 | Retry failed by kind | `awa job retry-failed --kind X` | `await client.retry_failed(kind="X")` | `awa_model::admin::retry_failed_by_kind(...)` |
@@ -846,7 +841,7 @@ health = await client.health_check()
 Awa workers are stateless. Deploy as a `Deployment` with `replicas: N`. All coordination happens through Postgres.
 
 ```yaml
-terminationGracePeriodSeconds: 35  # slightly > drain timeout (30s)
+terminationGracePeriodSeconds: 35 # slightly > drain timeout (30s)
 livenessProbe:
   httpGet: { path: /healthz, port: 8080 }
   initialDelaySeconds: 5
@@ -930,7 +925,7 @@ ERROR awa: job.failed kind=send_email job_id=12347 error="validation_error: fiel
 Run on a single elected leader via `pg_try_advisory_lock`. Maintenance uses reserved connections (`maintenance_pool_size`) to avoid contention with workers.
 
 | Task | Frequency | Description |
-|---|---|---|
+| --- | --- | --- |
 | Heartbeat rescue | 30s | `running` + stale `heartbeat_at` (>90s) → `retryable` |
 | Deadline rescue | 30s | `running` + past `deadline_at` → `retryable` |
 | Scheduled promotion | 5s | `scheduled` past `run_at` → `available` |
@@ -1039,7 +1034,7 @@ Web UI. COPY ingestion. Webhook completion. Periodic/cron jobs. Rate limiting. O
 ## 22. Risks
 
 | Risk | Severity | Mitigation |
-|---|---|---|
+| --- | --- | --- |
 | `pyo3-asyncio` spike fails | **Critical** | Phase 0 gate. Fallback: sync workers on thread pool. |
 | `AwaTransaction` adoption friction | Medium | Honest framing: atomic path, not a DB toolkit. ORM bridging in v0.2. |
 | Maturin/wheel distribution | Medium | `cibuildwheel` + `maturin` in CI. Treat as real workstream. |

--- a/docs/benchmarking.md
+++ b/docs/benchmarking.md
@@ -1,73 +1,39 @@
 # Benchmarking Notes
 
-This document captures the benchmark harnesses used in the repo and a few
-reference results from named development and comparison environments.
+This document captures the benchmark harnesses used in the repo and a few reference results from named development and comparison environments.
 
 ## Reference Environments
 
-- **Developer laptop reference**: Apple M5 MacBook Air (16 GB), PostgreSQL 17
-  in Docker (OrbStack). Several awa-only regression examples below come from
-  this environment.
-- **Dedicated enqueue reference**: PostgreSQL 17 on a separate Linux host.
-  These runs are useful for producer-path shape comparisons and are not
-  published throughput claims.
-- **Cross-system comparison reference**:
-  [postgresql-job-queue-benchmarking](https://github.com/hardbyte/postgresql-job-queue-benchmarking).
-  That repo owns fair-comparison hardware, adapter configuration, raw output,
-  and result summaries. Its default Postgres image is 17.2; `--pg-image
-  postgres:18-alpine` selects PG18.
-- Example commands assume a developer database URL:
-  `postgres://postgres:test@localhost:15432/awa_test`
-- Benchmarks live in:
-  `awa/tests/benchmark_test.rs`
-  `awa/tests/scheduling_benchmark_test.rs`
-  `awa/tests/failure_benchmark_test.rs`
-- Python worker benchmarks live in:
-  `awa-python/scripts/benchmark_runtime.py`
-- Shared output schema:
-  `awa/tests/bench_output.rs` (Rust)
-  `awa-python/scripts/bench_output.py` (Python)
+- **Developer laptop reference**: Apple M5 MacBook Air (16 GB), PostgreSQL 17 in Docker (OrbStack). Several awa-only regression examples below come from this environment.
+- **Dedicated enqueue reference**: PostgreSQL 17 on a separate Linux host. These runs are useful for producer-path shape comparisons and are not published throughput claims.
+- **Cross-system comparison reference**: [postgresql-job-queue-benchmarking](https://github.com/hardbyte/postgresql-job-queue-benchmarking). That repo owns fair-comparison hardware, adapter configuration, raw output, and result summaries. Its default Postgres image is 17.2; `--pg-image postgres:18-alpine` selects PG18.
+- Example commands assume a developer database URL: `postgres://postgres:test@localhost:15432/awa_test`
+- Benchmarks live in: `awa/tests/benchmark_test.rs` `awa/tests/scheduling_benchmark_test.rs` `awa/tests/failure_benchmark_test.rs`
+- Python worker benchmarks live in: `awa-python/scripts/benchmark_runtime.py`
+- Shared output schema: `awa/tests/bench_output.rs` (Rust) `awa-python/scripts/bench_output.py` (Python)
 
-These are engineering benchmarks, not published vendor-style numbers. The main
-goal is to compare shapes, validate architecture changes, and catch
-regressions. Treat each result as tied to the environment named beside it; do
-not compare numbers from different sections as though they came from one
-machine.
+These are engineering benchmarks, not published vendor-style numbers. The main goal is to compare shapes, validate architecture changes, and catch regressions. Treat each result as tied to the environment named beside it; do not compare numbers from different sections as though they came from one machine.
 
 ## North-Star Metrics
 
-Awa's performance target is sustainable end-to-end queue work, not the largest
-enqueue-only number. A benchmark table should lead with:
+Awa's performance target is sustainable end-to-end queue work, not the largest enqueue-only number. A benchmark table should lead with:
 
-- **completed jobs/sec** — durable terminal transitions, not just handler
-  returns
+- **completed jobs/sec** — durable terminal transitions, not just handler returns
 - **p99 end-to-end latency** — producer enqueue to durable completion
-- **queue depth / backlog growth** — whether offered load is being absorbed or
-  stored as future latency
-- **WAL bytes per completed job** — the main Postgres durability budget for the
-  hot path
+- **queue depth / backlog growth** — whether offered load is being absorbed or stored as future latency
+- **WAL bytes per completed job** — the main Postgres durability budget for the hot path
 - **transaction commits per completed job** — connection and commit pressure
-- **dead tuples and prune lag** — whether churn stays bounded under overlap
-  readers, retries, and terminal bursts
+- **dead tuples and prune lag** — whether churn stays bounded under overlap readers, retries, and terminal bursts
 
-Producer throughput is still measured, especially for `INSERT` vs `COPY` and
-`enqueue_shards` sweeps, but it is a secondary producer-path diagnostic. A
-configuration that can enqueue `50k/s` and complete `5k/s` is a backlog and
-latency problem unless the workload is intentionally bursty and has enough
-headroom to drain before the SLA window closes.
+Producer throughput is still measured, especially for `INSERT` vs `COPY` and `enqueue_shards` sweeps, but it is a secondary producer-path diagnostic. A configuration that can enqueue `50k/s` and complete `5k/s` is a backlog and latency problem unless the workload is intentionally bursty and has enough headroom to drain before the SLA window closes.
 
 ## Positioning Proof Checklist
 
 Queue storage changes Awa's comparison set.
 
-The interesting public question is no longer "can Postgres run jobs?" It is
-"can a Postgres job queue keep dispatch latency low while also keeping hot-path
-dead tuples bounded?"
+The interesting public question is no longer "can Postgres run jobs?" It is "can a Postgres job queue keep dispatch latency low while also keeping hot-path dead tuples bounded?"
 
-That means the benchmark burden for positioning is different from the benchmark
-burden for internal regressions. Before making the strongest public claim, the
-comparison needs to be rerun cleanly on the same hardware against the right
-reference points:
+That means the benchmark burden for positioning is different from the benchmark burden for internal regressions. Before making the strongest public claim, the comparison needs to be rerun cleanly on the same hardware against the right reference points:
 
 - Awa queue storage
 - PgQue
@@ -81,31 +47,21 @@ The benchmark set should include:
 - overlap readers / MVCC horizon pressure
 - mixed workload soak
 - terminal-failure burst
-- WAL bytes/job, commit pressure, queue depth, and dead-tuple pressure for every
-  headline table
+- WAL bytes/job, commit pressure, queue depth, and dead-tuple pressure for every headline table
 
 Operational differences should be called out, not hidden:
 
-- Awa does not require `pg_cron`; the worker runtime owns dispatch, rescue,
-  rotation, and prune.
+- Awa does not require `pg_cron`; the worker runtime owns dispatch, rescue, rotation, and prune.
 - PgQue is designed around a periodic ticker and recommends `pg_cron`.
-- River and Oban are job frameworks rather than shared-log event queues, so
-  they remain the more comparable references for worker semantics.
+- River and Oban are job frameworks rather than shared-log event queues, so they remain the more comparable references for worker semantics.
 
-Commands and raw output for any public-facing table should live in-repo under
-`docs/adr/bench/` or another stable location so the resulting claim is
-auditable.
+Commands and raw output for any public-facing table should live in-repo under `docs/adr/bench/` or another stable location so the resulting claim is auditable.
 
 ## Methodology Notes
 
-The most important lesson from this round of work is that benchmark isolation
-matters.
+The most important lesson from this round of work is that benchmark isolation matters.
 
-The maintenance service is global to the worker instance. If a benchmark leaves
-behind millions of deferred rows in `awa.scheduled_jobs`, later "hot path"
-benchmarks may accidentally measure background promotion work as well. The
-sustained hot/deferred benchmarks reset runtime state first to avoid that
-pollution.
+The maintenance service is global to the worker instance. If a benchmark leaves behind millions of deferred rows in `awa.scheduled_jobs`, later "hot path" benchmarks may accidentally measure background promotion work as well. The sustained hot/deferred benchmarks reset runtime state first to avoid that pollution.
 
 Two benchmark shapes are used:
 
@@ -116,26 +72,19 @@ Steady numbers are the better indicator of sustained runtime behavior.
 
 ## MVCC Horizon Benchmark
 
-`awa/tests/scheduling_benchmark_test.rs` also includes an ignored
-`test_mvcc_horizon_overlap_benchmark` scenario for the failure mode described in
-PlanetScale's "Keeping a Postgres queue healthy" post: overlapping long-lived
-transactions pin the MVCC horizon while queue churn continues.
+`awa/tests/scheduling_benchmark_test.rs` also includes an ignored `test_mvcc_horizon_overlap_benchmark` scenario for the failure mode described in PlanetScale's "Keeping a Postgres queue healthy" post: overlapping long-lived transactions pin the MVCC horizon while queue churn continues.
 
 The benchmark:
 
 - runs a steady producer feeding `awa.jobs_hot`
 - enables aggressive completed-job cleanup to generate update/delete churn
-- starts overlapping `REPEATABLE READ` reader transactions on separate
-  connections to hold old snapshots open
-- samples per-second throughput, queue depth, and `pg_stat_user_tables`
-  (`n_dead_tup`, vacuum counters) for `awa.jobs_hot`
+- starts overlapping `REPEATABLE READ` reader transactions on separate connections to hold old snapshots open
+- samples per-second throughput, queue depth, and `pg_stat_user_tables` (`n_dead_tup`, vacuum counters) for `awa.jobs_hot`
 
 Reader modes:
 
-- `idle_snapshot`: pins a snapshot and waits inside the transaction; useful for
-  the pure MVCC-horizon case
-- `active_scan`: runs repeated queue scans inside the open transaction so the
-  reader behaves more like overlapping analytics work on the primary
+- `idle_snapshot`: pins a snapshot and waits inside the transaction; useful for the pure MVCC-horizon case
+- `active_scan`: runs repeated queue scans inside the open transaction so the reader behaves more like overlapping analytics work on the primary
 
 Example:
 
@@ -145,11 +94,9 @@ DATABASE_URL=postgres://postgres:test@localhost:15432/awa_test \
   test_mvcc_horizon_overlap_benchmark -- --ignored --exact --nocapture
 ```
 
-This scenario is also wired into `.github/workflows/nightly-chaos.yml` and runs
-on PostgreSQL 18 in the Rust nightly benchmark lane.
+This scenario is also wired into `.github/workflows/nightly-chaos.yml` and runs on PostgreSQL 18 in the Rust nightly benchmark lane.
 
-The nightly lane uses a shorter CI profile so the benchmark stays cheap on
-shared runners while still exercising overlap readers and cleanup pressure:
+The nightly lane uses a shorter CI profile so the benchmark stays cheap on shared runners while still exercising overlap readers and cleanup pressure:
 
 - `AWA_MVCC_JOB_RATE=400`
 - `AWA_MVCC_BASELINE_SECS=5`
@@ -161,20 +108,11 @@ shared runners while still exercising overlap readers and cleanup pressure:
 - `AWA_MVCC_READER_MODE=active_scan`
 - `AWA_MVCC_ANALYTICS_TICK_MS=500`
 
-Nightly regression checks use per-run ratios (`overlap_handler_per_s` and
-`cooldown_handler_per_s` relative to the same run's baseline window) plus
-guardrails on `dead_tup_delta` and `max_available`.
+Nightly regression checks use per-run ratios (`overlap_handler_per_s` and `cooldown_handler_per_s` relative to the same run's baseline window) plus guardrails on `dead_tup_delta` and `max_available`.
 
-That nightly profile is intentionally short. It checks that Awa still behaves
-reasonably under overlapping analytical readers, but it is not the same thing
-as the 15-minute mixed-workload soak discussed in the PlanetScale post. For a
-closer reproduction, increase duration and reader hold times and keep the
-readers in `active_scan` mode so queries overlap continuously rather than
-simulating only `idle in transaction`.
+That nightly profile is intentionally short. It checks that Awa still behaves reasonably under overlapping analytical readers, but it is not the same thing as the 15-minute mixed-workload soak discussed in the PlanetScale post. For a closer reproduction, increase duration and reader hold times and keep the readers in `active_scan` mode so queries overlap continuously rather than simulating only `idle in transaction`.
 
-A second ignored benchmark target now exists for that longer profile:
-`test_mvcc_horizon_planetscale_soak`. Its default shape is closer to the blog's
-mixed-workload setup:
+A second ignored benchmark target now exists for that longer profile: `test_mvcc_horizon_planetscale_soak`. Its default shape is closer to the blog's mixed-workload setup:
 
 - `800` jobs/sec producer rate
 - `3` overlapping analytics readers
@@ -182,131 +120,74 @@ mixed-workload setup:
 - `20s` stagger between readers
 - `15m` overlap window with `active_scan`
 
-That soak benchmark is wired into CI as a weekly/manual run, while the shorter
-`test_mvcc_horizon_overlap_benchmark` remains the daily nightly smoke.
+That soak benchmark is wired into CI as a weekly/manual run, while the shorter `test_mvcc_horizon_overlap_benchmark` remains the daily nightly smoke.
 
 ### MVCC bench knobs
 
 - `AWA_MVCC_JOB_RATE` — steady producer rate in jobs/sec
 - `AWA_MVCC_BASELINE_SECS` / `AWA_MVCC_OVERLAP_SECS` / `AWA_MVCC_COOLDOWN_SECS`
-- `AWA_MVCC_OVERLAP_READERS` / `AWA_MVCC_OVERLAP_HOLD_SECS` /
-  `AWA_MVCC_OVERLAP_STAGGER_SECS`
+- `AWA_MVCC_OVERLAP_READERS` / `AWA_MVCC_OVERLAP_HOLD_SECS` / `AWA_MVCC_OVERLAP_STAGGER_SECS`
 - `AWA_MVCC_READER_MODE` — `idle_snapshot` or `active_scan`
-- `AWA_MVCC_ANALYTICS_TICK_MS` — cadence for repeated analytics scans in
-  `active_scan` mode
+- `AWA_MVCC_ANALYTICS_TICK_MS` — cadence for repeated analytics scans in `active_scan` mode
 - `AWA_MVCC_CLEANUP_INTERVAL_MS` / `AWA_MVCC_CLEANUP_BATCH_SIZE`
 
 ## Cross-system comparison
 
-The awa benches in this file are the awa-only regression detection track —
-fast, precise, hard thresholds, awa code only. They are not designed for
-fair comparison with other systems.
+The awa benches in this file are the awa-only regression detection track — fast, precise, hard thresholds, awa code only. They are not designed for fair comparison with other systems.
 
-For cross-system comparison, the long-horizon harness lives in a separate
-repository so each system-under-test can be benchmarked through its public
-API on equal footing:
+For cross-system comparison, the long-horizon harness lives in a separate repository so each system-under-test can be benchmarked through its public API on equal footing:
 
 [**hardbyte/postgresql-job-queue-benchmarking**](https://github.com/hardbyte/postgresql-job-queue-benchmarking)
 
-The companion repo currently benchmarks awa against pgque, procrastinate,
-pg-boss, river, oban, and pgmq using a shared subprocess contract: each
-adapter is a self-contained binary that emits one JSON sample per line.
-Headline numbers, per-system architectural notes, and reproducible run
-instructions are in that repo's
-[`SYSTEM_COMPARISONS.md`](https://github.com/hardbyte/postgresql-job-queue-benchmarking/blob/main/SYSTEM_COMPARISONS.md)
-and [`results/2026-04-28/SUMMARY.md`](https://github.com/hardbyte/postgresql-job-queue-benchmarking/blob/main/results/2026-04-28/SUMMARY.md).
+The companion repo currently benchmarks awa against pgque, procrastinate, pg-boss, river, oban, and pgmq using a shared subprocess contract: each adapter is a self-contained binary that emits one JSON sample per line. Headline numbers, per-system architectural notes, and reproducible run instructions are in that repo's [`SYSTEM_COMPARISONS.md`](https://github.com/hardbyte/postgresql-job-queue-benchmarking/blob/main/SYSTEM_COMPARISONS.md) and [`results/2026-04-28/SUMMARY.md`](https://github.com/hardbyte/postgresql-job-queue-benchmarking/blob/main/results/2026-04-28/SUMMARY.md).
 
-The two tracks are deliberately separate. If they ever diverge on
-workload shape or thresholds, the awa-only benches in this file are
-canonical for awa's own numbers and the cross-system runner defers.
+The two tracks are deliberately separate. If they ever diverge on workload shape or thresholds, the awa-only benches in this file are canonical for awa's own numbers and the cross-system runner defers.
 
 ### 2026-05-03 cross-system reference run
 
-An overnight run of the companion benchmark repo compared `awa` 0.6 alpha
-builds with the same phase-driven harness. Treat these as reference results for
-shape and regression tracking, not universal product guarantees.
+An overnight run of the companion benchmark repo compared `awa` 0.6 alpha builds with the same phase-driven harness. Treat these as reference results for shape and regression tracking, not universal product guarantees.
 
 Key observations:
 
-- `awa` peak throughput improved by `49%` from 0.6.0-alpha.2 to
-  0.6.0-alpha.3 at 128 workers and one replica: `4,576` to `6,834` jobs/s.
-  The same run showed a roughly `1.5x` to `1.7x` improvement across the
-  worker-count matrix.
-- Phase A matrix shape for `awa`: `296` -> `1,115` -> `3,961` -> `6,834`
-  jobs/s as worker count increased.
-- Phase B `pgmq` peaked at `13,290` jobs/s at 16 workers and collapsed at
-  128 workers, matching the previously observed high-worker behaviour.
-- Phase C multi-replica runs exposed the remaining `awa` topology sensitivity:
-  at fixed total workers, throughput fell from `3,560` to `2,491` to `1,503`
-  jobs/s across `1x64`, `2x32`, and `4x16`. That shape is consistent with
-  fleet-wide completion flusher contention (`processes x AWA_COMPLETION_SHARDS`).
-  `pgque` moved in the opposite direction in the same run (`18,660` ->
-  `34,388` -> `38,810`), so this remains a useful comparison target rather
-  than noise to smooth over.
-- Phase D 60-minute `awa` soak sustained a median `5,369` jobs/s with median
-  dead tuples around `396`, validating the ADR-019 / ADR-023 hot-path
-  dead-tuple promise under sustained churn.
+- `awa` peak throughput improved by `49%` from 0.6.0-alpha.2 to 0.6.0-alpha.3 at 128 workers and one replica: `4,576` to `6,834` jobs/s. The same run showed a roughly `1.5x` to `1.7x` improvement across the worker-count matrix.
+- Phase A matrix shape for `awa`: `296` -> `1,115` -> `3,961` -> `6,834` jobs/s as worker count increased.
+- Phase B `pgmq` peaked at `13,290` jobs/s at 16 workers and collapsed at 128 workers, matching the previously observed high-worker behaviour.
+- Phase C multi-replica runs exposed the remaining `awa` topology sensitivity: at fixed total workers, throughput fell from `3,560` to `2,491` to `1,503` jobs/s across `1x64`, `2x32`, and `4x16`. That shape is consistent with fleet-wide completion flusher contention (`processes x AWA_COMPLETION_SHARDS`). `pgque` moved in the opposite direction in the same run (`18,660` -> `34,388` -> `38,810`), so this remains a useful comparison target rather than noise to smooth over.
+- Phase D 60-minute `awa` soak sustained a median `5,369` jobs/s with median dead tuples around `396`, validating the ADR-019 / ADR-023 hot-path dead-tuple promise under sustained churn.
 
-Queue-storage e2e sweeps separate tuning from storage design. For the hot
-single-queue shape, `enqueue_shards = 4` plus larger completion batches
-sustained `7.9k` completed jobs/s with `200ms` p99 end-to-end latency and
-bounded depth. Increasing `claimers` did not materially improve that shape.
+Queue-storage e2e sweeps separate tuning from storage design. For the hot single-queue shape, `enqueue_shards = 4` plus larger completion batches sustained `7.9k` completed jobs/s with `200ms` p99 end-to-end latency and bounded depth. Increasing `claimers` did not materially improve that shape.
 
-The offered-rate benchmark exercises absorption directly and samples WAL. With
-one claimer, `claim_batch_size = 512`, `AWA_COMPLETION_BATCH_SIZE = 512`, the
-fused receipt completion path, and `max_workers = 1024`, a 10-second no-op run
-at `10k/s` offered load keeps durable completions at the offered rate, drains
-to zero backlog, and writes `1.80 KiB` WAL per completed job. `max_workers =
-512` is close but does not consistently meet the 10k offered target, because
-no-op handlers hold permits while waiting for durable completion
-acknowledgement.
+The offered-rate benchmark exercises absorption directly and samples WAL. With one claimer, `claim_batch_size = 512`, `AWA_COMPLETION_BATCH_SIZE = 512`, the fused receipt completion path, and `max_workers = 1024`, a 10-second no-op run at `10k/s` offered load keeps durable completions at the offered rate, drains to zero backlog, and writes `1.80 KiB` WAL per completed job. `max_workers = 512` is close but does not consistently meet the 10k offered target, because no-op handlers hold permits while waiting for durable completion acknowledgement.
 
-First-principles WAL accounting then compared the production path, a narrow
-`done_entries` row, and a deliberately non-production path that skipped
-`done_entries` entirely:
+First-principles WAL accounting then compared the production path, a narrow `done_entries` row, and a deliberately non-production path that skipped `done_entries` entirely:
 
-| Shape | Completed jobs/s | p99 e2e | WAL/job |
-|---|---:|---:|---:|
-| Tuned production queue storage | `7,885/s` | `203 ms` | `2,241 B` |
-| Narrow terminal history | `8,337/s` | `205 ms` | `1,932 B` |
-| Skip `done_entries` entirely | `8,402/s` | `230 ms` | `1,441 B` |
+| Shape                          | Completed jobs/s |  p99 e2e |   WAL/job |
+| ------------------------------ | ---------------: | -------: | --------: |
+| Tuned production queue storage |        `7,885/s` | `203 ms` | `2,241 B` |
+| Narrow terminal history        |        `8,337/s` | `205 ms` | `1,932 B` |
+| Skip `done_entries` entirely   |        `8,402/s` | `230 ms` | `1,441 B` |
 
-The shipped design is the middle row: keep the durable terminal fact, but avoid
-duplicating immutable ready-body fields on ready-backed terminal rows. The
-skip-`done_entries` experiment remains rejected because it weakens the
-terminal-history contract, and its small throughput gain over narrow terminal
-history points at durable WAL write/sync pressure rather than a hidden per-job
-query loop as the next ceiling.
+The shipped design is the middle row: keep the durable terminal fact, but avoid duplicating immutable ready-body fields on ready-backed terminal rows. The skip-`done_entries` experiment remains rejected because it weakens the terminal-history contract, and its small throughput gain over narrow terminal history points at durable WAL write/sync pressure rather than a hidden per-job query loop as the next ceiling.
 
 ### Queue-storage striping reference
 
-Queue striping is a contention-control knob for workloads dominated by one hot
-logical queue. The companion benchmark repo includes an awa-only sweep of
-`queue_storage_queue_stripe_count` over `1`, `2`, and `4` at `64`, `128`,
-`256`, and `512` workers. The source artifact lives in companion benchmark PR
-[#21](https://github.com/hardbyte/postgresql-job-queue-benchmarking/pull/21).
+Queue striping is a contention-control knob for workloads dominated by one hot logical queue. The companion benchmark repo includes an awa-only sweep of `queue_storage_queue_stripe_count` over `1`, `2`, and `4` at `64`, `128`, `256`, and `512` workers. The source artifact lives in companion benchmark PR [#21](https://github.com/hardbyte/postgresql-job-queue-benchmarking/pull/21).
 
 Reference result:
 
 | Stripes | 64 workers | 128 workers | 256 workers | 512 workers |
-|---:|---:|---:|---:|---:|
-| 1 | `3,408/s` | `4,741/s` | `9,530/s` | `11,188/s` |
-| 2 | `4,654/s` | `7,667/s` | `11,975/s` | `11,173/s` |
-| 4 | `4,378/s` | `7,596/s` | `11,418/s` | `11,443/s` |
+| ------: | ---------: | ----------: | ----------: | ----------: |
+|       1 |  `3,408/s` |   `4,741/s` |   `9,530/s` |  `11,188/s` |
+|       2 |  `4,654/s` |   `7,667/s` |  `11,975/s` |  `11,173/s` |
+|       4 |  `4,378/s` |   `7,596/s` |  `11,418/s` |  `11,443/s` |
 
-The clearest gain was the `1 -> 2` stripe step: at `128` workers throughput
-rose by `62%`, and at `256` workers throughput rose by `26%` while end-to-end
-p99 fell from `1,802 ms` to `1,027 ms`. `4` stripes mostly matched `2` stripes
-in this shape, with the only clear advantage at the `512` worker tail.
+The clearest gain was the `1 -> 2` stripe step: at `128` workers throughput rose by `62%`, and at `256` workers throughput rose by `26%` while end-to-end p99 fell from `1,802 ms` to `1,027 ms`. `4` stripes mostly matched `2` stripes in this shape, with the only clear advantage at the `512` worker tail.
 
-Treat this as tuning guidance, not an out-of-the-box setting. The default stays
-`queue_storage_queue_stripe_count=1`; hot single-queue deployments should
-consider `2` after measuring their own worker/replica shape.
+Treat this as tuning guidance, not an out-of-the-box setting. The default stays `queue_storage_queue_stripe_count=1`; hot single-queue deployments should consider `2` after measuring their own worker/replica shape.
 
 ## Python Runtime Benchmarks
 
-The Python benchmark script exercises the real `awa-python` worker path while
-reusing the same database-facing benchmark shapes as the Rust runtime:
+The Python benchmark script exercises the real `awa-python` worker path while reusing the same database-facing benchmark shapes as the Rust runtime:
 
 **Baseline scenarios** (`--scenario baseline`):
 
@@ -321,22 +202,17 @@ reusing the same database-facing benchmark shapes as the Rust runtime:
 - `callback_timeout_10pct`: callback registration with short timeout
 - `mixed_50pct`: rotating through terminal, retryable, and success modes
 
-The worker-focused scenarios seed with SQL directly so the reported number is
-about Python handler dispatch and runtime behavior, not enqueue serialization.
+The worker-focused scenarios seed with SQL directly so the reported number is about Python handler dispatch and runtime behavior, not enqueue serialization.
 
 ## Reference Results
 
 ### Immediate Enqueue Throughput
 
-The enqueue path that is being measured here has a few important architectural
-properties:
+The enqueue path that is being measured here has a few important architectural properties:
 
-- homogeneous inserts now route directly to `awa.jobs_hot` or
-  `awa.scheduled_jobs` instead of going through the compatibility view
-- admin metadata maintenance moved from row-level triggers to statement-level
-  trigger batches
-- COPY staging now reuses a session-local temp table and stages typed values
-  instead of reparsing text on the final `INSERT ... SELECT`
+- homogeneous inserts now route directly to `awa.jobs_hot` or `awa.scheduled_jobs` instead of going through the compatibility view
+- admin metadata maintenance moved from row-level triggers to statement-level trigger batches
+- COPY staging now reuses a session-local temp table and stages typed values instead of reparsing text on the final `INSERT ... SELECT`
 
 Example reference result from the developer laptop reference:
 
@@ -348,8 +224,7 @@ Example reference result from the developer laptop reference:
   - `insert_contention_same_queue` (4 producers x 3k): about `95k inserts/s`
   - `copy_contention_same_queue` (4 producers x 3k, chunk 1000): about `67k inserts/s`
 
-These are engineering comparisons, not product guarantees. Their main value is
-showing where the architecture bottlenecks move as the implementation changes.
+These are engineering comparisons, not product guarantees. Their main value is showing where the architecture bottlenecks move as the implementation changes.
 
 ### Sustained Hot Path
 
@@ -359,39 +234,27 @@ Measured with `test_runtime_sustained_hot_path` after resetting runtime state:
 - measurement window: 10s
 - queue size seeded: 200,000 immediately-available jobs
 
-Example reference result from the developer laptop reference (release mode,
-v0.5.0-alpha.0):
+Example reference result from the developer laptop reference (release mode, v0.5.0-alpha.0):
 
 - handler returns: about `5.6k jobs/s`
 - DB `completed` transitions: about `5.6k jobs/s`
 
-This benchmark enables the in-memory OpenTelemetry exporter and the
-production alerting metrics path (queue depth, lag, wait-duration histogram).
-Back-to-back A/B testing in the same reference environment shows v0.5.0 is
-~44% faster than v0.4.1 (5.9k vs 4.1k/s) — the promotion query optimizations
-more than offset the metrics instrumentation cost.
+This benchmark enables the in-memory OpenTelemetry exporter and the production alerting metrics path (queue depth, lag, wait-duration histogram). Back-to-back A/B testing in the same reference environment shows v0.5.0 is ~44% faster than v0.4.1 (5.9k vs 4.1k/s) — the promotion query optimizations more than offset the metrics instrumentation cost.
 
 ### Python Runtime Baseline
 
-Measured with `awa-python/scripts/benchmark_runtime.py` on the developer
-laptop reference database:
+Measured with `awa-python/scripts/benchmark_runtime.py` on the developer laptop reference database:
 
 - `enqueue_many_copy`: about `16.2k jobs/s` (`50,000` jobs in `3.09s`)
 - sustained hot path:
   - handler returns: about `3.2k jobs/s`
   - DB `completed` transitions: about `3.1k jobs/s`
 
-The `copy` scenario measures producer serialization and direct queue-storage
-COPY. The worker-focused scenarios seed with SQL so the runtime number is not
-dominated by Python-side enqueue serialization.
+The `copy` scenario measures producer serialization and direct queue-storage COPY. The worker-focused scenarios seed with SQL so the runtime number is not dominated by Python-side enqueue serialization.
 
 ### Deep Backlog Drain
 
-`test_queue_storage_deep_backlog_drain_benchmark` is an ignored regression
-benchmark for the spike shape where a large ready backlog drains more slowly
-than the same fleet processes steady offered load. It seeds with direct
-queue-storage COPY, optionally analyzes `ready_entries`, then measures
-claim/complete throughput and claim latency while draining a fixed backlog.
+`test_queue_storage_deep_backlog_drain_benchmark` is an ignored regression benchmark for the spike shape where a large ready backlog drains more slowly than the same fleet processes steady offered load. It seeds with direct queue-storage COPY, optionally analyzes `ready_entries`, then measures claim/complete throughput and claim latency while draining a fixed backlog.
 
 ```bash
 DATABASE_URL_QUEUE_STORAGE=postgres://postgres:test@localhost:15432/awa_test_queue_storage \
@@ -423,8 +286,7 @@ Measured with `test_scheduled_steady_10m_due_1k_per_sec`:
 Isolated 4-thread Tokio runtime result (release mode, v0.5.0-alpha.0):
 
 - `9,000` of `10,000` due jobs completed within the window
-- per-second completions: `0, 1000, 1000, 1000, 1000, 1000, 1000, 1000, 1000, 1000`
-  — perfectly steady after the first-tick startup delay
+- per-second completions: `0, 1000, 1000, 1000, 1000, 1000, 1000, 1000, 1000, 1000` — perfectly steady after the first-tick startup delay
 - pickup lateness:
   - `p50`: `229 ms`
   - `p95`: `332 ms`
@@ -432,15 +294,9 @@ Isolated 4-thread Tokio runtime result (release mode, v0.5.0-alpha.0):
 - promotion: `354` batches, mean `4.3 ms`, max `59 ms`
 - claim latency: mean `5.0 ms`
 
-This demonstrates that the hot/deferred split with literal-state promotion
-queries handles a 10M-row deferred frontier with steady, predictable throughput.
+This demonstrates that the hot/deferred split with literal-state promotion queries handles a 10M-row deferred frontier with steady, predictable throughput.
 
-**Key optimization (v0.5.0):** Promotion queries use literal state values
-(e.g., `WHERE state = 'scheduled'`) instead of parameterized (`WHERE state = $1`).
-This allows the Postgres planner to match the partial index
-`idx_awa_scheduled_jobs_run_at_scheduled` at plan time. With a parameterized
-query, the planner falls back to a full bitmap scan on multi-million-row tables,
-degrading promotion from ~4ms to ~400ms per batch (100x slower).
+**Key optimization (v0.5.0):** Promotion queries use literal state values (e.g., `WHERE state = 'scheduled'`) instead of parameterized (`WHERE state = $1`). This allows the Postgres planner to match the partial index `idx_awa_scheduled_jobs_run_at_scheduled` at plan time. With a parameterized query, the planner falls back to a full bitmap scan on multi-million-row tables, degrading promotion from ~4ms to ~400ms per batch (100x slower).
 
 ### Moderate Deferred Frontier — Higher Due Rate
 
@@ -457,8 +313,7 @@ Result (v0.5.0-alpha.0):
 - promotion: `214` batches, mean `10.0 ms`, max `176 ms`
 - claim latency: mean `12.4 ms`
 
-This validates the architecture at a realistic production scale: 2M deferred
-rows with 4k/s throughput and reliable promotion.
+This validates the architecture at a realistic production scale: 2M deferred rows with 4k/s throughput and reliable promotion.
 
 ### High-Rate Deferred Frontier: 10M at 6k/s
 
@@ -475,103 +330,59 @@ Result:
 - pickup lateness: `p50`: `0 ms`, `p95`: `310 ms`, `p99`: `476 ms`
 - promotion: `242` batches, mean `6.4 ms`, max `99 ms`
 
-This rate was previously a documented scaling limit (only 20-57k of 60k
-promoted, promotion at 1.7-3.6s per batch). The literal-state promotion
-fix (v0.5.0) eliminated the bottleneck entirely.
+This rate was previously a documented scaling limit (only 20-57k of 60k promoted, promotion at 1.7-3.6s per batch). The literal-state promotion fix (v0.5.0) eliminated the bottleneck entirely.
 
 **Promotion and completion throughput knobs:**
 
 - `promote_interval` (default `250 ms`): how often promotion runs
 - `AWA_COMPLETION_FLUSH_MS` (default `1 ms`): completion batcher flush interval
-- `AWA_COMPLETION_BATCH_SIZE` (default `512`): max rows per completion-batcher
-  flush. Queue-storage short-job completion uses a fused receipt-close +
-  terminal-insert statement, so the default keeps finalization latency low
-  while still amortising durable completion work under load.
-- `AWA_COMPLETION_SHARDS`: number of parallel completion flushers. The
-  runtime default is storage-dependent: `8` for canonical storage and `1`
-  for queue storage. Queue storage starts conservative because the terminal /
-  receipt path already batches heavily and the effective fleet-wide flusher
-  count is `processes × AWA_COMPLETION_SHARDS`. Increase only after measuring
-  end-to-end throughput, p99 latency, WAL bytes/job, and dead tuples for the
-  target worker-process topology.
+- `AWA_COMPLETION_BATCH_SIZE` (default `512`): max rows per completion-batcher flush. Queue-storage short-job completion uses a fused receipt-close + terminal-insert statement, so the default keeps finalization latency low while still amortising durable completion work under load.
+- `AWA_COMPLETION_SHARDS`: number of parallel completion flushers. The runtime default is storage-dependent: `8` for canonical storage and `1` for queue storage. Queue storage starts conservative because the terminal / receipt path already batches heavily and the effective fleet-wide flusher count is `processes × AWA_COMPLETION_SHARDS`. Increase only after measuring end-to-end throughput, p99 latency, WAL bytes/job, and dead tuples for the target worker-process topology.
 
-Internal promotion constants are fixed in the runtime:
-`PROMOTE_BATCH_SIZE = 4,096` rows per promotion batch and
-`PROMOTE_MAX_BATCHES_PER_TICK = 32` batches per maintenance tick. They are not
-environment variables or builder options.
+Internal promotion constants are fixed in the runtime: `PROMOTE_BATCH_SIZE = 4,096` rows per promotion batch and `PROMOTE_MAX_BATCHES_PER_TICK = 32` batches per maintenance tick. They are not environment variables or builder options.
 
 ### Concurrent Multi-Queue Lifecycle
 
-Measured with `concurrent_lifecycle_test.rs`. Four queues (`email:32`,
-`payments:16`, `analytics:64`, `webhooks:16` workers), 128 total workers,
-full insert → claim → execute → complete lifecycle.
+Measured with `concurrent_lifecycle_test.rs`. Four queues (`email:32`, `payments:16`, `analytics:64`, `webhooks:16` workers), 128 total workers, full insert → claim → execute → complete lifecycle.
 
 Queue-count sweep with 128 total workers, pool=50, 20k jobs (release mode):
 
-| Config | Workers/queue | Throughput | Per-worker |
-|--------|--------------|------------|------------|
-| 1 queue × 128 | 128 | `~1.9k/s` | `~14/s` |
-| 2 queues × 64 | 64 | `~2.0k/s` | `~15/s` |
-| 4 queues × 32 | 32 | `~350/s` | `~2.7/s` |
+| Config        | Workers/queue | Throughput | Per-worker |
+| ------------- | ------------- | ---------- | ---------- |
+| 1 queue × 128 | 128           | `~1.9k/s`  | `~14/s`    |
+| 2 queues × 64 | 64            | `~2.0k/s`  | `~15/s`    |
+| 4 queues × 32 | 32            | `~350/s`   | `~2.7/s`   |
 
-**Key finding**: 1-queue and 2-queue throughput is essentially identical,
-but 4 queues drops 5-6x. The cliff between 2 and 4 queues indicates
-that the per-queue dispatcher overhead (separate claim query, PgListener,
-semaphore) compounds non-linearly when many small queues share a pool.
+**Key finding**: 1-queue and 2-queue throughput is essentially identical, but 4 queues drops 5-6x. The cliff between 2 and 4 queues indicates that the per-queue dispatcher overhead (separate claim query, PgListener, semaphore) compounds non-linearly when many small queues share a pool.
 
-For comparison, the hot-path benchmark (200k pre-seeded into `jobs_hot`
-via SQL) reaches `~10k/s` because it bypasses insert triggers and has a
-fully warmed dispatch pipeline. The lifecycle benchmarks exercise the
-complete path including job-state triggers and notification.
+For comparison, the hot-path benchmark (200k pre-seeded into `jobs_hot` via SQL) reaches `~10k/s` because it bypasses insert triggers and has a fully warmed dispatch pipeline. The lifecycle benchmarks exercise the complete path including job-state triggers and notification.
 
 **Tuning guidelines**:
 
-- Size the connection pool to at least `num_queues * 4 + 20`. With
-  4 queues, that's 36+ connections.
-- Prefer fewer queues with larger worker pools over many small queues.
-  2 queues × 64 workers performs the same as 1 × 128.
-- Use multi-queue for isolation, priority, or rate limiting — not for
-  throughput.
+- Size the connection pool to at least `num_queues * 4 + 20`. With 4 queues, that's 36+ connections.
+- Prefer fewer queues with larger worker pools over many small queues. 2 queues × 64 workers performs the same as 1 × 128.
+- Use multi-queue for isolation, priority, or rate limiting — not for throughput.
 
-A unified cross-queue claim query (one SQL round-trip claiming across all
-queues via `LATERAL JOIN`) could eliminate the per-queue dispatch overhead.
-Prototyping shows 16ms for 48 jobs across 2 queues — comparable to
-single-queue performance. This is tracked as a future optimization.
+A unified cross-queue claim query (one SQL round-trip claiming across all queues via `LATERAL JOIN`) could eliminate the per-queue dispatch overhead. Prototyping shows 16ms for 48 jobs across 2 queues — comparable to single-queue performance. This is tracked as a future optimization.
 
 ### Progress Feature Overhead
 
-ADR-014 introduced the user-facing structured progress API and a two-tier
-heartbeat flush. In the current queue-storage engine, mutable progress lives in
-`{schema}.attempt_state` only after an attempt first needs per-attempt mutable
-state; short jobs that never report progress do not allocate an
-`attempt_state` row. Older benchmark notes refer to `progress` columns on
-`jobs_hot` / `scheduled_jobs`, which was the canonical-storage implementation.
+ADR-014 introduced the user-facing structured progress API and a two-tier heartbeat flush. In the current queue-storage engine, mutable progress lives in `{schema}.attempt_state` only after an attempt first needs per-attempt mutable state; short jobs that never report progress do not allocate an `attempt_state` row. Older benchmark notes refer to `progress` columns on `jobs_hot` / `scheduled_jobs`, which was the canonical-storage implementation.
 
 Performance impact was validated:
 
-- **Zero overhead when no progress is set.** The heartbeat service
-  partitions jobs by pending progress; jobs without mutations use the
-  heartbeat-only path, and `snapshot_pending_progress` returns empty when no
-  generation has been bumped.
-- **Completion remains narrow.** Successful completion clears the progress
-  snapshot while closing the attempt. On queue storage this is handled through
-  the attempt-state / terminal-snapshot path rather than rewriting the ready
-  row.
-- **Sustained hot-path throughput** was unchanged when the progress feature
-  was added. Current hot-path throughput (~5.6k/s) reflects the additional
-  v0.5.0 OTel metrics instrumentation, not progress overhead.
+- **Zero overhead when no progress is set.** The heartbeat service partitions jobs by pending progress; jobs without mutations use the heartbeat-only path, and `snapshot_pending_progress` returns empty when no generation has been bumped.
+- **Completion remains narrow.** Successful completion clears the progress snapshot while closing the attempt. On queue storage this is handled through the attempt-state / terminal-snapshot path rather than rewriting the ready row.
+- **Sustained hot-path throughput** was unchanged when the progress feature was added. Current hot-path throughput (~5.6k/s) reflects the additional v0.5.0 OTel metrics instrumentation, not progress overhead.
 
 ## Failure-Mode Benchmarks
 
-The failure-mode benchmark suite measures throughput, drain time, and recovery
-behaviour when a configurable percentage of jobs fail, retry, hang, or trigger
-rescue paths. This answers a question the happy-path benchmarks cannot: **how
-does failure impact healthy-job throughput?**
+The failure-mode benchmark suite measures throughput, drain time, and recovery behaviour when a configurable percentage of jobs fail, retry, hang, or trigger rescue paths. This answers a question the happy-path benchmarks cannot: **how does failure impact healthy-job throughput?**
 
 ### Benchmark matrix
 
 | Scenario | Description |
-|----------|-------------|
+| --- | --- |
 | `terminal_1pct` / `10pct` / `50pct` | N% of jobs fail terminally |
 | `retryable_1pct` / `10pct` / `50pct` | N% of jobs fail once then succeed on retry |
 | `callback_timeout_10pct` | 10% register a callback that times out, then succeed on retry |
@@ -582,31 +393,22 @@ does failure impact healthy-job throughput?**
 
 ### Rust harness
 
-Tests live in `awa/tests/failure_benchmark_test.rs`. Each scenario seeds jobs
-deterministically by mode, starts a Client with aggressive rescue intervals,
-drains to terminal states, and emits both human-readable output and a JSONL
-record. The full matrix command covers the 10 failure scenarios; the
-stale-heartbeat rescue benchmark is a separate test.
+Tests live in `awa/tests/failure_benchmark_test.rs`. Each scenario seeds jobs deterministically by mode, starts a Client with aggressive rescue intervals, drains to terminal states, and emits both human-readable output and a JSONL record. The full matrix command covers the 10 failure scenarios; the stale-heartbeat rescue benchmark is a separate test.
 
 ### Python harness
 
-The Python benchmark (`awa-python/scripts/benchmark_runtime.py`) supports a
-failure-mode subset via `--scenario failures`:
+The Python benchmark (`awa-python/scripts/benchmark_runtime.py`) supports a failure-mode subset via `--scenario failures`:
 
 - `terminal_1pct` / `10pct` / `50pct`
 - `retryable_1pct` / `10pct` / `50pct`
 - `callback_timeout_10pct`
 - `mixed_50pct`
 
-Python also includes heartbeat rescue via `--scenario rescue`. It still does
-not include the Rust-only `deadline_hang` and `snooze_once` scenarios. The
-worker returns `RetryAfter`, `WaitForCallback`, `Cancel`, or raises exceptions
-based on the job's `mode` field.
+Python also includes heartbeat rescue via `--scenario rescue`. It still does not include the Rust-only `deadline_hang` and `snooze_once` scenarios. The worker returns `RetryAfter`, `WaitForCallback`, `Cancel`, or raises exceptions based on the job's `mode` field.
 
 ### Structured output
 
-Both Rust and Python benchmarks emit one JSONL record per scenario, prefixed
-with `@@BENCH_JSON@@` for extraction. Schema version 2:
+Both Rust and Python benchmarks emit one JSONL record per scenario, prefixed with `@@BENCH_JSON@@` for extraction. Schema version 2:
 
 ```json
 {
@@ -634,25 +436,16 @@ with `@@BENCH_JSON@@` for extraction. Schema version 2:
 
 Extract JSONL from mixed stdout: `grep '@@BENCH_JSON@@' output.txt | sed 's/^@@BENCH_JSON@@//'`
 
-For enqueue-only benchmarks (`insert_only_single`, `copy_single`, and the
-contention matrix), `metrics.enqueue_per_s` is emitted instead of
-`metrics.throughput`. Those records still include `"measurement": "enqueue"` in
-`metadata`, plus optional Postgres-side deltas such as `wal_bytes`,
-`temp_bytes_delta`, and `xact_commit_delta`.
+For enqueue-only benchmarks (`insert_only_single`, `copy_single`, and the contention matrix), `metrics.enqueue_per_s` is emitted instead of `metrics.throughput`. Those records still include `"measurement": "enqueue"` in `metadata`, plus optional Postgres-side deltas such as `wal_bytes`, `temp_bytes_delta`, and `xact_commit_delta`.
 
 ## Interpreting The Results
 
 Some practical guidelines:
 
-- Compare like with like. Burst/frontier benchmarks and steady-state benchmarks
-  answer different questions.
-- Reset runtime state before sustained measurements if you want to isolate one
-  path. Global background work can distort results.
-- Prefer the `db_completed_delta` view when you care about end-to-end queue
-  completion, not just handler return rate.
-- Treat the numbers here as environment-specific reference points, not portable
-  guarantees. For cross-system claims, use the companion comparison repo and
-  its recorded environment.
+- Compare like with like. Burst/frontier benchmarks and steady-state benchmarks answer different questions.
+- Reset runtime state before sustained measurements if you want to isolate one path. Global background work can distort results.
+- Prefer the `db_completed_delta` view when you care about end-to-end queue completion, not just handler return rate.
+- Treat the numbers here as environment-specific reference points, not portable guarantees. For cross-system claims, use the companion comparison repo and its recorded environment.
 
 ## How To Run
 
@@ -670,9 +463,7 @@ DATABASE_URL=postgres://postgres:test@localhost:15432/awa_test \
 
 ### Enqueue contention benchmarks
 
-These are the most useful benchmarks when you want to compare single-producer
-enqueue against multi-producer contention, or compare chunked `INSERT` with the
-COPY staging path under concurrent writers.
+These are the most useful benchmarks when you want to compare single-producer enqueue against multi-producer contention, or compare chunked `INSERT` with the COPY staging path under concurrent writers.
 
 ```bash
 DATABASE_URL=postgres://postgres:test@localhost:15432/awa_test \
@@ -693,17 +484,11 @@ This emits six JSONL records:
 - `insert_contention_same_queue`
 - `copy_contention_same_queue`
 
-The matrix hard-resets Awa runtime tables before each scenario so later cases
-do not inherit a larger or dirtier jobs table from earlier ones.
+The matrix hard-resets Awa runtime tables before each scenario so later cases do not inherit a larger or dirtier jobs table from earlier ones.
 
-By default, `AWA_BENCH_COPY_CHUNK_SIZE` should match
-`AWA_BENCH_INSERT_BATCH_SIZE` if you want the closest apples-to-apples
-comparison between chunked `INSERT` and chunked COPY staging. If you want to
-test the current "one bulk COPY per producer" shape instead, set
-`AWA_BENCH_COPY_CHUNK_SIZE` to `AWA_BENCH_CONTENTION_JOBS_PER_PRODUCER`.
+By default, `AWA_BENCH_COPY_CHUNK_SIZE` should match `AWA_BENCH_INSERT_BATCH_SIZE` if you want the closest apples-to-apples comparison between chunked `INSERT` and chunked COPY staging. If you want to test the current "one bulk COPY per producer" shape instead, set `AWA_BENCH_COPY_CHUNK_SIZE` to `AWA_BENCH_CONTENTION_JOBS_PER_PRODUCER`.
 
-The optional Postgres profile block in `metadata.db_profile` is meant to make
-server runs easier to interpret. In particular:
+The optional Postgres profile block in `metadata.db_profile` is meant to make server runs easier to interpret. In particular:
 
 - `wal_bytes` shows how much WAL the scenario generated
 - `temp_bytes_delta` and `temp_files_delta` show temp-file pressure
@@ -750,25 +535,12 @@ PYTHONPATH=scripts DATABASE_URL=postgres://postgres:test@localhost:15432/awa_tes
 
 ## Caveats
 
-- Each number is tied to the environment stated near the result. The developer
-  commands use a localhost database URL for convenience, but that URL is not a
-  claim about where every result was produced.
+- Each number is tied to the environment stated near the result. The developer commands use a localhost database URL for convenience, but that URL is not a claim about where every result was produced.
 - Ignored benchmark tests are not part of the normal unit/integration test pass.
-- The current focus is relative behavior and architectural validation, not
-  cross-machine leaderboard comparisons.
+- The current focus is relative behavior and architectural validation, not cross-machine leaderboard comparisons.
 
 ## Cross-system numbers
 
-Cross-system comparison (awa vs pgque / procrastinate / pg-boss / river /
-oban / pgmq) lives in
-[hardbyte/postgresql-job-queue-benchmarking](https://github.com/hardbyte/postgresql-job-queue-benchmarking).
-That repo is the source of truth for fair-comparison numbers, chaos
-results across systems, and the long-horizon harness itself.
+Cross-system comparison (awa vs pgque / procrastinate / pg-boss / river / oban / pgmq) lives in [hardbyte/postgresql-job-queue-benchmarking](https://github.com/hardbyte/postgresql-job-queue-benchmarking). That repo is the source of truth for fair-comparison numbers, chaos results across systems, and the long-horizon harness itself.
 
-The reasoning for the split: cross-system benches need to evolve at the
-pace of the systems being compared (each gets new releases, new public
-APIs, new adapter caveats), and the awa-only regression track in this
-file needs to evolve at awa's pace. Keeping them in one repo coupled
-their schedules and conflated "did awa regress?" with "is awa still
-faster than X?". They're separate questions; they're now in separate
-places.
+The reasoning for the split: cross-system benches need to evolve at the pace of the systems being compared (each gets new releases, new public APIs, new adapter caveats), and the awa-only regression track in this file needs to evolve at awa's pace. Keeping them in one repo coupled their schedules and conflated "did awa regress?" with "is awa still faster than X?". They're separate questions; they're now in separate places.

--- a/docs/bridge-adapters.md
+++ b/docs/bridge-adapters.md
@@ -6,9 +6,7 @@ The core `awa::insert` and `awa::insert_with` functions require sqlx's `PgExecut
 
 ## Rust: external adapter API
 
-External Rust integration crates can reuse Awa's canonical insert preparation
-without depending on sqlx executors. The stable surface is
-`awa::adapter::postgres`:
+External Rust integration crates can reuse Awa's canonical insert preparation without depending on sqlx executors. The stable surface is `awa::adapter::postgres`:
 
 ```rust
 use awa::adapter::postgres::{
@@ -34,25 +32,11 @@ let prepared = prepare_job_insert(&args, InsertOpts::default())?;
 // 12. prepared.ordering_key()
 ```
 
-`prepare_job_insert` and `prepare_raw_job_insert` apply the same validation,
-scheduled-state selection, unique-key computation, unique-state bitmask
-formatting, and sharded enqueue ordering-key propagation as Awa's built-in
-sqlx insert path. Adapters should map Postgres SQLSTATE
-`UNIQUE_VIOLATION_SQLSTATE` to `AwaError::UniqueConflict`.
+`prepare_job_insert` and `prepare_raw_job_insert` apply the same validation, scheduled-state selection, unique-key computation, unique-state bitmask formatting, and sharded enqueue ordering-key propagation as Awa's built-in sqlx insert path. Adapters should map Postgres SQLSTATE `UNIQUE_VIOLATION_SQLSTATE` to `AwaError::UniqueConflict`.
 
-This API is intentionally single-row. High-throughput bulk ingestion remains
-on Awa's native SQLx-backed APIs (`insert_many_copy_from_pool`) and the
-queue-storage-native COPY path (`QueueStorage::enqueue_params_copy`), because
-COPY support, row return semantics, and uniqueness handling are
-driver-specific.
+This API is intentionally single-row. High-throughput bulk ingestion remains on Awa's native SQLx-backed APIs (`insert_many_copy_from_pool`) and the queue-storage-native COPY path (`QueueStorage::enqueue_params_copy`), because COPY support, row return semantics, and uniqueness handling are driver-specific.
 
-Worker polling, heartbeating, claiming, and completion remain on the Awa
-runtime. That does not prevent applications from using their existing
-database stack inside job handlers: pass a SeaORM connection, Diesel pool, or
-other app dependency through `Client::builder(...).state(...)` and extract it
-from `JobContext`. Integration crates can provide ergonomic helpers for this
-handler dependency wiring, but should not reimplement Awa's lease/runtime
-storage engine.
+Worker polling, heartbeating, claiming, and completion remain on the Awa runtime. That does not prevent applications from using their existing database stack inside job handlers: pass a SeaORM connection, Diesel pool, or other app dependency through `Client::builder(...).state(...)` and extract it from `JobContext`. Integration crates can provide ergonomic helpers for this handler dependency wiring, but should not reimplement Awa's lease/runtime storage engine.
 
 ## Rust: tokio-postgres
 
@@ -165,19 +149,9 @@ All functions return `awa::JobRow` with the full row from `RETURNING *` — same
 
 ## Rust: SeaORM
 
-SeaORM already sits on top of SQLx, so the integration is deliberately thin.
-A `sea_orm::DatabaseConnection` wraps a `sqlx::PgPool`, so for building a
-client, running migrations, or reading job state you can reach the pool
-directly (`awa_seaorm::pool(&db)` / `db.awa_pool()`) and use Awa's existing
-APIs unchanged.
+SeaORM already sits on top of SQLx, so the integration is deliberately thin. A `sea_orm::DatabaseConnection` wraps a `sqlx::PgPool`, so for building a client, running migrations, or reading job state you can reach the pool directly (`awa_seaorm::pool(&db)` / `db.awa_pool()`) and use Awa's existing APIs unchanged.
 
-The part that needs a real adapter is **transactional enqueue**.
-`get_postgres_connection_pool()` hands back a *separate* pooled connection, so
-a job inserted through it commits independently of your ORM writes. The
-`insert` / `insert_with` / `insert_raw` helpers instead run Awa's canonical
-insert SQL through SeaORM's `ConnectionTrait`, so they bind to whatever you
-pass — a `DatabaseConnection` *or* a `DatabaseTransaction` — letting a job
-commit atomically with the rest of a transaction.
+The part that needs a real adapter is **transactional enqueue**. `get_postgres_connection_pool()` hands back a _separate_ pooled connection, so a job inserted through it commits independently of your ORM writes. The `insert` / `insert_with` / `insert_raw` helpers instead run Awa's canonical insert SQL through SeaORM's `ConnectionTrait`, so they bind to whatever you pass — a `DatabaseConnection` _or_ a `DatabaseTransaction` — letting a job commit atomically with the rest of a transaction.
 
 The adapter lives in the optional `awa-seaorm` crate:
 
@@ -217,28 +191,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 }
 ```
 
-Without a transaction, pass the connection directly (`insert(&db, &job)`) to
-enqueue immediately, or use `client_builder(&db)` to build a worker client.
+Without a transaction, pass the connection directly (`insert(&db, &job)`) to enqueue immediately, or use `client_builder(&db)` to build a worker client.
 
 ### Why the adapter runs SQL rather than reusing `awa::insert_with`
 
-Awa's native `insert_with` is a *pull* API: hand it a `&mut sqlx::PgConnection`
-and it runs on it. A SeaORM `DatabaseTransaction` can't satisfy that. It owns
-the connection inside an `Arc<Mutex<…>>` and must keep it so a later
-`commit()`/`rollback()` runs on that same connection — so it never lends out a
-`&mut PgConnection`, and exposes no `Into`/`AsMut`/accessor for one. The only
-way it lets you use that connection is its `ConnectionTrait`, a *push* API:
-you give it a `Statement` and it runs it for you.
+Awa's native `insert_with` is a _pull_ API: hand it a `&mut sqlx::PgConnection` and it runs on it. A SeaORM `DatabaseTransaction` can't satisfy that. It owns the connection inside an `Arc<Mutex<…>>` and must keep it so a later `commit()`/`rollback()` runs on that same connection — so it never lends out a `&mut PgConnection`, and exposes no `Into`/`AsMut`/accessor for one. The only way it lets you use that connection is its `ConnectionTrait`, a _push_ API: you give it a `Statement` and it runs it for you.
 
-So the adapter inverts the direction — it pushes Awa's canonical insert SQL
-(`awa::adapter::postgres::INSERT_JOB_SQL`, the same statement and bind order
-the native path and the tokio-postgres bridge use) through `ConnectionTrait`.
-The result row, however, *is* surrendered: `QueryResult::try_as_pg_row` yields
-the underlying `sqlx::PgRow`, which Awa's own `JobRow: FromRow` decodes — so
-the returned job is identical to one from `awa::insert`, with no parallel
-decoder to drift. This is also why the workspace enables SeaORM's `with-chrono`
-and `with-json` features: only so the timestamp and JSONB bind values can
-become `sea_orm::Value`.
+So the adapter inverts the direction — it pushes Awa's canonical insert SQL (`awa::adapter::postgres::INSERT_JOB_SQL`, the same statement and bind order the native path and the tokio-postgres bridge use) through `ConnectionTrait`. The result row, however, _is_ surrendered: `QueryResult::try_as_pg_row` yields the underlying `sqlx::PgRow`, which Awa's own `JobRow: FromRow` decodes — so the returned job is identical to one from `awa::insert`, with no parallel decoder to drift. This is also why the workspace enables SeaORM's `with-chrono` and `with-json` features: only so the timestamp and JSONB bind values can become `sea_orm::Value`.
 
 ## Python: psycopg3, asyncpg, SQLAlchemy, Django
 
@@ -247,7 +206,7 @@ See [Python getting started — ORM Transaction Bridging](getting-started-python
 ## Rust feature flags
 
 | Feature | Crate | What it enables |
-|---------|-------|-----------------|
+| --- | --- | --- |
 | `tokio-postgres` | `awa` or `awa-model` | `awa::bridge::tokio_pg` adapter |
 | `cel` | `awa` or `awa-model` | CEL expression evaluation for callback filtering |
 | `anyhow` | `awa` | `From<anyhow::Error>` for `JobError` |

--- a/docs/callback-receivers.md
+++ b/docs/callback-receivers.md
@@ -2,37 +2,21 @@
 
 Awa supports three ways to host the HTTP callback ingress surface:
 
-1. **Bundled with the admin UI** — the default. `awa serve` exposes the
-   admin UI plus the three callback routes from the same router.
-2. **Standalone receiver** — `awa callbacks serve` runs a router that
-   mounts only the callback ingress endpoints. Use this when callbacks
-   must be reachable from outside the operator network but the admin
-   surface must remain private. See [`docs/http-callbacks.md`](./http-callbacks.md).
-3. **User-owned API layer** — mount the callback ingress routes inside
-   your own application (FastAPI / Starlette / Flask / Django / axum /
-   actix). This page covers option 3.
+1. **Bundled with the admin UI** — the default. `awa serve` exposes the admin UI plus the three callback routes from the same router.
+2. **Standalone receiver** — `awa callbacks serve` runs a router that mounts only the callback ingress endpoints. Use this when callbacks must be reachable from outside the operator network but the admin surface must remain private. See [`docs/http-callbacks.md`](./http-callbacks.md).
+3. **User-owned API layer** — mount the callback ingress routes inside your own application (FastAPI / Starlette / Flask / Django / axum / actix). This page covers option 3.
 
 The on-wire contract is identical across all three options:
 
 - Routes: `POST {prefix}/{callback_id}/{complete,fail,heartbeat}`.
-- Signature: BLAKE3 keyed-hash of the callback id, lowercase hex, in the
-  `X-Awa-Signature` header.
+- Signature: BLAKE3 keyed-hash of the callback id, lowercase hex, in the `X-Awa-Signature` header.
 - Payloads: see [`docs/http-callbacks.md`](./http-callbacks.md#callback-receiver-contract).
 
-When you host the routes yourself, **reuse the shared signing and URL
-helpers** from `awa::callback_contract` (Rust) or `awa.callback_contract`
-(Python) so your implementation cannot drift from the worker's. The
-helpers are exported specifically so this is a one-line dependency, not
-a copy-paste of the algorithm.
+When you host the routes yourself, **reuse the shared signing and URL helpers** from `awa::callback_contract` (Rust) or `awa.callback_contract` (Python) so your implementation cannot drift from the worker's. The helpers are exported specifically so this is a one-line dependency, not a copy-paste of the algorithm.
 
 ## Security
 
-The callback receiver routes mutate job state. Specifically, `complete`
-and `fail` are terminal — once they succeed, the job leaves
-`waiting_external`. A receiver that does not verify `X-Awa-Signature`
-must be protected another way (mTLS at the load balancer, IP allow-list,
-private VPC). See [ADR-027](./adr/027-callback-ingress-surface.md) for the
-deployable-role model.
+The callback receiver routes mutate job state. Specifically, `complete` and `fail` are terminal — once they succeed, the job leaves `waiting_external`. A receiver that does not verify `X-Awa-Signature` must be protected another way (mTLS at the load balancer, IP allow-list, private VPC). See [ADR-027](./adr/027-callback-ingress-surface.md) for the deployable-role model.
 
 ## Custom axum receiver (Rust)
 
@@ -106,9 +90,7 @@ pub fn callback_routes(state: Arc<CallbackState>) -> Router {
 }
 ```
 
-For most users the built-in receiver in `awa::callback_router` (PR #279)
-covers this case. Mount the routes yourself only when you need them
-*inside* an existing axum application.
+For most users the built-in receiver in `awa::callback_router` (PR #279) covers this case. Mount the routes yourself only when you need them _inside_ an existing axum application.
 
 ## Custom FastAPI receiver (Python)
 
@@ -200,19 +182,11 @@ app = FastAPI()
 app.include_router(router)
 ```
 
-The `awa.callback_contract` module wraps the same Rust signing
-implementation the worker uses, so a signature this verifier accepts is
-bit-for-bit identical to a signature `awa serve` would accept. There is
-a parity test (`awa-python/tests/test_callback_contract.py`) that pins
-a known BLAKE3 vector across both languages.
+The `awa.callback_contract` module wraps the same Rust signing implementation the worker uses, so a signature this verifier accepts is bit-for-bit identical to a signature `awa serve` would accept. There is a parity test (`awa-python/tests/test_callback_contract.py`) that pins a known BLAKE3 vector across both languages.
 
 ## Configuring the worker to point at your receiver
 
-Whichever option you pick, the worker side needs to know the full
-callback URL. Set [`HttpWorkerConfig::callback_base_url`](./http-callbacks.md)
-to your receiver's externally-reachable base URL, and override
-`callback_path_prefix` if your routes are mounted somewhere other than
-`/api/callbacks`:
+Whichever option you pick, the worker side needs to know the full callback URL. Set [`HttpWorkerConfig::callback_base_url`](./http-callbacks.md) to your receiver's externally-reachable base URL, and override `callback_path_prefix` if your routes are mounted somewhere other than `/api/callbacks`:
 
 ```rust
 HttpWorkerConfig {
@@ -223,6 +197,4 @@ HttpWorkerConfig {
 }
 ```
 
-The worker uses `awa::callback_contract::callback_url` internally to
-build the URL — the same helper your receiver can use to compute
-URLs for outbound retries or diagnostics.
+The worker uses `awa::callback_contract::callback_url` internally to build the URL — the same helper your receiver can use to compute URLs for outbound retries or diagnostics.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -6,15 +6,11 @@ Terms used throughout this guide:
 
 - A **queue** is the worker subscription and capacity boundary.
 - A **claim** is the act of reserving a ready job for one attempt.
-- A **claim lease** (`run_lease`) is the monotonically increasing attempt guard
-  on a job; stale completions with an old value are rejected.
-- A **scheduled job** has a future `run_at` and waits outside the ready claim
-  path. Retry backoff and snooze use the same deferred backlog until their
-  `run_at` is due.
+- A **claim lease** (`run_lease`) is the monotonically increasing attempt guard on a job; stale completions with an old value are rejected.
+- A **scheduled job** has a future `run_at` and waits outside the ready claim path. Retry backoff and snooze use the same deferred backlog until their `run_at` is due.
 - A **lane** is one ordered `(queue, priority, enqueue_shard)` stream.
 - A **segment** is a rotating partition that Awa eventually truncates.
-- A **receipt** is the lightweight short-attempt claim record; a **lease row**
-  is materialized when an attempt needs mutable execution state.
+- A **receipt** is the lightweight short-attempt claim record; a **lease row** is materialized when an attempt needs mutable execution state.
 
 ## How configuration flows
 
@@ -39,16 +35,11 @@ Workers and the UI server are separate processes. Workers own all queue machiner
 
 ## Worker scope: which queues and which kinds
 
-A single worker process handles work for the **set of queues it was
-configured with** and the **set of job kinds it registered handlers
-for**. There is no implicit fan-out across queues, and no implicit
-filter on kinds within a queue — these are two separate concerns.
+A single worker process handles work for the **set of queues it was configured with** and the **set of job kinds it registered handlers for**. There is no implicit fan-out across queues, and no implicit filter on kinds within a queue — these are two separate concerns.
 
 ### Targeting specific queues
 
-A worker only claims jobs from queues passed to its builder; everything
-else on the database is invisible to it. To run a worker dedicated to
-one queue, only declare that queue:
+A worker only claims jobs from queues passed to its builder; everything else on the database is invisible to it. To run a worker dedicated to one queue, only declare that queue:
 
 ```rust
 // Rust: this worker only ever processes the "email" queue.
@@ -67,42 +58,19 @@ async def handle(job): ...
 await client.start([("email", 8)])
 ```
 
-Run separate worker processes (or separate fleets) per queue when you
-want **isolation**: a stuck `etl` queue can't starve `email`,
-deployment of a slow handler doesn't pause unrelated queues, and per-
-queue scaling is just a deployment knob. Run **one worker process
-across multiple queues** with `global_max_workers` and weighted mode
-when you want elastic capacity sharing — see [Weighted
-mode](#weighted-mode).
+Run separate worker processes (or separate fleets) per queue when you want **isolation**: a stuck `etl` queue can't starve `email`, deployment of a slow handler doesn't pause unrelated queues, and per- queue scaling is just a deployment knob. Run **one worker process across multiple queues** with `global_max_workers` and weighted mode when you want elastic capacity sharing — see [Weighted mode](#weighted-mode).
 
 ### Targeting specific job kinds within a queue
 
-`register::<SomeJob, _, _>` (Rust) or `@client.task(SomeJob, ...)`
-(Python) tells the worker how to execute one specific job kind. At
-execute time the worker looks up the kind on the claimed job and runs
-the matching handler.
+`register::<SomeJob, _, _>` (Rust) or `@client.task(SomeJob, ...)` (Python) tells the worker how to execute one specific job kind. At execute time the worker looks up the kind on the claimed job and runs the matching handler.
 
-**Sharp edge:** the claim path is per-queue, not per-kind. If a queue
-holds jobs of kinds the worker didn't register, the worker still
-claims those jobs (it can't tell ahead of time) and then **fails them
-terminally** with `unknown job kind: <name>`. There is no soft re-
-enqueue. So the supported patterns for "this worker only handles a
-subset of kinds" are:
+**Sharp edge:** the claim path is per-queue, not per-kind. If a queue holds jobs of kinds the worker didn't register, the worker still claims those jobs (it can't tell ahead of time) and then **fails them terminally** with `unknown job kind: <name>`. There is no soft re- enqueue. So the supported patterns for "this worker only handles a subset of kinds" are:
 
-1. **Recommended: put each kind set on its own queue.** Queues are
-   cheap; this is the operator-shaped boundary. Workers with
-   different kind responsibilities subscribe to different queues, and
-   the queue boundary becomes the routing decision.
-2. **Acceptable: every worker on the queue registers handlers for
-   every kind that lands there.** Heterogeneous workloads on a single
-   queue work fine as long as no worker is missing a registration.
-3. **Not supported: have some workers on a queue claim jobs and
-   silently leave kinds they don't know for someone else.** This will
-   terminal-fail or DLQ jobs.
+1. **Recommended: put each kind set on its own queue.** Queues are cheap; this is the operator-shaped boundary. Workers with different kind responsibilities subscribe to different queues, and the queue boundary becomes the routing decision.
+2. **Acceptable: every worker on the queue registers handlers for every kind that lands there.** Heterogeneous workloads on a single queue work fine as long as no worker is missing a registration.
+3. **Not supported: have some workers on a queue claim jobs and silently leave kinds they don't know for someone else.** This will terminal-fail or DLQ jobs.
 
-If kinds drift out of sync (e.g. a deploy lags), the descriptor
-catalog in the admin UI flags missing handlers; see [Queue and
-job-kind descriptors](#queue-and-job-kind-descriptors) below.
+If kinds drift out of sync (e.g. a deploy lags), the descriptor catalog in the admin UI flags missing handlers; see [Queue and job-kind descriptors](#queue-and-job-kind-descriptors) below.
 
 ## Queue configuration
 
@@ -133,7 +101,7 @@ let client = Client::builder(pool.clone())
 The key `QueueConfig` fields:
 
 | Field | Default | When you'd change it |
-|---|---|---|
+| --- | --- | --- |
 | `max_workers` | `50` | Always — this is your concurrency cap per queue |
 | `rate_limit` | `None` | External API rate limits, backpressure |
 | `deadline_duration` | `5m` | Hard upper bound on a single attempt. Set to `Duration::ZERO` to skip the deadline rescue path; receipts mode (the 0.6 default storage) supports both shapes — the deadline lands on `lease_claims.deadline_at` and the maintenance rescue path force-closes expired claims. |
@@ -142,13 +110,7 @@ The key `QueueConfig` fields:
 | `claimers` | `1` | Hot queue-storage queues that need more than one dispatcher/claimer loop inside a single runtime. Claimers share the queue's worker permits. |
 | `claim_batch_size` | `512` | Maximum jobs each dispatcher tries to claim in one DB round-trip. Lower this for latency-sensitive small queues; benchmark before combining large batches with multiple claimers. |
 
-Defaults intentionally favor the smallest blast radius:
-`enqueue_shards = 1`, `claimers = 1`, and `claim_batch_size = 512`. Raise
-`enqueue_shards` only when the queue can accept partitioned FIFO semantics.
-For a single hot queue, a larger claim batch usually helps before extra
-claimers: it reduces claim round-trips without adding more concurrent head
-coordinators. Benchmark `claimers = 2` or `4` only when a single claimer cannot
-keep worker permits full.
+Defaults intentionally favor the smallest blast radius: `enqueue_shards = 1`, `claimers = 1`, and `claim_batch_size = 512`. Raise `enqueue_shards` only when the queue can accept partitioned FIFO semantics. For a single hot queue, a larger claim batch usually helps before extra claimers: it reduces claim round-trips without adding more concurrent head coordinators. Benchmark `claimers = 2` or `4` only when a single claimer cannot keep worker permits full.
 
 ### Python
 
@@ -187,12 +149,10 @@ Enabled by `global_max_workers(N)` (Rust) or `global_max_workers=N` (Python). Ea
 
 ### What can be tuned per queue vs per job
 
-Queue configuration is the normal way to express operational policy. Job
-kinds are primarily handler registrations and descriptor/catalog entries; if
-two kinds need different runtime policy, put them on different queues.
+Queue configuration is the normal way to express operational policy. Job kinds are primarily handler registrations and descriptor/catalog entries; if two kinds need different runtime policy, put them on different queues.
 
 | Scope | Knobs | Notes |
-|---|---|---|
+| --- | --- | --- |
 | Per queue | `max_workers`, `rate_limit`, `deadline_duration`, `priority_aging_interval`, `poll_interval`, `min_workers`, `weight` | Runtime dispatch policy. `deadline_duration` is the hard per-attempt wall-clock timeout for every job claimed from that queue. |
 | Per job enqueue | `queue`, `priority`, `max_attempts`, `run_at`, `tags`, `metadata`, `unique` | Stored with the job. Use this for routing, priority, retry budget, scheduling, identity, and operator context. |
 | Per job kind | handler registration plus `JobKindDescriptor` | Descriptors cover display name, owner, docs link, tags, and extra metadata. They do not set dispatch limits or timeouts. |
@@ -200,41 +160,30 @@ two kinds need different runtime policy, put them on different queues.
 | Per queue / global retention and DLQ policy | `completed_retention`, `failed_retention`, `queue_retention(...)`, `dlq_enabled_by_default`, `queue_dlq_enabled`, `dlq_retention` | Retention has global defaults with per-queue overrides. DLQ enablement is queue-scoped. Split job kinds across queues if only some kinds should DLQ. |
 | Per runtime / fleet | heartbeat timings, rescue scan intervals, cleanup batch size, descriptor retention, queue-storage slots/stripes/rotation | Process or storage-engine policy, not job-kind policy. `queue_storage_queue_stripe_count` currently applies to the queue-storage engine rather than to one named queue. |
 
-There is no active per-job-kind hard timeout today. The hard timeout is the
-queue's `deadline_duration`; moving long-running kinds onto their own queue is
-the intended way to give them a different timeout without making every job on a
-busy queue slower to rescue.
+There is no active per-job-kind hard timeout today. The hard timeout is the queue's `deadline_duration`; moving long-running kinds onto their own queue is the intended way to give them a different timeout without making every job on a busy queue slower to rescue.
 
 ## Scheduled jobs and deferred promotion
 
-Set `run_at` when enqueueing a job that should not be claimable yet. Awa stores
-that row in the deferred backlog and the maintenance leader promotes it to the
-ready ring once `run_at <= now()`.
+Set `run_at` when enqueueing a job that should not be claimable yet. Awa stores that row in the deferred backlog and the maintenance leader promotes it to the ready ring once `run_at <= now()`.
 
-Retry backoff and `Snooze` use the same mechanism: the current attempt closes,
-a retryable row is written with its next `run_at`, and promotion makes it ready
-again later. Cron schedules are producers on top of the same enqueue path; a
-cron fire atomically records the schedule fire and inserts the resulting job.
+Retry backoff and `Snooze` use the same mechanism: the current attempt closes, a retryable row is written with its next `run_at`, and promotion makes it ready again later. Cron schedules are producers on top of the same enqueue path; a cron fire atomically records the schedule fire and inserts the resulting job.
 
 Operational knobs:
 
-- `promote_interval` controls how often maintenance checks for due deferred
-  rows.
+- `promote_interval` controls how often maintenance checks for due deferred rows.
 - Per-job `run_at` controls the due time.
-- Periodic schedules are declared in worker code with `periodic()` and managed
-  through the CLI/UI `cron` surface.
+- Periodic schedules are declared in worker code with `periodic()` and managed through the CLI/UI `cron` surface.
 
 ## Job priority and aging
 
-Every job carries a **priority** (`i16`, lower number = higher
-priority). The default is `2`. Conventional usage:
+Every job carries a **priority** (`i16`, lower number = higher priority). The default is `2`. Conventional usage:
 
-| Priority | Typical meaning |
-|---|---|
-| `1` | Urgent / customer-facing / SLA-critical |
-| `2` | Default |
-| `3` | Background work |
-| `4` | Batch / catch-up / bulk reprocess |
+| Priority | Typical meaning                         |
+| -------- | --------------------------------------- |
+| `1`      | Urgent / customer-facing / SLA-critical |
+| `2`      | Default                                 |
+| `3`      | Background work                         |
+| `4`      | Batch / catch-up / bulk reprocess       |
 
 Values outside `1..=4` are rejected by the insert path.
 
@@ -264,15 +213,9 @@ await client.insert(
 
 ### Priority aging (escalation for fairness)
 
-Without aging, a steady stream of priority-1 work can starve every
-priority-2 job behind it. AWA escalates priority over time — the
-longer a job has been waiting, the higher (numerically lower) its
-**effective priority** becomes at claim time. A priority-4 job that
-has waited `3 × aging_interval` ages all the way down to priority 1
-and is no longer starvable.
+Without aging, a steady stream of priority-1 work can starve every priority-2 job behind it. AWA escalates priority over time — the longer a job has been waiting, the higher (numerically lower) its **effective priority** becomes at claim time. A priority-4 job that has waited `3 × aging_interval` ages all the way down to priority 1 and is no longer starvable.
 
-The cadence is per-queue via `QueueConfig.priority_aging_interval`
-(default `60s`):
+The cadence is per-queue via `QueueConfig.priority_aging_interval` (default `60s`):
 
 ```rust
 // Rust
@@ -295,49 +238,24 @@ await client.start([
 ])
 ```
 
-Aging is computed at claim time on queue-storage runtimes: ready rows keep
-their stored lane priority, and the claim SQL compares candidate lanes by
-effective priority. When a job is claimed, the live attempt records the
-effective priority used for that claim. In canonical storage, the maintenance
-leader physically rewrites waiting rows from priority N to N-1 and preserves
-the enqueue priority in `metadata._awa_original_priority`.
+Aging is computed at claim time on queue-storage runtimes: ready rows keep their stored lane priority, and the claim SQL compares candidate lanes by effective priority. When a job is claimed, the live attempt records the effective priority used for that claim. In canonical storage, the maintenance leader physically rewrites waiting rows from priority N to N-1 and preserves the enqueue priority in `metadata._awa_original_priority`.
 
-The admin UI shows the priority on the current job snapshot and, when
-`_awa_original_priority` is present, the original enqueue priority as
-`(enqueued as N)`. Set the value to `Duration::ZERO` (Rust) or
-`priority_aging_interval_ms: 0` (Python) to disable escalation
-entirely (strict static priority).
+The admin UI shows the priority on the current job snapshot and, when `_awa_original_priority` is present, the original enqueue priority as `(enqueued as N)`. Set the value to `Duration::ZERO` (Rust) or `priority_aging_interval_ms: 0` (Python) to disable escalation entirely (strict static priority).
 
-There is a separate top-level `ClientBuilder::priority_aging_interval`
-that controls the legacy canonical-storage maintenance pass that
-physically rewrites stored priorities. With queue storage (the 0.6
-default) it is a no-op; the per-queue setting above is the one to
-tune.
+There is a separate top-level `ClientBuilder::priority_aging_interval` that controls the legacy canonical-storage maintenance pass that physically rewrites stored priorities. With queue storage (the 0.6 default) it is a no-op; the per-queue setting above is the one to tune.
 
 ### Changing priority after enqueue
 
-The ordinary job retry/cancel/admin path does **not** currently expose a
-general "reprioritize this queued job" operation. In queue storage, priority is
-part of the physical lane key (`queue`, `priority`, `enqueue_shard`,
-`lane_seq`), so changing an already-queued job's priority means moving it to a
-different lane and assigning a new lane sequence. That is a semantic operation,
-not a metadata update.
+The ordinary job retry/cancel/admin path does **not** currently expose a general "reprioritize this queued job" operation. In queue storage, priority is part of the physical lane key (`queue`, `priority`, `enqueue_shard`, `lane_seq`), so changing an already-queued job's priority means moving it to a different lane and assigning a new lane sequence. That is a semantic operation, not a metadata update.
 
 Use one of these patterns instead:
 
-- Choose the priority when inserting the job, periodic schedule, or direct-COPY
-  batch.
-- Tune `priority_aging_interval` when the goal is fairness under sustained
-  high-priority load.
-- For DLQ recovery, use `retry_from_dlq(..., priority=...)` (Python) or
-  `RetryFromDlqOpts { priority: Some(...) }` (Rust/model API) to revive a DLQ
-  row at a different priority.
-- For a pending job that truly must move priority, cancel it and enqueue a
-  replacement with the new priority, after checking any uniqueness or
-  idempotency contract that applies to that job kind.
+- Choose the priority when inserting the job, periodic schedule, or direct-COPY batch.
+- Tune `priority_aging_interval` when the goal is fairness under sustained high-priority load.
+- For DLQ recovery, use `retry_from_dlq(..., priority=...)` (Python) or `RetryFromDlqOpts { priority: Some(...) }` (Rust/model API) to revive a DLQ row at a different priority.
+- For a pending job that truly must move priority, cancel it and enqueue a replacement with the new priority, after checking any uniqueness or idempotency contract that applies to that job kind.
 
-Plain `retry` of a failed/cancelled/waiting job keeps the job's existing
-priority.
+Plain `retry` of a failed/cancelled/waiting job keeps the job's existing priority.
 
 ## Queue and job-kind descriptors
 
@@ -398,105 +316,59 @@ Both surfaces must be called before `start()` / `build()`. Declaring a descripto
 
 ## Reliability timings: heartbeat, deadline, rescue
 
-These knobs control **how fast a stuck or crashed handler is noticed
-and rescued**. They live on `ClientBuilder` (Rust) and `client.start()`
-kwargs (Python). All of them have `_ms`-suffixed kwargs on the Python
-side (e.g. `heartbeat_interval_ms=15000`).
+These knobs control **how fast a stuck or crashed handler is noticed and rescued**. They live on `ClientBuilder` (Rust) and `client.start()` kwargs (Python). All of them have `_ms`-suffixed kwargs on the Python side (e.g. `heartbeat_interval_ms=15000`).
 
 ### Heartbeat — detecting crashed workers
 
-A running job updates a heartbeat row periodically while its handler
-is alive. If the heartbeat goes stale, the maintenance leader rescues
-the job (re-enqueues it for another attempt). Three knobs participate:
+A running job updates a heartbeat row periodically while its handler is alive. If the heartbeat goes stale, the maintenance leader rescues the job (re-enqueues it for another attempt). Three knobs participate:
 
 | Knob | Default | What it does |
-|---|---|---|
+| --- | --- | --- |
 | `heartbeat_interval` | `30s` | How often each running handler refreshes its heartbeat row. |
 | `heartbeat_staleness` | `90s` | How long the row may go un-refreshed before the maintenance leader treats the job as crashed. |
 | `heartbeat_rescue_interval` | `30s` | How often the maintenance leader scans for stale heartbeats. |
 
 Pick them in this order:
 
-1. **Decide your detection target.** "Crashes should be noticed within
-   X seconds." That target is roughly `heartbeat_staleness +
-   heartbeat_rescue_interval` in the worst case.
-2. **Set `heartbeat_staleness` to at least `3× heartbeat_interval`.**
-   The 3× rule absorbs scheduler hiccups, GC pauses, and the rescue
-   scan's own jitter; tighter ratios produce false rescues. The
-   builder logs a warning if you violate it.
-3. **`heartbeat_rescue_interval`** can match `heartbeat_interval` for
-   low-latency rescue, or be higher to reduce maintenance load on big
-   fleets.
+1. **Decide your detection target.** "Crashes should be noticed within X seconds." That target is roughly `heartbeat_staleness + heartbeat_rescue_interval` in the worst case.
+2. **Set `heartbeat_staleness` to at least `3× heartbeat_interval`.** The 3× rule absorbs scheduler hiccups, GC pauses, and the rescue scan's own jitter; tighter ratios produce false rescues. The builder logs a warning if you violate it.
+3. **`heartbeat_rescue_interval`** can match `heartbeat_interval` for low-latency rescue, or be higher to reduce maintenance load on big fleets.
 
-For a 5-second crash detection target: `heartbeat_interval=1s`,
-`heartbeat_staleness=4s`, `heartbeat_rescue_interval=1s`. For a
-1-minute target with the cheapest possible maintenance: keep all the
-defaults.
+For a 5-second crash detection target: `heartbeat_interval=1s`, `heartbeat_staleness=4s`, `heartbeat_rescue_interval=1s`. For a 1-minute target with the cheapest possible maintenance: keep all the defaults.
 
 ### Deadline — bounding a single attempt
 
-Each queue has a `deadline_duration` (default `5m` on
-`QueueConfig`). At claim time the runtime stamps
-`now() + deadline_duration` onto the claim, and a maintenance scan
-force-closes attempts that pass it without completing. This bounds a
-single attempt's wall-clock time independently of heartbeats — if a
-handler is hanging, looping forever, or wedged in a sync wait,
-the deadline rescues it even if its heartbeat is fresh.
+Each queue has a `deadline_duration` (default `5m` on `QueueConfig`). At claim time the runtime stamps `now() + deadline_duration` onto the claim, and a maintenance scan force-closes attempts that pass it without completing. This bounds a single attempt's wall-clock time independently of heartbeats — if a handler is hanging, looping forever, or wedged in a sync wait, the deadline rescues it even if its heartbeat is fresh.
 
 | Knob | Default | What it does |
-|---|---|---|
+| --- | --- | --- |
 | `QueueConfig.deadline_duration` (Rust) / `deadline_duration_ms` (Python dict form) | `5m` | Per-queue hard upper bound on one attempt. `Duration::ZERO` / `0` skips deadline rescue for that queue. |
 | `ClientBuilder::deadline_rescue_interval` (Rust) / `deadline_rescue_interval_ms` (Python kwarg) | `30s` | How often the maintenance leader scans for expired deadlines. |
 
-Receipts mode (the 0.6 default storage) supports both shapes: the
-deadline lands on `lease_claims.deadline_at` and is rescued there for
-short claims, or carried onto `leases.deadline_at` if the claim
-materializes for a long-running attempt. See [Queue storage
-tuning](#queue-storage-tuning) and ADR-023.
+Receipts mode (the 0.6 default storage) supports both shapes: the deadline lands on `lease_claims.deadline_at` and is rescued there for short claims, or carried onto `leases.deadline_at` if the claim materializes for a long-running attempt. See [Queue storage tuning](#queue-storage-tuning) and ADR-023.
 
 ### Callback timeout — bounding `wait_for_callback`
 
-If you suspend a handler with `wait_for_callback()` and the external
-system never resumes, a callback-timeout rescue brings the job back to
-ready (or DLQ if attempts are exhausted).
+If you suspend a handler with `wait_for_callback()` and the external system never resumes, a callback-timeout rescue brings the job back to ready (or DLQ if attempts are exhausted).
 
 | Knob | Default | What it does |
-|---|---|---|
+| --- | --- | --- |
 | `ClientBuilder::callback_rescue_interval` | `30s` | How often the maintenance leader scans for `callback_timeout_at < now()`. The per-callback timeout itself is set when registering the callback in the handler. |
 
 ### Retention and cleanup
 
 Retention depends on the storage path.
 
-Queue storage is the worker engine in `0.6`: ordinary terminal snapshots
-(`completed`, non-DLQ `failed`, and `cancelled`) live in the rotating
-`done_entries_*` partitions and are reclaimed by queue-ring prune after the
-matching ready segment is no longer live. Most terminal rows are narrow:
-the durable terminal fact lives in `done_entries_*`, while immutable job-body
-fields are hydrated from the retained `ready_entries_*` row until queue prune
-reclaims both together. Direct SQL against `done_entries` should therefore
-expect nullable body columns and join to `ready_entries` when it needs the full
-job body. Public Awa APIs perform that hydration, and
-`{schema}.terminal_jobs` exposes the same hydrated terminal shape for
-read-only SQL inspection.
+Queue storage is the worker engine in `0.6`: ordinary terminal snapshots (`completed`, non-DLQ `failed`, and `cancelled`) live in the rotating `done_entries_*` partitions and are reclaimed by queue-ring prune after the matching ready segment is no longer live. Most terminal rows are narrow: the durable terminal fact lives in `done_entries_*`, while immutable job-body fields are hydrated from the retained `ready_entries_*` row until queue prune reclaims both together. Direct SQL against `done_entries` should therefore expect nullable body columns and join to `ready_entries` when it needs the full job body. Public Awa APIs perform that hydration, and `{schema}.terminal_jobs` exposes the same hydrated terminal shape for read-only SQL inspection.
 
-Ready rows are not deleted for unclaimed cancellation, priority aging, or SQL
-compatibility deletes through `awa.jobs`. Those paths append to
-`{schema}.ready_tombstones_*`; claim and exact-count queries anti-join the
-tombstone ledger, and queue prune truncates it with the matching ready/done
-segment.
+Ready rows are not deleted for unclaimed cancellation, priority aging, or SQL compatibility deletes through `awa.jobs`. Those paths append to `{schema}.ready_tombstones_*`; claim and exact-count queries anti-join the tombstone ledger, and queue prune truncates it with the matching ready/done segment.
 
-The `completed_retention` and `failed_retention` knobs apply to the canonical
-compatibility path, not to queue-storage terminal history. In queue storage,
-use the queue-ring sizing and rotation knobs below to control how much
-ordinary terminal history remains queryable.
+The `completed_retention` and `failed_retention` knobs apply to the canonical compatibility path, not to queue-storage terminal history. In queue storage, use the queue-ring sizing and rotation knobs below to control how much ordinary terminal history remains queryable.
 
-DLQ rows are different: `dlq_entries` is a separate hold table and the
-maintenance leader deletes rows older than `dlq_retention` in bounded cleanup
-passes.
+DLQ rows are different: `dlq_entries` is a separate hold table and the maintenance leader deletes rows older than `dlq_retention` in bounded cleanup passes.
 
 | Knob | Default | What it does |
-|---|---|---|
+| --- | --- | --- |
 | `completed_retention` | `24h` | Canonical compatibility path only: how long completed jobs stay queryable before row cleanup deletes them. Queue storage uses queue-ring prune instead. |
 | `failed_retention` | `72h` | Canonical compatibility path only: same for failed/cancelled jobs excluding DLQ. Queue storage uses queue-ring prune instead. |
 | `dlq_retention` | `30d` | How long DLQ rows stay in `dlq_entries` before bounded cleanup deletes them. |
@@ -507,31 +379,15 @@ passes.
 
 ## Queue storage tuning
 
-Queue storage is the runtime engine in `0.6`, and most deployments can keep
-the defaults. Queue-storage tables live in the canonical `awa` schema; the
-main knobs are there for large fleets, very bursty queues, or operators who
-want to trade off the partition-reclaim window against rotation churn.
+Queue storage is the runtime engine in `0.6`, and most deployments can keep the defaults. Queue-storage tables live in the canonical `awa` schema; the main knobs are there for large fleets, very bursty queues, or operators who want to trade off the partition-reclaim window against rotation churn.
 
 ### Producer path choice
 
-For bulk producers on queue storage, prefer direct queue-storage COPY:
-Python `enqueue_many_copy()` or Rust `QueueStorage::enqueue_params_copy()`.
-Those paths stream rows straight into `ready_entries` / `deferred_jobs` and use
-the queue-storage enqueue heads directly.
+For bulk producers on queue storage, prefer direct queue-storage COPY: Python `enqueue_many_copy()` or Rust `QueueStorage::enqueue_params_copy()`. Those paths stream rows straight into `ready_entries` / `deferred_jobs` and use the queue-storage enqueue heads directly.
 
-Direct-copy producers must use the same queue-storage routing config as the
-worker fleet. This matters most for `queue_stripe_count` /
-`queue_storage_queue_stripe_count`: a producer using the default unstriped
-config can write to `queue` while striped workers claim from `queue#0`,
-`queue#1`, etc. Rust producers should construct `QueueStorage` with the same
-`QueueStorageConfig` used by workers. Python producers should pass the same
-`queue_storage_queue_stripe_count` to `enqueue_many_copy()` when the fleet uses
-non-default striping.
+Direct-copy producers must use the same queue-storage routing config as the worker fleet. This matters most for `queue_stripe_count` / `queue_storage_queue_stripe_count`: a producer using the default unstriped config can write to `queue` while striped workers claim from `queue#0`, `queue#1`, etc. Rust producers should construct `QueueStorage` with the same `QueueStorageConfig` used by workers. Python producers should pass the same `queue_storage_queue_stripe_count` to `enqueue_many_copy()` when the fleet uses non-default striping.
 
-`insert_many_copy()` is the compatibility insert API. It is still useful when a
-caller needs the canonical insert surface, but in queue-storage mode it routes
-through the compatibility function rather than being the primary producer fast
-path.
+`insert_many_copy()` is the compatibility insert API. It is still useful when a caller needs the canonical insert surface, but in queue-storage mode it routes through the compatibility function rather than being the primary producer fast path.
 
 ### Rust
 
@@ -572,7 +428,7 @@ await client.start(
 ### What the knobs mean
 
 | Knob | Default | What it controls |
-|---|---|---|
+| --- | --- | --- |
 | `queue_slot_count` | `16` | Number of rotating ready/tombstone/terminal queue partitions. Together with queue rotation cadence and how quickly segments become prunable, this bounds ordinary terminal-history visibility in queue storage. Ready-backed terminal rows rely on the matching ready partition until queue prune reclaims both. |
 | `lease_slot_count` | `8` | Number of rotating lease partitions |
 | `claim_slot_count` | `8` | Number of rotating ADR-023 claim-ring partitions (`lease_claims` + `lease_claim_closures` children). Both tables share the same `claim_slot` so each partition's claims and closures are reclaimed together by `TRUNCATE`. |
@@ -582,12 +438,7 @@ await client.start(
 | `lease_rotate_interval` | `250ms` | How often lease segments rotate |
 | `claim_rotate_interval` | matches `queue_rotate_interval` | How often the ADR-023 claim-ring rotates. Set with `ClientBuilder::claim_rotate_interval` (Rust) or `queue_storage_claim_rotate_interval_ms` (Python). Test harnesses sometimes set this to a long interval to pin claim-ring layout for deterministic count assertions. |
 
-The benchmark harness in
-[postgresql-job-queue-benchmarking](https://github.com/hardbyte/postgresql-job-queue-benchmarking)
-reads `QUEUE_SLOT_COUNT`, `LEASE_SLOT_COUNT`, `CLAIM_SLOT_COUNT`,
-`QUEUE_STRIPE_COUNT`, and `LEASE_CLAIM_RECEIPTS` from the environment.
-Those env vars are benchmark configuration, not general worker-runtime
-configuration.
+The benchmark harness in [postgresql-job-queue-benchmarking](https://github.com/hardbyte/postgresql-job-queue-benchmarking) reads `QUEUE_SLOT_COUNT`, `LEASE_SLOT_COUNT`, `CLAIM_SLOT_COUNT`, `QUEUE_STRIPE_COUNT`, and `LEASE_CLAIM_RECEIPTS` from the environment. Those env vars are benchmark configuration, not general worker-runtime configuration.
 
 Use the defaults unless you have a reason not to:
 
@@ -612,15 +463,9 @@ ON CONFLICT (queue)
 DO UPDATE SET enqueue_shards = EXCLUDED.enqueue_shards;
 ```
 
-Use an upsert rather than a plain `UPDATE`: the first enqueue can create
-queue-storage lane rows before an operator-owned `queue_meta` row exists, so a
-plain `UPDATE` may quietly affect zero rows.
+Use an upsert rather than a plain `UPDATE`: the first enqueue can create queue-storage lane rows before an operator-owned `queue_meta` row exists, so a plain `UPDATE` may quietly affect zero rows.
 
-A 16-producer same-queue reference sweep measured 1.0× / 1.60× / 2.75× /
-3.69× at S=1/2/4/8. Application authors who need per-key FIFO at S>1
-(per-customer, per-order, per-account) pass `InsertOpts::ordering_key` (Rust)
-or `ordering_key=...` (Python) on insert — jobs sharing the key always land on
-the same shard regardless of which producer batch emitted them.
+A 16-producer same-queue reference sweep measured 1.0× / 1.60× / 2.75× / 3.69× at S=1/2/4/8. Application authors who need per-key FIFO at S>1 (per-customer, per-order, per-account) pass `InsertOpts::ordering_key` (Rust) or `ordering_key=...` (Python) on insert — jobs sharing the key always land on the same shard regardless of which producer batch emitted them.
 
 Observability: the `awa.job.claimed` OTel counter carries an `awa.enqueue.shard` attribute on the queue-storage claim path. Dashboards can sum by that attribute to confirm the claim ordering is rotating fairly across shards.
 
@@ -628,67 +473,27 @@ Lowering the value is safe at any time — see [`docs/upgrade-0.5-to-0.6.md`](up
 
 ### Hot-Queue Claim Control
 
-Queue storage also uses a bounded-claimer control plane
-(`queue_claimer_state` / `queue_claimer_leases`) so not every replica hammers a
-hot queue's claim path at once. For a single hot queue, raising
-`QueueConfig.claimers` lets one runtime run multiple dispatcher/claimer loops
-while still sharing the queue's `max_workers` / `min_workers` permits.
+Queue storage also uses a bounded-claimer control plane (`queue_claimer_state` / `queue_claimer_leases`) so not every replica hammers a hot queue's claim path at once. For a single hot queue, raising `QueueConfig.claimers` lets one runtime run multiple dispatcher/claimer loops while still sharing the queue's `max_workers` / `min_workers` permits.
 
-Keep `claimers` modest. In the hot-queue reference shape, `enqueue_shards = 4`
-is the change that turns overload into bounded end-to-end throughput; raising
-`claimers` to `4` increases transaction pressure and worsens tail latency in
-that shape. For extreme single-queue workloads, raise `enqueue_shards` first
-when the ordering contract allows partitioned FIFO. Benchmark `claimers = 2`
-or `4` only for a workload-specific reason, and judge the result by durable
-completion rate, p99 end-to-end latency, queue depth, WAL bytes per completed
-job, transaction commits per completed job, and dead tuples. Lower
-`claim_batch_size` from `512` for small or latency-sensitive queues; raise
-claimers only with workload-specific evidence.
+Keep `claimers` modest. In the hot-queue reference shape, `enqueue_shards = 4` is the change that turns overload into bounded end-to-end throughput; raising `claimers` to `4` increases transaction pressure and worsens tail latency in that shape. For extreme single-queue workloads, raise `enqueue_shards` first when the ordering contract allows partitioned FIFO. Benchmark `claimers = 2` or `4` only for a workload-specific reason, and judge the result by durable completion rate, p99 end-to-end latency, queue depth, WAL bytes per completed job, transaction commits per completed job, and dead tuples. Lower `claim_batch_size` from `512` for small or latency-sensitive queues; raise claimers only with workload-specific evidence.
 
-Queue storage defaults `AWA_COMPLETION_SHARDS` to `1` (`8` on canonical
-storage). Extra completion flushers can improve some single-process shapes, but
-they also multiply terminal-write contention across a worker fleet. Raise this
-only after measuring the same north-star metrics for the target topology.
+Queue storage defaults `AWA_COMPLETION_SHARDS` to `1` (`8` on canonical storage). Extra completion flushers can improve some single-process shapes, but they also multiply terminal-write contention across a worker fleet. Raise this only after measuring the same north-star metrics for the target topology.
 
-`AWA_COMPLETION_BATCH_SIZE` defaults to `512` and `AWA_COMPLETION_FLUSH_MS`
-defaults to `1`. The queue-storage short-job path fuses receipt closure and
-terminal insertion into one statement, so the lower flush interval reduces the
-worker capacity tied up waiting for durable completion while the batch size
-still amortises the claim/complete path under load. That pairing is what moves
-the lower WAL budget into durable throughput.
+`AWA_COMPLETION_BATCH_SIZE` defaults to `512` and `AWA_COMPLETION_FLUSH_MS` defaults to `1`. The queue-storage short-job path fuses receipt closure and terminal insertion into one statement, so the lower flush interval reduces the worker capacity tied up waiting for durable completion while the batch size still amortises the claim/complete path under load. That pairing is what moves the lower WAL budget into durable throughput.
 
-For very high-throughput no-op queues, size `max_workers` for durable
-completion latency, not handler CPU alone. The `10k/s` offered-rate reference
-shape needs 1,024 in-flight worker permits to absorb the load consistently;
-real jobs with non-trivial handler time need workload-specific sizing.
+For very high-throughput no-op queues, size `max_workers` for durable completion latency, not handler CPU alone. The `10k/s` offered-rate reference shape needs 1,024 in-flight worker permits to absorb the load consistently; real jobs with non-trivial handler time need workload-specific sizing.
 
-The terminal write path is already narrow for running/waiting jobs: it stores
-the terminal fact in `done_entries_*` and avoids duplicating immutable ready
-body fields. That keeps the default completion settings conservative without
-giving up durable terminal history.
+The terminal write path is already narrow for running/waiting jobs: it stores the terminal fact in `done_entries_*` and avoids duplicating immutable ready body fields. That keeps the default completion settings conservative without giving up durable terminal history.
 
 ## Dead Letter Queue
 
-The DLQ is the **separate, durable hold-table for jobs that exhausted
-retries or hit a non-retryable terminal failure**. Without it,
-terminal failures live in ordinary queue-storage `done_entries_*` partitions
-and are reclaimed when queue-ring prune can safely truncate their segment.
-With DLQ enabled, those rows land in
-`dlq_entries`, are visible to the admin UI / API as a discrete
-backlog, and can be retried or purged by an operator.
+The DLQ is the **separate, durable hold-table for jobs that exhausted retries or hit a non-retryable terminal failure**. Without it, terminal failures live in ordinary queue-storage `done_entries_*` partitions and are reclaimed when queue-ring prune can safely truncate their segment. With DLQ enabled, those rows land in `dlq_entries`, are visible to the admin UI / API as a discrete backlog, and can be retried or purged by an operator.
 
 ### When to enable
 
-- **Enable DLQ for queues whose terminal failures need an operator
-  decision.** Payment, notification, billing — anything where you'd
-  rather a human triages a failure than have the job silently age out.
-- **Leave DLQ disabled for high-throughput queues whose failures are
-  fire-and-forget.** Logging, telemetry, ETL retries that get
-  re-driven from upstream — accumulating dead rows here is just
-  storage cost.
-- **Default to disabled** unless you've decided either way; the
-  builder's `dlq_enabled_by_default` is the global switch and
-  `queue_dlq_enabled` is the per-queue override.
+- **Enable DLQ for queues whose terminal failures need an operator decision.** Payment, notification, billing — anything where you'd rather a human triages a failure than have the job silently age out.
+- **Leave DLQ disabled for high-throughput queues whose failures are fire-and-forget.** Logging, telemetry, ETL retries that get re-driven from upstream — accumulating dead rows here is just storage cost.
+- **Default to disabled** unless you've decided either way; the builder's `dlq_enabled_by_default` is the global switch and `queue_dlq_enabled` is the per-queue override.
 
 ### Configuring
 
@@ -704,14 +509,9 @@ let client = Client::builder(pool.clone())
     .await?;
 ```
 
-DLQ policy is per-queue, not per-job-kind. If you need a single queue
-to handle some kinds with DLQ and some without, split them onto two
-queues (the same shape recommended for [worker scope by
-kind](#targeting-specific-job-kinds-within-a-queue)).
+DLQ policy is per-queue, not per-job-kind. If you need a single queue to handle some kinds with DLQ and some without, split them onto two queues (the same shape recommended for [worker scope by kind](#targeting-specific-job-kinds-within-a-queue)).
 
-Per-queue retention overrides go through `RetentionPolicy.dlq` on
-`queue_retention(queue, policy)` — handy if one queue's failures need
-to live longer than the global `dlq_retention`.
+Per-queue retention overrides go through `RetentionPolicy.dlq` on `queue_retention(queue, policy)` — handy if one queue's failures need to live longer than the global `dlq_retention`.
 
 ### Operator workflow
 
@@ -720,13 +520,9 @@ Once DLQ is on, operators interact with it through:
 - **Web UI** — DLQ tab with retry, purge, and per-row failure detail.
 - **CLI** — `awa dlq list`, `awa dlq retry <id>`, `awa dlq purge`.
 - **REST** — `/api/dlq/*` endpoints (same actions as the UI).
-- **Python / Rust** — `client.dlq_*` admin methods for programmatic
-  retry / purge.
+- **Python / Rust** — `client.dlq_*` admin methods for programmatic retry / purge.
 
-Queue-policy declaration is still a runtime-side concern; the UI /
-API report state but don't toggle DLQ on/off (that's a code-level
-decision so it doesn't drift between deployments). See
-[ADR-020](adr/020-dead-letter-queue.md).
+Queue-policy declaration is still a runtime-side concern; the UI / API report state but don't toggle DLQ on/off (that's a code-level decision so it doesn't drift between deployments). See [ADR-020](adr/020-dead-letter-queue.md).
 
 ## CLI and `awa serve`
 
@@ -741,7 +537,7 @@ awa serve --pool-max 10 --cache-ttl 5
 Every flag has a corresponding `AWA_*` environment variable (shown in `--help`):
 
 | Flag | Env var | Default | Purpose |
-|---|---|---|---|
+| --- | --- | --- | --- |
 | `--pool-max` | `AWA_POOL_MAX` | `10` | Max database connections |
 | `--pool-min` | `AWA_POOL_MIN` | `2` | Min idle connections |
 | `--pool-idle-timeout` | `AWA_POOL_IDLE_TIMEOUT` | `300` | Idle connection timeout (seconds) |
@@ -762,7 +558,7 @@ If you're connecting to a read replica, increase `--cache-ttl` to reduce load. T
 There are two ways to opt in:
 
 | Mode | Trigger | When to use |
-|---|---|---|
+| --- | --- | --- |
 | Auto-detect (default) | Server probes `current_setting('transaction_read_only')` on startup | Pointed at a read replica or a Postgres role without write grants |
 | Forced | `--read-only` flag or `AWA_READ_ONLY=1` env var | Writable DB but you want mutations off — incident read-outs, shared debugging instances, less-trusted public UI sessions |
 

--- a/docs/dead-letter-queue.md
+++ b/docs/dead-letter-queue.md
@@ -1,28 +1,14 @@
 # Dead Letter Queue
 
-The Dead Letter Queue (DLQ) holds jobs that have exhausted all of their retry
-attempts. It is the recovery surface for terminal failures: an operator can
-inspect what failed, decide whether the underlying problem has been fixed,
-and either retry or purge.
+The Dead Letter Queue (DLQ) holds jobs that have exhausted all of their retry attempts. It is the recovery surface for terminal failures: an operator can inspect what failed, decide whether the underlying problem has been fixed, and either retry or purge.
 
 ## When a job lands in the DLQ
 
-Per-queue policy controls DLQ behaviour. When `dlq_enabled = true` on a
-queue, a job that reaches its `max_attempts` ceiling without succeeding is
-moved into `dlq_entries` rather than left as a `failed` terminal row. The
-job's final error history, args, payload, and lifecycle metadata travel with
-it; the DLQ row is a faithful snapshot of the job at the moment it gave up.
+Per-queue policy controls DLQ behaviour. When `dlq_enabled = true` on a queue, a job that reaches its `max_attempts` ceiling without succeeding is moved into `dlq_entries` rather than left as a `failed` terminal row. The job's final error history, args, payload, and lifecycle metadata travel with it; the DLQ row is a faithful snapshot of the job at the moment it gave up.
 
-A queue with `dlq_enabled = false` (the default before 0.6) leaves terminal
-failures as `failed` rows in the canonical / queue-storage tables. They can
-still be inspected and re-queued manually, but they do not flow through the
-DLQ-specific commands and dashboards.
+A queue with `dlq_enabled = false` (the default before 0.6) leaves terminal failures as `failed` rows in the canonical / queue-storage tables. They can still be inspected and re-queued manually, but they do not flow through the DLQ-specific commands and dashboards.
 
-The DLQ is **not** a job state — it is a separate physical surface
-(`awa.dlq_entries` in the queue-storage schema). A job in the DLQ does not
-sit on the dispatchable path and cannot be claimed by a worker until it is
-retried out of the DLQ. See [ADR-020](adr/020-dead-letter-queue.md) for the
-design rationale.
+The DLQ is **not** a job state — it is a separate physical surface (`awa.dlq_entries` in the queue-storage schema). A job in the DLQ does not sit on the dispatchable path and cannot be claimed by a worker until it is retried out of the DLQ. See [ADR-020](adr/020-dead-letter-queue.md) for the design rationale.
 
 ## Inspecting
 
@@ -37,12 +23,11 @@ awa dlq list --queue billing --kind charge_card --limit 50
 awa dlq list --tag urgent --before-dlq-at 2026-04-30T00:00:00Z
 ```
 
-The web UI's **DLQ** tab (the one served by `awa serve`) shows the same data
-with filters and per-row drill-down.
+The web UI's **DLQ** tab (the one served by `awa serve`) shows the same data with filters and per-row drill-down.
 
 Each DLQ row carries:
-- `dlq_reason` — short string identifying why the job was dead-lettered
-  (e.g., `max_attempts`, `manual`, `deadline_expired`).
+
+- `dlq_reason` — short string identifying why the job was dead-lettered (e.g., `max_attempts`, `manual`, `deadline_expired`).
 - `dlq_at` — when the job entered the DLQ.
 - `original_run_lease` — the run-lease the job held at the moment it failed.
 - The full error history from the `payload.errors[]` array.
@@ -62,22 +47,13 @@ awa dlq retry-bulk --kind charge_card --tag manual_review
 awa dlq retry-bulk --all
 ```
 
-Retry moves the row out of `dlq_entries` and back into the runnable path
-with `attempt = 0` and `run_lease = 0`, ready for fresh processing. The
-retry is recorded in the job's error history; the original failure trail is
-preserved.
+Retry moves the row out of `dlq_entries` and back into the runnable path with `attempt = 0` and `run_lease = 0`, ready for fresh processing. The retry is recorded in the job's error history; the original failure trail is preserved.
 
-The CLI retries with the stored queue, priority, and immediate `run_at`. The
-programmatic APIs can override those when reviving a DLQ row; use Python
-`retry_from_dlq(job_id, priority=..., queue=..., run_at=...)` or Rust
-`RetryFromDlqOpts` when recovery should promote, demote, reroute, or delay the
-job.
+The CLI retries with the stored queue, priority, and immediate `run_at`. The programmatic APIs can override those when reviving a DLQ row; use Python `retry_from_dlq(job_id, priority=..., queue=..., run_at=...)` or Rust `RetryFromDlqOpts` when recovery should promote, demote, reroute, or delay the job.
 
 ## Moving existing terminal failures into the DLQ
 
-If you turn on `dlq_enabled` for a queue that already has accumulated
-`failed` rows, the existing terminal failures stay where they are. To pull
-them into the DLQ for inspection:
+If you turn on `dlq_enabled` for a queue that already has accumulated `failed` rows, the existing terminal failures stay where they are. To pull them into the DLQ for inspection:
 
 ```bash
 # Move all failed rows on a queue into the DLQ
@@ -87,8 +63,7 @@ awa dlq move --queue billing --reason "audit_2026_q2" --all
 awa dlq move --kind charge_card --reason "audit_2026_q2"
 ```
 
-The `--reason` is recorded in `dlq_reason` so you can distinguish bulk
-historical moves from runtime-driven dead-lettering.
+The `--reason` is recorded in `dlq_reason` so you can distinguish bulk historical moves from runtime-driven dead-lettering.
 
 ## Purging
 
@@ -100,36 +75,20 @@ awa dlq purge --queue billing --kind charge_card
 awa dlq purge --all
 ```
 
-Purging is destructive: the rows are deleted from `dlq_entries` and not
-recoverable through the DLQ tools. Use with care; prefer `retry-bulk` if
-you might want the data back.
+Purging is destructive: the rows are deleted from `dlq_entries` and not recoverable through the DLQ tools. Use with care; prefer `retry-bulk` if you might want the data back.
 
 ## Retention
 
-The maintenance leader periodically prunes DLQ rows older than the
-configured retention window. See [`docs/configuration.md`](configuration.md)
-for the `dlq_retention_*` knobs. Retention runs alongside the rotation /
-prune work for the queue and lease rings, so a busy DLQ does not delay
-queue-plane reclamation.
+The maintenance leader periodically prunes DLQ rows older than the configured retention window. See [`docs/configuration.md`](configuration.md) for the `dlq_retention_*` knobs. Retention runs alongside the rotation / prune work for the queue and lease rings, so a busy DLQ does not delay queue-plane reclamation.
 
 ## Programmatic access
 
-Rust callers use `awa_model::dlq` directly, or `awa::model::dlq` through the
-facade crate, for DLQ list, retry, move, and purge helpers. Admin helpers
-such as `awa::admin::fail_to_dlq`, `move_failed_to_dlq`, and
-`bulk_move_failed_to_dlq` route failed terminal jobs into the DLQ.
+Rust callers use `awa_model::dlq` directly, or `awa::model::dlq` through the facade crate, for DLQ list, retry, move, and purge helpers. Admin helpers such as `awa::admin::fail_to_dlq`, `move_failed_to_dlq`, and `bulk_move_failed_to_dlq` route failed terminal jobs into the DLQ.
 
-Python callers use direct client methods:
-`list_dlq`, `get_dlq_job`, `dlq_depth`, `dlq_depth_by_queue`, `retry_from_dlq`,
-`bulk_retry_from_dlq`, `move_failed_to_dlq`, `purge_dlq`, and
-`purge_dlq_job`. `purge_dlq(...)` is the bulk purge helper; `purge_dlq_job(...)`
-purges one DLQ row by job ID. These wrap the same SQL helpers the CLI uses.
+Python callers use direct client methods: `list_dlq`, `get_dlq_job`, `dlq_depth`, `dlq_depth_by_queue`, `retry_from_dlq`, `bulk_retry_from_dlq`, `move_failed_to_dlq`, `purge_dlq`, and `purge_dlq_job`. `purge_dlq(...)` is the bulk purge helper; `purge_dlq_job(...)` purges one DLQ row by job ID. These wrap the same SQL helpers the CLI uses.
 
 ## See also
 
-- [ADR-020 — Dead Letter Queue](adr/020-dead-letter-queue.md) — design and
-  trade-offs.
-- [configuration.md](configuration.md) — `dlq_enabled` per queue, retention
-  knobs.
-- [troubleshooting.md](troubleshooting.md) — diagnosing why a particular job
-  reached the DLQ.
+- [ADR-020 — Dead Letter Queue](adr/020-dead-letter-queue.md) — design and trade-offs.
+- [configuration.md](configuration.md) — `dlq_enabled` per queue, retention knobs.
+- [troubleshooting.md](troubleshooting.md) — diagnosing why a particular job reached the DLQ.

--- a/docs/deploying-on-managed-postgres.md
+++ b/docs/deploying-on-managed-postgres.md
@@ -1,102 +1,56 @@
 # Deploying awa on managed Postgres
 
-This page collects the operational gotchas and sizing data we learned
-running awa workers against Google Cloud SQL and AlloyDB in staging.
-Most of it applies to any managed Postgres (Amazon RDS / Aurora, Azure
-Database for PostgreSQL, etc.); GCP-specific advice is called out.
+This page collects the operational gotchas and sizing data we learned running awa workers against Google Cloud SQL and AlloyDB in staging. Most of it applies to any managed Postgres (Amazon RDS / Aurora, Azure Database for PostgreSQL, etc.); GCP-specific advice is called out.
 
-The reference data here was captured on a single 4-pod consumer × 4-pod
-producer fleet against a dedicated benchmarking database on each
-engine, with `enqueue_shards = 16` and the queue-storage direct COPY
-producer path. See [`benchmarking.md`](benchmarking.md) for methodology
-and the `awa-bench-driver` reports for raw numbers and EXPLAIN traces.
+The reference data here was captured on a single 4-pod consumer × 4-pod producer fleet against a dedicated benchmarking database on each engine, with `enqueue_shards = 16` and the queue-storage direct COPY producer path. See [`benchmarking.md`](benchmarking.md) for methodology and the `awa-bench-driver` reports for raw numbers and EXPLAIN traces.
 
 ## Pick a Postgres version
 
-**Use Postgres 18 if it's available.** On AlloyDB specifically we
-measured a hard cap at 4 vCPU on PG17 (~2 k jobs/s sustained, with
-`AccessShareLock` waiters queueing behind ring-rotation
-`ACCESS EXCLUSIVE` operations from the maintenance loop) that
-disappeared after an in-place upgrade to PG18 — the same 4 vCPU
-instance jumped to ~5 k jobs/s sustained, matching Cloud SQL PG18 at
-the same shape exactly.
+**Use Postgres 18 if it's available.** On AlloyDB specifically we measured a hard cap at 4 vCPU on PG17 (~2 k jobs/s sustained, with `AccessShareLock` waiters queueing behind ring-rotation `ACCESS EXCLUSIVE` operations from the maintenance loop) that disappeared after an in-place upgrade to PG18 — the same 4 vCPU instance jumped to ~5 k jobs/s sustained, matching Cloud SQL PG18 at the same shape exactly.
 
-Cloud SQL on PG17 is fine in our measurements; we did not see the same
-cap there. If you're on AlloyDB PG17 today and considering an upgrade
-for other reasons, awa throughput is one more reason to do it.
+Cloud SQL on PG17 is fine in our measurements; we did not see the same cap there. If you're on AlloyDB PG17 today and considering an upgrade for other reasons, awa throughput is one more reason to do it.
 
 ## Pick a vCPU size
 
-The numbers below are *steady-state job completion* and *burst enqueue*
-on the queue-storage direct COPY producer path with `bench.noop`
-handlers (no per-job work). Real handlers reduce the consumer side
-proportionally; the burst-enqueue side is producer-bound and largely
-indifferent to handler cost.
+The numbers below are _steady-state job completion_ and _burst enqueue_ on the queue-storage direct COPY producer path with `bench.noop` handlers (no per-job work). Real handlers reduce the consumer side proportionally; the burst-enqueue side is producer-bound and largely indifferent to handler cost.
 
 | Engine | vCPU | PG | Sustained completed | 1 M spike enqueue | 1 M backlog drain |
-|---|---:|---:|---:|---:|---:|
-| Cloud SQL | 1  | 17 | ~500   jobs/s | ~40,000 inserts/s | — |
-| Cloud SQL | 4  | 18 | ~5,000 jobs/s | ~70,000 inserts/s | — |
+| --- | --: | --: | --: | --: | --: |
+| Cloud SQL | 1 | 17 | ~500 jobs/s | ~40,000 inserts/s | — |
+| Cloud SQL | 4 | 18 | ~5,000 jobs/s | ~70,000 inserts/s | — |
 | Cloud SQL | 16 | 18 | ~14,000 jobs/s | ~77,000 inserts/s | ~14,000 jobs/s |
-| AlloyDB  | 4  | 18 | ~5,200 jobs/s | ~52,000 inserts/s | ~9,000 jobs/s |
+| AlloyDB | 4 | 18 | ~5,200 jobs/s | ~52,000 inserts/s | ~9,000 jobs/s |
 
 Reading the table:
 
-- **Sustained completed** scales roughly linearly with vCPU on Cloud
-  SQL PG18: 4 → 5 k/s, 16 → 14 k/s. AlloyDB PG18 4 vCPU matches Cloud
-  SQL PG18 4 vCPU end-to-end at this scale.
-- **Burst enqueue rate** saturates near 70–80 k/s on any 4 vCPU or
-  larger instance — the bottleneck is the producer-side COPY pipeline
-  and connection fan-out, not the DB CPU. Even a 1 vCPU Cloud SQL
-  absorbed 1 M jobs at 40 k/s.
-- **Backlog drain** matches the steady-state completion rate after
-  awa-model v021 (PR #263) — heavy depth no longer collapses the
-  dispatcher to ~10× slower than equilibrium.
+- **Sustained completed** scales roughly linearly with vCPU on Cloud SQL PG18: 4 → 5 k/s, 16 → 14 k/s. AlloyDB PG18 4 vCPU matches Cloud SQL PG18 4 vCPU end-to-end at this scale.
+- **Burst enqueue rate** saturates near 70–80 k/s on any 4 vCPU or larger instance — the bottleneck is the producer-side COPY pipeline and connection fan-out, not the DB CPU. Even a 1 vCPU Cloud SQL absorbed 1 M jobs at 40 k/s.
+- **Backlog drain** matches the steady-state completion rate after awa-model v021 (PR #263) — heavy depth no longer collapses the dispatcher to ~10× slower than equilibrium.
 
-Sizing rule of thumb: pick the vCPU count for your steady-state
-completion target, not the burst. Burst-only workloads can run on
-much smaller instances than their peak insertion rate would suggest.
+Sizing rule of thumb: pick the vCPU count for your steady-state completion target, not the burst. Burst-only workloads can run on much smaller instances than their peak insertion rate would suggest.
 
 ## IAM and Cloud SQL connectivity
 
-Migrations and custom queue-storage schema preparation need DDL-capable
-credentials. Ordinary workers can run with the runtime grants in
-[`security.md`](security.md) once `awa migrate` has materialized the default
-`awa` substrate, or once `awa storage prepare-queue-storage-schema` has
-materialized a custom queue-storage schema. If you rely on fresh-install
-auto-prepare from the first worker startup instead, that worker connection also
-needs the DDL privileges required by `prepare_schema()`.
+Migrations and custom queue-storage schema preparation need DDL-capable credentials. Ordinary workers can run with the runtime grants in [`security.md`](security.md) once `awa migrate` has materialized the default `awa` substrate, or once `awa storage prepare-queue-storage-schema` has materialized a custom queue-storage schema. If you rely on fresh-install auto-prepare from the first worker startup instead, that worker connection also needs the DDL privileges required by `prepare_schema()`.
 
 ### Cloud SQL with IAM authentication
 
-If your runtime SA authenticates via Cloud SQL IAM (recommended over
-password-based auth in GCP), the SA needs `cloudsqlsuperuser` to call
-`CREATE SEQUENCE`, `CREATE TABLE`, and a handful of other DDL the
-queue-storage substrate uses. Granting the role is a one-shot manual
-step — Cloud SQL doesn't expose it through the IAM grant — so it
-typically lives next to your Terraform that creates the IAM user:
+If your runtime SA authenticates via Cloud SQL IAM (recommended over password-based auth in GCP), the SA needs `cloudsqlsuperuser` to call `CREATE SEQUENCE`, `CREATE TABLE`, and a handful of other DDL the queue-storage substrate uses. Granting the role is a one-shot manual step — Cloud SQL doesn't expose it through the IAM grant — so it typically lives next to your Terraform that creates the IAM user:
 
 ```sql
 -- Run once per instance as a built-in superuser (e.g. `postgres`).
 GRANT cloudsqlsuperuser TO "operator@PROJECT.iam";
 ```
 
-If you skip this for the role that runs migrations / schema preparation, the
-setup job can fail with ownership or DDL permission errors before workers ever
-reach the queue-storage engine.
+If you skip this for the role that runs migrations / schema preparation, the setup job can fail with ownership or DDL permission errors before workers ever reach the queue-storage engine.
 
 ### AlloyDB
 
-AlloyDB grants `alloydbsuperuser` to IAM SAs automatically — no manual
-GRANT step needed.
+AlloyDB grants `alloydbsuperuser` to IAM SAs automatically — no manual GRANT step needed.
 
 ### Cloud SQL Auth Proxy / AlloyDB Auth Proxy as a native sidecar
 
-Both Cloud SQL Auth Proxy 2.x and AlloyDB Auth Proxy 1.x work well as
-Kubernetes native sidecars (initContainer with `restartPolicy:
-Always`) — preferable to a regular container because the proxy starts
-before the main container and the lifecycle is tied to the pod.
-Example consumer-pod fragment:
+Both Cloud SQL Auth Proxy 2.x and AlloyDB Auth Proxy 1.x work well as Kubernetes native sidecars (initContainer with `restartPolicy: Always`) — preferable to a regular container because the proxy starts before the main container and the lifecycle is tied to the pod. Example consumer-pod fragment:
 
 ```yaml
 spec:
@@ -105,14 +59,14 @@ spec:
     - name: auth-proxy
       image: gcr.io/cloud-sql-connectors/cloud-sql-proxy:2.13.0
       imagePullPolicy: IfNotPresent
-      restartPolicy: Always               # makes it a native sidecar
+      restartPolicy: Always # makes it a native sidecar
       args:
         - "--auto-iam-authn"
         - "--port=5432"
         - "PROJECT:REGION:INSTANCE"
       resources:
         requests: { cpu: 100m, memory: 128Mi }
-        limits:   { cpu: 500m, memory: 256Mi }
+        limits: { cpu: 500m, memory: 256Mi }
   containers:
     - name: worker
       image: ghcr.io/your-org/your-worker:tag
@@ -121,26 +75,13 @@ spec:
           value: "postgres://operator%40PROJECT.iam@127.0.0.1:5432/your_db?sslmode=disable"
 ```
 
-The same shape works for AlloyDB; swap the image to
-`gcr.io/alloydb-connectors/alloydb-auth-proxy:1.13.0` and the
-connection arg to
-`projects/PROJECT/locations/REGION/clusters/CLUSTER/instances/INSTANCE`.
+The same shape works for AlloyDB; swap the image to `gcr.io/alloydb-connectors/alloydb-auth-proxy:1.13.0` and the connection arg to `projects/PROJECT/locations/REGION/clusters/CLUSTER/instances/INSTANCE`.
 
 ## `enqueue_shards`: set this explicitly
 
-The default `awa.queue_meta.enqueue_shards = 1` means every producer
-contends on a single enqueue-head row per `(queue, priority)`. With
-multiple concurrent producers this serialises the entire enqueue path.
+The default `awa.queue_meta.enqueue_shards = 1` means every producer contends on a single enqueue-head row per `(queue, priority)`. With multiple concurrent producers this serialises the entire enqueue path.
 
-**Recommendation: insert a `queue_meta` row for every high-volume queue and
-set `enqueue_shards` to at least 4 only when that queue can accept
-partitioned FIFO.** Keep `enqueue_shards = 1` for queues that require strict
-FIFO across the whole `(queue, priority)` lane. A 16-producer same-queue sweep
-in awa's own benchmark measured 1.0× / 1.60× / 2.75× / 3.69× at S=1/2/4/8 —
-that's about a 2.75× lift from S=1 to S=4 on a contended queue. The staging
-benchmark sweep at S=4/8/16/32 (a different, 4-producer setup with the
-producer not the bottleneck) showed no material difference between those
-values at 10 k offered.
+**Recommendation: insert a `queue_meta` row for every high-volume queue and set `enqueue_shards` to at least 4 only when that queue can accept partitioned FIFO.** Keep `enqueue_shards = 1` for queues that require strict FIFO across the whole `(queue, priority)` lane. A 16-producer same-queue sweep in awa's own benchmark measured 1.0× / 1.60× / 2.75× / 3.69× at S=1/2/4/8 — that's about a 2.75× lift from S=1 to S=4 on a contended queue. The staging benchmark sweep at S=4/8/16/32 (a different, 4-producer setup with the producer not the bottleneck) showed no material difference between those values at 10 k offered.
 
 ```sql
 INSERT INTO awa.queue_meta (queue, enqueue_shards)
@@ -149,74 +90,35 @@ ON CONFLICT (queue)
 DO UPDATE SET enqueue_shards = EXCLUDED.enqueue_shards;
 ```
 
-Use an upsert — first-enqueue may create lane rows before any operator
-inserts a `queue_meta` row, so a plain `UPDATE` can quietly affect zero
-rows.
+Use an upsert — first-enqueue may create lane rows before any operator inserts a `queue_meta` row, so a plain `UPDATE` can quietly affect zero rows.
 
-Going higher than 4 only helps when producer-side head-row contention
-is your bottleneck; raise it after measuring. Lowering it later is
-safe (see [`upgrade-0.5-to-0.6.md`](upgrade-0.5-to-0.6.md#lowering-enqueue_shards))
-but the FIFO contract changes — see
-[`configuration.md`](configuration.md#sharding-the-enqueue-head-per-queue)
-and [ADR-025](adr/025-sharded-enqueue-heads.md).
+Going higher than 4 only helps when producer-side head-row contention is your bottleneck; raise it after measuring. Lowering it later is safe (see [`upgrade-0.5-to-0.6.md`](upgrade-0.5-to-0.6.md#lowering-enqueue_shards)) but the FIFO contract changes — see [`configuration.md`](configuration.md#sharding-the-enqueue-head-per-queue) and [ADR-025](adr/025-sharded-enqueue-heads.md).
 
 ## Producer path: use the direct COPY entry point
 
-For any high-volume producer running against managed Postgres (rather
-than a Docker-localhost benchmark) prefer the queue-storage native
-COPY path:
+For any high-volume producer running against managed Postgres (rather than a Docker-localhost benchmark) prefer the queue-storage native COPY path:
 
 - **Rust:** `QueueStorage::enqueue_params_copy(pool, &jobs)`.
 - **Python:** `client.enqueue_many_copy(jobs)`.
 
-The compat-friendly `insert_many_copy_from_pool` / `client.insert_many_copy`
-path routes each row through the `awa.insert_job_compat()` SQL function
-once per row. On a real DB the per-row function-call cost (lane head
-update, NOTIFY, admin metadata) sums to ~100–150 ms per row on
-AlloyDB through the auth-proxy — fine when the goal is "one writer,
-strict compatibility", catastrophic when the goal is "burst 10⁶ jobs
-in seconds." The direct path runs at the inserts-per-second numbers in
-the sizing table above.
+The compat-friendly `insert_many_copy_from_pool` / `client.insert_many_copy` path routes each row through the `awa.insert_job_compat()` SQL function once per row. On a real DB the per-row function-call cost (lane head update, NOTIFY, admin metadata) sums to ~100–150 ms per row on AlloyDB through the auth-proxy — fine when the goal is "one writer, strict compatibility", catastrophic when the goal is "burst 10⁶ jobs in seconds." The direct path runs at the inserts-per-second numbers in the sizing table above.
 
-See [`configuration.md`](configuration.md#producer-path-choice) for the
-full surface comparison.
+See [`configuration.md`](configuration.md#producer-path-choice) for the full surface comparison.
 
 ## Things that broke for us in staging — worth pre-empting
 
-These all eventually have fixes or workarounds, but each one cost
-hours the first time:
+These all eventually have fixes or workarounds, but each one cost hours the first time:
 
-- **Concurrent worker startup on a fresh DB used to expose
-  `prepare_schema` races.** The #264 fix serializes schema preparation under a
-  transaction-scoped advisory lock and keeps the install body on that same
-  connection. Still prefer running `awa migrate` as the explicit rollout step
-  for the default `awa` substrate, or `awa storage prepare-queue-storage-schema`
-  for custom queue-storage schemas, in production: it gives you one clear DDL
-  owner, avoids first-request startup surprises, and lets workers use
-  runtime-only grants.
+- **Concurrent worker startup on a fresh DB used to expose `prepare_schema` races.** The #264 fix serializes schema preparation under a transaction-scoped advisory lock and keeps the install body on that same connection. Still prefer running `awa migrate` as the explicit rollout step for the default `awa` substrate, or `awa storage prepare-queue-storage-schema` for custom queue-storage schemas, in production: it gives you one clear DDL owner, avoids first-request startup surprises, and lets workers use runtime-only grants.
 
-- **PG18-on-AlloyDB upgrade preserves the schema and v021 indexes
-  across the cut-over.** No re-bootstrap needed; just verify the
-  upgrade completed cleanly with `gcloud alloydb clusters describe`
-  showing `databaseVersion: POSTGRES_18` and run a smoke
-  enqueue/claim.
+- **PG18-on-AlloyDB upgrade preserves the schema and v021 indexes across the cut-over.** No re-bootstrap needed; just verify the upgrade completed cleanly with `gcloud alloydb clusters describe` showing `databaseVersion: POSTGRES_18` and run a smoke enqueue/claim.
 
-- **Cloud SQL `must be owner of database` errors when cleaning up.**
-  Test databases created by `partly_staging` (or whatever non-IAM user
-  ran your migration job) can't be dropped by the IAM SA. Use the
-  built-in `postgres` user via password from the
-  `*-postgres-password` Secret Manager secret, or grant ownership over
-  before dropping.
+- **Cloud SQL `must be owner of database` errors when cleaning up.** Test databases created by `partly_staging` (or whatever non-IAM user ran your migration job) can't be dropped by the IAM SA. Use the built-in `postgres` user via password from the `*-postgres-password` Secret Manager secret, or grant ownership over before dropping.
 
 ## Next
 
-- [Configuration knobs](configuration.md) — `enqueue_shards`, claimers,
-  retention, etc.
-- [PostgreSQL roles and privileges](security.md) — the SQL grants the
-  runtime expects.
-- [Migration guide](migrations.md) — schema version table and upgrade
-  ordering, including v021's shard-aware lane indexes.
-- [Deployment guide](deployment.md) — generic deployment patterns
-  (Docker, K8s, rolling deploys) not specific to managed Postgres.
-- [Benchmarking notes](benchmarking.md) — the in-repo benchmark
-  harness and reference numbers.
+- [Configuration knobs](configuration.md) — `enqueue_shards`, claimers, retention, etc.
+- [PostgreSQL roles and privileges](security.md) — the SQL grants the runtime expects.
+- [Migration guide](migrations.md) — schema version table and upgrade ordering, including v021's shard-aware lane indexes.
+- [Deployment guide](deployment.md) — generic deployment patterns (Docker, K8s, rolling deploys) not specific to managed Postgres.
+- [Benchmarking notes](benchmarking.md) — the in-repo benchmark harness and reference numbers.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -25,41 +25,26 @@ In production, treat these as separate concerns:
 
 ## Queue Storage Cutover
 
-Fresh 0.6 installs use queue storage as the worker engine. Existing 0.5.x
-clusters must use the staged storage-transition flow documented in
-[migrations.md](migrations.md) and the short operator checklist in
-[upgrade-0.5-to-0.6.md](upgrade-0.5-to-0.6.md).
+Fresh 0.6 installs use queue storage as the worker engine. Existing 0.5.x clusters must use the staged storage-transition flow documented in [migrations.md](migrations.md) and the short operator checklist in [upgrade-0.5-to-0.6.md](upgrade-0.5-to-0.6.md).
 
 Operationally:
 
 - queue storage is the 0.6 worker engine
-- canonical tables remain in the schema for migration, rollback boundaries,
-  and compatibility SQL surfaces
-- while state is `canonical` or `prepared`, 0.5.x and 0.6 pods may coexist and
-  all writes/execution remain canonical
-- after `enter-mixed-transition`, new writes route to queue storage while 0.6
-  drain workers finish the canonical backlog
-- once queue-storage rows exist, rollback to a 0.5.x-only fleet is not
-  supported; finish the transition or restore from backup
+- canonical tables remain in the schema for migration, rollback boundaries, and compatibility SQL surfaces
+- while state is `canonical` or `prepared`, 0.5.x and 0.6 pods may coexist and all writes/execution remain canonical
+- after `enter-mixed-transition`, new writes route to queue storage while 0.6 drain workers finish the canonical backlog
+- once queue-storage rows exist, rollback to a 0.5.x-only fleet is not supported; finish the transition or restore from backup
 
-For a 0.5.x cluster, do not stop canonical workers and start queue-storage
-workers as a separate manual cutover. Use the storage commands so producer
-routing, canonical drain, queue-storage executor readiness, and rollback
-interlocks move together.
+For a 0.5.x cluster, do not stop canonical workers and start queue-storage workers as a separate manual cutover. Use the storage commands so producer routing, canonical drain, queue-storage executor readiness, and rollback interlocks move together.
 
-Current Rust and Python worker starts default to the correct effective engine
-for the storage-transition state. Only set `queue_storage_schema` /
-`ClientBuilder::queue_storage(...)` when you need to override the default
-schema name or segment sizing.
+Current Rust and Python worker starts default to the correct effective engine for the storage-transition state. Only set `queue_storage_schema` / `ClientBuilder::queue_storage(...)` when you need to override the default schema name or segment sizing.
 
 ## Connection Pool Sizing
 
 Practical starting point, based on the current runtime internals:
 
-- each active queue claimer keeps one `LISTEN` connection open for wakeups
-  (`sum(queue.claimers)`, which equals `queue_count` with default claimers)
-- one cancel listener keeps a `LISTEN` connection open for admin-cancel
-  notifications
+- each active queue claimer keeps one `LISTEN` connection open for wakeups (`sum(queue.claimers)`, which equals `queue_count` with default claimers)
+- one cancel listener keeps a `LISTEN` connection open for admin-cancel notifications
 - the elected leader holds one advisory-lock connection while it remains leader
 - claim, heartbeat, completion, cleanup, and handler SQL all share the same pool
 
@@ -69,8 +54,7 @@ Conservative starting heuristic, not a hard requirement:
 max_connections >= sum(queue.claimers) + 5
 ```
 
-With the default `claimers = 1`, this is the old shortcut:
-`max_connections >= queue_count + 5`.
+With the default `claimers = 1`, this is the old shortcut: `max_connections >= queue_count + 5`.
 
 Then add headroom for:
 
@@ -88,11 +72,7 @@ The Python client defaults to `max_connections=10`. `awa serve` defaults to a po
 
 ## Primary Database Hygiene
 
-Queue storage keeps the main ready path append-only, but Awa is still a
-high-churn Postgres workload. The main operational pitfall is no longer one
-giant mutable queue heap; it is long-lived readers or stale transactions that
-block lease or segment prune while the maintenance leader keeps rotating
-forward.
+Queue storage keeps the main ready path append-only, but Awa is still a high-churn Postgres workload. The main operational pitfall is no longer one giant mutable queue heap; it is long-lived readers or stale transactions that block lease or segment prune while the maintenance leader keeps rotating forward.
 
 Recommended practice:
 
@@ -100,15 +80,10 @@ Recommended practice:
 - run long-lived reporting queries against a replica when possible
 - avoid leaving sessions `idle in transaction`
 - monitor `pg_stat_activity` for long transactions
-- monitor `pg_stat_user_tables` on the active queue-storage schema; `ready`
-  segments should stay near zero dead tuples, lease segments may spike within
-  the rotation window but should collapse after prune, and `attempt_state`
-  should roughly track live long-running attempts
+- monitor `pg_stat_user_tables` on the active queue-storage schema; `ready` segments should stay near zero dead tuples, lease segments may spike within the rotation window but should collapse after prune, and `attempt_state` should roughly track live long-running attempts
 - tune autovacuum for the database if the lease tables churn heavily
 
-The nightly MVCC benchmark exists to catch changes that make this failure mode
-worse, but it is not a substitute for keeping the primary free of stale
-snapshots.
+The nightly MVCC benchmark exists to catch changes that make this failure mode worse, but it is not a substitute for keeping the primary free of stale snapshots.
 
 ## Docker
 
@@ -221,13 +196,9 @@ For smooth rollouts:
 3. Let old pods drain with `shutdown(...)`.
 4. Keep `terminationGracePeriodSeconds` slightly above that drain timeout.
 
-Code-only releases can roll normally because the schema migrations are
-additive-only.
+Code-only releases can roll normally because the schema migrations are additive-only.
 
-Storage-engine cutovers are different from normal code-only releases. Follow
-the staged `prepare -> enter-mixed-transition -> finalize` flow in
-[upgrade-0.5-to-0.6.md](upgrade-0.5-to-0.6.md) so the database state, producer
-routing, and runtime roles remain aligned.
+Storage-engine cutovers are different from normal code-only releases. Follow the staged `prepare -> enter-mixed-transition -> finalize` flow in [upgrade-0.5-to-0.6.md](upgrade-0.5-to-0.6.md) so the database state, producer routing, and runtime roles remain aligned.
 
 ## Queue Isolation Patterns
 
@@ -260,11 +231,7 @@ awa --database-url "$DATABASE_URL" serve --read-only
 
 This forces read-only even when the Postgres connection is fully writable — the UI hides mutation buttons and every mutation endpoint returns 503. See [configuration.md#read-only-mode](configuration.md#read-only-mode) for the tradeoff versus pointing at a read replica.
 
-If you expose the callback receiver endpoints for `HttpWorker`, also configure
-`AWA_CALLBACK_HMAC_SECRET` (or `--callback-hmac-secret`) so `awa-ui` verifies
-`X-Awa-Signature` on callback requests. See
-[HTTP workers and callback signatures](http-callbacks.md) for the worker,
-function, and receiver contract.
+If you expose the callback receiver endpoints for `HttpWorker`, also configure `AWA_CALLBACK_HMAC_SECRET` (or `--callback-hmac-secret`) so `awa-ui` verifies `X-Awa-Signature` on callback requests. See [HTTP workers and callback signatures](http-callbacks.md) for the worker, function, and receiver contract.
 
 ## Next
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -2,9 +2,7 @@
 
 ## Release Process
 
-Use pre-release tags before publishing a final version. Both crates.io and PyPI
-treat published versions as immutable — a botched release cannot be overwritten
-and the version number is burned.
+Use pre-release tags before publishing a final version. Both crates.io and PyPI treat published versions as immutable — a botched release cannot be overwritten and the version number is burned.
 
 ### Workflow
 
@@ -24,8 +22,7 @@ and the version number is burned.
 ### Steps
 
 1. Bump version in these release manifests:
-   - `Cargo.toml` (workspace `[workspace.package].version` and every
-     workspace dependency whose version points at an Awa crate being released)
+   - `Cargo.toml` (workspace `[workspace.package].version` and every workspace dependency whose version points at an Awa crate being released)
    - `awa/Cargo.toml` (`awa-testing` dev-dependency version)
    - `awa-cli/Cargo.toml` (`awa-ui` dependency version)
    - `awa-cli/pyproject.toml` (`[project].version` — controls CLI wheel version on PyPI)
@@ -34,18 +31,15 @@ and the version number is burned.
 2. Commit: `Bump version to 0.x.0-alpha.1`
 3. Push to a branch, wait for CI green.
 4. Tag and push: `git tag v0.x.0-alpha.1 && git push origin v0.x.0-alpha.1`
-5. The Release workflow builds wheels, publishes to crates.io and PyPI, and
-   creates a GitHub Release with binary assets.
+5. The Release workflow builds wheels, publishes to crates.io and PyPI, and creates a GitHub Release with binary assets.
 6. When ready for final: bump version to `0.x.0`, merge to main, tag `v0.x.0`.
 
 ### Why pre-releases matter
 
-v0.2.0 was published directly. The GitHub Release workflow tried to attach
-binary assets to an already-published release, which GitHub blocks. Pre-release
-tags avoid this because:
+v0.2.0 was published directly. The GitHub Release workflow tried to attach binary assets to an already-published release, which GitHub blocks. Pre-release tags avoid this because:
+
 - Draft releases are created by the workflow, not manually
-- If a pre-release has problems, you bump to `-alpha.2` instead of fighting
-  immutable registries
+- If a pre-release has problems, you bump to `-alpha.2` instead of fighting immutable registries
 
 ## Crate Dependencies
 
@@ -70,12 +64,12 @@ awa (facade)   awa-testing
 
 Key dependencies per crate:
 
-| Crate | Key deps |
-|-------|----------|
-| `awa-model` | sqlx, blake3, serde, chrono, chrono-tz, croner |
-| `awa-worker` | awa-model, tokio, opentelemetry |
-| `awa-ui` | awa-model, axum, rust-embed |
-| `awa-cli` | awa-model, awa-ui, axum, clap |
+| Crate        | Key deps                                         |
+| ------------ | ------------------------------------------------ |
+| `awa-model`  | sqlx, blake3, serde, chrono, chrono-tz, croner   |
+| `awa-worker` | awa-model, tokio, opentelemetry                  |
+| `awa-ui`     | awa-model, axum, rust-embed                      |
+| `awa-cli`    | awa-model, awa-ui, axum, clap                    |
 | `awa-python` | awa-model, awa-worker, pyo3, pyo3-async-runtimes |
 
 ## Running Tests

--- a/docs/getting-started-python.md
+++ b/docs/getting-started-python.md
@@ -129,10 +129,7 @@ python -m awa --database-url "$DATABASE_URL" serve
 
 ## ORM Transaction Bridging
 
-Most applications should keep using their normal database stack for business
-tables. Use `AsyncClient`/`Client` for workers, admin calls, migrations, and
-queue-only producers; when a web request already has a transaction, enqueue
-through `awa.bridge` on that same connection/session.
+Most applications should keep using their normal database stack for business tables. Use `AsyncClient`/`Client` for workers, admin calls, migrations, and queue-only producers; when a web request already has a transaction, enqueue through `awa.bridge` on that same connection/session.
 
 Install the app database libraries you already use, for example:
 
@@ -170,8 +167,7 @@ async def create_order(session: AsyncSession, order_id: str, email: str) -> int:
     return job["id"]
 ```
 
-The same bridge supports asyncpg, psycopg3, SQLAlchemy, and Django; see
-[Bridge Adapters](bridge-adapters.md) for driver-specific examples.
+The same bridge supports asyncpg, psycopg3, SQLAlchemy, and Django; see [Bridge Adapters](bridge-adapters.md) for driver-specific examples.
 
 ### Routing related jobs to the same shard
 

--- a/docs/getting-started-rust.md
+++ b/docs/getting-started-rust.md
@@ -153,8 +153,7 @@ The UI starts on `http://127.0.0.1:3000` by default.
 - `Client::shutdown(Duration)` is the graceful drain path. Set your container or process shutdown timeout slightly above that duration.
 - If you only need to enqueue jobs from Rust, depend on `awa-model` instead of `awa`.
 
-When enqueueing from a request or service method that already writes app
-data, use your existing `sqlx` transaction and pass it to Awa:
+When enqueueing from a request or service method that already writes app data, use your existing `sqlx` transaction and pass it to Awa:
 
 ```rust
 let mut tx = pool.begin().await?;
@@ -205,24 +204,16 @@ At the default `enqueue_shards = 1` the key is ignored. See [ADR-025](adr/025-sh
 - [Migration guide](migrations.md)
 - [Troubleshooting](troubleshooting.md)
 - [Advanced Rust example](../awa/examples/etl_pipeline.rs)
-- [Deadline-bounded polling pattern](../awa/examples/poll_until_deadline.rs) —
-  poll an external system every X until it's ready or the deadline
-  expires, using `JobResult::Snooze` so polls don't burn attempts.
+- [Deadline-bounded polling pattern](../awa/examples/poll_until_deadline.rs) — poll an external system every X until it's ready or the deadline expires, using `JobResult::Snooze` so polls don't burn attempts.
 
-  **Dashboard mid-run** — three polling jobs in flight (1 failed terminally,
-  1 scheduled between snoozes, 1 completed).
+  **Dashboard mid-run** — three polling jobs in flight (1 failed terminally, 1 scheduled between snoozes, 1 completed).
 
   ![AWA dashboard during deadline-bounded polling](assets/poll-until-deadline/dashboard.png)
 
-  **Jobs list at terminal state** — `failed` (upstream rejected),
-  `cancelled` (deadline exceeded), `completed` (upstream ready). All three
-  show `attempt 1/25` — Snooze did not consume attempts.
+  **Jobs list at terminal state** — `failed` (upstream rejected), `cancelled` (deadline exceeded), `completed` (upstream ready). All three show `attempt 1/25` — Snooze did not consume attempts.
 
   ![Jobs list showing failed, cancelled, and completed states side-by-side](assets/poll-until-deadline/jobs-list.png)
 
-  **Cancelled job detail** — timeline, error message naming the deadline
-  and poll count, progress bar tracking the deadline window, and progress
-  metadata `{"poll": 30}` proving the per-job counter survived 30 Snooze
-  cycles via `ctx.job.progress`.
+  **Cancelled job detail** — timeline, error message naming the deadline and poll count, progress bar tracking the deadline window, and progress metadata `{"poll": 30}` proving the per-job counter survived 30 Snooze cycles via `ctx.job.progress`.
 
   ![Cancelled job detail with timeline, progress, and arguments](assets/poll-until-deadline/cancelled-job-detail.png)

--- a/docs/grafana/README.md
+++ b/docs/grafana/README.md
@@ -7,8 +7,8 @@ Two dashboards are provided:
 
 Previews (live demo workload, both dashboards rendered against a local `grafana/otel-lgtm` collector + Postgres):
 
-| Postgres | OTel / Prometheus |
-|---|---|
+| Postgres                          | OTel / Prometheus             |
+| --------------------------------- | ----------------------------- |
 | ![](screenshots/awa-postgres.png) | ![](screenshots/awa-otel.png) |
 
 Alert rules (see [`alerts/`](alerts/)) import as Grafana unified-alerting file provisioning. Here's the rule browser after provisioning both variants, with the "no active runtime (Postgres)" rule firing after we stopped the demo worker:
@@ -38,7 +38,7 @@ The dashboard ships three example panels — **Queue Descriptor Catalog**, **Job
 ### Panels
 
 | Panel | Type | What it shows |
-|-------|------|---------------|
+| --- | --- | --- |
 | **Queue Lag** | Time series | Age of the oldest available job per queue |
 | **Queue Depth** | Stacked time series | Current jobs by queue and state (available, running, failed, scheduled, retryable, waiting external) |
 | **Job Wait Time (p50/p95/p99)** | Time series | Time from job creation to claim |
@@ -83,18 +83,20 @@ opentelemetry::global::set_meter_provider(provider);
 ### 2. Import the dashboard
 
 **Option A: Grafana UI**
+
 1. Open Grafana (default: http://localhost:3000)
 2. Go to Dashboards → Import
 3. Upload `awa-dashboard.json`
 4. Select your Prometheus datasource
 
-**Option B: Provisioning**
-Copy `awa-dashboard.json` to your Grafana provisioning directory:
+**Option B: Provisioning** Copy `awa-dashboard.json` to your Grafana provisioning directory:
+
 ```
 /etc/grafana/provisioning/dashboards/awa-dashboard.json
 ```
 
 **Option C: API**
+
 ```bash
 # The Grafana API requires a wrapper object around the dashboard JSON
 curl -X POST "http://admin:admin@localhost:3000/api/dashboards/db" \
@@ -105,6 +107,7 @@ curl -X POST "http://admin:admin@localhost:3000/api/dashboards/db" \
 ### 3. Verify metrics are flowing
 
 Check Prometheus has awa metrics:
+
 ```
 curl -s "http://localhost:9090/api/v1/label/__name__/values" | grep awa
 ```
@@ -116,8 +119,9 @@ Expected metrics: `awa_job_completed_total`, `awa_job_in_flight`, `awa_job_durat
 All metrics use the `awa` OTel meter name and are exported via OTLP to your configured collector.
 
 ### Job lifecycle
+
 | Metric | Type | Labels | Description |
-|--------|------|--------|-------------|
+| --- | --- | --- | --- |
 | `awa.job.completed` | Counter | kind, queue | Jobs completed |
 | `awa.job.failed` | Counter | kind, queue, terminal | Jobs failed |
 | `awa.job.retried` | Counter | kind, queue | Jobs retried |
@@ -129,38 +133,42 @@ All metrics use the `awa` OTel meter name and are exported via OTLP to your conf
 | `awa.job.waiting_external` | Counter | kind, queue | Parked for callback |
 
 ### Dispatcher
-| Metric | Type | Labels | Description |
-|--------|------|--------|-------------|
-| `awa.dispatch.claim_batches` | Counter | queue | Claim queries |
-| `awa.dispatch.claim_batch_size` | Histogram | queue | Jobs per claim |
-| `awa.dispatch.claim_duration` | Histogram (s) | queue | Claim query time |
+
+| Metric                          | Type          | Labels | Description      |
+| ------------------------------- | ------------- | ------ | ---------------- |
+| `awa.dispatch.claim_batches`    | Counter       | queue  | Claim queries    |
+| `awa.dispatch.claim_batch_size` | Histogram     | queue  | Jobs per claim   |
+| `awa.dispatch.claim_duration`   | Histogram (s) | queue  | Claim query time |
 
 ### Completion batcher
+
 | Metric | Type | Labels | Description |
-|--------|------|--------|-------------|
+| --- | --- | --- | --- |
 | `awa.completion.flushes` | Counter | shard | Flush operations |
 | `awa.completion.flush_batch_size` | Histogram | shard | Jobs per flush |
 | `awa.completion.flush_duration` | Histogram (s) | shard | Flush time |
 
 ### Maintenance
+
 | Metric | Type | Labels | Description |
-|--------|------|--------|-------------|
+| --- | --- | --- | --- |
 | `awa.maintenance.promote_batches` | Counter | state | Promotion batches |
 | `awa.maintenance.promote_batch_size` | Histogram | state | Jobs promoted |
 | `awa.maintenance.promote_duration` | Histogram (s) | state | Promotion time |
 | `awa.maintenance.rescues` | Counter | rescue_kind | Jobs rescued |
 
 ### Heartbeat
-| Metric | Type | Labels | Description |
-|--------|------|--------|-------------|
-| `awa.heartbeat.batches` | Counter | — | Heartbeat updates |
+
+| Metric                  | Type    | Labels | Description       |
+| ----------------------- | ------- | ------ | ----------------- |
+| `awa.heartbeat.batches` | Counter | —      | Heartbeat updates |
 
 ### Descriptors (info-style gauges)
 
 Emitted on every `runtime_snapshot_interval` tick. Value is always 1; the useful payload is the label set. Use with `group_left` joins to enrich other panels (see the "Descriptor metrics on the OTel dashboard" section above).
 
 | Metric | Type | Labels | Description |
-|--------|------|--------|-------------|
+| --- | --- | --- | --- |
 | `awa.queue.info` | Gauge | queue, display_name?, description?, owner?, docs_url?, tags? | Declared queue descriptor (label-join target) |
 | `awa.job_kind.info` | Gauge | kind, display_name?, description?, owner?, docs_url?, tags? | Declared job-kind descriptor (label-join target) |
 

--- a/docs/grafana/alerts/README.md
+++ b/docs/grafana/alerts/README.md
@@ -8,12 +8,12 @@ Two rule sets, pick whichever matches your observability stack:
 ## What fires, and when
 
 | Rule | Severity | Fires when | Clears |
-|------|----------|-----------|--------|
+| --- | --- | --- | --- |
 | `awa_queue_lag_high` | warning | oldest `available` job > 5m for 2m | lag drops below 5m |
 | `awa_error_rate_elevated` | warning | failed / (completed + failed) > 5% for 5m | ratio drops below 5% |
-| `awa_rescues_spiking` *(Prom only)* | warning | rescues > 1/s for 5m | rescue rate drops |
+| `awa_rescues_spiking` _(Prom only)_ | warning | rescues > 1/s for 5m | rescue rate drops |
 | `awa_no_active_runtime` | critical | active runtimes = 0 for 5m | at least one runtime reporting |
-| `awa_throughput_collapsed` *(Prom only)* | warning | completion rate < 10% of 1h baseline for 10m | rate recovers |
+| `awa_throughput_collapsed` _(Prom only)_ | warning | completion rate < 10% of 1h baseline for 10m | rate recovers |
 | `awa_descriptor_drift_persistent` | info | descriptor drift detected for 15m | all live runtimes agree |
 
 Every rule's `description` annotation names the dashboard panel an operator should look at and links to the relevant awa-ui page. The 2–15 minute `for` windows deliberately skip transient spikes (rolling deploys, CI runs).
@@ -50,11 +50,7 @@ sed 's/DS_PROMETHEUS/prom/' docs/grafana/alerts/awa-alerts-prometheus.yaml \
 
 ## Validating the rules locally
 
-For the Prometheus rule set, run the observability side-stack in
-`docker/observability/` and point a local worker or benchmark at
-`OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317`. For the Postgres rule set,
-provision a Postgres datasource that can read the Awa schema and use Grafana's
-rule test UI after replacing `DS_POSTGRES` with that datasource UID.
+For the Prometheus rule set, run the observability side-stack in `docker/observability/` and point a local worker or benchmark at `OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317`. For the Postgres rule set, provision a Postgres datasource that can read the Awa schema and use Grafana's rule test UI after replacing `DS_POSTGRES` with that datasource UID.
 
 ## Extending
 

--- a/docs/http-callbacks.md
+++ b/docs/http-callbacks.md
@@ -2,15 +2,10 @@
 
 Awa has two callback-related surfaces:
 
-- **In-process sequential callbacks**: a Rust or Python handler calls
-  `register_callback()` / `wait_for_callback()` and an external system later
-  resolves that callback through the SDK/admin API.
-- **HTTP worker callbacks**: the Rust `http-worker` feature dispatches a job to
-  an HTTP endpoint, parks the job in `waiting_external`, and expects the remote
-  function to call Awa's callback receiver when it is done.
+- **In-process sequential callbacks**: a Rust or Python handler calls `register_callback()` / `wait_for_callback()` and an external system later resolves that callback through the SDK/admin API.
+- **HTTP worker callbacks**: the Rust `http-worker` feature dispatches a job to an HTTP endpoint, parks the job in `waiting_external`, and expects the remote function to call Awa's callback receiver when it is done.
 
-This page documents the second path: `HttpWorker` async mode and the
-`awa serve` callback receiver.
+This page documents the second path: `HttpWorker` async mode and the `awa serve` callback receiver.
 
 ## End-to-end flow
 
@@ -34,9 +29,7 @@ Awa runtime                  Function endpoint                  awa serve
     | job becomes completed         |                               |
 ```
 
-The worker signs the callback ID before it calls the function. The function
-does not need the shared secret if it simply forwards the `X-Awa-Signature`
-header it received from the worker when it calls Awa back.
+The worker signs the callback ID before it calls the function. The function does not need the shared secret if it simply forwards the `X-Awa-Signature` header it received from the worker when it calls Awa back.
 
 ## Configure the receiver
 
@@ -47,14 +40,9 @@ export AWA_CALLBACK_HMAC_SECRET=0123456789abcdef0123456789abcdef0123456789abcdef
 awa --database-url "$DATABASE_URL" serve --host 0.0.0.0 --port 3000
 ```
 
-The secret must be 32 bytes encoded as 64 hex characters. When it is set,
-`awa serve` rejects callback requests that do not include a valid
-`X-Awa-Signature` header. When it is not set, signature verification is
-disabled, so the callback receiver must be protected by private networking or
-an authenticating proxy.
+The secret must be 32 bytes encoded as 64 hex characters. When it is set, `awa serve` rejects callback requests that do not include a valid `X-Awa-Signature` header. When it is not set, signature verification is disabled, so the callback receiver must be protected by private networking or an authenticating proxy.
 
-`--read-only` disables callback resolution because callback endpoints mutate
-job state.
+`--read-only` disables callback resolution because callback endpoints mutate job state.
 
 ## Configure the worker
 
@@ -84,18 +72,13 @@ let client = Client::builder(pool)
     .build()?;
 ```
 
-`callback_base_url` is the externally reachable base URL for `awa serve`.
-The runtime builds callback URLs as:
+`callback_base_url` is the externally reachable base URL for `awa serve`. The runtime builds callback URLs as:
 
 ```text
 {callback_base_url}{callback_path_prefix}/{callback_id}/complete
 ```
 
-`callback_path_prefix` defaults to `/api/callbacks`, which matches the
-built-in `awa serve` route layout. Override it when the callback receiver
-is mounted somewhere else — for example, a callback-only deployment behind
-a reverse proxy, or a user-owned API layer that hosts the routes inside
-a FastAPI / axum application (see [ADR-027](./adr/027-callback-ingress-surface.md)):
+`callback_path_prefix` defaults to `/api/callbacks`, which matches the built-in `awa serve` route layout. Override it when the callback receiver is mounted somewhere else — for example, a callback-only deployment behind a reverse proxy, or a user-owned API layer that hosts the routes inside a FastAPI / axum application (see [ADR-027](./adr/027-callback-ingress-surface.md)):
 
 ```rust
 let client = Client::builder(pool)
@@ -110,13 +93,9 @@ let client = Client::builder(pool)
     .build()?;
 ```
 
-That config produces URLs like
-`https://api.example.com/awa-cb/{callback_id}/complete`. Empty / missing
-leading slashes are normalized; trailing slashes are stripped.
+That config produces URLs like `https://api.example.com/awa-cb/{callback_id}/complete`. Empty / missing leading slashes are normalized; trailing slashes are stripped.
 
-User-owned receivers should reuse [`awa::callback_contract::callback_url`]
-to build URLs and [`awa::callback_contract::verify`] to authenticate
-inbound requests so the wire contract cannot drift.
+User-owned receivers should reuse [`awa::callback_contract::callback_url`] to build URLs and [`awa::callback_contract::verify`] to authenticate inbound requests so the wire contract cannot drift.
 
 ## Function request contract
 
@@ -140,9 +119,7 @@ and, when `hmac_secret` is configured, this header:
 X-Awa-Signature: <64-character hex signature>
 ```
 
-A `2xx` response means the function accepted the job and Awa parks the attempt
-in `waiting_external`. A `5xx` response is treated as retryable. A `4xx`
-response is treated as terminal.
+A `2xx` response means the function accepted the job and Awa parks the attempt in `waiting_external`. A `5xx` response is treated as retryable. A `4xx` response is treated as terminal.
 
 ## Callback receiver contract
 
@@ -154,17 +131,13 @@ POST /api/callbacks/{callback_id}/fail
 POST /api/callbacks/{callback_id}/heartbeat
 ```
 
-All three verify `X-Awa-Signature` when `AWA_CALLBACK_HMAC_SECRET` is set.
-The signature is computed over the callback ID string, not over the request
-body:
+All three verify `X-Awa-Signature` when `AWA_CALLBACK_HMAC_SECRET` is set. The signature is computed over the callback ID string, not over the request body:
 
 ```text
 hex(blake3_keyed_hash(secret_32_bytes, callback_id_utf8))
 ```
 
-Despite the `hmac_secret` option name, the algorithm is BLAKE3 keyed hashing,
-not RFC HMAC. The option name is retained because the secret is used for the
-same operational purpose: authenticating callback requests.
+Despite the `hmac_secret` option name, the algorithm is BLAKE3 keyed hashing, not RFC HMAC. The option name is retained because the secret is used for the same operational purpose: authenticating callback requests.
 
 Complete a callback:
 
@@ -193,19 +166,13 @@ curl -X POST "https://awa.example.com/api/callbacks/$CALLBACK_ID/heartbeat" \
   -d '{"timeout_seconds":3600}'
 ```
 
-The `complete` endpoint completes the job. It does not resume an in-process
-handler for sequential callback workflows; use the Rust/Python admin API
-`resume_external` path for that pattern.
+The `complete` endpoint completes the job. It does not resume an in-process handler for sequential callback workflows; use the Rust/Python admin API `resume_external` path for that pattern.
 
 ## Deploying callback ingress separately
 
-`awa serve` bundles the admin UI, admin REST API, static fallback, and the
-callback receiver behind a single router with permissive CORS. That is
-convenient for development but undesirable when callbacks must be
-externally reachable while the admin surface must stay private.
+`awa serve` bundles the admin UI, admin REST API, static fallback, and the callback receiver behind a single router with permissive CORS. That is convenient for development but undesirable when callbacks must be externally reachable while the admin surface must stay private.
 
-For that case Awa ships a callback-only receiver as a deployable role
-(see [ADR-027](./adr/027-callback-ingress-surface.md)):
+For that case Awa ships a callback-only receiver as a deployable role (see [ADR-027](./adr/027-callback-ingress-surface.md)):
 
 ```text
 awa callbacks serve \
@@ -219,11 +186,8 @@ The router:
 - Mounts only `POST {prefix}/{callback_id}/{complete,fail,heartbeat}`.
 - Does not serve static UI assets or admin REST routes.
 - Does not apply permissive CORS.
-- Refuses to build against a read-only database (all three routes mutate
-  job state).
-- Requires a callback signing secret by default. Pass `--allow-unsigned`
-  only when the receiver lives on a trusted network (mTLS at the load
-  balancer, IP allow-list, private VPC, etc.).
+- Refuses to build against a read-only database (all three routes mutate job state).
+- Requires a callback signing secret by default. Pass `--allow-unsigned` only when the receiver lives on a trusted network (mTLS at the load balancer, IP allow-list, private VPC, etc.).
 
 The same router is available as a Rust library for embedding:
 
@@ -237,22 +201,13 @@ let router = callback_router(
 .await?;
 ```
 
-Use [`HttpWorkerConfig::callback_path_prefix`](#configuration) on the
-worker side to match a non-default `--path-prefix` so the URLs the worker
-hands to your function point at the receiver.
+Use [`HttpWorkerConfig::callback_path_prefix`](#configuration) on the worker side to match a non-default `--path-prefix` so the URLs the worker hands to your function point at the receiver.
 
-If you want callbacks to land inside your own application (FastAPI,
-axum, etc.) rather than running Awa's receiver at all, see
-[`docs/callback-receivers.md`](./callback-receivers.md) for the
-user-owned API integration pattern.
+If you want callbacks to land inside your own application (FastAPI, axum, etc.) rather than running Awa's receiver at all, see [`docs/callback-receivers.md`](./callback-receivers.md) for the user-owned API integration pattern.
 
 ## Function-side verification
 
-The signature primarily protects the Awa callback receiver from unauthorized
-completion requests. If the function endpoint is public, you may also verify
-the worker-to-function request before starting work. In that case the function
-must know the same 32-byte secret and recompute the BLAKE3 keyed hash over the
-received `callback_id`.
+The signature primarily protects the Awa callback receiver from unauthorized completion requests. If the function endpoint is public, you may also verify the worker-to-function request before starting work. In that case the function must know the same 32-byte secret and recompute the BLAKE3 keyed hash over the received `callback_id`.
 
 Python example:
 
@@ -276,5 +231,4 @@ fn valid_signature(secret: &[u8; 32], callback_id: &str, provided: &str) -> bool
 }
 ```
 
-If the function does not verify the inbound request, keep it behind your normal
-cloud auth layer and still forward `X-Awa-Signature` to the callback receiver.
+If the function does not verify the inbound request, keep it behind your normal cloud auth layer and still forward `X-Awa-Signature` to the callback receiver.

--- a/docs/lifecycle-hooks.md
+++ b/docs/lifecycle-hooks.md
@@ -1,13 +1,8 @@
 # Lifecycle hooks
 
-Lifecycle hooks let application code react to the points in a job's life —
-when it starts, finishes, retries, parks on an external callback, and so on —
-without putting that logic inside the job handler itself. Typical uses are
-metrics, alerting, and job-type-specific cleanup on permanent failure.
+Lifecycle hooks let application code react to the points in a job's life — when it starts, finishes, retries, parks on an external callback, and so on — without putting that logic inside the job handler itself. Typical uses are metrics, alerting, and job-type-specific cleanup on permanent failure.
 
-Hooks are registered on the `ClientBuilder` and keyed by job kind. They work
-for both the typed (`register::<T, _>()`) and raw (`register_worker(...)`)
-worker paths.
+Hooks are registered on the `ClientBuilder` and keyed by job kind. They work for both the typed (`register::<T, _>()`) and raw (`register_worker(...)`) worker paths.
 
 ## Registering a hook
 
@@ -29,14 +24,12 @@ let client = Client::builder(pool)
     .build()?;
 ```
 
-`on_event::<T>()` gives you typed `args`; `on_event_kind("send_email", ...)`
-gives an untyped handler keyed by the kind string. Multiple hooks may be
-registered for the same kind; they stack and run sequentially.
+`on_event::<T>()` gives you typed `args`; `on_event_kind("send_email", ...)` gives an untyped handler keyed by the kind string. Multiple hooks may be registered for the same kind; they stack and run sequentially.
 
 ## Events
 
 | Event | Fires when |
-|---|---|
+| --- | --- |
 | `Started` | the claim transaction commits, just before the handler runs (`job.state == running`) |
 | `WaitingForCallback` | the handler returned `WaitForCallback` and the job parked (`job.state == waiting_external`; `job.callback_id` is set) |
 | `Completed` | the job finished successfully |
@@ -48,7 +41,7 @@ registered for the same kind; they stack and run sequentially.
 How `JobResult` / outcomes map to events:
 
 | Outcome | Event |
-|---|---|
+| --- | --- |
 | claim commits | `Started` |
 | `Ok(Completed)` | `Completed` |
 | `Ok(RetryAfter)` / retryable `Err` (retries left) | `Retried` |
@@ -59,10 +52,7 @@ How `JobResult` / outcomes map to events:
 
 ## Callbacks
 
-A job that returns `WaitForCallback` parks in `waiting_external` and emits
-`WaitingForCallback`. The terminal event fires later, when the callback is
-resolved — **but only if you resolve it through the worker `Client`**, which
-owns the hook registry:
+A job that returns `WaitForCallback` parks in `waiting_external` and emits `WaitingForCallback`. The terminal event fires later, when the callback is resolved — **but only if you resolve it through the worker `Client`**, which owns the hook registry:
 
 ```rust
 // In your callback endpoint (same process as the worker Client):
@@ -73,58 +63,27 @@ client.fail_external(callback_id, error, None).await?;       // -> Exhausted
 client.retry_external(callback_id, None).await?;             // -> Retried
 ```
 
-Resolving through the bare `awa_model::admin::*` functions (or the CLI, or a
-process that has no worker `Client`) still transitions the job correctly but
-fires no hook — hooks are an in-process, worker-side facility. Dispatch happens
-once, in the process that performs the resolution, mirroring how an inline
-outcome fires once from the worker that claimed the job.
+Resolving through the bare `awa_model::admin::*` functions (or the CLI, or a process that has no worker `Client`) still transitions the job correctly but fires no hook — hooks are an in-process, worker-side facility. Dispatch happens once, in the process that performs the resolution, mirroring how an inline outcome fires once from the worker that claimed the job.
 
-For a callback-driven `Completed`, `duration` is `Duration::ZERO` (no handler
-ran during the parked phase).
+For a callback-driven `Completed`, `duration` is `Duration::ZERO` (no handler ran during the parked phase).
 
-A callback that *resumes* the job to `running` emits no event itself; the job
-re-enters execution and emits `Started` plus a terminal event as usual.
+A callback that _resumes_ the job to `running` emits no event itself; the job re-enters execution and emits `Started` plus a terminal event as usual.
 
 ## Semantics
 
-Hooks are **best-effort, in-process notifications** — not a durable workflow
-mechanism:
+Hooks are **best-effort, in-process notifications** — not a durable workflow mechanism:
 
-- They observe **committed** state. An outcome hook carries the post-transition
-  `JobRow`; a stale/rejected finalization emits no outcome event (though a
-  `Started` may already have fired for that attempt).
-- They do not block executor progress or queue capacity, and `shutdown()` does
-  not wait for them. They can be lost on process crash or shutdown.
-- **Dispatch is not atomic with the state transition.** The hook runs *after*
-  the job's transition commits, as a separate in-process step — it is not a
-  transactional outbox. If the process dies between the commit and the
-  dispatch, the job state is durable but the event is lost. The same applies to
-  callback resolution: `complete_external` / `resolve_callback` commit the
-  outcome first, then dispatch.
-- `Started` is dispatched detached, so a very fast job may finish before its
-  `Started` hook completes — do not rely on strict started-before-outcome
-  ordering for short jobs.
+- They observe **committed** state. An outcome hook carries the post-transition `JobRow`; a stale/rejected finalization emits no outcome event (though a `Started` may already have fired for that attempt).
+- They do not block executor progress or queue capacity, and `shutdown()` does not wait for them. They can be lost on process crash or shutdown.
+- **Dispatch is not atomic with the state transition.** The hook runs _after_ the job's transition commits, as a separate in-process step — it is not a transactional outbox. If the process dies between the commit and the dispatch, the job state is durable but the event is lost. The same applies to callback resolution: `complete_external` / `resolve_callback` commit the outcome first, then dispatch.
+- `Started` is dispatched detached, so a very fast job may finish before its `Started` hook completes — do not rely on strict started-before-outcome ordering for short jobs.
 - A panicking hook is logged; later hooks for the same kind still run.
 
-If a side effect must fire exactly once or survive a crash, do not drive it
-from a hook at all — the dispatch may never run, and enqueueing the follow-up
-work *from* the hook just inherits that same unreliability. See the next
-section for the durable mechanism.
+If a side effect must fire exactly once or survive a crash, do not drive it from a hook at all — the dispatch may never run, and enqueueing the follow-up work _from_ the hook just inherits that same unreliability. See the next section for the durable mechanism.
 
 ## Durable follow-up jobs (`on_*_enqueue`)
 
-For side effects that **must survive a process crash** — sending a welcome
-email after signup, kicking off downstream work, persisting an audit row —
-use the transactional follow-up API instead of an `on_event` hook. For
-worker-driven outcomes (the trigger handler returned `Ok`/`Err`) and
-for callback resolution via the worker `Client` —
-`complete_external`, `fail_external`, `retry_external`, and
-`resolve_callback` — the follow-up `INSERT`s in the **same database
-transaction** as the triggering state transition: either both commit
-or both roll back, with no in-between. Maintenance rescue dispatches follow-ups in a **separate
-transaction** (best-effort) — see the [atomicity table
-below](#atomicity-guarantees) before designing a workflow that depends
-on rescue-driven follow-ups landing.
+For side effects that **must survive a process crash** — sending a welcome email after signup, kicking off downstream work, persisting an audit row — use the transactional follow-up API instead of an `on_event` hook. For worker-driven outcomes (the trigger handler returned `Ok`/`Err`) and for callback resolution via the worker `Client` — `complete_external`, `fail_external`, `retry_external`, and `resolve_callback` — the follow-up `INSERT`s in the **same database transaction** as the triggering state transition: either both commit or both roll back, with no in-between. Maintenance rescue dispatches follow-ups in a **separate transaction** (best-effort) — see the [atomicity table below](#atomicity-guarantees) before designing a workflow that depends on rescue-driven follow-ups landing.
 
 ```rust
 use awa::{Client, EnqueueRequest, QueueConfig};
@@ -141,13 +100,10 @@ let client = Client::builder(pool)
     .build()?;
 ```
 
-There is one builder per outcome, plus a `_with` variant whose closure
-returns `EnqueueRequest<F>` so you can override `InsertOpts` on the
-follow-up (queue, priority, max_attempts, metadata, tags, unique, run_at,
-deadline_duration, ordering_key):
+There is one builder per outcome, plus a `_with` variant whose closure returns `EnqueueRequest<F>` so you can override `InsertOpts` on the follow-up (queue, priority, max_attempts, metadata, tags, unique, run_at, deadline_duration, ordering_key):
 
 | Builder | Fires when | Closure signature |
-|---|---|---|
+| --- | --- | --- |
 | `on_completed_enqueue` | `JobResult::Completed` | `(args, &job)` |
 | `on_cancelled_enqueue` | `JobResult::Cancel(reason)` | `(args, &job, &reason)` |
 | `on_retried_enqueue` | retryable err (retries left) or `RetryAfter` | `(args, &job, &error, attempt, next_run_at)` |
@@ -168,35 +124,20 @@ deadline_duration, ordering_key):
 ### Atomicity guarantees
 
 | Emission site | Atomic with state commit? |
-|---|---|
+| --- | --- |
 | Worker-driven outcomes (handler returns `Ok`/`Err`) on either storage engine | **yes** — one transaction, one commit |
 | Callback resolution on `Client` (`complete_external`, `fail_external`, `retry_external`, `resolve_callback`) on either storage engine | **yes** — one transaction, one commit. A spec INSERT failure (or a panic in the user-supplied closure) rolls the callback transition back together with the follow-up; `Client::*_external` returns `Err` and the external sender can retry. |
 | Maintenance rescue (stale heartbeat / deadline / expired callback) | **no — best-effort.** The rescue commits first, then specs dispatch in a separate tx. A spec failure leaves the rescue applied and is logged. |
 
-The trigger transition and the follow-up `INSERT` either both commit
-or neither does — exactly-once *enqueue* per committed worker outcome
-or callback resolution. The follow-up itself, once enqueued, is
-delivered with Awa's usual at-least-once semantics, so the follow-up
-handler still needs to be safe under re-execution.
+The trigger transition and the follow-up `INSERT` either both commit or neither does — exactly-once _enqueue_ per committed worker outcome or callback resolution. The follow-up itself, once enqueued, is delivered with Awa's usual at-least-once semantics, so the follow-up handler still needs to be safe under re-execution.
 
-Rescue stays best-effort by design: making it atomic would couple
-rescue liveness to the correctness of user follow-up code (a panic in
-`on_rescued_enqueue` would roll back a stale-heartbeat rescue and
-leave the job stuck in `running`). Zero-loss rescue notifications
-belong in an outbox/sweeper, not inlined into the rescue tx.
+Rescue stays best-effort by design: making it atomic would couple rescue liveness to the correctness of user follow-up code (a panic in `on_rescued_enqueue` would roll back a stale-heartbeat rescue and leave the job stuck in `running`). Zero-loss rescue notifications belong in an outbox/sweeper, not inlined into the rescue tx.
 
 ### When to choose which API
 
-- **Observation** (metrics, traces, alerts) → `on_event` — cheap, in-process,
-  acceptable to drop a sample on a crash.
-- **Side effect that must survive a crash** (send email, persist record,
-  kick off downstream work) → `on_*_enqueue` — slightly more expensive
-  (it's an Awa job) but durable, retried, DLQ'd, and visible in admin.
+- **Observation** (metrics, traces, alerts) → `on_event` — cheap, in-process, acceptable to drop a sample on a crash.
+- **Side effect that must survive a crash** (send email, persist record, kick off downstream work) → `on_*_enqueue` — slightly more expensive (it's an Awa job) but durable, retried, DLQ'd, and visible in admin.
 
-If you can't tell which you want, use `on_*_enqueue`. The cost of an
-unnecessary follow-up is bounded; the cost of a lost reliable side effect
-is not.
+If you can't tell which you want, use `on_*_enqueue`. The cost of an unnecessary follow-up is bounded; the cost of a lost reliable side effect is not.
 
-See [ADR-015](adr/015-post-commit-lifecycle-hooks.md) for hook rationale,
-and [ADR-029](adr/029-transactional-followup-jobs.md) for the follow-up
-enqueue design and atomicity matrix.
+See [ADR-015](adr/015-post-commit-lifecycle-hooks.md) for hook rationale, and [ADR-029](adr/029-transactional-followup-jobs.md) for the follow-up enqueue design and atomicity matrix.

--- a/docs/migrations.md
+++ b/docs/migrations.md
@@ -13,22 +13,9 @@ Current guarantees from the migration layer:
 - rerunning migrations is safe
 - older pre-0.4 version numbering is normalized during upgrade
 
-Most migrations are additive, but storage-engine migrations can be
-non-additive when they are protected by rollout gates. For example,
-queue-storage migrations reshape internal keys and drop obsolete
-columns. Rolling upgrades stay practical because those changes are
-forward-only, idempotent where possible, and gated by the storage
-transition state rather than by assuming every DDL step is additive.
+Most migrations are additive, but storage-engine migrations can be non-additive when they are protected by rollout gates. For example, queue-storage migrations reshape internal keys and drop obsolete columns. Rolling upgrades stay practical because those changes are forward-only, idempotent where possible, and gated by the storage transition state rather than by assuming every DDL step is additive.
 
-The default queue-storage substrate at `awa.*` is owned by
-`awa migrate` via the `v023_install_queue_storage_substrate`
-migration, which calls the `awa.install_queue_storage_substrate(schema, ...)`
-SQL helper. `prepare_schema()` (Rust) and
-`awa storage prepare-queue-storage-schema` (CLI) call the same helper
-for custom queue-storage schemas. See
-[Queue-storage substrate](queue-storage-substrate.md) for the full
-ownership contract, the rejection of `--reset --schema awa`, and how
-to install a custom-shaped substrate.
+The default queue-storage substrate at `awa.*` is owned by `awa migrate` via the `v023_install_queue_storage_substrate` migration, which calls the `awa.install_queue_storage_substrate(schema, ...)` SQL helper. `prepare_schema()` (Rust) and `awa storage prepare-queue-storage-schema` (CLI) call the same helper for custom queue-storage schemas. See [Queue-storage substrate](queue-storage-substrate.md) for the full ownership contract, the rejection of `--reset --schema awa`, and how to install a custom-shaped substrate.
 
 ## Fresh Install
 
@@ -68,18 +55,14 @@ Because migrations are additive-only, old workers should continue to function du
 
 ## Storage Transition Preparation
 
-This release introduces a generic storage-transition framework that future
-storage-engine upgrades can build on.
+This release introduces a generic storage-transition framework that future storage-engine upgrades can build on.
 
-The 0.5.x prep-release migration does **not** change the current execution
-engine. The 0.6 compatibility migration builds on that foundation and also
-adds:
+The 0.5.x prep-release migration does **not** change the current execution engine. The 0.6 compatibility migration builds on that foundation and also adds:
 
 - the queue-storage compatibility layer
 - the active-backend selector in `awa.runtime_storage_backends`
 - the segmented DLQ table in the active queue-storage schema (`{schema}.dlq_entries`)
-- `awa.jobs` / `awa.insert_job_compat()` routing that follows the active
-  backend when queue storage is activated
+- `awa.jobs` / `awa.insert_job_compat()` routing that follows the active backend when queue storage is activated
 
 New operator surfaces:
 
@@ -103,28 +86,13 @@ SELECT * FROM awa.storage_prepare(
 SELECT * FROM awa.storage_abort();
 ```
 
-These functions are one-shot operational commands. They are not schema-migration
-DDL and should be run deliberately by an operator or rollout tool, not embedded
-into the extracted migration SQL itself.
+These functions are one-shot operational commands. They are not schema-migration DDL and should be run deliberately by an operator or rollout tool, not embedded into the extracted migration SQL itself.
 
-`awa migrate` materializes the default queue-storage substrate in the `awa`
-schema with the default slot counts. `storage prepare-queue-storage-schema` is
-still the operational command for custom queue-storage schemas, custom slot
-counts, or idempotent preflight checks. It only materializes the queue-storage
-schema: it does **not** change `awa.storage_transition_state` and it does
-**not** activate routing.
+`awa migrate` materializes the default queue-storage substrate in the `awa` schema with the default slot counts. `storage prepare-queue-storage-schema` is still the operational command for custom queue-storage schemas, custom slot counts, or idempotent preflight checks. It only materializes the queue-storage schema: it does **not** change `awa.storage_transition_state` and it does **not** activate routing.
 
-Queue-storage schema preparation may also relax the physical `done_entries`
-body columns (`args`, `max_attempts`, `run_at`, `created_at`) to allow narrow
-terminal history. This is part of the queue-storage operational DDL, not an
-additive canonical `awa.jobs` migration: public Awa APIs still hydrate terminal
-jobs through the retained ready row, while direct SQL against `done_entries`
-must tolerate nullable duplicated body fields. Preparation also creates or
-replaces the read-only `{schema}.terminal_jobs` compatibility view, which is
-the preferred SQL surface for hydrated terminal history.
+Queue-storage schema preparation may also relax the physical `done_entries` body columns (`args`, `max_attempts`, `run_at`, `created_at`) to allow narrow terminal history. This is part of the queue-storage operational DDL, not an additive canonical `awa.jobs` migration: public Awa APIs still hydrate terminal jobs through the retained ready row, while direct SQL against `done_entries` must tolerate nullable duplicated body fields. Preparation also creates or replaces the read-only `{schema}.terminal_jobs` compatibility view, which is the preferred SQL surface for hydrated terminal history.
 
-On the `0.5.x` prep release these SQL identities existed as stubs. On this
-`0.6` branch they are implemented:
+On the `0.5.x` prep release these SQL identities existed as stubs. On this `0.6` branch they are implemented:
 
 - `awa.storage_enter_mixed_transition()`
 - `awa.storage_finalize()`
@@ -132,25 +100,17 @@ On the `0.5.x` prep release these SQL identities existed as stubs. On this
 Current behavior:
 
 - `storage status` reports the singleton row in `awa.storage_transition_state`
-- `storage status` also reports canonical live backlog, live runtime capability counts,
-  and blocker lists for `enter-mixed-transition` / `finalize`
-- `storage prepare` records a future engine and optional metadata, but keeps
-  enqueue routing and worker execution on canonical storage
-- `awa migrate` creates the default `awa` queue-storage substrate; `storage
-  prepare-queue-storage-schema` creates custom queue-storage schemas ahead of
-  time without changing routing
-- `storage abort` returns routing to canonical and clears a prepared or mixed-transition
-  rollout before final activation
-- `storage enter-mixed-transition` requires prepared queue-storage metadata,
-  a prepared queue-storage schema, and no live canonical-only runtimes
-- `storage finalize` requires zero canonical live backlog and no live
-  canonical / drain-only runtimes
+- `storage status` also reports canonical live backlog, live runtime capability counts, and blocker lists for `enter-mixed-transition` / `finalize`
+- `storage prepare` records a future engine and optional metadata, but keeps enqueue routing and worker execution on canonical storage
+- `awa migrate` creates the default `awa` queue-storage substrate; `storage prepare-queue-storage-schema` creates custom queue-storage schemas ahead of time without changing routing
+- `storage abort` returns routing to canonical and clears a prepared or mixed-transition rollout before final activation
+- `storage enter-mixed-transition` requires prepared queue-storage metadata, a prepared queue-storage schema, and no live canonical-only runtimes
+- `storage finalize` requires zero canonical live backlog and no live canonical / drain-only runtimes
 - workers continue to run the canonical engine before and after `prepare`
 
 ### `0.5.x` -> `0.6` Queue-Storage Rollout
 
-The 0.6 storage-engine upgrade uses the transition protocol introduced in the
-0.5.x prep release. The intended operator sequence has two phases.
+The 0.6 storage-engine upgrade uses the transition protocol introduced in the 0.5.x prep release. The intended operator sequence has two phases.
 
 #### Phase 1: last `0.5.x` release everywhere
 
@@ -168,7 +128,6 @@ The 0.6 storage-engine upgrade uses the transition protocol introduced in the
    ```
 
    Expected:
-
    - `current_engine = canonical`
    - `active_engine = canonical`
    - `prepared_engine = NULL`
@@ -182,14 +141,11 @@ The 0.6 storage-engine upgrade uses the transition protocol introduced in the
    ORDER BY last_seen_at DESC;
    ```
 
-5. This is a safe stopping point. The queue is still fully canonical and
-   behavior is unchanged. Operators can remain here indefinitely.
+5. This is a safe stopping point. The queue is still fully canonical and behavior is unchanged. Operators can remain here indefinitely.
 
 #### Phase 2: `0.6` rollout on top of the prep release
 
-1. Roll out `0.6` binaries. `0.5.x` and `0.6` pods may coexist at this stage.
-   While state is still `canonical` or `prepared`, all execution and writes
-   remain canonical.
+1. Roll out `0.6` binaries. `0.5.x` and `0.6` pods may coexist at this stage. While state is still `canonical` or `prepared`, all execution and writes remain canonical.
 2. Run:
 
    ```bash
@@ -197,47 +153,28 @@ The 0.6 storage-engine upgrade uses the transition protocol introduced in the
    ```
 
 3. Verify prepared state:
-
    - `current_engine = canonical`
    - `active_engine = canonical`
    - `prepared_engine = queue_storage`
    - `state = prepared`
 
-4. Confirm every live runtime instance is now queue-storage capable before the
-   routing flip. This is the gate that prevents canonical-only workers from
-   surviving into `mixed_transition`.
+4. Confirm every live runtime instance is now queue-storage capable before the routing flip. This is the gate that prevents canonical-only workers from surviving into `mixed_transition`.
 
    In `0.6`, the intended worker roles are:
+   - the default `auto` role, which stays canonical before the routing flip and becomes `canonical_drain_only` once mixed transition starts
+   - an explicit queue-storage target role, which prepares the queue-storage executor before the routing flip so new work can start executing immediately after `enter-mixed-transition`
 
-   - the default `auto` role, which stays canonical before the routing flip
-     and becomes `canonical_drain_only` once mixed transition starts
-   - an explicit queue-storage target role, which prepares the queue-storage
-     executor before the routing flip so new work can start executing
-     immediately after `enter-mixed-transition`
-
-   The `enter_mixed_transition()` SQL gate requires at least
-   one live runtime running with `transition_role = 'queue_storage_target'`
-   reporting `storage_capability = 'queue_storage'`. Auto-role runtimes
-   that pre-date the flip will downgrade to `canonical_drain_only` after
-   routing flips, so they cannot satisfy the gate on their own — there
-   would be no queue-storage executor post-flip. Auto-role runtimes
-   started *after* `enter-mixed-transition` resolve to queue storage at
-   startup and behave normally.
+   The `enter_mixed_transition()` SQL gate requires at least one live runtime running with `transition_role = 'queue_storage_target'` reporting `storage_capability = 'queue_storage'`. Auto-role runtimes that pre-date the flip will downgrade to `canonical_drain_only` after routing flips, so they cannot satisfy the gate on their own — there would be no queue-storage executor post-flip. Auto-role runtimes started _after_ `enter-mixed-transition` resolve to queue storage at startup and behave normally.
 
    Current APIs:
-
    - Rust: `Client::builder(...).transition_role(TransitionWorkerRole::QueueStorageTarget)`
    - Python: `AsyncClient.start(..., storage_transition_role="queue_storage_target")`
 
 5. From here, the `0.6` sequence is:
-
-   - `awa storage enter-mixed-transition` flips new writes and cron enqueues to
-     queue storage
-   - queue-storage-capable workers report capability for the new engine, while
-     canonical drain work is handled by `0.6` workers in drain-only mode
+   - `awa storage enter-mixed-transition` flips new writes and cron enqueues to queue storage
+   - queue-storage-capable workers report capability for the new engine, while canonical drain work is handled by `0.6` workers in drain-only mode
    - canonical backlog drains while new work lands in queue storage
-   - `awa storage finalize` advances the state to `active` once live capability
-     and backlog checks pass
+   - `awa storage finalize` advances the state to `active` once live capability and backlog checks pass
 
 Expected status progression during that rollout:
 
@@ -246,9 +183,7 @@ Expected status progression during that rollout:
 - during mixed transition: `canonical / queue_storage / queue_storage / mixed_transition`
 - after finalization: `queue_storage / queue_storage / NULL / active`
 
-Running `storage prepare` before every worker is on `0.5.latest` is harmless.
-The prepared flag is dormant in `0.5.x`; it only becomes operational when `0.6`
-code starts acting on it.
+Running `storage prepare` before every worker is on `0.5.latest` is harmless. The prepared flag is dormant in `0.5.x`; it only becomes operational when `0.6` code starts acting on it.
 
 If rollout stalls because some workers never upgrade, use:
 
@@ -258,78 +193,34 @@ FROM awa.runtime_instances
 ORDER BY last_seen_at DESC;
 ```
 
-alongside `awa storage status` or the `/api/runtime` UI/API view to identify
-which runtime instances are still reporting canonical capability. The cluster
-must not enter `mixed_transition` until canonical-only workers have stopped
-heartbeating. Finalization must also wait until canonical backlog is empty.
+alongside `awa storage status` or the `/api/runtime` UI/API view to identify which runtime instances are still reporting canonical capability. The cluster must not enter `mixed_transition` until canonical-only workers have stopped heartbeating. Finalization must also wait until canonical backlog is empty.
 
-If you need to stop the rollout before final activation, `storage abort` is the
-intended primitive. In `prepared`, it returns the singleton row to `canonical`
-and clears the prepared engine metadata. In `mixed_transition`, `0.6` now
-enforces a rollback interlock: abort is only allowed while there are **no**
-live queue-storage runtimes and **no** rows in queue-storage tables. Once
-queue-storage has started accepting work, abort is rejected instead of trying
-to paper over a partial rollback.
+If you need to stop the rollout before final activation, `storage abort` is the intended primitive. In `prepared`, it returns the singleton row to `canonical` and clears the prepared engine metadata. In `mixed_transition`, `0.6` now enforces a rollback interlock: abort is only allowed while there are **no** live queue-storage runtimes and **no** rows in queue-storage tables. Once queue-storage has started accepting work, abort is rejected instead of trying to paper over a partial rollback.
 
-Current `0.5.x` fail-safe behavior if someone forces the state forward without
-`0.6` support:
+Current `0.5.x` fail-safe behavior if someone forces the state forward without `0.6` support:
 
 - `awa.insert_job_compat()` raises `55000`
 - batch insert and COPY insert paths also fail closed
-- the reserved `awa.storage_enter_mixed_transition()` and
-  `awa.storage_finalize()` functions raise “requires 0.6”
+- the reserved `awa.storage_enter_mixed_transition()` and `awa.storage_finalize()` functions raise “requires 0.6”
 
 #### `0.6` Receipt-plane partition migration (ADR-023)
 
-The `0.6` queue-storage engine partitions the receipt plane:
-`lease_claims` and `lease_claim_closures` are
-`PARTITIONED BY LIST (claim_slot)` parents with one child per
-claim-ring slot. Upgrading from a 0.5.x deploy where these were
-regular (non-partitioned) tables runs an in-place migration inside
-`prepare_schema()`:
+The `0.6` queue-storage engine partitions the receipt plane: `lease_claims` and `lease_claim_closures` are `PARTITIONED BY LIST (claim_slot)` parents with one child per claim-ring slot. Upgrading from a 0.5.x deploy where these were regular (non-partitioned) tables runs an in-place migration inside `prepare_schema()`:
 
-1. The legacy tables are renamed in place to
-   `lease_claims_legacy` / `lease_claim_closures_legacy`.
-2. The new partitioned parents are created alongside the legacy
-   tables.
-3. Rows are copied from the legacy tables into the partitioned
-   parents, all landing in the current `claim_ring_state.current_slot`
-   (so existing receipts close out on their normal lifecycle in
-   that partition; the ring's natural rotation re-balances over
-   subsequent claims).
+1. The legacy tables are renamed in place to `lease_claims_legacy` / `lease_claim_closures_legacy`.
+2. The new partitioned parents are created alongside the legacy tables.
+3. Rows are copied from the legacy tables into the partitioned parents, all landing in the current `claim_ring_state.current_slot` (so existing receipts close out on their normal lifecycle in that partition; the ring's natural rotation re-balances over subsequent claims).
 4. The legacy tables are dropped.
 
-Steps 3 and 4 run inside a single Postgres transaction so a crash
-mid-migration leaves the schema in exactly one of two states:
-pre-migration (legacy tables still present, partitioned parents
-empty) or post-migration (legacy tables gone, partitioned parents
-populated). On restart, `prepare_schema()` detects whichever state
-is current and either re-runs the migration or skips it. The
-`ON CONFLICT DO NOTHING` on the copy step is a defensive
-belt-and-braces; under the transactional shape it should never
-fire.
+Steps 3 and 4 run inside a single Postgres transaction so a crash mid-migration leaves the schema in exactly one of two states: pre-migration (legacy tables still present, partitioned parents empty) or post-migration (legacy tables gone, partitioned parents populated). On restart, `prepare_schema()` detects whichever state is current and either re-runs the migration or skips it. The `ON CONFLICT DO NOTHING` on the copy step is a defensive belt-and-braces; under the transactional shape it should never fire.
 
-If the migration is partially applied at the time of a `reset()`
-call, the legacy tables are dropped explicitly before the main
-`TRUNCATE`. Without that, `reset()` would TRUNCATE the partitioned
-parents but leave the legacy data intact, and the next
-`prepare_schema()` would re-run the migration on top and silently
-re-insert old rows. Operators should not normally call `reset()`
-during an upgrade — it's a test fixture rather than a recovery
-primitive — but the safety net is there.
+If the migration is partially applied at the time of a `reset()` call, the legacy tables are dropped explicitly before the main `TRUNCATE`. Without that, `reset()` would TRUNCATE the partitioned parents but leave the legacy data intact, and the next `prepare_schema()` would re-run the migration on top and silently re-insert old rows. Operators should not normally call `reset()` during an upgrade — it's a test fixture rather than a recovery primitive — but the safety net is there.
 
-**Reverse migration** (only relevant if a production rollback fires
-between an ADR-023 deploy and the older runtime catching up): create
-unpartitioned `lease_claims` and `lease_claim_closures` tables,
-`INSERT ... SELECT * FROM` each partitioned parent, drop the
-partitioned parents. This is not committed to source — the forward
-path is the only supported one — but operators are expected to keep
-this recipe in their runbook for the rollout window.
+**Reverse migration** (only relevant if a production rollback fires between an ADR-023 deploy and the older runtime catching up): create unpartitioned `lease_claims` and `lease_claim_closures` tables, `INSERT ... SELECT * FROM` each partitioned parent, drop the partitioned parents. This is not committed to source — the forward path is the only supported one — but operators are expected to keep this recipe in their runbook for the rollout window.
 
 ### Why This Exists
 
-If Awa needs another storage redesign in the future, the plan is to reuse the
-same framework:
+If Awa needs another storage redesign in the future, the plan is to reuse the same framework:
 
 - `awa.storage_transition_state`
 - transition epochs
@@ -337,8 +228,7 @@ same framework:
 - runtime storage capability reporting
 - `awa.insert_job_compat()` as the write-routing seam
 
-Only the engine-specific install, backlog checks, and finalization logic should
-change between migrations.
+Only the engine-specific install, backlog checks, and finalization logic should change between migrations.
 
 ## External Migration Tooling
 
@@ -391,16 +281,12 @@ If a release has to be reverted but the Awa schema migration already ran:
 
 That is the expected path because the migrations are additive-only.
 
-For the planned `0.5.x` -> `0.6` storage transition, there is an additional
-constraint:
+For the planned `0.5.x` -> `0.6` storage transition, there is an additional constraint:
 
-- once the cluster has entered `mixed_transition` and `0.6` has routed jobs to
-  queue storage, a pure fleet downgrade back to `0.5` is not supported
+- once the cluster has entered `mixed_transition` and `0.6` has routed jobs to queue storage, a pure fleet downgrade back to `0.5` is not supported
 - `0.5` workers do not know how to claim queue-storage work
-- `storage abort` is only a rollback path from `mixed_transition` before any
-  queue-storage runtime is live and before any queue-storage rows exist
-- once queue-storage has accepted work, keep `0.6` workers available and treat
-  the transition as one-way until finalize or full database restore
+- `storage abort` is only a rollback path from `mixed_transition` before any queue-storage runtime is live and before any queue-storage rows exist
+- once queue-storage has accepted work, keep `0.6` workers available and treat the transition as one-way until finalize or full database restore
 
 ### 2. Database Rollback
 
@@ -417,8 +303,7 @@ If Awa ever needs a non-additive schema change, the intended contract is a major
 
 ## Recommended Production Flow
 
-The shape depends on whether you're doing a **fresh install** or
-**upgrading from `0.5.x`**.
+The shape depends on whether you're doing a **fresh install** or **upgrading from `0.5.x`**.
 
 ### Fresh install (no prior canonical data)
 
@@ -429,38 +314,24 @@ awa --database-url "$DATABASE_URL" migrate
 # 2. Start workers (Rust or Python). queue-storage runs by default.
 ```
 
-That's the whole flow. The first worker that comes up in `auto` mode
-detects the DB is fresh — `state=canonical`, `prepared_engine=NULL`,
-no canonical jobs ever, no other live workers — and atomically
-installs the queue-storage schema and advances state directly to
-`active` via `awa.storage_auto_finalize_if_fresh()`. Subsequent
-workers see `state=active` and run as queue-storage straight away.
+That's the whole flow. The first worker that comes up in `auto` mode detects the DB is fresh — `state=canonical`, `prepared_engine=NULL`, no canonical jobs ever, no other live workers — and atomically installs the queue-storage schema and advances state directly to `active` via `awa.storage_auto_finalize_if_fresh()`. Subsequent workers see `state=active` and run as queue-storage straight away.
 
-The auto-finalize fast-path **only** fires on a truly fresh DB. Any
-of these conditions disqualify it and force the operator down the
-staged `prepare → enter-mixed-transition → finalize` path:
+The auto-finalize fast-path **only** fires on a truly fresh DB. Any of these conditions disqualify it and force the operator down the staged `prepare → enter-mixed-transition → finalize` path:
 
 - canonical jobs exist in `awa.jobs` (even terminal-state)
 - `prepared_engine` is already set (operator started the staged path)
 - another runtime is heartbeating in `awa.runtime_instances`
 
-If you specifically want the staged path on a fresh cluster (e.g.,
-to rehearse the transition flow), insert one canonical job before
-starting any worker, then follow the upgrade-from-0.5.x path.
+If you specifically want the staged path on a fresh cluster (e.g., to rehearse the transition flow), insert one canonical job before starting any worker, then follow the upgrade-from-0.5.x path.
 
 ### Upgrading from `0.5.x`
 
-**Do not use the fresh-install recipe.** Live canonical data and
-canonical-only `0.5.x` workers must drain through `mixed_transition`
-before queue storage can take over. Follow the staged transition flow
-documented above under
-[`0.5.x` -> `0.6` Queue-Storage Rollout](#05x---06-queue-storage-rollout):
+**Do not use the fresh-install recipe.** Live canonical data and canonical-only `0.5.x` workers must drain through `mixed_transition` before queue storage can take over. Follow the staged transition flow documented above under [`0.5.x` -> `0.6` Queue-Storage Rollout](#05x---06-queue-storage-rollout):
 
 1. Phase 1 — last `0.5.x` release everywhere with `awa migrate` applied.
 2. Phase 2 — roll out `0.6` binaries, then `prepare → enter-mixed-transition → finalize`.
 
-Rollback boundaries and `storage abort` semantics are documented in
-[Rollback Strategy](#rollback-strategy) below.
+Rollback boundaries and `storage abort` semantics are documented in [Rollback Strategy](#rollback-strategy) below.
 
 ## Next
 

--- a/docs/positioning.md
+++ b/docs/positioning.md
@@ -1,8 +1,6 @@
 # Where Awa Fits
 
-Awa is a Postgres-native job queue for Rust and Python: more capable than
-a Postgres event queue, less ecosystem-bound than a language-specific job
-framework. It is for teams that want:
+Awa is a Postgres-native job queue for Rust and Python: more capable than a Postgres event queue, less ecosystem-bound than a language-specific job framework. It is for teams that want:
 
 - full job-queue behavior, not just enqueue/dequeue
 - Rust and Python worker runtimes on the same queues
@@ -11,14 +9,10 @@ framework. It is for teams that want:
 
 Typical scenarios where Awa fits:
 
-- **Transactional side-effects** — webhook fan-out, email, payment
-  confirmation enqueued inside the business transaction that causes them.
-- **Mixed-runtime fleets** — Rust request-path services and Python ML /
-  ETL workers sharing the same queues.
-- **Long-running jobs with checkpoints** — batch imports, data pipelines
-  that need to resume after retry without restarting from zero.
-- **External orchestration** — jobs that park mid-execution for a webhook
-  or external system to respond, then resume in the same handler.
+- **Transactional side-effects** — webhook fan-out, email, payment confirmation enqueued inside the business transaction that causes them.
+- **Mixed-runtime fleets** — Rust request-path services and Python ML / ETL workers sharing the same queues.
+- **Long-running jobs with checkpoints** — batch imports, data pipelines that need to resume after retry without restarting from zero.
+- **External orchestration** — jobs that park mid-execution for a webhook or external system to respond, then resume in the same handler.
 
 ## Best fit
 
@@ -27,30 +21,23 @@ Awa is a strong fit when you want:
 - priorities, retries, snoozes, cron, callbacks, DLQ, and UI in one system
 - mixed Rust and Python worker fleets
 - Postgres as the only required infrastructure dependency
-- worker-owned dispatch, rescue, rotation, and prune instead of external
-  tickers or `pg_cron`
+- worker-owned dispatch, rescue, rotation, and prune instead of external tickers or `pg_cron`
 
 ## Nearby categories
 
 ### Postgres event and message queues
 
-PgQue and its PgQ historical lineage are the clearest reference points
-here. That category is a good fit when you want:
+PgQue and its PgQ historical lineage are the clearest reference points here. That category is a good fit when you want:
 
 - an event log
 - independent consumer cursors
 - a system optimized first around event-stream retention and rotation
 
-It is not the right fit when you need per-job priorities, unique jobs,
-cron scheduling, callback orchestration, or richer job lifecycle controls.
+It is not the right fit when you need per-job priorities, unique jobs, cron scheduling, callback orchestration, or richer job lifecycle controls.
 
 ### Language-specific Postgres job frameworks
 
-River (Go) and Oban (Elixir; Oban Pro adds a partitioned tier) are the
-clearest references here. That category is a good fit when you want a
-job framework deeply shaped around one host language and one surrounding
-ecosystem. If your stack is Go-only or Elixir-only, those are usually
-the right answer.
+River (Go) and Oban (Elixir; Oban Pro adds a partitioned tier) are the clearest references here. That category is a good fit when you want a job framework deeply shaped around one host language and one surrounding ecosystem. If your stack is Go-only or Elixir-only, those are usually the right answer.
 
 ## Awa's slot
 
@@ -59,20 +46,15 @@ Awa sits between those categories:
 - it is a job queue, not just a stream
 - it keeps Postgres as the only hard dependency
 - it supports Rust and Python as first-class runtimes
-- it uses segmented queue storage so queue history and lease churn do
-  not sit in one mutable queue heap
+- it uses segmented queue storage so queue history and lease churn do not sit in one mutable queue heap
 
-The storage engine is a differentiator, not the whole identity. The
-product story starts with "Postgres job queue for Rust and Python" and
-then explains why the storage engine matters operationally.
+The storage engine is a differentiator, not the whole identity. The product story starts with "Postgres job queue for Rust and Python" and then explains why the storage engine matters operationally.
 
 ## What you can rely on
 
 - Queue storage keeps dead tuples out of the main ready path.
-- Queue storage materially improves pickup-latency tails versus the
-  pre-0.6 mutable-row engine.
-- Awa keeps full job-queue behavior while using a segmented storage
-  engine.
+- Queue storage materially improves pickup-latency tails versus the pre-0.6 mutable-row engine.
+- Awa keeps full job-queue behavior while using a segmented storage engine.
 
 ## See also
 

--- a/docs/queue-storage-substrate.md
+++ b/docs/queue-storage-substrate.md
@@ -1,46 +1,31 @@
 # Queue-storage substrate: ownership and customisation
 
-Awa's queue-storage substrate is the set of per-schema tables, indexes,
-sequences, and helper functions the runtime relies on to claim,
-execute, and finalise jobs against the queue-storage engine. This page
-explains who owns those objects, how to customise them, and the
-guardrails that protect the default `awa` schema from accidental
-destructive operations.
+Awa's queue-storage substrate is the set of per-schema tables, indexes, sequences, and helper functions the runtime relies on to claim, execute, and finalise jobs against the queue-storage engine. This page explains who owns those objects, how to customise them, and the guardrails that protect the default `awa` schema from accidental destructive operations.
 
 ## Ownership contract
 
 | Owner | Scope | When it runs |
-|---|---|---|
+| --- | --- | --- |
 | **`awa migrate`** | The canonical schema (`awa.schema_version`, `awa.runtime_instances`, `awa.storage_transition_state`, `awa.runtime_storage_backends`, etc.) **plus** the default queue-storage substrate at `awa.*` (`awa.ready_entries`, `awa.ready_tombstones`, `awa.done_entries`, `awa.leases`, `awa.queue_ring_state`, `awa.queue_terminal_live_counts`, the partitions for each, the `awa.claim_ready_runtime` helper, and the `awa.install_queue_storage_substrate` function itself). | Install time and operator-driven upgrades. |
 | **`QueueStorage::prepare_schema()` (Rust) / `awa storage prepare-queue-storage-schema` (CLI)** | Non-default queue-storage schemas (anything other than `awa`), repair flows, test setups. Calls `awa.install_queue_storage_substrate(<schema>, ...)` and performs a small set of legacy upgrade fixups that don't belong in a forward-only DDL function. | Custom-schema deployments; targeted repair; the test suite. |
 | **The `awa.install_queue_storage_substrate(p_schema, ...)` SQL helper** | Per-schema DDL only. Idempotent. Activation-neutral — does NOT touch `awa.runtime_storage_backends` or `awa.storage_transition_state`. | Called by both `awa migrate` (for the default schema) and `prepare_schema()` (for custom schemas). Single source of truth for substrate DDL. |
 
-The helper takes a per-schema advisory transaction lock
-(`awa.queue_storage.install:<schema>`) so concurrent installs from
-Rust workers, the CLI, Python, or externally-extracted migration SQL
-serialise on the same key.
+The helper takes a per-schema advisory transaction lock (`awa.queue_storage.install:<schema>`) so concurrent installs from Rust workers, the CLI, Python, or externally-extracted migration SQL serialise on the same key.
 
 ## The default `awa` schema is migration-owned and default-shaped
 
-For `p_schema = 'awa'` the helper rejects non-default configuration
-with `ERRCODE = 22023`:
+For `p_schema = 'awa'` the helper rejects non-default configuration with `ERRCODE = 22023`:
 
 - `lease_claim_receipts` must be `TRUE`
 - `queue_slot_count` must be `16`
 - `lease_slot_count` must be `8`
 - `claim_slot_count` must be `8`
 
-The default `awa.*` substrate is the single stable shape every fresh
-installation gets. If you need different slot counts or
-`lease_claim_receipts = FALSE`, use a custom queue-storage schema (see
-below). Attempts to tune the default schema get a clear error
-pointing at the custom-schema path.
+The default `awa.*` substrate is the single stable shape every fresh installation gets. If you need different slot counts or `lease_claim_receipts = FALSE`, use a custom queue-storage schema (see below). Attempts to tune the default schema get a clear error pointing at the custom-schema path.
 
 ## Custom queue-storage schemas
 
-For non-default deployments — say a high-throughput tenant that wants
-`queue_slot_count = 32`, or a side-by-side rebuild during an
-incident — install a substrate under a different schema name:
+For non-default deployments — say a high-throughput tenant that wants `queue_slot_count = 32`, or a side-by-side rebuild during an incident — install a substrate under a different schema name:
 
 ```bash
 awa storage prepare-queue-storage-schema \
@@ -49,20 +34,11 @@ awa storage prepare-queue-storage-schema \
   --lease-slot-count 16
 ```
 
-The CLI calls `awa.install_queue_storage_substrate('my_jobs', 32, 16, 8, TRUE)`
-under the per-schema advisory lock. Activate the schema as the
-queue-storage backend via `awa storage prepare`, `awa storage
-enter-mixed-transition`, and `awa storage finalize` once you're ready.
-See [the upgrade guide](upgrade-0.5-to-0.6.md) for the staged flow.
+The CLI calls `awa.install_queue_storage_substrate('my_jobs', 32, 16, 8, TRUE)` under the per-schema advisory lock. Activate the schema as the queue-storage backend via `awa storage prepare`, `awa storage enter-mixed-transition`, and `awa storage finalize` once you're ready. See [the upgrade guide](upgrade-0.5-to-0.6.md) for the staged flow.
 
 ## `--reset` is rejected for `--schema awa`
 
-`awa storage prepare-queue-storage-schema --reset` runs
-`DROP SCHEMA IF EXISTS <schema> CASCADE` before re-preparing. For
-`--schema awa` that would also drop `schema_version`,
-`runtime_instances`, `storage_transition_state`, and every other
-canonical migration table, leaving the database in an unrecoverable
-state.
+`awa storage prepare-queue-storage-schema --reset` runs `DROP SCHEMA IF EXISTS <schema> CASCADE` before re-preparing. For `--schema awa` that would also drop `schema_version`, `runtime_instances`, `storage_transition_state`, and every other canonical migration table, leaving the database in an unrecoverable state.
 
 The CLI rejects this combination:
 
@@ -76,8 +52,7 @@ substrate, or 'awa storage abort' to rewind an in-flight transition."
 
 To rebuild a queue-storage substrate from scratch:
 
-- **Testing or recovery:** target a custom schema name with
-  `--schema <other>` and activate it via the storage transition flow.
+- **Testing or recovery:** target a custom schema name with `--schema <other>` and activate it via the storage transition flow.
 - **Rewind an in-flight transition:** use `awa storage abort`.
 - **Full cluster rebuild:** restore from backup, then run `awa migrate`.
 
@@ -85,39 +60,21 @@ To rebuild a queue-storage substrate from scratch:
 
 ## Driving installs and upgrades from external migration tooling
 
-Teams that already run their schema changes through a tool like
-Sqitch, Liquibase, or a hand-rolled migration runner do not need to
-invoke `awa migrate` or any other Rust binary. The migration set
-extracted with `awa migrate --sql` (or `--extract-to`) is complete:
-it includes the substrate DDL via the v023 helper, and the staged
-transition is driven by SQL functions.
+Teams that already run their schema changes through a tool like Sqitch, Liquibase, or a hand-rolled migration runner do not need to invoke `awa migrate` or any other Rust binary. The migration set extracted with `awa migrate --sql` (or `--extract-to`) is complete: it includes the substrate DDL via the v023 helper, and the staged transition is driven by SQL functions.
 
 ### Fresh install (no canonical data yet)
 
-After applying the migration files, the first runtime that boots
-calls `awa.storage_auto_finalize_if_fresh('awa')` which atomically
-advances `canonical → active` when `awa.jobs` is empty and no live
-runtimes have heartbeated. External tooling can call the same
-function as a post-migrate step to land in `active` before the first
-worker even starts:
+After applying the migration files, the first runtime that boots calls `awa.storage_auto_finalize_if_fresh('awa')` which atomically advances `canonical → active` when `awa.jobs` is empty and no live runtimes have heartbeated. External tooling can call the same function as a post-migrate step to land in `active` before the first worker even starts:
 
 ```sql
 SELECT awa.storage_auto_finalize_if_fresh('awa');
 ```
 
-`storage_auto_finalize_if_fresh` has `GRANT EXECUTE ... TO PUBLIC`,
-so the EXECUTE bit is open to any role. The function is
-`SECURITY INVOKER` and reads/writes
-`awa.storage_transition_state`, `awa.jobs`, `awa.runtime_instances`,
-and `awa.runtime_storage_backends`, so callers still need the normal
-runtime/migrator table privileges on those.
+`storage_auto_finalize_if_fresh` has `GRANT EXECUTE ... TO PUBLIC`, so the EXECUTE bit is open to any role. The function is `SECURITY INVOKER` and reads/writes `awa.storage_transition_state`, `awa.jobs`, `awa.runtime_instances`, and `awa.runtime_storage_backends`, so callers still need the normal runtime/migrator table privileges on those.
 
 ### Upgrade from an existing canonical-only deployment
 
-`storage_auto_finalize_if_fresh` refuses to short-circuit when
-canonical work or live runtimes exist. The operator drives the
-staged transition with three SQL function calls, each of which
-mirrors the equivalent `awa storage` CLI subcommand:
+`storage_auto_finalize_if_fresh` refuses to short-circuit when canonical work or live runtimes exist. The operator drives the staged transition with three SQL function calls, each of which mirrors the equivalent `awa storage` CLI subcommand:
 
 ```sql
 -- (1) Mark queue-storage as the prepared target.
@@ -147,48 +104,23 @@ SELECT awa.storage_enter_mixed_transition();
 SELECT awa.storage_finalize();
 ```
 
-`storage_enter_mixed_transition` will reject the call until at least
-one live `queue_storage_target` runtime is heartbeating.
-`storage_finalize` will reject the call while
-`awa.canonical_live_backlog() > 0` or while any canonical /
-canonical-drain-only runtime is still inside its liveness window.
-Both gates are deliberate — they prevent operators from flipping
-routing onto a substrate that has no executor or while canonical
-work or canonical-mode workers are still active.
+`storage_enter_mixed_transition` will reject the call until at least one live `queue_storage_target` runtime is heartbeating. `storage_finalize` will reject the call while `awa.canonical_live_backlog() > 0` or while any canonical / canonical-drain-only runtime is still inside its liveness window. Both gates are deliberate — they prevent operators from flipping routing onto a substrate that has no executor or while canonical work or canonical-mode workers are still active.
 
-The orchestration (start new-mode workers, stop old-mode workers,
-wait for drain) is unchanged from the CLI flow — only the invocation
-surface is different.
+The orchestration (start new-mode workers, stop old-mode workers, wait for drain) is unchanged from the CLI flow — only the invocation surface is different.
 
 ## Design rationale
 
-The split between migration-owned default substrate and helper-installed
-custom substrate exists for three reasons:
+The split between migration-owned default substrate and helper-installed custom substrate exists for three reasons:
 
-- **`awa migrate --sql` / `--extract-to` must reproduce the full
-  default runtime schema** for external migration tools to be useful.
-  All substrate DDL is reachable from the migration through the SQL
-  helper, so the extracted SQL is complete.
-- **Migrations that depend on queue-storage tables can write
-  unconditional DDL.** Operations like the
-  `queue_terminal_live_counts` decrement inside
-  `awa.delete_job_compat()` need the counter table to exist. Migration
-  ordering guarantees it.
-- **The default schema cannot be accidentally destroyed.** The reset
-  guard above protects operators from a `DROP SCHEMA awa CASCADE` that
-  would take the canonical migration tables with it.
+- **`awa migrate --sql` / `--extract-to` must reproduce the full default runtime schema** for external migration tools to be useful. All substrate DDL is reachable from the migration through the SQL helper, so the extracted SQL is complete.
+- **Migrations that depend on queue-storage tables can write unconditional DDL.** Operations like the `queue_terminal_live_counts` decrement inside `awa.delete_job_compat()` need the counter table to exist. Migration ordering guarantees it.
+- **The default schema cannot be accidentally destroyed.** The reset guard above protects operators from a `DROP SCHEMA awa CASCADE` that would take the canonical migration tables with it.
 
-The helper is `SECURITY INVOKER` so callers need their own DDL
-privileges on the target schema; the runtime role does not gain DDL
-through the helper, which keeps the principle-of-least-privilege role
-model intact.
+The helper is `SECURITY INVOKER` so callers need their own DDL privileges on the target schema; the runtime role does not gain DDL through the helper, which keeps the principle-of-least-privilege role model intact.
 
 ## See also
 
-- [`docs/migrations.md`](migrations.md) — migration policy and the
-  `awa migrate --sql` / `--extract-to` story.
+- [`docs/migrations.md`](migrations.md) — migration policy and the `awa migrate --sql` / `--extract-to` story.
 - [`docs/architecture.md`](architecture.md) — overall storage layering.
-- [`docs/security.md`](security.md) — role boundaries and the
-  `SECURITY INVOKER` posture.
-- [`docs/upgrade-0.5-to-0.6.md`](upgrade-0.5-to-0.6.md) — operator flow
-  for an existing cluster.
+- [`docs/security.md`](security.md) — role boundaries and the `SECURITY INVOKER` posture.
+- [`docs/upgrade-0.5-to-0.6.md`](upgrade-0.5-to-0.6.md) — operator flow for an existing cluster.

--- a/docs/security.md
+++ b/docs/security.md
@@ -140,34 +140,19 @@ ALTER DEFAULT PRIVILEGES FOR ROLE awa_migrator IN SCHEMA awa
   GRANT EXECUTE ON FUNCTIONS TO awa_runtime;
 ```
 
-If you use the compatibility `insert_many_copy` path (Rust
-`InsertOpts::copy()`), also grant:
+If you use the compatibility `insert_many_copy` path (Rust `InsertOpts::copy()`), also grant:
 
 ```sql
 GRANT TEMP ON DATABASE mydb TO awa_runtime;
 ```
 
-This allows creating temporary staging tables for the `COPY` bulk insert path.
-Queue-storage direct COPY (`QueueStorage::enqueue_params_copy` in Rust,
-`enqueue_many_copy` in Python) writes to the queue-storage tables directly and
-does not need this temporary-table grant.
+This allows creating temporary staging tables for the `COPY` bulk insert path. Queue-storage direct COPY (`QueueStorage::enqueue_params_copy` in Rust, `enqueue_many_copy` in Python) writes to the queue-storage tables directly and does not need this temporary-table grant.
 
 ### Custom queue-storage schema
 
-The queue-storage backend defaults to keeping its tables in the same
-`awa` schema, so the grants above cover both control-plane and
-queue-storage tables. See
-[Queue-storage substrate](queue-storage-substrate.md) for the full
-ownership contract — what `awa migrate` installs by default, how
-custom schemas are materialised via
-`awa.install_queue_storage_substrate()`, and why
-`awa storage prepare-queue-storage-schema --schema awa --reset` is
-rejected.
+The queue-storage backend defaults to keeping its tables in the same `awa` schema, so the grants above cover both control-plane and queue-storage tables. See [Queue-storage substrate](queue-storage-substrate.md) for the full ownership contract — what `awa migrate` installs by default, how custom schemas are materialised via `awa.install_queue_storage_substrate()`, and why `awa storage prepare-queue-storage-schema --schema awa --reset` is rejected.
 
-If you override the schema name (Rust:
-`QueueStorageConfig.schema`; Python: `queue_storage_schema=...`; CLI:
-`awa storage prepare-queue-storage-schema --schema <name>`), repeat
-the grant block against that schema:
+If you override the schema name (Rust: `QueueStorageConfig.schema`; Python: `queue_storage_schema=...`; CLI: `awa storage prepare-queue-storage-schema --schema <name>`), repeat the grant block against that schema:
 
 ```sql
 GRANT USAGE ON SCHEMA my_qs_schema TO awa_runtime;
@@ -188,17 +173,12 @@ ALTER DEFAULT PRIVILEGES FOR ROLE awa_migrator IN SCHEMA my_qs_schema
   GRANT EXECUTE ON FUNCTIONS TO awa_runtime;
 ```
 
-The default `awa` queue-storage substrate is migrated by `awa migrate`. Custom
-queue-storage schemas are migrated by
-`awa storage prepare-queue-storage-schema`, which should also run as the
-migrator role and creates objects owned by `awa_migrator` / `awa_owner`. The
-runtime role needs read/write/execute privileges plus `TRUNCATE` for
-ring-partition rotation; it never needs DDL.
+The default `awa` queue-storage substrate is migrated by `awa migrate`. Custom queue-storage schemas are migrated by `awa storage prepare-queue-storage-schema`, which should also run as the migrator role and creates objects owned by `awa_migrator` / `awa_owner`. The runtime role needs read/write/execute privileges plus `TRUNCATE` for ring-partition rotation; it never needs DDL.
 
 ### 5. Configure your processes
 
 | Process | Role | Connection string |
-|---|---|---|
+| --- | --- | --- |
 | `awa migrate` | `awa_migrator` | `postgres://awa_migrator:pass@host/db` |
 | Workers (Rust/Python) | `awa_runtime` | `postgres://awa_runtime:pass@host/db` |
 | `awa serve` (UI + API) | `awa_runtime` | `postgres://awa_runtime:pass@host/db` |
@@ -228,7 +208,7 @@ These writes are not trigger-driven; they come from `ClientBuilder::build()` / `
 Other PostgreSQL features used at runtime:
 
 | Feature | Purpose | Privilege needed |
-|---|---|---|
+| --- | --- | --- |
 | `LISTEN` / `NOTIFY` | Queue wakeup without polling | `CONNECT` (no extra grant) |
 | `pg_try_advisory_lock` | Leader election for maintenance | Built-in function (no grant) |
 | `COPY ... FROM STDIN` | Bulk insert path | `TEMP` on database |
@@ -297,27 +277,14 @@ This is additive — no schema changes, no downtime.
 
 ## Future: tighter runtime grants
 
-The current model requires broad table grants because compatibility triggers
-and helper functions still use `SECURITY INVOKER`. A future migration could
-convert the internal queue-storage helpers to `SECURITY DEFINER` (running as
-`awa_owner`), which would let the runtime role be restricted to the active
-queue-storage schema plus the shared control tables (`queue_meta`,
-`job_unique_claims`, `cron_jobs`, `runtime_instances`, and
-`runtime_storage_backends`). This is tracked but not yet implemented — the
-current model is secure for the separation it provides (runtime can't modify
-schema).
+The current model requires broad table grants because compatibility triggers and helper functions still use `SECURITY INVOKER`. A future migration could convert the internal queue-storage helpers to `SECURITY DEFINER` (running as `awa_owner`), which would let the runtime role be restricted to the active queue-storage schema plus the shared control tables (`queue_meta`, `job_unique_claims`, `cron_jobs`, `runtime_instances`, and `runtime_storage_backends`). This is tracked but not yet implemented — the current model is secure for the separation it provides (runtime can't modify schema).
 
 ## Deployable roles
 
-Awa is one process binary, but for production it splits into several
-*deployable roles*. Each role has a different exposure profile, and
-mixing them onto the same listener is the most common source of
-operational risk. See [ADR-027](adr/027-callback-ingress-surface.md) for
-the design rationale and [`docs/http-callbacks.md`](http-callbacks.md)
-for the per-role deployment shape.
+Awa is one process binary, but for production it splits into several _deployable roles_. Each role has a different exposure profile, and mixing them onto the same listener is the most common source of operational risk. See [ADR-027](adr/027-callback-ingress-surface.md) for the design rationale and [`docs/http-callbacks.md`](http-callbacks.md) for the per-role deployment shape.
 
 | Role | Purpose | Exposure | Mutates job state? |
-|---|---|---|---|
+| --- | --- | --- | --- |
 | **Admin UI / API** (`awa serve`) | operator inspection and mutation — jobs, queues, runtime, DLQ, stats | private operator network | yes |
 | **Callback receiver** (`awa callbacks serve` or user-owned router) | `complete` / `fail` / `heartbeat` for `HttpWorker` async mode and external systems | public or partner-facing, signed | yes |
 | **Workers / dispatchers** (`awa::Client` with registered workers) | claim jobs, execute handlers, dispatch via `HttpWorker` | internal | yes |
@@ -332,7 +299,7 @@ A single development setup can collapse these onto one process: `awa serve` runs
 - **Private admin + public callback receiver:** `awa serve` on a private VPC subnet, `awa callbacks serve --callback-hmac-secret …` on an external load balancer. The receiver router omits static UI assets, the admin REST routes, and permissive CORS.
 - **User-owned callback API:** mount the three callback ingress routes inside your existing FastAPI / axum / Flask app, using `awa_model::callback_contract::verify` (Rust) or `awa.callback_contract.verify` (Python) so the signature contract cannot drift. See [`docs/callback-receivers.md`](callback-receivers.md).
 - **Receiver + maintenance-only runtime:** the receiver handles ingress while a dedicated runtime instance runs promotion / rescue / pruning. Workers stay on their own deployment. Maintenance-only runtime is tracked in [ADR-028](adr/028-maintenance-only-runtime-role.md).
-- **HTTP-worker deployments:** the worker process still runs an `awa::Client` — it claims jobs, calls the function, and registers the callback. The receiver is a separate listener. A function endpoint without a corresponding dispatcher process will *never* see jobs.
+- **HTTP-worker deployments:** the worker process still runs an `awa::Client` — it claims jobs, calls the function, and registers the callback. The receiver is a separate listener. A function endpoint without a corresponding dispatcher process will _never_ see jobs.
 
 ## Admin Surface
 
@@ -379,8 +346,7 @@ awa --database-url "$DATABASE_URL" serve --host 0.0.0.0 --port 3000
 
 If no callback secret is configured, signature verification is disabled. That is acceptable only for trusted internal deployments where the callback receiver is already protected by network boundaries or an authenticating proxy.
 
-The option name says `hmac` for operational familiarity, but the implementation
-uses BLAKE3 keyed hashing over the callback ID string, not RFC HMAC.
+The option name says `hmac` for operational familiarity, but the implementation uses BLAKE3 keyed hashing over the callback ID string, not RFC HMAC.
 
 ## Custom Callback Receivers
 

--- a/docs/test-plan.md
+++ b/docs/test-plan.md
@@ -1,9 +1,6 @@
 # AWA — Validation Test Plan
 
-Tests run against real Postgres 15+ (not managed services) using a dedicated
-test database. Most Rust/Python rows below are automated in CI; heavyweight
-soak, failover, benchmark, TLA+, and managed-service checks are run manually or
-in scheduled lanes when they need special infrastructure.
+Tests run against real Postgres 15+ (not managed services) using a dedicated test database. Most Rust/Python rows below are automated in CI; heavyweight soak, failover, benchmark, TLA+, and managed-service checks are run manually or in scheduled lanes when they need special infrastructure.
 
 ## Test Matrix
 
@@ -12,74 +9,68 @@ in scheduled lanes when they need special infrastructure.
 ### Correctness & Crash Recovery
 
 | # | Test | Rust | Py |
-|---|------|------|----|
-| T1 | No duplicate processing (100k jobs) | ✓ | |
-| T4 | `kill -9` crash recovery | ✓ | |
-| T5 | Deadline rescue (hung job) | ✓ | |
-| T6 | Transactional atomicity | ✓ | |
-| T7 | Transactional atomicity (Python) | | ✓ |
+| --- | --- | --- | --- |
+| T1 | No duplicate processing (100k jobs) | ✓ |  |
+| T4 | `kill -9` crash recovery | ✓ |  |
+| T5 | Deadline rescue (hung job) | ✓ |  |
+| T6 | Transactional atomicity | ✓ |  |
+| T7 | Transactional atomicity (Python) |  | ✓ |
 | T8 | Uniqueness under contention | ✓ | ✓ |
-| T9 | Hash cross-language consistency | ✓ | |
-| T10 | Priority ordering | ✓ | |
-| T12 | Queue isolation | ✓ | |
-| T18 | Backoff timing | ✓ | |
-| T19 | Snooze semantics | ✓ | |
-| T20 | Terminal error semantics | ✓ | |
-| T21 | Deserialization failure | ✓ | |
-| B1 | Late completion after rescue is no-op | ✓ | |
-| B2 | Late completion after cancel is no-op | ✓ | |
-| B3 | Shutdown waits for in-flight jobs | ✓ | |
-| B4 | Heartbeat alive during shutdown drain | ✓ | |
-| B5 | Deadline rescue signals ctx.is_cancelled() | ✓ | |
-| B6 | UniqueConflict.constraint field | ✓ | |
+| T9 | Hash cross-language consistency | ✓ |  |
+| T10 | Priority ordering | ✓ |  |
+| T12 | Queue isolation | ✓ |  |
+| T18 | Backoff timing | ✓ |  |
+| T19 | Snooze semantics | ✓ |  |
+| T20 | Terminal error semantics | ✓ |  |
+| T21 | Deserialization failure | ✓ |  |
+| B1 | Late completion after rescue is no-op | ✓ |  |
+| B2 | Late completion after cancel is no-op | ✓ |  |
+| B3 | Shutdown waits for in-flight jobs | ✓ |  |
+| B4 | Heartbeat alive during shutdown drain | ✓ |  |
+| B5 | Deadline rescue signals ctx.is_cancelled() | ✓ |  |
+| B6 | UniqueConflict.constraint field | ✓ |  |
 | B7 | Admin cancel signals in-flight handler cancellation | ✓ | ✓ |
-| T75 | Priority aging maintenance task promotes long-waiting low-priority jobs | ✓ | |
+| T75 | Priority aging maintenance task promotes long-waiting low-priority jobs | ✓ |  |
 
 ### Uniqueness (Python)
 
-| # | Test | Rust | Py |
-|---|------|------|----|
-| T8 | Uniqueness under contention (10 concurrent producers) | ✓ | |
-| PU1 | Unique insert happy path | | ✓ |
-| PU2 | Duplicate rejected (UniqueConflict) | | ✓ |
-| PU3 | by_queue: different queues allowed | | ✓ |
-| PU4 | by_queue: same queue rejected | | ✓ |
-| PU5 | by_args: different args allowed | | ✓ |
-| PU6 | by_period: same bucket rejected | | ✓ |
-| PU7 | by_period: different bucket allowed | | ✓ |
-| PU8 | Unicode args hash consistently | | ✓ |
-| PU9 | Nested dict args hash consistently | | ✓ |
-| PU10 | Empty args hash consistently | | ✓ |
-| PU11 | Large args (~100KB) hash consistently | | ✓ |
-| PU12 | No unique_opts allows duplicates | | ✓ |
-| PU13 | Sync insert with unique_opts | | ✓ |
+| #    | Test                                                  | Rust | Py  |
+| ---- | ----------------------------------------------------- | ---- | --- |
+| T8   | Uniqueness under contention (10 concurrent producers) | ✓    |     |
+| PU1  | Unique insert happy path                              |      | ✓   |
+| PU2  | Duplicate rejected (UniqueConflict)                   |      | ✓   |
+| PU3  | by_queue: different queues allowed                    |      | ✓   |
+| PU4  | by_queue: same queue rejected                         |      | ✓   |
+| PU5  | by_args: different args allowed                       |      | ✓   |
+| PU6  | by_period: same bucket rejected                       |      | ✓   |
+| PU7  | by_period: different bucket allowed                   |      | ✓   |
+| PU8  | Unicode args hash consistently                        |      | ✓   |
+| PU9  | Nested dict args hash consistently                    |      | ✓   |
+| PU10 | Empty args hash consistently                          |      | ✓   |
+| PU11 | Large args (~100KB) hash consistently                 |      | ✓   |
+| PU12 | No unique_opts allows duplicates                      |      | ✓   |
+| PU13 | Sync insert with unique_opts                          |      | ✓   |
 
 ### Admin & Resilience
 
 | # | Test | Rust | Py |
-|---|------|------|----|
-| T13 | Queue pause/resume | ✓ | |
-| T22 | Pool exhaustion resilience | ✓ | |
-| T26 | Migration idempotency | ✓ | |
-| T27 | Admin ops under load | ✓ | |
-| T72 | Runtime recovers after terminating Postgres backends | ✓ | |
+| --- | --- | --- | --- |
+| T13 | Queue pause/resume | ✓ |  |
+| T22 | Pool exhaustion resilience | ✓ |  |
+| T26 | Migration idempotency | ✓ |  |
+| T27 | Admin ops under load | ✓ |  |
+| T72 | Runtime recovers after terminating Postgres backends | ✓ |  |
 | T71 | Mixed Rust/Python workers share queue | Both | Both |
 | T73 | Sustained mixed workload survives node failure (see below) | Both | Both |
-| T74 | Hot-standby promotion | ✓ | |
-| HA1 | Postgres failover smoke | ✓ | |
+| T74 | Hot-standby promotion | ✓ |  |
+| HA1 | Postgres failover smoke | ✓ |  |
 
-**T73 ordering invariant:** Jobs are inserted *before* Rust clients start so that
-the Python worker exclusively claims `simple_chaos_job` rows. This avoids a race
-where Rust's instant `CompleteWorker` steals all simple jobs before the slower
-Python worker (400 ms/job) can claim any. The test confirms Python is mid-execution
-via its `START` stdout line, then kills it. Heartbeat backdating triggers rescue,
-and the `max_simple_attempt >= 2` assertion verifies re-processing by a surviving
-Rust worker.
+**T73 ordering invariant:** Jobs are inserted _before_ Rust clients start so that the Python worker exclusively claims `simple_chaos_job` rows. This avoids a race where Rust's instant `CompleteWorker` steals all simple jobs before the slower Python worker (400 ms/job) can claim any. The test confirms Python is mid-execution via its `START` stdout line, then kills it. Heartbeat backdating triggers rescue, and the `max_simple_attempt >= 2` assertion verifies re-processing by a surviving Rust worker.
 
 ### External Callbacks
 
 | # | Test | Rust | Py |
-|---|------|------|----|
+| --- | --- | --- | --- |
 | E1 | register_callback + WaitForCallback → waiting_external | ✓ | ✓ |
 | E2 | complete_external → completed | ✓ | ✓ |
 | E3 | fail_external → failed | ✓ | ✓ |
@@ -91,150 +82,150 @@ Rust worker.
 | E9/PE5 | Admin retry while waiting_external | ✓ | ✓ |
 | E10/PE6 | drain_queue includes waiting_external | ✓ | ✓ |
 | E11/PE7 | Race: complete during running (before WaitForCallback) | ✓ | ✓ |
-| E12 | Crash clears stale callback | ✓ | |
-| E13 | Uniqueness during waiting_external | ✓ | |
-| E15 | resolve_callback accepts running state | ✓ | |
+| E12 | Crash clears stale callback | ✓ |  |
+| E13 | Uniqueness during waiting_external | ✓ |  |
+| E15 | resolve_callback accepts running state | ✓ |  |
 | E16/PE8 | Stale callback rejected after rescue | ✓ | ✓ |
-| E17 | cancel_callback clears fields | ✓ | |
-| E18 | cancel_callback wrong lease is noop | ✓ | |
-| PE9 | Callback timeout rescued end-to-end by live runtime | | ✓ |
+| E17 | cancel_callback clears fields | ✓ |  |
+| E18 | cancel_callback wrong lease is noop | ✓ |  |
+| PE9 | Callback timeout rescued end-to-end by live runtime |  | ✓ |
 
 ### CEL Callback Expressions
 
-| # | Test | Rust | Py |
-|---|------|------|----|
-| C1-C2 | resolve_callback default actions (complete/ignore) | ✓ | ✓ |
-| C3-C4 | Filter expressions (pass/fail) | ✓ | |
-| C5-C6 | on_fail takes precedence over on_complete | ✓ | |
-| C7 | Transform payload | ✓ | |
-| C8-C9 | Invalid CEL fail-open | ✓ | |
-| C10 | Fallthrough to default action | ✓ | |
-| C11 | Invalid CEL at registration → validation error | ✓ | |
-| C12 | Double resolve → CallbackNotFound | ✓ | |
-| C14-C15 | Deeply nested / missing field (fail-open) | ✓ | |
-| C16 | resolve_callback accepts running state | ✓ | |
-| C17 | Concurrent resolve (FOR UPDATE prevents race) | ✓ | |
-| C18-C19 | CEL disabled: registration + resolution errors | ✓ | |
+| #       | Test                                               | Rust | Py  |
+| ------- | -------------------------------------------------- | ---- | --- |
+| C1-C2   | resolve_callback default actions (complete/ignore) | ✓    | ✓   |
+| C3-C4   | Filter expressions (pass/fail)                     | ✓    |     |
+| C5-C6   | on_fail takes precedence over on_complete          | ✓    |     |
+| C7      | Transform payload                                  | ✓    |     |
+| C8-C9   | Invalid CEL fail-open                              | ✓    |     |
+| C10     | Fallthrough to default action                      | ✓    |     |
+| C11     | Invalid CEL at registration → validation error     | ✓    |     |
+| C12     | Double resolve → CallbackNotFound                  | ✓    |     |
+| C14-C15 | Deeply nested / missing field (fail-open)          | ✓    |     |
+| C16     | resolve_callback accepts running state             | ✓    |     |
+| C17     | Concurrent resolve (FOR UPDATE prevents race)      | ✓    |     |
+| C18-C19 | CEL disabled: registration + resolution errors     | ✓    |     |
 
 ### Sequential Callbacks
 
 | # | Test | Rust | Py |
-|---|------|------|----|
+| --- | --- | --- | --- |
 | SC1 | wait_for_callback: suspend + resume | ✓ | ✓ (SC14) |
 | SC2 | Two sequential callbacks via admin API | ✓ | ✓ (SC15) |
-| SC3 | Timeout during second callback → retryable | ✓ | |
+| SC3 | Timeout during second callback → retryable | ✓ |  |
 | SC4/SC16 | Heartbeat extends timeout during wait | ✓ | ✓ |
-| SC5 | Concurrent resume: exactly one succeeds | ✓ | |
-| SC6 | Resume with wrong run_lease rejected | ✓ | |
-| SC7 | Crash/rescue after resume | ✓ | |
-| SC8 | Admin cancel after resume | ✓ | |
+| SC5 | Concurrent resume: exactly one succeeds | ✓ |  |
+| SC6 | Resume with wrong run_lease rejected | ✓ |  |
+| SC7 | Crash/rescue after resume | ✓ |  |
+| SC8 | Admin cancel after resume | ✓ |  |
 | SC9 | Resume preserves metadata | ✓ | ✓ |
-| SC10-SC12 | fail/resolve/retry on second callback | ✓ | |
-| SC13 | resume_external transitions to running with payload | | ✓ |
-| SC17 | Double resume fails with CallbackNotFound | | ✓ |
+| SC10-SC12 | fail/resolve/retry on second callback | ✓ |  |
+| SC13 | resume_external transitions to running with payload |  | ✓ |
+| SC17 | Double resume fails with CallbackNotFound |  | ✓ |
 
 ### HTTP Worker
 
-| # | Test | Rust | Py |
-|---|------|------|----|
-| HW1 | Sync mode 200 → completed | ✓ | — |
-| HW2 | Sync mode 500 → retryable | ✓ | — |
-| HW3 | Sync mode 400 → terminal fail | ✓ | — |
-| HW4 | Async mode 202 → callback complete | ✓ | — |
-| HW5 | Async mode 503 → retryable | ✓ | — |
-| HW6 | Async unreachable → retryable | ✓ | — |
-| HW7 | Custom headers | ✓ | — |
-| HW8 | BLAKE3 callback signature | ✓ | — |
-| HW9 | Callback URL construction | ✓ | — |
+| #   | Test                               | Rust | Py  |
+| --- | ---------------------------------- | ---- | --- |
+| HW1 | Sync mode 200 → completed          | ✓    | —   |
+| HW2 | Sync mode 500 → retryable          | ✓    | —   |
+| HW3 | Sync mode 400 → terminal fail      | ✓    | —   |
+| HW4 | Async mode 202 → callback complete | ✓    | —   |
+| HW5 | Async mode 503 → retryable         | ✓    | —   |
+| HW6 | Async unreachable → retryable      | ✓    | —   |
+| HW7 | Custom headers                     | ✓    | —   |
+| HW8 | BLAKE3 callback signature          | ✓    | —   |
+| HW9 | Callback URL construction          | ✓    | —   |
 
-*HTTPWorker is a Rust-only feature (ADR-018: serverless function dispatch). Not exposed to Python.*
+_HTTPWorker is a Rust-only feature (ADR-018: serverless function dispatch). Not exposed to Python._
 
 ### Python SDK
 
-| # | Test | Py |
-|---|------|----|
-| T58-T70 | Sync API variants (insert, cancel, retry, drain, list, etc.) | ✓ |
-| P12-P16 | start() config validation (dict, tuple, weighted, errors) | ✓ |
-| P17 | start() accepts all maintenance interval kwargs | ✓ |
-| PP1-PP5 | Progress tracking (set, merge, flush, checkpoint) | ✓ |
-| BR4 | Bridge: asyncpg/psycopg/SQLAlchemy/Django insert | ✓ |
+| #       | Test                                                         | Py  |
+| ------- | ------------------------------------------------------------ | --- |
+| T58-T70 | Sync API variants (insert, cancel, retry, drain, list, etc.) | ✓   |
+| P12-P16 | start() config validation (dict, tuple, weighted, errors)    | ✓   |
+| P17     | start() accepts all maintenance interval kwargs              | ✓   |
+| PP1-PP5 | Progress tracking (set, merge, flush, checkpoint)            | ✓   |
+| BR4     | Bridge: asyncpg/psycopg/SQLAlchemy/Django insert             | ✓   |
 
 ### Cron / Periodic Jobs
 
 | # | Test | Rust | Py |
-|---|------|------|----|
-| T34-T46 | Cron: migration, upsert, atomic CTE, dedup, backfill, DST | ✓ | |
-| T40-T41 | End-to-end periodic + metadata propagation | ✓ | |
-| CRP1-CRP9 | Cron pause / resume: state transitions, CTE guard, upsert preserves pause, manual trigger bypass, queue interaction | ✓ | |
+| --- | --- | --- | --- |
+| T34-T46 | Cron: migration, upsert, atomic CTE, dedup, backfill, DST | ✓ |  |
+| T40-T41 | End-to-end periodic + metadata propagation | ✓ |  |
+| CRP1-CRP9 | Cron pause / resume: state transitions, CTE guard, upsert preserves pause, manual trigger bypass, queue interaction | ✓ |  |
 
 ### COPY Batch Ingestion
 
 | # | Test | Rust | Py |
-|---|------|------|----|
+| --- | --- | --- | --- |
 | T47-T57a | COPY: empty, single, 1000, special chars, tags, unique, atomic | ✓ | ✓ |
 | QSC1-QSC2 | Queue storage COPY producer: ready/deferred direct COPY, unique-conflict rollback | ✓ | ✓ |
 
 ### Rate Limiting & Weighted Concurrency
 
 | # | Test | Rust | Py |
-|---|------|------|----|
-| RL1-RL6 | Rate limit: fast, throttle, burst, bottleneck, invalid | ✓ | |
-| W5-W13 | Weighted: backward compat, overflow, floor, cap, proportionality | ✓ | |
+| --- | --- | --- | --- |
+| RL1-RL6 | Rate limit: fast, throttle, burst, bottleneck, invalid | ✓ |  |
+| W5-W13 | Weighted: backward compat, overflow, floor, cap, proportionality | ✓ |  |
 
 ### Observability
 
-| # | Test | Rust |
-|---|------|------|
-| T28-T30 | Tracing spans + OTel metrics | ✓ |
-| OT1-OT4 | OTLP export end-to-end | ✓ |
+| #       | Test                         | Rust |
+| ------- | ---------------------------- | ---- |
+| T28-T30 | Tracing spans + OTel metrics | ✓    |
+| OT1-OT4 | OTLP export end-to-end       | ✓    |
 
 ### Bridge Adapters
 
 | # | Test | Rust | Py |
-|---|------|------|----|
-| BR1-BR3 | tokio-postgres bridge: atomicity, lease guard, unique conflict | ✓ | |
-| BR4 | Python bridge: asyncpg/psycopg/SQLAlchemy/Django | | ✓ |
+| --- | --- | --- | --- |
+| BR1-BR3 | tokio-postgres bridge: atomicity, lease guard, unique conflict | ✓ |  |
+| BR4 | Python bridge: asyncpg/psycopg/SQLAlchemy/Django |  | ✓ |
 
 ### UI (Admin)
 
 | # | Test | Rust |
-|---|------|------|
+| --- | --- | --- |
 | RO1-RO3 | Read-only serve: capabilities, mutations blocked, UI disables | ✓ |
 
 ### Admin Metadata Guardrails
 
-| # | Test | Rust |
-|---|------|------|
-| AM1 | Heartbeat/progress-only UPDATEs do not dirty queues or kinds | ✓ |
-| AM2 | flush_dirty_admin_metadata() drains backlog > 100 keys | ✓ |
+| #   | Test                                                         | Rust |
+| --- | ------------------------------------------------------------ | ---- |
+| AM1 | Heartbeat/progress-only UPDATEs do not dirty queues or kinds | ✓    |
+| AM2 | flush_dirty_admin_metadata() drains backlog > 100 keys       | ✓    |
 
 ### Benchmarks
 
 | # | Test | Rust | Py |
-|---|------|------|----|
-| T31-T33 | Throughput + latency + insert speed | ✓ | |
-| CL1-CL2 | Concurrent multi-queue lifecycle | ✓ | |
-| SP1-SP2 | Scheduled promotion at scale | ✓ | |
-| FB1-FB7 | Failure modes: terminal, retryable, callback, deadline, mixed | ✓ | |
-| FB8 | Failure modes (Python) | | ✓ |
-| PB1 | Portable cross-system enqueue throughput (Awa vs River vs Oban, 10k and 50k jobs) | | |
-| PB2 | Portable cross-system worker throughput (50/100/200 workers, no-op jobs) | | |
-| PB3 | Portable cross-system pickup latency (single job to idle queue) | | |
+| --- | --- | --- | --- |
+| T31-T33 | Throughput + latency + insert speed | ✓ |  |
+| CL1-CL2 | Concurrent multi-queue lifecycle | ✓ |  |
+| SP1-SP2 | Scheduled promotion at scale | ✓ |  |
+| FB1-FB7 | Failure modes: terminal, retryable, callback, deadline, mixed | ✓ |  |
+| FB8 | Failure modes (Python) |  | ✓ |
+| PB1 | Portable cross-system enqueue throughput (Awa vs River vs Oban, 10k and 50k jobs) |  |  |
+| PB2 | Portable cross-system worker throughput (50/100/200 workers, no-op jobs) |  |  |
+| PB3 | Portable cross-system pickup latency (single job to idle queue) |  |  |
 
 ### Dirty-key trigger overhead (measured v0.5.1, debug build, Docker PG 17)
 
 Concurrent lifecycle benchmark (1 queue × 128 workers, 20K jobs):
 
-| Config | Throughput | Overhead |
-|--------|-----------|----------|
-| No triggers (baseline) | 1963/s | — |
-| Noop PL/pgSQL trigger | 1855/s | 5.5% |
-| Full dirty-key triggers | 1832/s | **~7%** |
+| Config                  | Throughput | Overhead |
+| ----------------------- | ---------- | -------- |
+| No triggers (baseline)  | 1963/s     | —        |
+| Noop PL/pgSQL trigger   | 1855/s     | 5.5%     |
+| Full dirty-key triggers | 1832/s     | **~7%**  |
 
 ### Formal Models (TLA+)
 
 | # | Model | Invariants |
-|---|-------|------------|
+| --- | --- | --- |
 | TLA1 | AwaCore | Lease-guarded finalization, stale completion rejected |
 | TLA2 | AwaExtended | Shutdown/rescue/permit/fairness protocol |
 | TLA3 | AwaCbk | At-most-once callback resolution, sequential resume |
@@ -250,12 +241,7 @@ Concurrent lifecycle benchmark (1 queue × 128 workers, 20K jobs):
 | TLA13 | AwaStorageTransition | Storage-transition prepare, mixed-entry, finalize, and abort gates |
 | TLA14 | AwaDeadTupleContract | Hot-table reclaim-kind and partition-truncate contract |
 
-The formal suite includes passing configs and expected-counterexample configs.
-The expected-counterexample configs keep historical bugs executable: old
-dispatch claim, old view trigger, naive segment race, old storage-transition
-gate, shard-ignorant prune, and deliberate lock-order cycles. Trace configs
-use a `TraceIncomplete` invariant as a positive witness: a valid trace violates
-that invariant after TLC consumes every event.
+The formal suite includes passing configs and expected-counterexample configs. The expected-counterexample configs keep historical bugs executable: old dispatch claim, old view trigger, naive segment race, old storage-transition gate, shard-ignorant prune, and deliberate lock-order cycles. Trace configs use a `TraceIncomplete` invariant as a positive witness: a valid trace violates that invariant after TLC consumes every event.
 
 ## Running Tests
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -27,11 +27,7 @@ A job staying in `running` is not automatically a bug. It usually means one of t
 
 ### Inspect Running Jobs
 
-In 0.6 with the default queue-storage backend, running attempts live
-in `{schema}.leases` (lease-materialized attempts) and unmaterialized
-short-job claims live in `{schema}.lease_claims`. The `{schema}` is
-`awa` unless the operator chose a different name; replace below as
-needed.
+In 0.6 with the default queue-storage backend, running attempts live in `{schema}.leases` (lease-materialized attempts) and unmaterialized short-job claims live in `{schema}.lease_claims`. The `{schema}` is `awa` unless the operator chose a different name; replace below as needed.
 
 ```sql
 -- Materialized leases. heartbeat_at and deadline_at both populated.
@@ -119,90 +115,48 @@ Then investigate why the worker stopped.
 
 ### Admin Cancel Doesn't Wake A Running Worker
 
-`awa job cancel <id>` writes the cancellation to the database and emits
-`pg_notify('awa:cancel', {job_id, run_lease})`. Each worker runtime
-runs a `CancelListener` (PgListener-based) that picks up the
-notification and fires the matching `Arc<AtomicBool>` cancel flag the
-handler's `JobContext` holds — so the handler sees
-`ctx.is_cancelled() == true` on its next check and can stop cleanly.
+`awa job cancel <id>` writes the cancellation to the database and emits `pg_notify('awa:cancel', {job_id, run_lease})`. Each worker runtime runs a `CancelListener` (PgListener-based) that picks up the notification and fires the matching `Arc<AtomicBool>` cancel flag the handler's `JobContext` holds — so the handler sees `ctx.is_cancelled() == true` on its next check and can stop cleanly.
 
-If the listener fails to start or its connection drops, the listener
-logs a `warn!` and exits; admin cancels then silently fall back to
-heartbeat / deadline rescue for detection (i.e. the cancel does take
-effect on the next completion-time `run_lease` check, but the handler
-doesn't get the early wake-up). Symptoms: `awa job cancel` returns
-success and the database shows the job as `cancelled`, but a worker
-reports completing the cancelled `run_lease` long after the cancel
-was issued; the completion is rejected by `StaleCompleteRejected` so
-no harm done, just wasted work.
+If the listener fails to start or its connection drops, the listener logs a `warn!` and exits; admin cancels then silently fall back to heartbeat / deadline rescue for detection (i.e. the cancel does take effect on the next completion-time `run_lease` check, but the handler doesn't get the early wake-up). Symptoms: `awa job cancel` returns success and the database shows the job as `cancelled`, but a worker reports completing the cancelled `run_lease` long after the cancel was issued; the completion is rejected by `StaleCompleteRejected` so no harm done, just wasted work.
 
 To diagnose:
 
-- Search the worker logs for `Failed to create PG listener for admin
-  cancel` or `Failed to LISTEN on cancel channel`. Either message
-  means the listener started, hit the failure, and the runtime is
-  now in fallback mode.
-- Search for `PG cancel listener error; will retry` — the listener
-  saw a transient error and is sleeping 1s before reconnecting; not
-  a steady-state failure unless it spams the log.
-- Confirm `pg_listener` works from outside the runtime:
-  `psql -c "LISTEN \"awa:cancel\";"` and watch a separate session
-  fire `SELECT pg_notify('awa:cancel', '{}');`.
+- Search the worker logs for `Failed to create PG listener for admin cancel` or `Failed to LISTEN on cancel channel`. Either message means the listener started, hit the failure, and the runtime is now in fallback mode.
+- Search for `PG cancel listener error; will retry` — the listener saw a transient error and is sleeping 1s before reconnecting; not a steady-state failure unless it spams the log.
+- Confirm `pg_listener` works from outside the runtime: `psql -c "LISTEN \"awa:cancel\";"` and watch a separate session fire `SELECT pg_notify('awa:cancel', '{}');`.
 
 To recover:
 
-- Restart the worker process — the listener spawns at runtime
-  startup, so restart re-creates the listener with a fresh
-  connection.
-- If the failure is steady (e.g. a Postgres pool sized so all
-  connections are saturated by claim/complete traffic and `LISTEN`
-  can't acquire one), increase the pool max or dedicate a
-  connection to listening.
+- Restart the worker process — the listener spawns at runtime startup, so restart re-creates the listener with a fresh connection.
+- If the failure is steady (e.g. a Postgres pool sized so all connections are saturated by claim/complete traffic and `LISTEN` can't acquire one), increase the pool max or dedicate a connection to listening.
 
-In all cases the cancel itself is durable — only the early wake-up
-is lost. Long-running handlers that don't poll `ctx.is_cancelled()`
-between heartbeats won't notice the cancel until they finish or
-heartbeat-rescue fires.
+In all cases the cancel itself is durable — only the early wake-up is lost. Long-running handlers that don't poll `ctx.is_cancelled()` between heartbeats won't notice the cancel until they finish or heartbeat-rescue fires.
 
 ## Producer Enqueue Is Slower Than Expected
 
 ### What It Usually Means
 
-Producers are enqueuing well below the rate the application offers, batches
-are taking longer than expected, or the consumer fleet is permanently
-undersaturated despite plenty of producer concurrency.
+Producers are enqueuing well below the rate the application offers, batches are taking longer than expected, or the consumer fleet is permanently undersaturated despite plenty of producer concurrency.
 
 ### Reading The Producer Histograms
 
-The direct queue-storage COPY path
-(`QueueStorage::enqueue_params_copy` in Rust, `Client.enqueue_many_copy` in
-Python) records two histograms per batch:
+The direct queue-storage COPY path (`QueueStorage::enqueue_params_copy` in Rust, `Client.enqueue_many_copy` in Python) records two histograms per batch:
 
-| Metric | What it measures |
-|---|---|
-| `awa.enqueue.batch_size` | Rows per COPY call |
-| `awa.enqueue.duration` | Wall-clock time per COPY call |
+| Metric                   | What it measures              |
+| ------------------------ | ----------------------------- |
+| `awa.enqueue.batch_size` | Rows per COPY call            |
+| `awa.enqueue.duration`   | Wall-clock time per COPY call |
 
 Reading them together separates the two usual failure modes:
 
-- **Batches are tiny.** `batch_size` p50 sits at a handful of rows when the
-  upstream flow is bursty or chunked too aggressively. Throughput is bounded
-  by the per-batch round-trip cost, not the COPY itself. Increase chunk size
-  or batch the upstream side.
-- **Batches are slow.** `batch_size` p50 is reasonable (say ≥100) but
-  `duration` p99 is high. The COPY itself is contended on the DB side; see
-  the diagnoses below.
+- **Batches are tiny.** `batch_size` p50 sits at a handful of rows when the upstream flow is bursty or chunked too aggressively. Throughput is bounded by the per-batch round-trip cost, not the COPY itself. Increase chunk size or batch the upstream side.
+- **Batches are slow.** `batch_size` p50 is reasonable (say ≥100) but `duration` p99 is high. The COPY itself is contended on the DB side; see the diagnoses below.
 
 ### Diagnoses
 
 **1. Producer is going through the compatibility insert path.**
 
-`insert_many_copy_from_pool` / `client.insert_many_copy` routes every row
-through `awa.insert_job_compat()` once per row. On any database with
-non-trivial per-statement latency (auth-proxy hop, managed Postgres,
-network) the per-row function call dominates — measured at ~100–150 ms per
-row through a Cloud SQL Auth Proxy in staging, which caps a single producer
-at ~7 rows/sec regardless of batch or chunk size.
+`insert_many_copy_from_pool` / `client.insert_many_copy` routes every row through `awa.insert_job_compat()` once per row. On any database with non-trivial per-statement latency (auth-proxy hop, managed Postgres, network) the per-row function call dominates — measured at ~100–150 ms per row through a Cloud SQL Auth Proxy in staging, which caps a single producer at ~7 rows/sec regardless of batch or chunk size.
 
 Switch the producer to the direct queue-storage COPY entry point:
 
@@ -213,17 +167,13 @@ See [Producer path choice](configuration.md#producer-path-choice).
 
 **2. `enqueue_shards` is `1` for the contended queue.**
 
-The default `enqueue_shards = 1` means every producer contends on a single
-enqueue-head row per `(queue, priority)`. Multi-producer enqueue serialises
-through that row. Check the live value:
+The default `enqueue_shards = 1` means every producer contends on a single enqueue-head row per `(queue, priority)`. Multi-producer enqueue serialises through that row. Check the live value:
 
 ```sql
 SELECT queue, enqueue_shards FROM awa.queue_meta WHERE queue = '<queue>';
 ```
 
-If no row is returned the queue is running with the default `1`. Raise it
-explicitly (a 16-producer same-queue reference sweep measured 1.0× → 1.60× →
-2.75× → 3.69× at `S = 1/2/4/8`):
+If no row is returned the queue is running with the default `1`. Raise it explicitly (a 16-producer same-queue reference sweep measured 1.0× → 1.60× → 2.75× → 3.69× at `S = 1/2/4/8`):
 
 ```sql
 INSERT INTO awa.queue_meta (queue, enqueue_shards)
@@ -232,19 +182,11 @@ ON CONFLICT (queue)
 DO UPDATE SET enqueue_shards = EXCLUDED.enqueue_shards;
 ```
 
-Use an upsert: first-enqueue may create lane rows before any operator
-inserts a `queue_meta` row, so a plain `UPDATE` quietly affects zero rows.
-Raising `enqueue_shards` is a semantic switch from strict to partitioned
-FIFO; see [ADR-025](adr/025-sharded-enqueue-heads.md).
+Use an upsert: first-enqueue may create lane rows before any operator inserts a `queue_meta` row, so a plain `UPDATE` quietly affects zero rows. Raising `enqueue_shards` is a semantic switch from strict to partitioned FIFO; see [ADR-025](adr/025-sharded-enqueue-heads.md).
 
 **3. WAL or commit pressure on the database.**
 
-If batch size and shard count both look healthy, sample `pg_stat_activity`
-for `LWLock:WALWrite` / `LWLock:WALSync` waits and confirm the database is
-sized for the offered rate. The per-vCPU sustained-completion and
-burst-enqueue numbers in
-[`docs/deploying-on-managed-postgres.md`](deploying-on-managed-postgres.md#pick-a-vcpu-size)
-are useful reference points.
+If batch size and shard count both look healthy, sample `pg_stat_activity` for `LWLock:WALWrite` / `LWLock:WALSync` waits and confirm the database is sized for the offered rate. The per-vCPU sustained-completion and burst-enqueue numbers in [`docs/deploying-on-managed-postgres.md`](deploying-on-managed-postgres.md#pick-a-vcpu-size) are useful reference points.
 
 ## Leader Election Delays
 
@@ -317,19 +259,14 @@ If a job really needs `20m`, set a longer deadline for that queue.
 
 ### What It Usually Means
 
-If queue throughput starts to sag while lease tables keep accumulating dead
-tuples, the usual cause is not duplicate dispatch. The more common pattern is:
+If queue throughput starts to sag while lease tables keep accumulating dead tuples, the usual cause is not duplicate dispatch. The more common pattern is:
 
 - workers are still claiming and completing jobs
 - the maintenance leader is still rotating and pruning
-- one or more long-lived transactions on the primary are holding an old
-  snapshot open or touching older segments
-- prune cannot truncate old lease or terminal segments aggressively enough
-  because the MVCC horizon is pinned or a reader still holds a lockable view of
-  the segment
+- one or more long-lived transactions on the primary are holding an old snapshot open or touching older segments
+- prune cannot truncate old lease or terminal segments aggressively enough because the MVCC horizon is pinned or a reader still holds a lockable view of the segment
 
-This is the same general failure mode described in PlanetScale's "Keeping a
-Postgres queue healthy" post.
+This is the same general failure mode described in PlanetScale's "Keeping a Postgres queue healthy" post.
 
 ### Find The Active Queue-Storage Schema
 
@@ -371,14 +308,10 @@ ORDER BY n_dead_tup DESC, relname;
 Interpretation:
 
 - `ready_entries%` and `ready_tombstones%` should usually stay at or near zero dead tuples
-- `leases%` can rise within the current rotation window, but should fall again
-  after prune
-- `attempt_state` should roughly match live long-running attempts, not total
-  queue depth, and should return close to zero after drain
-- `autovacuum_count` staying flat for a long time can indicate vacuum is not
-  keeping up on churn-heavy lease partitions
-- persistent dead tuples across many `leases%` tables usually means prune is
-  blocked or the maintenance leader is unhealthy
+- `leases%` can rise within the current rotation window, but should fall again after prune
+- `attempt_state` should roughly match live long-running attempts, not total queue depth, and should return close to zero after drain
+- `autovacuum_count` staying flat for a long time can indicate vacuum is not keeping up on churn-heavy lease partitions
+- persistent dead tuples across many `leases%` tables usually means prune is blocked or the maintenance leader is unhealthy
 
 ### Inspect Long Transactions
 
@@ -413,14 +346,11 @@ Pay particular attention to:
 - reduce terminal-row retention if the terminal history is much larger than needed
 - review autovacuum settings if lease churn is expected continuously
 
-If you want to reproduce the behavior locally before changing settings, run the
-MVCC benchmark documented in `docs/benchmarking.md`.
+If you want to reproduce the behavior locally before changing settings, run the MVCC benchmark documented in `docs/benchmarking.md`.
 
 ## Something's In The DLQ
 
-The Dead Letter Queue is where terminal failures land when a queue has DLQ
-enabled. These rows are never claimed. Operators retry them, purge them, or let
-retention remove them.
+The Dead Letter Queue is where terminal failures land when a queue has DLQ enabled. These rows are never claimed. Operators retry them, purge them, or let retention remove them.
 
 Quick checks:
 
@@ -451,8 +381,7 @@ If DLQ depth is growing quickly:
 - inspect a few rows and compare `dlq_reason`
 - sample `awa job dump <id>` for the full error/progress chain
 - pause the upstream queue or producer if one failure mode is dominating
-- tune `dlq_retention` or `RetentionPolicy.dlq` if forensic retention is too
-  long for the incident volume
+- tune `dlq_retention` or `RetentionPolicy.dlq` if forensic retention is too long for the incident volume
 
 ## Common Error Cases
 
@@ -472,23 +401,15 @@ awa --database-url "$DATABASE_URL" migrate
 
 Cause:
 
-- A producer started before the queue-storage substrate had been
-  materialised on a fresh database, or the schema was dropped under a
-  running fleet.
+- A producer started before the queue-storage substrate had been materialised on a fresh database, or the schema was dropped under a running fleet.
 
-`awa.job_id_seq` is part of the queue-storage substrate created by the
-runtime's `prepare_schema` step the first time a worker boots against a
-schema — not by `awa migrate` alone, which builds the canonical surface.
-Migrations + worker startup together produce a usable schema.
+`awa.job_id_seq` is part of the queue-storage substrate created by the runtime's `prepare_schema` step the first time a worker boots against a schema — not by `awa migrate` alone, which builds the canonical surface. Migrations + worker startup together produce a usable schema.
 
 Fix:
 
-- Wait for the first consumer pod to log `Awa worker runtime started`
-  before scaling up producers.
-- If the schema was deliberately reset, re-run `awa migrate` **and** let
-  one worker pod boot to completion before resuming producer traffic.
-- If the error persists after both, the runtime may be pointing at a
-  different schema than the producer. Confirm with:
+- Wait for the first consumer pod to log `Awa worker runtime started` before scaling up producers.
+- If the schema was deliberately reset, re-run `awa migrate` **and** let one worker pod boot to completion before resuming producer traffic.
+- If the error persists after both, the runtime may be pointing at a different schema than the producer. Confirm with:
   ```sql
   SELECT awa.active_queue_storage_schema();
   ```
@@ -528,7 +449,7 @@ The descriptor catalog is refreshed by live workers on every runtime snapshot ti
   DELETE FROM awa.queue_descriptors WHERE queue = 'retired-queue';
   DELETE FROM awa.job_kind_descriptors WHERE kind = 'retired_kind';
   ```
-- If workers *should* be running, check `/runtime` for missing instances.
+- If workers _should_ be running, check `/runtime` for missing instances.
 - If the declaration moved to a different worker role that isn't deployed yet, the stale status will clear once that rollout completes.
 
 ### Queue or job-kind shows "descriptor drift" in the UI

--- a/docs/ui-design.md
+++ b/docs/ui-design.md
@@ -132,16 +132,12 @@ When the target queue is itself paused, the row shows a "queue paused" badge alo
 
 Operator surface for queue-storage `dlq_entries`.
 
-- **List (`/dlq`)** — filterable table showing ID, kind, queue, reason, age,
-  and attempts.
-- **Bulk actions** — filter-scoped bulk retry and purge. Empty-filter actions
-  require explicit `all=true` confirmation through the API.
+- **List (`/dlq`)** — filterable table showing ID, kind, queue, reason, age, and attempts.
+- **Bulk actions** — filter-scoped bulk retry and purge. Empty-filter actions require explicit `all=true` confirmation through the API.
 - **Detail (`/dlq/:id`)** — single-row inspection with retry and purge actions.
-- **Queue badge** — `/queues` shows a `+N DLQ` link next to queues with non-zero
-  DLQ depth.
+- **Queue badge** — `/queues` shows a `+N DLQ` link next to queues with non-zero DLQ depth.
 
-The shared `/jobs/:id` detail page also carries DLQ metadata when a job has
-already moved into the DLQ, so direct links keep working after routing.
+The shared `/jobs/:id` detail page also carries DLQ metadata when a job has already moved into the DLQ, so direct links keep working after routing.
 
 ## Interaction Patterns
 

--- a/docs/upgrade-0.5-to-0.6.md
+++ b/docs/upgrade-0.5-to-0.6.md
@@ -1,18 +1,8 @@
 # Upgrade Checklist: 0.5.x → 0.6
 
-This is the operator-facing rollout sheet for moving an existing 0.5.x
-cluster to 0.6 (queue-storage-by-default). The companion long-form
-explanation is in [migrations.md](migrations.md). This file is the
-short version: one-screen pre-flight, two phases, an explicit rollback
-boundary, and the health checks to run at each step.
+This is the operator-facing rollout sheet for moving an existing 0.5.x cluster to 0.6 (queue-storage-by-default). The companion long-form explanation is in [migrations.md](migrations.md). This file is the short version: one-screen pre-flight, two phases, an explicit rollback boundary, and the health checks to run at each step.
 
-> **Fresh installs do not need this file.** A new cluster runs
-> `awa migrate` and starts workers; the first worker auto-finalizes
-> via `awa.storage_auto_finalize_if_fresh()`. See
-> migrations.md ["Fresh install"](migrations.md#fresh-install-no-prior-canonical-data).
-> This checklist is for **upgrading existing 0.5.x clusters**, where
-> canonical drain is unavoidable and auto-finalize correctly defers to
-> the staged path.
+> **Fresh installs do not need this file.** A new cluster runs `awa migrate` and starts workers; the first worker auto-finalizes via `awa.storage_auto_finalize_if_fresh()`. See migrations.md ["Fresh install"](migrations.md#fresh-install-no-prior-canonical-data). This checklist is for **upgrading existing 0.5.x clusters**, where canonical drain is unavoidable and auto-finalize correctly defers to the staged path.
 
 ## Pre-flight
 
@@ -43,18 +33,13 @@ psql "$DATABASE_URL" -c "
 "
 ```
 
-**Expected:** `current_engine=canonical`, `active_engine=canonical`,
-`prepared_engine=NULL`, `state=canonical`. Every live `runtime_instance`
-reports `storage_capability=canonical` (not `queue_storage`).
+**Expected:** `current_engine=canonical`, `active_engine=canonical`, `prepared_engine=NULL`, `state=canonical`. Every live `runtime_instance` reports `storage_capability=canonical` (not `queue_storage`).
 
-This is a **safe stopping point**. The queue is fully canonical and
-behavior is unchanged. You can sit here indefinitely.
+This is a **safe stopping point**. The queue is fully canonical and behavior is unchanged. You can sit here indefinitely.
 
 ## Rollback boundaries
 
-Read this before starting Phase 2. The rollout has one explicit one-way
-door — knowing exactly where it sits is the difference between "abort"
-and "restore from backup":
+Read this before starting Phase 2. The rollout has one explicit one-way door — knowing exactly where it sits is the difference between "abort" and "restore from backup":
 
 - **canonical → prepared**: `awa storage abort` returns to canonical. Trivial.
 - **prepared → canonical**: `awa storage abort` clears the prepared engine metadata. Trivial.
@@ -62,44 +47,22 @@ and "restore from backup":
 - **mixed_transition (queue-storage rows exist) — ONE-WAY**: `awa storage abort` is rejected. From this point onward you must either finish the transition (`finalize`) or restore from backup. A pure fleet downgrade to 0.5 is **not supported** because 0.5 workers don't know how to claim queue-storage work.
 - **active → anything**: not supported by `awa storage abort`. Use database restore.
 
-The `/api/storage` dashboard card surfaces the current boundary
-explicitly: "Rollback is still available" on `canonical` / `prepared`,
-"From here it's restore-only" once the cluster has crossed into
-`mixed_transition`, and "Finalized" once the transition has completed.
+The `/api/storage` dashboard card surfaces the current boundary explicitly: "Rollback is still available" on `canonical` / `prepared`, "From here it's restore-only" once the cluster has crossed into `mixed_transition`, and "Finalized" once the transition has completed.
 
 ### The Storage transition card
 
-When a transition is in flight the runtime page renders a "Storage
-transition" card with four panels operators reload during a cutover:
+When a transition is in flight the runtime page renders a "Storage transition" card with four panels operators reload during a cutover:
 
-1. **Header row** — current engine, prepared engine, state, and the
-   live canonical backlog. The state pill is paired with an
-   `in <state> for Nh Mm` time-in-state stamp that ticks once per
-   second, so a stuck transition is visually distinct from a slow one
-   without having to compare timestamps by hand.
-2. **Backlog sparkline** — appears next to the canonical-backlog number
-   once the cluster enters `mixed_transition`. The series is anchored
-   to the current `transition_epoch`, so it always shows the timeline
-   of *this* cutover (an `abort`/re-`prepare` resets the line).
-3. **Schema-readiness warning** — if `prepared_engine = queue_storage`
-   but the queue-storage tables are missing, a yellow alert spells out
-   the exact `awa storage prepare-queue-storage-schema --schema <name>`
-   command to run before the routing flip.
-4. **Rollback-boundary panel** — the wording above ("reversible via
-   abort", "from here it's restore-only", "finalized") rendered as a
-   coloured block so the operator never has to infer the boundary from
-   the state string alone.
+1. **Header row** — current engine, prepared engine, state, and the live canonical backlog. The state pill is paired with an `in <state> for Nh Mm` time-in-state stamp that ticks once per second, so a stuck transition is visually distinct from a slow one without having to compare timestamps by hand.
+2. **Backlog sparkline** — appears next to the canonical-backlog number once the cluster enters `mixed_transition`. The series is anchored to the current `transition_epoch`, so it always shows the timeline of _this_ cutover (an `abort`/re-`prepare` resets the line).
+3. **Schema-readiness warning** — if `prepared_engine = queue_storage` but the queue-storage tables are missing, a yellow alert spells out the exact `awa storage prepare-queue-storage-schema --schema <name>` command to run before the routing flip.
+4. **Rollback-boundary panel** — the wording above ("reversible via abort", "from here it's restore-only", "finalized") rendered as a coloured block so the operator never has to infer the boundary from the state string alone.
 
-Samples for the sparkline are accumulated client-side from the existing
-poll (no audit table, per the #180 decision); they're discarded on a
-tab reload and that's fine — the operator only needs the trend since
-they opened the page, not historical replay.
+Samples for the sparkline are accumulated client-side from the existing poll (no audit table, per the #180 decision); they're discarded on a tab reload and that's fine — the operator only needs the trend since they opened the page, not historical replay.
 
 ## Phase 2 — 0.6 rollout
 
-> **Crossing the line below is a one-way door once any queue-storage
-> work has been accepted.** Re-read [Rollback boundaries](#rollback-boundaries)
-> above before kicking off Phase 2.
+> **Crossing the line below is a one-way door once any queue-storage work has been accepted.** Re-read [Rollback boundaries](#rollback-boundaries) above before kicking off Phase 2.
 
 ```bash
 # 1. Roll out 0.6 binaries (rolling deploy). 0.5.x and 0.6 pods may
@@ -192,7 +155,7 @@ awa --database-url "$DATABASE_URL" storage status
 ## Health checks per step
 
 | After step | Watch for |
-|------------|-----------|
+| --- | --- |
 | migrate | `SELECT MAX(version) FROM awa.schema_version` advances; `\dt awa.ready_entries` and `\dt awa.ready_tombstones` exist for the default schema |
 | prepare custom queue-storage schema | `\dt <custom_schema>.ready_entries` and `\dt <custom_schema>.ready_tombstones` exist when using a custom schema |
 | prepare | `awa storage status` reports `state=prepared` |


### PR DESCRIPTION
## Summary

- Add a root `.prettierrc.json` with `proseWrap: never`.
- Reformat tracked Markdown files with Prettier so prose is not manually hard-wrapped.
- Normalize Markdown tables and list spacing according to Prettier defaults.

## Why

GitHub and most Markdown editors soft-wrap prose at the viewport. Keeping paragraphs as single logical lines reduces future churn when editing a sentence in the middle of a paragraph, and makes broad documentation updates easier to review when content changes are not mixed with manual wrapping decisions.

This PR is intentionally formatting-only and separate from the ready tombstone ledger work.

## Validation

- `prettier --check $(git ls-files "*.md") .prettierrc.json`
- `git diff --check`
