### PR TITLE
Add awa-seaorm to the crates.io publish chain

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -746,3 +746,14 @@ jobs:
         run: cargo publish --package awa --no-verify
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.crates-io-auth.outputs.token }}
+
+      - name: Wait for index
+        run: sleep 30
+
+      # awa-seaorm depends on the awa facade, so it publishes last. First
+      # publish auto-creates the crate on crates.io under the token owner's
+      # namespace.
+      - name: Publish awa-seaorm
+        run: cargo publish --package awa-seaorm --no-verify
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}


### PR DESCRIPTION
## Summary

`awa-seaorm` (#275) has full crates.io metadata and no `publish = false`, but `release.yml` doesn't publish it — tagging `v0.6.0-beta.2` today would ship every crate except the new one. Same gap that bit `awa-ui` in `v0.3.0-alpha.1`.

It depends on the `awa` facade, so the new step publishes last in the chain. It uses the raw `CARGO_REGISTRY_TOKEN` secret like the `awa-metrics` first-publish step, since the first publish auto-creates the crate under the token owner's namespace.

**This should merge before tagging `v0.6.0-beta.2`.**

Refs #197.