### PR TITLE
ci: bump setup-uv to v8.2.0 for Node 24 runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,7 +141,7 @@ jobs:
         with:
           python-version: "3.12"
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v8.2.0
       - name: Create venv and install deps
         run: |
           uv venv .venv

--- a/.github/workflows/nightly-chaos.yml
+++ b/.github/workflows/nightly-chaos.yml
@@ -370,7 +370,7 @@ jobs:
         with:
           python-version: "3.12"
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v8.2.0
       - name: Create venv and install deps
         run: |
           uv venv .venv


### PR DESCRIPTION
GitHub forces Node.js 20 actions to run on Node 24 starting **June 16th, 2026** and removes Node 20 from runners in September 2026. Everything in this repo is already on node24 majors except `astral-sh/setup-uv@v6` (node20) in `ci.yml` and `nightly-chaos.yml`.

Two notes:
- Pinned to the **exact tag** `v8.2.0` rather than `@v8`: setup-uv stopped publishing floating major/minor tags in v8 as supply-chain hardening, so `@v8` doesn't resolve.
- The v7/v8 breaking changes (removal of `server-url` and the old `manifest-file` format) don't apply — both usages install uv with no inputs.

Same sweep as thepartly/reflectapi#172.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow infrastructure with the latest build automation tooling to enhance build reliability and consistency across development environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->