### PR TITLE
Add Python batch operation APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -425,6 +425,12 @@ All coordination through Postgres. The Rust runtime owns dispatch, leases, heart
 - [021: Sequential callbacks and callback heartbeats](docs/adr/021-enhanced-external-wait.md)
 - [022: Descriptor catalog](docs/adr/022-descriptor-catalog.md)
 - [023: Receipt plane ring partitioning](docs/adr/023-receipt-plane-ring-partitioning.md)
+- [025: Sharded enqueue heads](docs/adr/025-sharded-enqueue-heads.md)
+- [026: Narrow terminal history](docs/adr/026-narrow-terminal-history.md)
+- [027: Callback ingress as a deployable surface](docs/adr/027-callback-ingress-surface.md)
+- [028: Maintenance-only runtime role](docs/adr/028-maintenance-only-runtime-role.md)
+- [029: Transactional follow-up jobs](docs/adr/029-transactional-followup-jobs.md)
+- [030: Durable batch operations](docs/adr/030-batch-operations.md)
 
 See [docs/adr/README.md](docs/adr/README.md) for the index with status and supersession.
 

--- a/awa-python/README.md
+++ b/awa-python/README.md
@@ -54,6 +54,7 @@ For application tables, keep using your existing database library. The `awa.brid
 - **Queue fanout** — `QueueFanout` maps one hot logical queue to several physical queues so workers can drain independent streams without changing Awa's durability model.
 - **Crash-safe execution** — heartbeat-based lease tracking; jobs whose workers vanish are rescued automatically.
 - **Per-queue policy** — priorities, priority aging, weighted concurrency, rate limits, deadlines, retry/backoff, cron, dead-letter queue.
+- **Durable batch operations** — preview, submit, monitor, and cancel async operator mutations such as reprioritizing queued jobs or moving a backlog to another queue.
 - **Progress tracking** — handlers can write structured progress that survives across retries.
 - **Web UI (optional)** — `pip install 'awa-pg[ui]'` pulls in the [`awa-cli`](https://pypi.org/project/awa-cli/) wheel, which ships the dashboard binary. Then `python -m awa serve` (or `awa serve` directly) runs a live queue inspector, DLQ triage console, and retry controls on `http://127.0.0.1:3000`. The default `awa-pg` install stays small for workers and producers that don't need the dashboard.
 
