### PR TITLE
Relax registered handler future bound

### DIFF
--- a/awa-worker/src/client.rs
+++ b/awa-worker/src/client.rs
@@ -296,7 +296,7 @@ impl ClientBuilder {
     where
         T: JobArgs + DeserializeOwned + Send + Sync + 'static,
         F: Fn(T, &crate::context::JobContext) -> Fut + Send + Sync + 'static,
-        Fut: std::future::Future<Output = Result<JobResult, JobError>> + Send + Sync + 'static,
+        Fut: std::future::Future<Output = Result<JobResult, JobError>> + Send + 'static,
     {
         let kind = T::kind().to_string();
         let worker = TypedWorker {
@@ -1113,7 +1113,7 @@ struct TypedWorker<T, F, Fut>
 where
     T: JobArgs + DeserializeOwned + Send + Sync + 'static,
     F: Fn(T, &crate::context::JobContext) -> Fut + Send + Sync + 'static,
-    Fut: std::future::Future<Output = Result<JobResult, JobError>> + Send + Sync + 'static,
+    Fut: std::future::Future<Output = Result<JobResult, JobError>> + Send + 'static,
 {
     kind: &'static str,
     handler: Arc<F>,
@@ -1125,7 +1125,7 @@ impl<T, F, Fut> Worker for TypedWorker<T, F, Fut>
 where
     T: JobArgs + DeserializeOwned + Send + Sync + 'static,
     F: Fn(T, &crate::context::JobContext) -> Fut + Send + Sync + 'static,
-    Fut: std::future::Future<Output = Result<JobResult, JobError>> + Send + Sync + 'static,
+    Fut: std::future::Future<Output = Result<JobResult, JobError>> + Send + 'static,
 {
     fn kind(&self) -> &'static str {
         self.kind
@@ -2426,6 +2426,23 @@ mod tests {
         let config = QueueConfig::default();
         assert_eq!(config.claimers, 1);
         assert_eq!(config.claim_batch_size, 512);
+    }
+
+    #[tokio::test]
+    async fn register_accepts_send_non_sync_handler_future() {
+        #[derive(serde::Serialize, serde::Deserialize, awa_macros::JobArgs)]
+        struct NonSyncFutureJob;
+
+        let _client = Client::builder(lazy_pool())
+            .queue("non_sync_future", QueueConfig::default())
+            .register::<NonSyncFutureJob, _, _>(|_, _| async move {
+                let cell = std::cell::Cell::new(0_u8);
+                tokio::task::yield_now().await;
+                cell.set(1);
+                Ok(JobResult::Completed)
+            })
+            .build()
+            .expect("send but non-sync handler future should compile");
     }
 
     fn base_database_url() -> String {


### PR DESCRIPTION
## Summary
- remove unnecessary `Sync` bound from typed `ClientBuilder::register` handler futures
- keep handler closures and worker objects `Send + Sync`, but only require returned futures to be `Send + 'static`
- add a regression test that registers a handler returning a `Send + !Sync` future

## Rationale
Handler futures are per-invocation values polled by one task at a time. Tokio needs them to be `Send` when they can move across worker threads, but they do not need to be `Sync`. Requiring `Sync` rejects common async handlers that await `sqlx` / `reqwest` work.

## Validation
- `cargo fmt --all`
- `SQLX_OFFLINE=true cargo test -p awa-worker register_accepts_send_non_sync_handler_future -- --nocapture`
- `SQLX_OFFLINE=true cargo check -p awa-worker`
- `SQLX_OFFLINE=true cargo clippy -p awa-worker --all-targets --all-features -- -D warnings`
- `SQLX_OFFLINE=true cargo build -p awa-worker`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Job handler futures now support capturing non-thread-safe values, enabling greater flexibility in handler implementations.

* **Tests**
  * Added validation test for job handlers with non-thread-safe futures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->