### PR TITLE
Fix concurrent queue-storage sequence reservations

### DIFF
--- a/awa-model/migrations/v023_install_queue_storage_substrate.sql
+++ b/awa-model/migrations/v023_install_queue_storage_substrate.sql
@@ -428,26 +428,40 @@ BEGIN
         LANGUAGE plpgsql
         SET search_path = pg_catalog
         AS $func$
+        DECLARE
+            v_lock_key TEXT;
         BEGIN
             IF p_seq_name IS NULL THEN
                 RAISE EXCEPTION 'lane sequence name is NULL'
                     USING ERRCODE = '55000';
             END IF;
 
-            p_next := GREATEST(p_next, %1$I.sequence_next_value(p_seq_name));
+            v_lock_key := format('%%I.%%I', %1$L, p_seq_name);
 
-            IF p_next <= 1 THEN
-                EXECUTE format(
-                    'SELECT setval(%%L::regclass, 1, false)',
-                    format('%%I.%%I', %1$L, p_seq_name)
-                );
-            ELSE
-                EXECUTE format(
-                    'SELECT setval(%%L::regclass, %%s, true)',
-                    format('%%I.%%I', %1$L, p_seq_name),
-                    p_next - 1
-                );
-            END IF;
+            -- `setval` is not a compare-and-swap. Serialize it against
+            -- reservation-side block allocation so this helper's "move to at
+            -- least p_next" contract cannot rewind a hot enqueue sequence.
+            PERFORM pg_advisory_lock(hashtextextended(v_lock_key, 0));
+            BEGIN
+                p_next := GREATEST(p_next, %1$I.sequence_next_value(p_seq_name));
+
+                IF p_next <= 1 THEN
+                    EXECUTE format(
+                        'SELECT setval(%%L::regclass, 1, false)',
+                        format('%%I.%%I', %1$L, p_seq_name)
+                    );
+                ELSE
+                    EXECUTE format(
+                        'SELECT setval(%%L::regclass, %%s, true)',
+                        format('%%I.%%I', %1$L, p_seq_name),
+                        p_next - 1
+                    );
+                END IF;
+            EXCEPTION WHEN OTHERS THEN
+                PERFORM pg_advisory_unlock(hashtextextended(v_lock_key, 0));
+                RAISE;
+            END;
+            PERFORM pg_advisory_unlock(hashtextextended(v_lock_key, 0));
         END;
         $func$
         $ddl$,
@@ -523,6 +537,7 @@ BEGIN
         AS $func$
         DECLARE
             v_seq_name TEXT;
+            v_lock_key TEXT;
             v_start BIGINT;
         BEGIN
             IF p_count <= 0 THEN
@@ -550,12 +565,27 @@ BEGIN
                     USING ERRCODE = '55000';
             END IF;
 
-            EXECUTE format(
-                'SELECT min(nextval(%%L::regclass))::bigint FROM generate_series(1::bigint, $1)',
-                format('%%I.%%I', %1$L, v_seq_name)
-            )
-            INTO v_start
-            USING p_count;
+            v_lock_key := format('%%I.%%I', %1$L, v_seq_name);
+            PERFORM pg_advisory_lock(hashtextextended(v_lock_key, 0));
+            BEGIN
+                EXECUTE format(
+                    'SELECT nextval(%%L::regclass)::bigint',
+                    format('%%I.%%I', %1$L, v_seq_name)
+                )
+                INTO v_start;
+
+                IF p_count > 1 THEN
+                    EXECUTE format(
+                        'SELECT setval(%%L::regclass, %%s, true)',
+                        format('%%I.%%I', %1$L, v_seq_name),
+                        v_start + p_count - 1
+                    );
+                END IF;
+            EXCEPTION WHEN OTHERS THEN
+                PERFORM pg_advisory_unlock(hashtextextended(v_lock_key, 0));
+                RAISE;
+            END;
+            PERFORM pg_advisory_unlock(hashtextextended(v_lock_key, 0));
 
             RETURN v_start;
         END;
@@ -594,12 +624,26 @@ BEGIN
                AND NEW.next_seq > OLD.next_seq
             THEN
                 v_count := NEW.next_seq - OLD.next_seq;
-                EXECUTE format(
-                    'SELECT min(nextval(%%L::regclass))::bigint FROM generate_series(1::bigint, $1)',
-                    v_qualified_seq
-                )
-                INTO v_start
-                USING v_count;
+                PERFORM pg_advisory_lock(hashtextextended(v_qualified_seq, 0));
+                BEGIN
+                    EXECUTE format(
+                        'SELECT nextval(%%L::regclass)::bigint',
+                        v_qualified_seq
+                    )
+                    INTO v_start;
+
+                    IF v_count > 1 THEN
+                        EXECUTE format(
+                            'SELECT setval(%%L::regclass, %%s, true)',
+                            v_qualified_seq,
+                            v_start + v_count - 1
+                        );
+                    END IF;
+                EXCEPTION WHEN OTHERS THEN
+                    PERFORM pg_advisory_unlock(hashtextextended(v_qualified_seq, 0));
+                    RAISE;
+                END;
+                PERFORM pg_advisory_unlock(hashtextextended(v_qualified_seq, 0));
                 NEW.next_seq := v_start + v_count;
             ELSE
                 PERFORM %1$I.set_sequence_next(v_seq_name, NEW.next_seq);