@@ -64,6 +65,34 @@ python -m awa --database-url "$DATABASE_URL" migrate
 ```
 
 Fresh installs go straight to the queue-storage engine on first migrate. Existing 0.5.x installations should follow [`docs/upgrade-0.5-to-0.6.md`](https://github.com/hardbyte/awa/blob/main/docs/upgrade-0.5-to-0.6.md) for the staged transition.
+
+## Durable batch operations
+
+Batch operations are for operator-scale mutations. They preview a filtered set, persist a control-plane record, and let the maintenance leader apply the mutation in small chunks. Python exposes the generic envelope and helpers for the first two operation kinds:
+
+```python
+preview = await client.preview_set_priority(
+    1,
+    filter={"queue": "default", "state": "available"},
+)
+
+operation = await client.set_priority(
+    1,
+    filter={"queue": "default"},
+    submitted_by="ops@example.com",
+)
+
+operation = await client.move_queue(
+    "escalations",
+    priority=1,
+    filter={"tag": "incident-123"},
+)
+
+active = await client.list_batch_operations(state="running")
+await client.cancel_batch_operation(operation["id"])
+```
+
+`awa.Client` has the same methods for synchronous scripts. Batch operations affect queued `available` and `scheduled` jobs; running, waiting, terminal, and DLQ rows keep their current attempt state.
 
 ## Partitioned FIFO and ordering keys
 

--- a/awa-python/python/awa/__init__.py
+++ b/awa-python/python/awa/__init__.py
@@ -43,7 +43,15 @@ from awa._awa import (
     CallbackNotFound,
 )
 
-from awa.client import AsyncClient, Client
+from awa.client import (
+    AsyncClient,
+    BatchOperation,
+    BatchOperationFilter,
+    BatchOperationKind,
+    BatchOperationPreview,
+    BatchOperationState,
+    Client,
+)
 from awa import callback_contract
 
 __all__ = [
@@ -51,6 +59,11 @@ __all__ = [
     "Client",
     "AsyncClient",
     "RawClient",
+    "BatchOperation",
+    "BatchOperationFilter",
+    "BatchOperationKind",
+    "BatchOperationPreview",
+    "BatchOperationState",
     # Job types
     "Job",
     "JobState",

--- a/awa-python/python/awa/_awa.pyi
+++ b/awa-python/python/awa/_awa.pyi
@@ -365,6 +365,36 @@ class Client:
         limit: int = 100,
     ) -> list[Job[dict[str, Any]]]: ...
     async def get_job(self, job_id: int) -> Job[dict[str, Any]]: ...
+    async def preview_batch_operation(
+        self,
+        op_kind: str,
+        spec: dict[str, Any],
+        *,
+        filter: dict[str, Any] | None = None,
+    ) -> dict[str, Any]: ...
+    async def submit_batch_operation(
+        self,
+        op_kind: str,
+        spec: dict[str, Any],
+        *,
+        filter: dict[str, Any] | None = None,
+        submitted_by: str | None = None,
+        allow_all: bool = False,
+    ) -> dict[str, Any]: ...
+    async def list_batch_operations(
+        self,
+        *,
+        state: str | None = None,
+        limit: int = 100,
+    ) -> list[dict[str, Any]]: ...
+    async def get_batch_operation(self, id: str) -> dict[str, Any]: ...
+    async def cancel_batch_operation(self, id: str) -> dict[str, Any]: ...
+    async def purge_batch_operations(
+        self,
+        before: datetime.datetime,
+        *,
+        limit: int = 1000,
+    ) -> int: ...
     async def list_dlq(
         self,
         *,
@@ -625,6 +655,36 @@ class Client:
         limit: int = 100,
     ) -> list[Job[dict[str, Any]]]: ...
     def get_job_sync(self, job_id: int) -> Job[dict[str, Any]]: ...
+    def preview_batch_operation_sync(
+        self,
+        op_kind: str,
+        spec: dict[str, Any],
+        *,
+        filter: dict[str, Any] | None = None,
+    ) -> dict[str, Any]: ...
+    def submit_batch_operation_sync(
+        self,
+        op_kind: str,
+        spec: dict[str, Any],
+        *,
+        filter: dict[str, Any] | None = None,
+        submitted_by: str | None = None,
+        allow_all: bool = False,
+    ) -> dict[str, Any]: ...
+    def list_batch_operations_sync(
+        self,
+        *,
+        state: str | None = None,
+        limit: int = 100,
+    ) -> list[dict[str, Any]]: ...
+    def get_batch_operation_sync(self, id: str) -> dict[str, Any]: ...
+    def cancel_batch_operation_sync(self, id: str) -> dict[str, Any]: ...
+    def purge_batch_operations_sync(
+        self,
+        before: datetime.datetime,
+        *,
+        limit: int = 1000,
+    ) -> int: ...
     def health_check_sync(self) -> HealthCheck: ...
     def insert_many_copy_sync(
         self,

--- a/awa-python/python/awa/client.py
+++ b/awa-python/python/awa/client.py
@@ -58,7 +58,7 @@ class BatchOperationFilter(TypedDict, total=False):
 
 class BatchOperationPreview(TypedDict, total=False):
     total_matched: int
-    sample: list[Job]
+    sample: list[dict[str, Any]]
 
 
 class BatchOperation(TypedDict, total=False):

--- a/awa-python/python/awa/client.py
+++ b/awa-python/python/awa/client.py
@@ -12,7 +12,7 @@ use or for legacy code that uses the ``_sync`` method suffixes directly.
 from __future__ import annotations
 
 import datetime as dt
-from typing import Any, Awaitable, Callable, Literal, TypeVar
+from typing import Any, Awaitable, Callable, Literal, TypedDict, TypeVar
 
 from awa._awa import (
     CallbackToken,
@@ -33,6 +33,53 @@ DEFAULT_QUEUE_STORAGE_QUEUE_SLOT_COUNT = 16
 DEFAULT_QUEUE_STORAGE_LEASE_SLOT_COUNT = 8
 DEFAULT_QUEUE_STORAGE_CLAIM_SLOT_COUNT = 8
 DEFAULT_QUEUE_STORAGE_QUEUE_STRIPE_COUNT = 1
+
+BatchOperationKind = Literal["set_priority", "move_queue"]
+BatchOperationState = Literal[
+    "pending",
+    "scanning",
+    "running",
+    "cancelling",
+    "completed",
+    "cancelled",
+    "failed",
+]
+
+
+class BatchOperationFilter(TypedDict, total=False):
+    kind: str
+    queue: str
+    ids: list[int]
+    tag: str
+    state: str
+    created_at_gte: dt.datetime | str
+    created_at_lt: dt.datetime | str
+
+
+class BatchOperationPreview(TypedDict, total=False):
+    total_matched: int
+    sample: list[Job]
+
+
+class BatchOperation(TypedDict, total=False):
+    id: str
+    op_kind: str
+    filter: dict[str, Any]
+    spec: dict[str, Any]
+    state: str
+    submitted_by: str | None
+    submitted_at: str
+    started_at: str | None
+    finalized_at: str | None
+    cursor: dict[str, Any] | None
+    total_matched: int | None
+    processed: int
+    skipped: int
+    errored: int
+    last_error: str | None
+    runner_instance: str | None
+    retention_until: str | None
+    updated_at: str
 
 
 class AsyncClient:
@@ -318,6 +365,132 @@ class AsyncClient:
         return await self._raw.list_jobs(
             state=state, kind=kind, queue=queue, limit=limit
         )
+
+    # --- Durable batch operations -----------------------------------------
+    #
+    # Batch operations are maintenance-led admin mutations. They snapshot an
+    # eligible job set, apply changes in small chunks, and keep progress /
+    # cancellation state in `awa.batch_operations`.
+
+    async def preview_batch_operation(
+        self,
+        op_kind: BatchOperationKind,
+        *,
+        spec: dict[str, Any],
+        filter: BatchOperationFilter | None = None,
+    ) -> BatchOperationPreview:
+        """Preview a durable batch operation without submitting it."""
+        return await self._raw.preview_batch_operation(
+            op_kind, spec, filter=filter
+        )
+
+    async def submit_batch_operation(
+        self,
+        op_kind: BatchOperationKind,
+        *,
+        spec: dict[str, Any],
+        filter: BatchOperationFilter | None = None,
+        submitted_by: str | None = None,
+        allow_all: bool = False,
+    ) -> BatchOperation:
+        """Submit a durable batch operation for maintenance-led execution."""
+        return await self._raw.submit_batch_operation(
+            op_kind,
+            spec,
+            filter=filter,
+            submitted_by=submitted_by,
+            allow_all=allow_all,
+        )
+
+    async def preview_set_priority(
+        self,
+        priority: int,
+        *,
+        filter: BatchOperationFilter | None = None,
+    ) -> BatchOperationPreview:
+        """Preview reprioritizing queued `available` / `scheduled` jobs."""
+        return await self.preview_batch_operation(
+            "set_priority", spec={"priority": priority}, filter=filter
+        )
+
+    async def set_priority(
+        self,
+        priority: int,
+        *,
+        filter: BatchOperationFilter | None = None,
+        submitted_by: str | None = None,
+        allow_all: bool = False,
+    ) -> BatchOperation:
+        """Submit a durable batch operation that changes queued job priority."""
+        return await self.submit_batch_operation(
+            "set_priority",
+            spec={"priority": priority},
+            filter=filter,
+            submitted_by=submitted_by,
+            allow_all=allow_all,
+        )
+
+    async def preview_move_queue(
+        self,
+        queue: str,
+        *,
+        priority: int | None = None,
+        filter: BatchOperationFilter | None = None,
+    ) -> BatchOperationPreview:
+        """Preview moving queued `available` / `scheduled` jobs to another queue."""
+        spec: dict[str, Any] = {"queue": queue}
+        if priority is not None:
+            spec["priority"] = priority
+        return await self.preview_batch_operation(
+            "move_queue", spec=spec, filter=filter
+        )
+
+    async def move_queue(
+        self,
+        queue: str,
+        *,
+        priority: int | None = None,
+        filter: BatchOperationFilter | None = None,
+        submitted_by: str | None = None,
+        allow_all: bool = False,
+    ) -> BatchOperation:
+        """Submit a durable batch operation that moves queued jobs to another queue."""
+        spec: dict[str, Any] = {"queue": queue}
+        if priority is not None:
+            spec["priority"] = priority
+        return await self.submit_batch_operation(
+            "move_queue",
+            spec=spec,
+            filter=filter,
+            submitted_by=submitted_by,
+            allow_all=allow_all,
+        )
+
+    async def list_batch_operations(
+        self,
+        *,
+        state: BatchOperationState | None = None,
+        limit: int = 100,
+    ) -> list[BatchOperation]:
+        """List recent durable batch operations."""
+        return await self._raw.list_batch_operations(state=state, limit=limit)
+
+    async def get_batch_operation(self, operation_id: str) -> BatchOperation:
+        """Fetch one durable batch operation by UUID."""
+        return await self._raw.get_batch_operation(operation_id)
+
+    async def cancel_batch_operation(self, operation_id: str) -> BatchOperation:
+        """Request cooperative cancellation for an active batch operation."""
+        return await self._raw.cancel_batch_operation(operation_id)
+
+    async def purge_batch_operations(
+        self,
+        before: dt.datetime,
+        *,
+        limit: int = 1000,
+    ) -> int:
+        """Purge finalized batch operations whose `finalized_at` is before `before`."""
+        return await self._raw.purge_batch_operations(before, limit=limit)
 
     # --- Dead Letter Queue -------------------------------------------------
     #
@@ -978,6 +1151,124 @@ class Client:
         return self._raw.list_jobs_sync(
             state=state, kind=kind, queue=queue, limit=limit
         )
+
+    # --- Durable batch operations (sync) ----------------------------------
+
+    def preview_batch_operation(
+        self,
+        op_kind: BatchOperationKind,
+        *,
+        spec: dict[str, Any],
+        filter: BatchOperationFilter | None = None,
+    ) -> BatchOperationPreview:
+        """Preview a durable batch operation without submitting it."""
+        return self._raw.preview_batch_operation_sync(op_kind, spec, filter=filter)
+
+    def submit_batch_operation(
+        self,
+        op_kind: BatchOperationKind,
+        *,
+        spec: dict[str, Any],
+        filter: BatchOperationFilter | None = None,
+        submitted_by: str | None = None,
+        allow_all: bool = False,
+    ) -> BatchOperation:
+        """Submit a durable batch operation for maintenance-led execution."""
+        return self._raw.submit_batch_operation_sync(
+            op_kind,
+            spec,
+            filter=filter,
+            submitted_by=submitted_by,
+            allow_all=allow_all,
+        )
+
+    def preview_set_priority(
+        self,
+        priority: int,
+        *,
+        filter: BatchOperationFilter | None = None,
+    ) -> BatchOperationPreview:
+        """Preview reprioritizing queued `available` / `scheduled` jobs."""
+        return self.preview_batch_operation(
+            "set_priority", spec={"priority": priority}, filter=filter
+        )
+
+    def set_priority(
+        self,
+        priority: int,
+        *,
+        filter: BatchOperationFilter | None = None,
+        submitted_by: str | None = None,
+        allow_all: bool = False,
+    ) -> BatchOperation:
+        """Submit a durable batch operation that changes queued job priority."""
+        return self.submit_batch_operation(
+            "set_priority",
+            spec={"priority": priority},
+            filter=filter,
+            submitted_by=submitted_by,
+            allow_all=allow_all,
+        )
+
+    def preview_move_queue(
+        self,
+        queue: str,
+        *,
+        priority: int | None = None,
+        filter: BatchOperationFilter | None = None,
+    ) -> BatchOperationPreview:
+        """Preview moving queued `available` / `scheduled` jobs to another queue."""
+        spec: dict[str, Any] = {"queue": queue}
+        if priority is not None:
+            spec["priority"] = priority
+        return self.preview_batch_operation("move_queue", spec=spec, filter=filter)
+
+    def move_queue(
+        self,
+        queue: str,
+        *,
+        priority: int | None = None,
+        filter: BatchOperationFilter | None = None,
+        submitted_by: str | None = None,
+        allow_all: bool = False,
+    ) -> BatchOperation:
+        """Submit a durable batch operation that moves queued jobs to another queue."""
+        spec: dict[str, Any] = {"queue": queue}
+        if priority is not None:
+            spec["priority"] = priority
+        return self.submit_batch_operation(
+            "move_queue",
+            spec=spec,
+            filter=filter,
+            submitted_by=submitted_by,
+            allow_all=allow_all,
+        )
+
+    def list_batch_operations(
+        self,
+        *,
+        state: BatchOperationState | None = None,
+        limit: int = 100,
+    ) -> list[BatchOperation]:
+        """List recent durable batch operations."""
+        return self._raw.list_batch_operations_sync(state=state, limit=limit)
+
+    def get_batch_operation(self, operation_id: str) -> BatchOperation:
+        """Fetch one durable batch operation by UUID."""
+        return self._raw.get_batch_operation_sync(operation_id)
+
+    def cancel_batch_operation(self, operation_id: str) -> BatchOperation:
+        """Request cooperative cancellation for an active batch operation."""
+        return self._raw.cancel_batch_operation_sync(operation_id)
+
+    def purge_batch_operations(
+        self,
+        before: dt.datetime,
+        *,
+        limit: int = 1000,
+    ) -> int:
+        """Purge finalized batch operations whose `finalized_at` is before `before`."""
+        return self._raw.purge_batch_operations_sync(before, limit=limit)
 
     def health_check(self) -> HealthCheck:
         """Runtime health check."""

--- a/awa-python/src/client.rs
+++ b/awa-python/src/client.rs
@@ -7,6 +7,10 @@ use crate::transaction::{
 };
 use crate::worker::PythonWorker;
 use awa_model::admin::{JobKindDescriptor, ListJobsFilter, QueueDescriptor};
+use awa_model::batch_operations::{
+    BatchOperationFilter, BatchOperationKind, BatchOperationSpec, BatchOperationState,
+    ListBatchOperationsFilter, SubmitBatchOperation,
+};
 use awa_model::{
     CronMissedFirePolicy, InsertOpts, InsertParams, JobState, PeriodicJob, QueueStorage,
     QueueStorageConfig,
@@ -19,6 +23,7 @@ use sqlx::PgPool;
 use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, Mutex, RwLock};
 use std::time::Duration;
+use uuid::Uuid;
 
 fn validate_timeout_seconds(timeout_seconds: f64) -> PyResult<Duration> {
     if !timeout_seconds.is_finite() || timeout_seconds.is_sign_negative() {
@@ -1255,6 +1260,136 @@ impl PyClient {
                 }
                 Ok(list.unbind())
             })
+        })
+    }
+
+    /// Preview a durable batch operation without submitting it.
+    #[pyo3(signature = (op_kind, spec, *, filter=None))]
+    fn preview_batch_operation<'py>(
+        &self,
+        py: Python<'py>,
+        op_kind: String,
+        spec: Py<PyAny>,
+        filter: Option<Py<PyAny>>,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        let spec = parse_batch_operation_spec(py, &op_kind, &spec)?;
+        let filter = parse_batch_operation_filter(py, filter.as_ref())?;
+        let pool = self.pool.clone();
+        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+            let preview = awa_model::batch_operations::preview_batch_operation(&pool, spec, filter)
+                .await
+                .map_err(map_awa_error)?;
+            Python::attach(|py| batch_operation_to_py(py, &preview))
+        })
+    }
+
+    /// Submit a durable batch operation for maintenance-led execution.
+    #[pyo3(signature = (op_kind, spec, *, filter=None, submitted_by=None, allow_all=false))]
+    fn submit_batch_operation<'py>(
+        &self,
+        py: Python<'py>,
+        op_kind: String,
+        spec: Py<PyAny>,
+        filter: Option<Py<PyAny>>,
+        submitted_by: Option<String>,
+        allow_all: bool,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        let spec = parse_batch_operation_spec(py, &op_kind, &spec)?;
+        let filter = parse_batch_operation_filter(py, filter.as_ref())?;
+        let pool = self.pool.clone();
+        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+            let operation = awa_model::batch_operations::submit_batch_operation(
+                &pool,
+                SubmitBatchOperation {
+                    spec,
+                    filter,
+                    submitted_by,
+                    allow_all,
+                },
+            )
+            .await
+            .map_err(map_awa_error)?;
+            Python::attach(|py| batch_operation_to_py(py, &operation))
+        })
+    }
+
+    /// List recent durable batch operations.
+    #[pyo3(signature = (*, state=None, limit=100))]
+    fn list_batch_operations<'py>(
+        &self,
+        py: Python<'py>,
+        state: Option<String>,
+        limit: i64,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        let state = state
+            .as_deref()
+            .map(parse_batch_operation_state)
+            .transpose()?;
+        let pool = self.pool.clone();
+        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+            let operations = awa_model::batch_operations::list_batch_operations(
+                &pool,
+                &ListBatchOperationsFilter {
+                    state,
+                    limit: Some(limit),
+                },
+            )
+            .await
+            .map_err(map_awa_error)?;
+            Python::attach(|py| batch_operation_to_py(py, &operations))
+        })
+    }
+
+    /// Fetch one durable batch operation by UUID string.
+    fn get_batch_operation<'py>(
+        &self,
+        py: Python<'py>,
+        id: String,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        let id = Uuid::parse_str(&id).map_err(|err| {
+            pyo3::exceptions::PyValueError::new_err(format!("invalid batch operation id: {err}"))
+        })?;
+        let pool = self.pool.clone();
+        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+            let operation = awa_model::batch_operations::get_batch_operation(&pool, id)
+                .await
+                .map_err(map_awa_error)?;
+            Python::attach(|py| batch_operation_to_py(py, &operation))
+        })
+    }
+
+    /// Request cooperative cancellation for an active durable batch operation.
+    fn cancel_batch_operation<'py>(
+        &self,
+        py: Python<'py>,
+        id: String,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        let id = Uuid::parse_str(&id).map_err(|err| {
+            pyo3::exceptions::PyValueError::new_err(format!("invalid batch operation id: {err}"))
+        })?;
+        let pool = self.pool.clone();
+        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+            let operation =
+                awa_model::batch_operations::request_batch_operation_cancellation(&pool, id)
+                    .await
+                    .map_err(map_awa_error)?;
+            Python::attach(|py| batch_operation_to_py(py, &operation))
+        })
+    }
+
+    /// Purge finalized durable batch operations older than `before`.
+    #[pyo3(signature = (before, *, limit=1000))]
+    fn purge_batch_operations<'py>(
+        &self,
+        py: Python<'py>,
+        before: DateTime<Utc>,
+        limit: i64,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        let pool = self.pool.clone();
+        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+            awa_model::batch_operations::purge_batch_operations_before(&pool, before, limit)
+                .await
+                .map_err(map_awa_error)
         })
     }
 
@@ -2611,6 +2746,135 @@ impl PyClient {
         })
     }
 
+    #[pyo3(signature = (op_kind, spec, *, filter=None))]
+    fn preview_batch_operation_sync(
+        &self,
+        py: Python<'_>,
+        op_kind: String,
+        spec: Py<PyAny>,
+        filter: Option<Py<PyAny>>,
+    ) -> PyResult<Py<PyAny>> {
+        let spec = parse_batch_operation_spec(py, &op_kind, &spec)?;
+        let filter = parse_batch_operation_filter(py, filter.as_ref())?;
+        let pool = self.pool.clone();
+        py.detach(|| {
+            pyo3_async_runtimes::tokio::get_runtime().block_on(async {
+                let preview =
+                    awa_model::batch_operations::preview_batch_operation(&pool, spec, filter)
+                        .await
+                        .map_err(map_awa_error)?;
+                Python::attach(|py| batch_operation_to_py(py, &preview))
+            })
+        })
+    }
+
+    #[pyo3(signature = (op_kind, spec, *, filter=None, submitted_by=None, allow_all=false))]
+    fn submit_batch_operation_sync(
+        &self,
+        py: Python<'_>,
+        op_kind: String,
+        spec: Py<PyAny>,
+        filter: Option<Py<PyAny>>,
+        submitted_by: Option<String>,
+        allow_all: bool,
+    ) -> PyResult<Py<PyAny>> {
+        let spec = parse_batch_operation_spec(py, &op_kind, &spec)?;
+        let filter = parse_batch_operation_filter(py, filter.as_ref())?;
+        let pool = self.pool.clone();
+        py.detach(|| {
+            pyo3_async_runtimes::tokio::get_runtime().block_on(async {
+                let operation = awa_model::batch_operations::submit_batch_operation(
+                    &pool,
+                    SubmitBatchOperation {
+                        spec,
+                        filter,
+                        submitted_by,
+                        allow_all,
+                    },
+                )
+                .await
+                .map_err(map_awa_error)?;
+                Python::attach(|py| batch_operation_to_py(py, &operation))
+            })
+        })
+    }
+
+    #[pyo3(signature = (*, state=None, limit=100))]
+    fn list_batch_operations_sync(
+        &self,
+        py: Python<'_>,
+        state: Option<String>,
+        limit: i64,
+    ) -> PyResult<Py<PyAny>> {
+        let state = state
+            .as_deref()
+            .map(parse_batch_operation_state)
+            .transpose()?;
+        let pool = self.pool.clone();
+        py.detach(|| {
+            pyo3_async_runtimes::tokio::get_runtime().block_on(async {
+                let operations = awa_model::batch_operations::list_batch_operations(
+                    &pool,
+                    &ListBatchOperationsFilter {
+                        state,
+                        limit: Some(limit),
+                    },
+                )
+                .await
+                .map_err(map_awa_error)?;
+                Python::attach(|py| batch_operation_to_py(py, &operations))
+            })
+        })
+    }
+
+    fn get_batch_operation_sync(&self, py: Python<'_>, id: String) -> PyResult<Py<PyAny>> {
+        let id = Uuid::parse_str(&id).map_err(|err| {
+            pyo3::exceptions::PyValueError::new_err(format!("invalid batch operation id: {err}"))
+        })?;
+        let pool = self.pool.clone();
+        py.detach(|| {
+            pyo3_async_runtimes::tokio::get_runtime().block_on(async {
+                let operation = awa_model::batch_operations::get_batch_operation(&pool, id)
+                    .await
+                    .map_err(map_awa_error)?;
+                Python::attach(|py| batch_operation_to_py(py, &operation))
+            })
+        })
+    }
+
+    fn cancel_batch_operation_sync(&self, py: Python<'_>, id: String) -> PyResult<Py<PyAny>> {
+        let id = Uuid::parse_str(&id).map_err(|err| {
+            pyo3::exceptions::PyValueError::new_err(format!("invalid batch operation id: {err}"))
+        })?;
+        let pool = self.pool.clone();
+        py.detach(|| {
+            pyo3_async_runtimes::tokio::get_runtime().block_on(async {
+                let operation =
+                    awa_model::batch_operations::request_batch_operation_cancellation(&pool, id)
+                        .await
+                        .map_err(map_awa_error)?;
+                Python::attach(|py| batch_operation_to_py(py, &operation))
+            })
+        })
+    }
+
+    #[pyo3(signature = (before, *, limit=1000))]
+    fn purge_batch_operations_sync(
+        &self,
+        py: Python<'_>,
+        before: DateTime<Utc>,
+        limit: i64,
+    ) -> PyResult<u64> {
+        let pool = self.pool.clone();
+        py.detach(|| {
+            pyo3_async_runtimes::tokio::get_runtime().block_on(async {
+                awa_model::batch_operations::purge_batch_operations_before(&pool, before, limit)
+                    .await
+                    .map_err(map_awa_error)
+            })
+        })
+    }
+
     /// Get a single job by ID (sync).
     fn get_job_sync(&self, py: Python<'_>, job_id: i64) -> PyResult<PyJob> {
         let pool = self.pool.clone();
@@ -3209,6 +3473,120 @@ fn parse_job_state(value: &str) -> PyResult<JobState> {
             "unknown job state: {other}"
         ))),
     }
+}
+
+fn parse_batch_operation_kind(value: &str) -> PyResult<BatchOperationKind> {
+    BatchOperationKind::try_from(value).map_err(map_awa_error)
+}
+
+fn parse_batch_operation_state(value: &str) -> PyResult<BatchOperationState> {
+    BatchOperationState::try_from(value).map_err(map_awa_error)
+}
+
+fn parse_batch_operation_spec(
+    py: Python<'_>,
+    op_kind: &str,
+    spec: &Py<PyAny>,
+) -> PyResult<BatchOperationSpec> {
+    let spec = spec.bind(py);
+    let dict: &Bound<'_, PyDict> = spec.cast().map_err(|_| {
+        pyo3::exceptions::PyTypeError::new_err("batch operation spec must be a dict")
+    })?;
+
+    match parse_batch_operation_kind(op_kind)? {
+        BatchOperationKind::SetPriority => {
+            let priority: i16 = required_dict_item(dict, "priority")?.extract()?;
+            Ok(BatchOperationSpec::SetPriority { priority })
+        }
+        BatchOperationKind::MoveQueue => {
+            let queue: String = required_dict_item(dict, "queue")?.extract()?;
+            let priority = optional_dict_item(dict, "priority")?
+                .map(|value| value.extract::<i16>())
+                .transpose()?;
+            Ok(BatchOperationSpec::MoveQueue { queue, priority })
+        }
+    }
+}
+
+fn parse_batch_operation_filter(
+    py: Python<'_>,
+    filter: Option<&Py<PyAny>>,
+) -> PyResult<BatchOperationFilter> {
+    let Some(filter) = filter else {
+        return Ok(BatchOperationFilter::default());
+    };
+
+    let filter = filter.bind(py);
+    if filter.is_none() {
+        return Ok(BatchOperationFilter::default());
+    }
+
+    let dict: &Bound<'_, PyDict> = filter.cast().map_err(|_| {
+        pyo3::exceptions::PyTypeError::new_err("batch operation filter must be a dict or None")
+    })?;
+
+    let kind = optional_dict_item(dict, "kind")?
+        .map(|value| value.extract::<String>())
+        .transpose()?;
+    let queue = optional_dict_item(dict, "queue")?
+        .map(|value| value.extract::<String>())
+        .transpose()?;
+    let ids = optional_dict_item(dict, "ids")?
+        .map(|value| value.extract::<Vec<i64>>())
+        .transpose()?;
+    let tag = optional_dict_item(dict, "tag")?
+        .map(|value| value.extract::<String>())
+        .transpose()?;
+    let state = optional_dict_item(dict, "state")?
+        .map(|value| value.extract::<String>().and_then(|s| parse_job_state(&s)))
+        .transpose()?;
+    let created_at_gte =
+        optional_dict_item(dict, "created_at_gte")?.map(extract_datetime).transpose()?;
+    let created_at_lt =
+        optional_dict_item(dict, "created_at_lt")?.map(extract_datetime).transpose()?;
+
+    Ok(BatchOperationFilter {
+        kind,
+        queue,
+        ids,
+        tag,
+        state,
+        created_at_gte,
+        created_at_lt,
+    })
+}
+
+fn optional_dict_item<'py>(
+    dict: &Bound<'py, PyDict>,
+    key: &str,
+) -> PyResult<Option<Bound<'py, PyAny>>> {
+    Ok(dict.get_item(key)?.filter(|value| !value.is_none()))
+}
+
+fn required_dict_item<'py>(dict: &Bound<'py, PyDict>, key: &str) -> PyResult<Bound<'py, PyAny>> {
+    optional_dict_item(dict, key)?.ok_or_else(|| {
+        pyo3::exceptions::PyValueError::new_err(format!("batch operation spec missing '{key}'"))
+    })
+}
+
+fn extract_datetime(value: Bound<'_, PyAny>) -> PyResult<DateTime<Utc>> {
+    if let Ok(datetime) = value.extract::<DateTime<Utc>>() {
+        return Ok(datetime);
+    }
+
+    let text: String = value.extract()?;
+    DateTime::parse_from_rfc3339(&text)
+        .map(|dt| dt.with_timezone(&Utc))
+        .map_err(|err| {
+            pyo3::exceptions::PyValueError::new_err(format!("invalid RFC3339 timestamp: {err}"))
+        })
+}
+
+fn batch_operation_to_py<T: serde::Serialize>(py: Python<'_>, value: &T) -> PyResult<Py<PyAny>> {
+    let json = serde_json::to_value(value)
+        .map_err(awa_model::AwaError::Serialization)
+        .map_err(map_awa_error)?;
+    crate::job::json_to_py(py, &json)
 }
 
 fn parse_default_action(value: &str) -> PyResult<awa_model::admin::DefaultAction> {

--- a/awa-python/tests/test_batch_operations.py
+++ b/awa-python/tests/test_batch_operations.py
@@ -68,7 +68,6 @@ async def async_client():
     finally:
         reset = awa.Client(DATABASE_URL)
         try:
-            reset.migrate()
             _reset_control_plane(reset)
         finally:
             reset.close()

--- a/awa-python/tests/test_batch_operations.py
+++ b/awa-python/tests/test_batch_operations.py
@@ -1,0 +1,160 @@
+"""Python bindings for durable batch operations."""
+
+from __future__ import annotations
+
+import datetime as dt
+import os
+from dataclasses import dataclass
+
+import pytest
+
+import awa
+
+DATABASE_URL = os.environ.get(
+    "DATABASE_URL", "postgres://postgres:test@localhost:15432/awa_test"
+)
+
+
+@dataclass
+class BatchPyJob:
+    value: str
+
+
+def _reset_control_plane(client: awa.Client) -> None:
+    tx = client.transaction()
+    tx.execute(
+        """
+        UPDATE awa.storage_transition_state
+        SET current_engine = 'canonical',
+            prepared_engine = NULL,
+            state = 'canonical',
+            transition_epoch = transition_epoch + 1,
+            details = '{}'::jsonb,
+            updated_at = now(),
+            finalized_at = NULL
+        WHERE singleton
+        """
+    )
+    tx.execute("DELETE FROM awa.runtime_storage_backends WHERE backend = 'queue_storage'")
+    tx.execute("DELETE FROM awa.batch_operation_items")
+    tx.execute("DELETE FROM awa.batch_operations")
+    tx.execute("DELETE FROM awa.jobs_hot WHERE queue LIKE 'pybatch_%'")
+    tx.commit()
+
+
+@pytest.fixture
+def sync_client():
+    client = awa.Client(DATABASE_URL)
+    client.migrate()
+    _reset_control_plane(client)
+    try:
+        yield client
+    finally:
+        _reset_control_plane(client)
+        client.close()
+
+
+@pytest.fixture
+async def async_client():
+    client = awa.AsyncClient(DATABASE_URL)
+    await client.migrate()
+    reset = awa.Client(DATABASE_URL)
+    try:
+        _reset_control_plane(reset)
+    finally:
+        reset.close()
+    try:
+        yield client
+    finally:
+        reset = awa.Client(DATABASE_URL)
+        try:
+            reset.migrate()
+            _reset_control_plane(reset)
+        finally:
+            reset.close()
+            await client.close()
+
+
+def test_sync_batch_operation_helpers_preview_submit_list_and_cancel(sync_client):
+    queue = "pybatch_sync"
+    job = sync_client.insert(BatchPyJob("one"), queue=queue, priority=4)
+    second = sync_client.insert(BatchPyJob("two"), queue=queue, priority=4)
+
+    preview = sync_client.preview_set_priority(
+        1,
+        filter={"queue": queue, "state": "available"},
+    )
+    assert preview["total_matched"] == 2
+    assert {row["id"] for row in preview["sample"]} == {job.id, second.id}
+
+    operation = sync_client.set_priority(
+        1,
+        filter={"queue": queue},
+        submitted_by="pytest",
+    )
+    assert operation["op_kind"] == "set_priority"
+    assert operation["state"] == "pending"
+    assert operation["submitted_by"] == "pytest"
+    assert operation["spec"]["priority"] == 1
+
+    listed = sync_client.list_batch_operations(state="pending")
+    assert [row["id"] for row in listed] == [operation["id"]]
+
+    fetched = sync_client.get_batch_operation(operation["id"])
+    assert fetched["id"] == operation["id"]
+
+    cancelled = sync_client.cancel_batch_operation(operation["id"])
+    assert cancelled["state"] == "cancelling"
+
+
+def test_sync_batch_operation_move_queue_and_validation(sync_client):
+    queue = "pybatch_move"
+    job = sync_client.insert(BatchPyJob("move"), queue=queue, priority=3)
+
+    preview = sync_client.preview_move_queue(
+        "pybatch_dest",
+        priority=2,
+        filter={"ids": [job.id]},
+    )
+    assert preview["total_matched"] == 1
+
+    operation = sync_client.move_queue(
+        "pybatch_dest",
+        priority=2,
+        filter={"ids": [job.id]},
+    )
+    assert operation["op_kind"] == "move_queue"
+    assert operation["spec"]["queue"] == "pybatch_dest"
+    assert operation["spec"]["priority"] == 2
+
+    with pytest.raises(awa.ValidationError, match="requires a filter"):
+        sync_client.set_priority(1)
+
+
+@pytest.mark.asyncio
+async def test_async_batch_operation_helpers_accept_datetime_filters(async_client):
+    queue = "pybatch_async"
+    job = await async_client.insert(BatchPyJob("async"), queue=queue, priority=4)
+    created_before = dt.datetime.now(dt.timezone.utc) + dt.timedelta(minutes=1)
+
+    preview = await async_client.preview_batch_operation(
+        "set_priority",
+        spec={"priority": 1},
+        filter={
+            "queue": queue,
+            "created_at_lt": created_before,
+        },
+    )
+    assert preview["total_matched"] == 1
+
+    operation = await async_client.submit_batch_operation(
+        "move_queue",
+        spec={"queue": "pybatch_async_dest"},
+        filter={"ids": [job.id]},
+        submitted_by="pytest-async",
+    )
+    assert operation["op_kind"] == "move_queue"
+    assert operation["submitted_by"] == "pytest-async"
+
+    cancelled = await async_client.cancel_batch_operation(operation["id"])
+    assert cancelled["state"] == "cancelling"

--- a/awa-ui/frontend/e2e/batch-ops.spec.ts
+++ b/awa-ui/frontend/e2e/batch-ops.spec.ts
@@ -1,46 +1,49 @@
 import { test, expect } from "@playwright/test";
 
+function operation(overrides = {}) {
+  return {
+    id: "11111111-1111-4111-8111-111111111111",
+    op_kind: "set_priority",
+    filter: { queue: "e2e_test" },
+    spec: { priority: 1 },
+    state: "pending",
+    submitted_by: "ui",
+    submitted_at: new Date().toISOString(),
+    started_at: null,
+    finalized_at: null,
+    cursor: null,
+    total_matched: null,
+    processed: 0,
+    skipped: 0,
+    errored: 0,
+    last_error: null,
+    runner_instance: null,
+    retention_until: null,
+    updated_at: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+async function stubSharedApi(page, operations) {
+  await page.route("**/api/runtime", (route) =>
+    route.fulfill({ json: { total_instances: 0, live_instances: 0, stale_instances: 0, healthy_instances: 0, leader_instances: 0, instances: [] } })
+  );
+  await page.route("**/api/capabilities", (route) =>
+    route.fulfill({ json: { read_only: false, poll_interval_ms: 2000 } })
+  );
+  await page.route("**/api/batch-ops*", (route) => {
+    if (route.request().method() !== "GET") return route.fallback();
+    const url = new URL(route.request().url());
+    if (url.pathname !== "/api/batch-ops") return route.fallback();
+    return route.fulfill({ json: operations });
+  });
+}
+
 test.describe("Batch operations page", () => {
   test("previews and submits a set-priority operation", async ({ page }) => {
-    let submitted = false;
+    const operations = [];
 
-    await page.route("**/api/runtime", (route) =>
-      route.fulfill({ json: { total_instances: 0, live_instances: 0, stale_instances: 0, healthy_instances: 0, leader_instances: 0, instances: [] } })
-    );
-    await page.route("**/api/capabilities", (route) =>
-      route.fulfill({ json: { read_only: false, poll_interval_ms: 2000 } })
-    );
-    await page.route("**/api/batch-ops*", (route) => {
-      if (route.request().method() !== "GET") return route.fallback();
-      const url = new URL(route.request().url());
-      if (url.pathname !== "/api/batch-ops") return route.fallback();
-      return route.fulfill({
-        json: submitted
-          ? [
-              {
-                id: "11111111-1111-4111-8111-111111111111",
-                op_kind: "set_priority",
-                filter: { queue: "e2e_test" },
-                spec: { op_kind: "set_priority", priority: 1 },
-                state: "pending",
-                submitted_by: "ui",
-                submitted_at: new Date().toISOString(),
-                started_at: null,
-                finalized_at: null,
-                cursor: null,
-                total_matched: null,
-                processed: 0,
-                skipped: 0,
-                errored: 0,
-                last_error: null,
-                runner_instance: null,
-                retention_until: null,
-                updated_at: new Date().toISOString(),
-              },
-            ]
-          : [],
-      });
-    });
+    await stubSharedApi(page, operations);
     await page.route("**/api/batch-ops/preview", (route) =>
       route.fulfill({ json: { total_matched: 2, sample: [] } })
     );
@@ -52,28 +55,13 @@ test.describe("Batch operations page", () => {
           filter: { queue: "e2e_test" },
           spec: { priority: 1 },
         });
-        submitted = true;
+        const submitted = operation({
+          filter: body.filter,
+          spec: body.spec,
+        });
+        operations.push(submitted);
         await route.fulfill({
-          json: {
-            id: "11111111-1111-4111-8111-111111111111",
-            op_kind: "set_priority",
-            filter: body.filter,
-            spec: body.spec,
-            state: "pending",
-            submitted_by: "ui",
-            submitted_at: new Date().toISOString(),
-            started_at: null,
-            finalized_at: null,
-            cursor: null,
-            total_matched: null,
-            processed: 0,
-            skipped: 0,
-            errored: 0,
-            last_error: null,
-            runner_instance: null,
-            retention_until: null,
-            updated_at: new Date().toISOString(),
-          },
+          json: submitted,
         });
         return;
       }
@@ -88,5 +76,93 @@ test.describe("Batch operations page", () => {
     await expect(page.getByText("Preview matched 2 job(s)")).toBeVisible();
     await page.getByRole("button", { name: "Submit" }).click();
     await expect(page.getByRole("gridcell", { name: "11111111" })).toBeVisible();
+  });
+
+  test("submits a move-queue operation with filters", async ({ page }) => {
+    const operations = [];
+
+    await stubSharedApi(page, operations);
+    await page.route("**/api/batch-ops/preview", async (route) => {
+      const body = route.request().postDataJSON();
+      expect(body).toMatchObject({
+        op_kind: "move_queue",
+        filter: {
+          queue: "e2e_test",
+          kind: "e2e_job",
+          ids: [800006],
+        },
+        spec: {
+          queue: "escalations",
+          priority: 2,
+        },
+      });
+      await route.fulfill({ json: { total_matched: 1, sample: [] } });
+    });
+    await page.route("**/api/batch-ops", async (route) => {
+      if (route.request().method() === "POST") {
+        const body = route.request().postDataJSON();
+        expect(body).toMatchObject({
+          op_kind: "move_queue",
+          filter: {
+            queue: "e2e_test",
+            kind: "e2e_job",
+            ids: [800006],
+          },
+          spec: {
+            queue: "escalations",
+            priority: 2,
+          },
+        });
+        const submitted = operation({
+          op_kind: "move_queue",
+          filter: body.filter,
+          spec: body.spec,
+        });
+        operations.push(submitted);
+        await route.fulfill({ json: submitted });
+        return;
+      }
+      await route.fallback();
+    });
+
+    await page.goto("/batch-ops");
+    await page.locator("select").selectOption("move_queue");
+    await page.getByLabel("Queue filter").fill("e2e_test");
+    await page.getByLabel("Kind filter").fill("e2e_job");
+    await page.getByLabel("IDs filter").fill("800006");
+    await page.getByRole("textbox", { name: "Priority" }).fill("2");
+    await page.getByLabel("Destination queue").fill("escalations");
+    await page.getByRole("button", { name: "Preview" }).click();
+    await expect(page.getByText("Preview matched 1 job(s)")).toBeVisible();
+    await page.getByRole("button", { name: "Submit" }).click();
+    await expect(page.getByRole("gridcell", { name: "move queue" })).toBeVisible();
+  });
+
+  test("requests cancellation for an active operation", async ({ page }) => {
+    const operations = [
+      operation({
+        state: "running",
+        total_matched: 10,
+        processed: 3,
+      }),
+    ];
+
+    await stubSharedApi(page, operations);
+    await page.route("**/api/batch-ops/11111111-1111-4111-8111-111111111111", async (route) => {
+      expect(route.request().method()).toBe("PATCH");
+      expect(route.request().postDataJSON()).toMatchObject({ state: "cancelling" });
+      operations[0] = {
+        ...operations[0],
+        state: "cancelling",
+        updated_at: new Date().toISOString(),
+      };
+      await route.fulfill({ json: operations[0] });
+    });
+
+    await page.goto("/batch-ops");
+    await expect(page.getByRole("gridcell", { name: "running" })).toBeVisible();
+    await page.getByRole("button", { name: "Cancel" }).click();
+    await expect(page.getByText("Cancellation requested")).toBeVisible();
+    await expect(page.getByRole("gridcell", { name: "cancelling" })).toBeVisible();
   });
 });

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -339,6 +339,34 @@ awa batch-ops submit \
   --spec '{"priority":1}'
 ```
 
+Python clients expose the same durable control-plane operation. Async and sync clients use the same method names; omit `await` when using `awa.Client`:
+
+```python
+preview = await client.preview_set_priority(
+    1,
+    filter={"queue": "default", "state": "available"},
+)
+print(preview["total_matched"])
+
+operation = await client.set_priority(
+    1,
+    filter={"queue": "default"},
+    submitted_by="ops@example.com",
+)
+
+operation = await client.cancel_batch_operation(operation["id"])
+```
+
+The generic Python envelope is also available when you want exact parity with the HTTP API:
+
+```python
+operation = await client.submit_batch_operation(
+    "move_queue",
+    spec={"queue": "escalations", "priority": 1},
+    filter={"tag": "incident-123"},
+)
+```
+
 Batch-operation history is retained for `AWA_BATCH_OP_RETENTION_DAYS` days (default `90`). Use `awa batch-ops purge --before <timestamp>` for explicit cleanup of finalized operations.
 
 ## Queue and job-kind descriptors

--- a/docs/test-plan.md
+++ b/docs/test-plan.md
@@ -191,6 +191,7 @@ _HTTPWorker is a Rust-only feature (ADR-018: serverless function dispatch). Not 
 | # | Test | Rust |
 | --- | --- | --- |
 | RO1-RO3 | Read-only serve: capabilities, mutations blocked, UI disables | ✓ |