--- a/awa-model/tests/queue_storage_copy_test.rs
+++ b/awa-model/tests/queue_storage_copy_test.rs
@@ -7,7 +7,7 @@ use sqlx::PgPool;
 use std::sync::Arc;
 use std::sync::LazyLock;
 use std::time::Instant;
-use tokio::sync::Mutex;
+use tokio::sync::{Barrier, Mutex};
 
 static QUEUE_STORAGE_COPY_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
 
@@ -433,6 +433,186 @@ async fn queue_storage_copy_concurrent_lane_seq_is_dense() {
     let available_count =
         lane_available_count(&pool, store.schema(), vec![queue.to_string()]).await;
     assert_eq!(available_count, expected);
+}
+
+#[tokio::test]
+async fn queue_storage_copy_independent_stores_keep_lane_seq_unique() {
+    let _guard = QUEUE_STORAGE_COPY_LOCK.lock().await;
+    let config = QueueStorageConfig {
+        schema: "awa_qs_copy_independent_stores".to_string(),
+        queue_slot_count: 4,
+        lease_slot_count: 2,
+        claim_slot_count: 2,
+        ..Default::default()
+    };
+    let (pool, store) = setup_store_with_config(config.clone(), 4).await;
+    let queue = "qs_copy_independent_stores";
+    let task_count = 12_i64;
+    let jobs_per_task = 48_i64;
+    let start = Arc::new(Barrier::new(task_count as usize));
+
+    let mut handles = Vec::new();
+    for task in 0..task_count {
+        let config = config.clone();
+        let start = Arc::clone(&start);
+        handles.push(tokio::spawn(async move {
+            let pool = PgPoolOptions::new()
+                .max_connections(4)
+                .connect(&database_url())
+                .await
+                .expect("connect independent pool");
+            let store = QueueStorage::new(config).expect("create independent store");
+            let jobs: Vec<_> = (0..jobs_per_task)
+                .map(|idx| copy_job("copy_independent_stores", queue, task * jobs_per_task + idx))
+                .collect();
+
+            start.wait().await;
+            store.enqueue_params_copy(&pool, &jobs).await
+        }));
+    }
+
+    for handle in handles {
+        assert_eq!(
+            handle
+                .await
+                .expect("join independent copy task")
+                .expect("independent copy task"),
+            jobs_per_task as usize
+        );
+    }
+
+    let lane_seqs: Vec<i64> = sqlx::query_scalar(&format!(
+        "SELECT lane_seq FROM {}.ready_entries WHERE queue = $1 ORDER BY lane_seq",
+        store.schema()
+    ))
+    .bind(queue)
+    .fetch_all(&pool)
+    .await
+    .expect("read independent lane seqs");
+    let expected = task_count * jobs_per_task;
+    assert_eq!(lane_seqs.len(), expected as usize);
+    for (offset, actual_seq) in lane_seqs.into_iter().enumerate() {
+        assert_eq!(actual_seq, 1 + offset as i64);
+    }
+
+    let available_count =
+        lane_available_count(&pool, store.schema(), vec![queue.to_string()]).await;
+    assert_eq!(available_count, expected);
+}
+
+#[tokio::test]
+async fn queue_storage_sequence_sync_does_not_rewind_hot_reservations() {
+    let _guard = QUEUE_STORAGE_COPY_LOCK.lock().await;
+    let config = QueueStorageConfig {
+        schema: "awa_qs_copy_sequence_sync_hot".to_string(),
+        queue_slot_count: 4,
+        lease_slot_count: 2,
+        claim_slot_count: 2,
+        ..Default::default()
+    };
+    let (pool, store) = setup_store_with_config(config.clone(), 4).await;
+    let queue = "qs_copy_sequence_sync_hot";
+    store
+        .enqueue_params_copy(&pool, &[copy_job("copy_sequence_sync_seed", queue, 0)])
+        .await
+        .expect("seed lane");
+
+    let seq_name: String = sqlx::query_scalar(&format!(
+        "SELECT seq_name FROM {}.queue_enqueue_heads WHERE queue = $1 AND priority = 2 AND enqueue_shard = 0",
+        store.schema()
+    ))
+    .bind(queue)
+    .fetch_one(&pool)
+    .await
+    .expect("read enqueue sequence name");
+
+    sqlx::query(&format!(
+        "CREATE TABLE {}.sequence_sync_seen (lane_seq BIGINT PRIMARY KEY)",
+        store.schema()
+    ))
+    .execute(&pool)
+    .await
+    .expect("create sequence seen table");
+
+    let reserver_count = 8_i64;
+    let rounds = 24_i64;
+    let values_per_round = 16_i64;
+    let start = Arc::new(Barrier::new(reserver_count as usize + 1));
+
+    let sync_schema = store.schema().to_string();
+    let sync_start = Arc::clone(&start);
+    let sync_task = tokio::spawn(async move {
+        let pool = PgPoolOptions::new()
+            .max_connections(2)
+            .connect(&database_url())
+            .await
+            .expect("connect sync pool");
+        sync_start.wait().await;
+        for _ in 0..(reserver_count * rounds) {
+            sqlx::query(&format!(
+                "SELECT {}.set_sequence_next($1, 1::bigint)",
+                sync_schema
+            ))
+            .bind(&seq_name)
+            .execute(&pool)
+            .await
+            .expect("set_sequence_next should not race reservations");
+        }
+    });
+
+    let mut reservers = Vec::new();
+    for _ in 0..reserver_count {
+        let schema = store.schema().to_string();
+        let queue = queue.to_string();
+        let start = Arc::clone(&start);
+        reservers.push(tokio::spawn(async move {
+            let pool = PgPoolOptions::new()
+                .max_connections(4)
+                .connect(&database_url())
+                .await
+                .expect("connect reserver pool");
+
+            start.wait().await;
+            for _ in 0..rounds {
+                let mut tx = pool.begin().await.expect("begin reserve tx");
+                let range_start: i64 = sqlx::query_scalar(&format!(
+                    "SELECT {}.reserve_enqueue_seq($1, 2::smallint, 0::smallint, $2::bigint)",
+                    schema
+                ))
+                .bind(&queue)
+                .bind(values_per_round)
+                .fetch_one(tx.as_mut())
+                .await
+                .expect("reserve enqueue sequence range");
+                sqlx::query(&format!(
+                    "INSERT INTO {}.sequence_sync_seen (lane_seq) SELECT generate_series($1::bigint, $2::bigint)",
+                    schema
+                ))
+                .bind(range_start)
+                .bind(range_start + values_per_round - 1)
+                .execute(tx.as_mut())
+                .await
+                .expect("record reserved sequence values");
+                tx.commit().await.expect("commit reserve tx");
+            }
+        }));
+    }
+
+    sync_task.await.expect("join sync task");
+    for reserver in reservers {
+        reserver.await.expect("join reserver task");
+    }
+
+    let (seen, distinct_seen): (i64, i64) = sqlx::query_as(&format!(
+        "SELECT count(*)::bigint, count(DISTINCT lane_seq)::bigint FROM {}.sequence_sync_seen",
+        store.schema()
+    ))
+    .fetch_one(&pool)
+    .await
+    .expect("count reserved sequence values");
+    let expected = reserver_count * rounds * values_per_round;
+    assert_eq!(seen, expected);
+    assert_eq!(distinct_seen, expected);
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

Fix queue-storage lane sequence reservation under concurrent producers. `reserve_enqueue_seq` previously called `nextval()` `N` times and returned `min()`, which assumes those sequence values are contiguous. PostgreSQL sequences can interleave calls across sessions, so concurrent COPY producers could reserve overlapping assumed ranges and hit `ready_entries_*_pkey`.

This changes reservation to allocate the whole block under a per-sequence advisory lock: one `nextval()` gives the start, then `setval()` advances to the reserved end. `set_sequence_next` and the legacy enqueue-head trigger use the same lock so compatibility sync cannot rewind a hot enqueue sequence.

## Tests

- `cargo fmt`
- `DATABASE_URL=postgres://postgres:test@localhost:15432/awa_codex_allocator5 cargo test -p awa-model --test sql_only_storage_upgrade_test -- --nocapture`
- `DATABASE_URL=postgres://postgres:test@localhost:15432/awa_codex_allocator5 cargo test -p awa-model --test queue_storage_copy_test -- --nocapture`

## Benchmark evidence

Before the fix, a 2-replica Awa run at 800 jobs/s per replica reproduced repeated `UniqueConflict { constraint: Some("ready_entries_*_pkey") }` producer errors. After the fix, the same shape completed without those errors and sustained about 1,600 jobs/s with median queue depth 48 and e2e p99 around 89 ms.

A capped 2-process x 64-worker run at 1,000 jobs/s per process sustained about 2,005 jobs/s with median depth 61 and e2e p99 around 194 ms on this machine.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced queue storage synchronization to improve reliability and prevent potential race conditions during concurrent enqueue operations.

* **Tests**
  * Added concurrency tests validating queue operations maintain sequence integrity and data consistency across multiple concurrent transactions and independent storage instances.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->