+| UIB1-UIB3 | Batch operations page: set-priority preview/submit, move-queue payload, cancellation request | ✓ |
 
 ### Admin Metadata Guardrails
 

--- a/docs/ui-design.md
+++ b/docs/ui-design.md
@@ -134,6 +134,17 @@ Paused schedules render with a "paused" badge and the `paused_by` label. Pause/R
 
 When the target queue is itself paused, the row shows a "queue paused" badge alongside the queue name and the expanded detail explains that fires continue to enqueue jobs into the paused queue but those jobs dispatch only after the queue is resumed. Cron pause and queue pause are independent — one is "stop scheduling," the other is "stop dispatching."
 
+### Batch Operations (`/batch-ops`)
+
+Operator surface for durable async mutations recorded in `awa.batch_operations`.
+
+- **New operation form** — choose `set_priority` or `move_queue`, filter by queue, kind, or explicit ids, then preview before submitting.
+- **Preview** — calls `/api/batch-ops/preview` and reports the eligible row count. Preview is advisory; execution rechecks eligibility while the maintenance leader runs the operation.
+- **History table** — lists recent operations with id, kind, state, progress, error count, and submitted age.
+- **Cancellation** — active `pending`, `scanning`, and `running` operations expose a Cancel action, which requests cooperative cancellation at chunk boundaries.
+
+The first UI form intentionally covers the common operator paths. The API and Python/Rust surfaces also support tag, state, and created-at filters for callers that need more precise automation.
+
 ### Dead Letter Queue (`/dlq`, `/dlq/:id`)
 
 Operator surface for queue-storage `dlq_entries`.


### PR DESCRIPTION
## Summary

- Expose durable batch operations through awa-python raw PyO3 methods and friendly sync/async `Client` helpers.
- Add typed Python payload/record hints, stubs, and package exports for batch operations.
- Cover `set_priority`, `move_queue`, cancellation, and validation in Python tests, and expand Playwright coverage for the Batch Ops UI.
- Update the README, Python README, configuration docs, UI design docs, and test plan.

## Issue #307

Closes #307 by using the accepted ADR-030 durable batch-operation surface rather than adding separate synchronous priority endpoints. Operators can now preview, submit, cancel, list, and inspect `set_priority` and `move_queue` operations from the Rust/model, CLI, UI, and Python surfaces.

The literal job-detail editable priority field and `awa job priority` command aliases remain possible UX shortcuts, but the load-bearing reprioritization capability is now exposed consistently through the durable batch-operation API.

## Validation

- `cargo fmt --check`
- `PYO3_PYTHON=python3.12 cargo check --manifest-path awa-python/Cargo.toml`
- `cd awa-python && .venv/bin/pytest tests/test_batch_operations.py -q`
- `cd awa-ui/frontend && npm run lint`
- `cargo test -p awa-ui test_batch_ops_api_preview_submit_and_cancel`
- `cd awa-ui/frontend && npx playwright test e2e/batch-ops.spec.ts`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Durable batch operations: preview, submit (set-priority, move-queue), list, fetch, cancel, and purge — available in both async and sync Python clients
  * Admin UI page for creating/managing batch operations

* **Documentation**
  * Updated README/ADR index and docs with usage examples and design notes for batch operations
  * Configuration guide shows Python client examples

* **Tests**
  * New unit and end-to-end tests covering previews, submits, cancellation, and UI flows
<!-- end of auto-generated comment: release notes by coderabbit.ai -->