### PR TITLE
feat(admin): transactional cancel_tx / cancel_by_unique_key_tx (0.6.0-rc.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Notable changes between releases. Detailed migration notes for storage transitio
 
 ### Added
 
-- **Transaction-scoped admin cancel** (PR_LINK_PLACEHOLDER). `admin::cancel_tx` and `admin::cancel_by_unique_key_tx` accept a caller-provided `&mut sqlx::Transaction` and run the cancellation inside it, so the cancel commits or rolls back atomically with the caller's other work and the cooperative `awa:cancel` NOTIFY to a running worker fires only on the caller's commit. The pool-based `cancel` / `cancel_by_unique_key` are unchanged. On the queue-storage engine the `_tx` variants skip the best-effort post-commit claim-cursor advance the pool variants perform — the derived queue depth can briefly over-count by one until later committed rows on the lane are claimed; canonical counts are unaffected.
+- **Transaction-scoped admin cancel** ([#357](https://github.com/hardbyte/awa/pull/357)). `admin::cancel_tx` and `admin::cancel_by_unique_key_tx` accept a caller-provided `&mut sqlx::Transaction` and run the cancellation inside it, so the cancel commits or rolls back atomically with the caller's other work and the cooperative `awa:cancel` NOTIFY to a running worker fires only on the caller's commit. The pool-based `cancel` / `cancel_by_unique_key` are unchanged. On the queue-storage engine the `_tx` variants skip the best-effort post-commit claim-cursor advance the pool variants perform — the derived queue depth can briefly over-count by one until later committed rows on the lane are claimed; canonical counts are unaffected.
 
 ## [0.6.0-rc.1] — 2026-06-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ Notable changes between releases. Detailed migration notes for storage transitio
 
 ## [Unreleased]
 
+## [0.6.0-rc.2] — 2026-06-25
+
+### Added
+
+- **Transaction-scoped admin cancel** (PR_LINK_PLACEHOLDER). `admin::cancel_tx` and `admin::cancel_by_unique_key_tx` accept a caller-provided `&mut sqlx::Transaction` and run the cancellation inside it, so the cancel commits or rolls back atomically with the caller's other work and the cooperative `awa:cancel` NOTIFY to a running worker fires only on the caller's commit. The pool-based `cancel` / `cancel_by_unique_key` are unchanged. On the queue-storage engine the `_tx` variants skip the best-effort post-commit claim-cursor advance the pool variants perform — the derived queue depth can briefly over-count by one until later committed rows on the lane are claimed; canonical counts are unaffected.
+
 ## [0.6.0-rc.1] — 2026-06-24
 
 First release candidate for the 0.6 line. It promotes the beta.2 queue-storage engine after the [#169](https://github.com/hardbyte/awa/issues/169) pinned-MVCC dead-tuple gate passed on `main`: a 60-minute idle-in-transaction soak now holds throughput with no dead-tuple cliff, and the last dominant pinned-horizon hot row (`queue_claim_heads`) is removed in this delta. Migrations v032–v039 apply via `awa migrate` (or the SQL-only path in [`docs/migrations.md`](docs/migrations.md) for external migration tooling).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -383,7 +383,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "awa"
-version = "0.6.0-rc.1"
+version = "0.6.0-rc.2"
 dependencies = [
  "async-trait",
  "awa-macros",
@@ -408,7 +408,7 @@ dependencies = [
 
 [[package]]
 name = "awa-cli"
-version = "0.6.0-rc.1"
+version = "0.6.0-rc.2"
 dependencies = [
  "assert_cmd",
  "awa-model",
@@ -430,7 +430,7 @@ dependencies = [
 
 [[package]]
 name = "awa-macros"
-version = "0.6.0-rc.1"
+version = "0.6.0-rc.2"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -440,7 +440,7 @@ dependencies = [
 
 [[package]]
 name = "awa-metrics"
-version = "0.6.0-rc.1"
+version = "0.6.0-rc.2"
 dependencies = [
  "awa-model",
  "opentelemetry",
@@ -448,7 +448,7 @@ dependencies = [
 
 [[package]]
 name = "awa-model"
-version = "0.6.0-rc.1"
+version = "0.6.0-rc.2"
 dependencies = [
  "awa-macros",
  "blake3",
@@ -469,7 +469,7 @@ dependencies = [
 
 [[package]]
 name = "awa-seaorm"
-version = "0.6.0-rc.1"
+version = "0.6.0-rc.2"
 dependencies = [
  "awa",
  "awa-testing",
@@ -482,7 +482,7 @@ dependencies = [
 
 [[package]]
 name = "awa-testing"
-version = "0.6.0-rc.1"
+version = "0.6.0-rc.2"
 dependencies = [
  "async-trait",
  "awa-model",
@@ -497,7 +497,7 @@ dependencies = [
 
 [[package]]
 name = "awa-ui"
-version = "0.6.0-rc.1"
+version = "0.6.0-rc.2"
 dependencies = [
  "awa-metrics",
  "awa-model",
@@ -520,7 +520,7 @@ dependencies = [
 
 [[package]]
 name = "awa-worker"
-version = "0.6.0-rc.1"
+version = "0.6.0-rc.2"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 exclude = ["awa-python", "spike"]
 
 [workspace.package]
-version = "0.6.0-rc.1"
+version = "0.6.0-rc.2"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "Postgres-native background job queue — transactional enqueue, heartbeat crash recovery, SKIP LOCKED dispatch"
@@ -25,11 +25,11 @@ categories = ["database", "asynchronous", "web-programming"]
 
 [workspace.dependencies]
 # Internal crates
-awa-model = { path = "awa-model", version = "0.6.0-rc.1" }
-awa-macros = { path = "awa-macros", version = "0.6.0-rc.1" }
-awa-metrics = { path = "awa-metrics", version = "0.6.0-rc.1" }
-awa-worker = { path = "awa-worker", version = "0.6.0-rc.1" }
-awa = { path = "awa", version = "0.6.0-rc.1" }
+awa-model = { path = "awa-model", version = "0.6.0-rc.2" }
+awa-macros = { path = "awa-macros", version = "0.6.0-rc.2" }
+awa-metrics = { path = "awa-metrics", version = "0.6.0-rc.2" }
+awa-worker = { path = "awa-worker", version = "0.6.0-rc.2" }
+awa = { path = "awa", version = "0.6.0-rc.2" }
 
 # Database
 sea-orm = { version = "=2.0.0-rc.38", default-features = false, features = ["sqlx-postgres", "runtime-tokio-rustls", "with-chrono", "with-json"] }

--- a/awa-cli/Cargo.toml
+++ b/awa-cli/Cargo.toml
@@ -14,7 +14,7 @@ path = "src/main.rs"
 [dependencies]
 awa-model.workspace = true
 awa-worker.workspace = true
-awa-ui = { path = "../awa-ui", version = "0.6.0-rc.1" }
+awa-ui = { path = "../awa-ui", version = "0.6.0-rc.2" }
 axum.workspace = true
 sqlx.workspace = true
 tokio.workspace = true
@@ -28,5 +28,5 @@ hex.workspace = true
 uuid.workspace = true
 
 [dev-dependencies]
-awa-testing = { path = "../awa-testing", version = "0.6.0-rc.1" }
+awa-testing = { path = "../awa-testing", version = "0.6.0-rc.2" }
 assert_cmd = "2"

--- a/awa-cli/pyproject.toml
+++ b/awa-cli/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "awa-cli"
-version = "0.6.0-rc.1"
+version = "0.6.0-rc.2"
 description = "CLI for the Awa Postgres-native job queue (migrations, admin, serve)"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/awa-model/src/admin.rs
+++ b/awa-model/src/admin.rs
@@ -517,6 +517,127 @@ pub async fn cancel(pool: &PgPool, job_id: i64) -> Result<Option<JobRow>, AwaErr
     Ok(Some(job))
 }
 
+/// Transaction-scoped variant of [`cancel`].
+///
+/// Runs the cancellation inside the caller's transaction `tx` instead of opening
+/// its own, so the cancel commits (or rolls back) atomically with the caller's
+/// other work, and the cooperative `awa:cancel` NOTIFY to a running worker fires
+/// only when the caller commits.
+///
+/// On the queue-storage engine this skips the best-effort claim-cursor advance
+/// that [`cancel`] performs after its own commit (it cannot run inside the
+/// caller's transaction); the derived queue depth may briefly over-count by one
+/// until later committed rows on the lane are claimed. Counts are unaffected on
+/// the canonical engine.
+pub async fn cancel_tx<'a>(
+    tx: &mut sqlx::Transaction<'a, sqlx::Postgres>,
+    job_id: i64,
+) -> Result<Option<JobRow>, AwaError> {
+    if let Some(store) = active_queue_storage_in_tx(tx).await? {
+        return store
+            .cancel_job_in_tx(tx, job_id)
+            .await?
+            .ok_or(AwaError::JobNotFound { id: job_id })
+            .map(Some);
+    }
+
+    let prior_state: Option<JobState> =
+        sqlx::query_scalar::<_, JobState>("SELECT state FROM awa.jobs WHERE id = $1 FOR UPDATE")
+            .bind(job_id)
+            .fetch_optional(tx.as_mut())
+            .await?;
+
+    let Some(prior_state) = prior_state else {
+        return Err(AwaError::JobNotFound { id: job_id });
+    };
+
+    let job: Option<JobRow> = sqlx::query_as::<_, JobRow>(
+        r#"
+        UPDATE awa.jobs
+        SET state = 'cancelled', finalized_at = now(),
+            callback_id = NULL, callback_timeout_at = NULL,
+            callback_filter = NULL, callback_on_complete = NULL,
+            callback_on_fail = NULL, callback_transform = NULL
+        WHERE id = $1 AND state NOT IN ('completed', 'failed', 'cancelled')
+        RETURNING *
+        "#,
+    )
+    .bind(job_id)
+    .fetch_optional(tx.as_mut())
+    .await?;
+
+    let Some(job) = job else {
+        return Err(AwaError::JobNotFound { id: job_id });
+    };
+
+    if matches!(prior_state, JobState::Running | JobState::WaitingExternal) {
+        notify_cancellation_tx(tx, job.id, job.run_lease).await?;
+    }
+
+    Ok(Some(job))
+}
+
+/// Queue-storage candidate lookup for a unique key. Shared by
+/// [`cancel_by_unique_key`] and [`cancel_by_unique_key_tx`] so the two cannot
+/// drift.
+fn unique_key_candidate_sql(schema: &str) -> String {
+    format!(
+        r#"
+        WITH current_available AS (
+            SELECT ready.job_id, ready.unique_key
+            FROM {schema}.ready_entries AS ready
+            JOIN {schema}.queue_claim_heads AS claims
+              ON claims.queue = ready.queue
+             AND claims.priority = ready.priority
+             AND claims.enqueue_shard = ready.enqueue_shard
+            WHERE ready.lane_seq >= {schema}.sequence_next_value(claims.seq_name)
+              AND NOT EXISTS (
+                  SELECT 1 FROM {schema}.ready_tombstones AS tomb
+                  WHERE tomb.ready_slot = ready.ready_slot
+                    AND tomb.ready_generation = ready.ready_generation
+                    AND tomb.queue = ready.queue
+                    AND tomb.priority = ready.priority
+                    AND tomb.enqueue_shard = ready.enqueue_shard
+                    AND tomb.lane_seq = ready.lane_seq
+              )
+        ),
+        candidates AS (
+            SELECT job_id
+            FROM current_available
+            WHERE unique_key = $1
+            UNION ALL
+            SELECT job_id
+            FROM {schema}.deferred_jobs
+            WHERE unique_key = $1
+            UNION ALL
+            SELECT job_id
+            FROM {schema}.leases
+            WHERE unique_key = $1
+        )
+        SELECT job_id
+        FROM candidates
+        ORDER BY job_id ASC
+        LIMIT 1
+        "#,
+        schema = schema
+    )
+}
+
+/// Canonical (non queue-storage) candidate lookup for a unique key.
+const UNIQUE_KEY_CANDIDATE_SQL_CANONICAL: &str = r#"
+    WITH candidates AS (
+        SELECT id FROM awa.jobs_hot
+        WHERE unique_key = $1 AND state NOT IN ('completed', 'failed', 'cancelled')
+        UNION ALL
+        SELECT id FROM awa.scheduled_jobs
+        WHERE unique_key = $1 AND state NOT IN ('completed', 'failed', 'cancelled')
+        ORDER BY id ASC
+        LIMIT 1
+    )
+    SELECT id
+    FROM candidates
+    "#;
+
 /// Cancel a job by its unique key components.
 ///
 /// Reconstructs the BLAKE3 unique key from the same inputs used at insert time
@@ -560,47 +681,7 @@ pub async fn cancel_by_unique_key(
     let unique_key = crate::unique::compute_unique_key(kind, queue, args, period_bucket);
 
     if let Some(store) = active_queue_storage(pool).await? {
-        let sql = format!(
-            r#"
-            WITH current_available AS (
-                SELECT ready.job_id, ready.unique_key
-                FROM {schema}.ready_entries AS ready
-                JOIN {schema}.queue_claim_heads AS claims
-                  ON claims.queue = ready.queue
-                 AND claims.priority = ready.priority
-                 AND claims.enqueue_shard = ready.enqueue_shard
-                WHERE ready.lane_seq >= {schema}.sequence_next_value(claims.seq_name)
-                  AND NOT EXISTS (
-                      SELECT 1 FROM {schema}.ready_tombstones AS tomb
-                      WHERE tomb.ready_slot = ready.ready_slot
-                        AND tomb.ready_generation = ready.ready_generation
-                        AND tomb.queue = ready.queue
-                        AND tomb.priority = ready.priority
-                        AND tomb.enqueue_shard = ready.enqueue_shard
-                        AND tomb.lane_seq = ready.lane_seq
-                  )
-            ),
-            candidates AS (
-                SELECT job_id
-                FROM current_available
-                WHERE unique_key = $1
-                UNION ALL
-                SELECT job_id
-                FROM {schema}.deferred_jobs
-                WHERE unique_key = $1
-                UNION ALL
-                SELECT job_id
-                FROM {schema}.leases
-                WHERE unique_key = $1
-            )
-            SELECT job_id
-            FROM candidates
-            ORDER BY job_id ASC
-            LIMIT 1
-            "#,
-            schema = store.schema()
-        );
-
+        let sql = unique_key_candidate_sql(store.schema());
         let candidate: Option<i64> = sqlx::query_scalar(&sql)
             .bind(&unique_key)
             .fetch_optional(pool)
@@ -615,27 +696,56 @@ pub async fn cancel_by_unique_key(
     // Find the oldest matching job across both physical tables, then route
     // through `cancel(...)` so running jobs emit the same cooperative
     // cancellation notification as ID-based admin cancels.
-    let candidate: Option<i64> = sqlx::query_scalar(
-        r#"
-        WITH candidates AS (
-            SELECT id FROM awa.jobs_hot
-            WHERE unique_key = $1 AND state NOT IN ('completed', 'failed', 'cancelled')
-            UNION ALL
-            SELECT id FROM awa.scheduled_jobs
-            WHERE unique_key = $1 AND state NOT IN ('completed', 'failed', 'cancelled')
-            ORDER BY id ASC
-            LIMIT 1
-        )
-        SELECT id
-        FROM candidates
-        "#,
-    )
-    .bind(&unique_key)
-    .fetch_optional(pool)
-    .await?;
+    let candidate: Option<i64> = sqlx::query_scalar(UNIQUE_KEY_CANDIDATE_SQL_CANONICAL)
+        .bind(&unique_key)
+        .fetch_optional(pool)
+        .await?;
 
     match candidate {
         Some(job_id) => match cancel(pool, job_id).await {
+            Ok(row) => Ok(row),
+            Err(AwaError::JobNotFound { .. }) => Ok(None),
+            Err(err) => Err(err),
+        },
+        None => Ok(None),
+    }
+}
+
+/// Transaction-scoped variant of [`cancel_by_unique_key`].
+///
+/// Resolves the candidate and cancels it inside the caller's transaction `tx`,
+/// so the cancel is atomic with the caller's other work (and the `awa:cancel`
+/// NOTIFY fires only on the caller's commit). See [`cancel_tx`] for the
+/// queue-storage claim-cursor caveat.
+pub async fn cancel_by_unique_key_tx<'a>(
+    tx: &mut sqlx::Transaction<'a, sqlx::Postgres>,
+    kind: &str,
+    queue: Option<&str>,
+    args: Option<&serde_json::Value>,
+    period_bucket: Option<i64>,
+) -> Result<Option<JobRow>, AwaError> {
+    let unique_key = crate::unique::compute_unique_key(kind, queue, args, period_bucket);
+
+    if let Some(store) = active_queue_storage_in_tx(tx).await? {
+        let sql = unique_key_candidate_sql(store.schema());
+        let candidate: Option<i64> = sqlx::query_scalar(&sql)
+            .bind(&unique_key)
+            .fetch_optional(tx.as_mut())
+            .await?;
+
+        return match candidate {
+            Some(job_id) => cancel_tx(tx, job_id).await,
+            None => Ok(None),
+        };
+    }
+
+    let candidate: Option<i64> = sqlx::query_scalar(UNIQUE_KEY_CANDIDATE_SQL_CANONICAL)
+        .bind(&unique_key)
+        .fetch_optional(tx.as_mut())
+        .await?;
+
+    match candidate {
+        Some(job_id) => match cancel_tx(tx, job_id).await {
             Ok(row) => Ok(row),
             Err(AwaError::JobNotFound { .. }) => Ok(None),
             Err(err) => Err(err),

--- a/awa-model/src/queue_storage.rs
+++ b/awa-model/src/queue_storage.rs
@@ -8197,6 +8197,22 @@ impl QueueStorage {
         }
     }
 
+    /// Transaction-scoped cancel used by [`crate::admin::cancel_tx`]. Runs the
+    /// full cancellation on the caller's transaction and returns the cancelled
+    /// row. Unlike [`Self::cancel_job`] this does NOT perform the post-commit
+    /// claim-cursor advance, so the derived queue depth may briefly over-count
+    /// by one until later committed rows on the lane are claimed.
+    pub(crate) async fn cancel_job_in_tx<'a>(
+        &self,
+        tx: &mut sqlx::Transaction<'a, sqlx::Postgres>,
+        job_id: i64,
+    ) -> Result<Option<JobRow>, AwaError> {
+        Ok(self
+            .cancel_job_tx(tx, job_id)
+            .await?
+            .map(|result| result.row))
+    }
+
     pub async fn cancel_jobs_by_ids(
         &self,
         pool: &PgPool,

--- a/awa-python/Cargo.toml
+++ b/awa-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "awa-python"
-version = "0.6.0-rc.1"
+version = "0.6.0-rc.2"
 edition = "2021"
 
 [lib]
@@ -12,8 +12,8 @@ default = ["cel"]
 cel = ["awa-model/cel"]
 
 [dependencies]
-awa-model = { path = "../awa-model", version = "0.6.0-rc.1" }
-awa-worker = { path = "../awa-worker", version = "0.6.0-rc.1", features = ["__python-bridge"] }
+awa-model = { path = "../awa-model", version = "0.6.0-rc.2" }
+awa-worker = { path = "../awa-worker", version = "0.6.0-rc.2", features = ["__python-bridge"] }
 pyo3 = { version = "0.28", features = ["macros", "abi3-py310", "chrono"] }
 pyo3-async-runtimes = { version = "0.28", features = ["tokio-runtime"] }
 sqlx = { version = "0.8", features = ["runtime-tokio-rustls", "postgres", "chrono", "json"] }

--- a/awa-python/pyproject.toml
+++ b/awa-python/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "maturin"
 [project]
 name = "awa-pg"
 requires-python = ">=3.10"
-version = "0.6.0-rc.1"
+version = "0.6.0-rc.2"
 description = "Postgres-native background job queue — Python SDK with async/sync workers, transactional enqueue, and progress tracking. Install awa-pg[ui] to add the bundled web dashboard."
 readme = "README.md"
 license = {text = "MIT OR Apache-2.0"}
@@ -32,7 +32,7 @@ classifiers = [
 #
 # Kept opt-in so the default `awa-pg` install stays small — workers and
 # producers don't need the ~10 MB UI bundle.
-ui = ["awa-cli==0.6.0-rc.1"]
+ui = ["awa-cli==0.6.0-rc.2"]
 
 [project.urls]
 Homepage = "https://github.com/hardbyte/awa"

--- a/awa-seaorm/Cargo.toml
+++ b/awa-seaorm/Cargo.toml
@@ -14,7 +14,7 @@ serde_json.workspace = true
 sqlx.workspace = true
 
 [dev-dependencies]
-awa-testing = { path = "../awa-testing", version = "0.6.0-rc.1" }
+awa-testing = { path = "../awa-testing", version = "0.6.0-rc.2" }
 serde = { workspace = true, features = ["derive"] }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 

--- a/awa/Cargo.toml
+++ b/awa/Cargo.toml
@@ -20,7 +20,7 @@ awa-macros.workspace = true
 awa-worker.workspace = true
 
 [dev-dependencies]
-awa-testing = { path = "../awa-testing", version = "0.6.0-rc.1" }
+awa-testing = { path = "../awa-testing", version = "0.6.0-rc.2" }
 sqlx.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/awa/tests/integration_test.rs
+++ b/awa/tests/integration_test.rs
@@ -923,6 +923,73 @@ async fn test_admin_cancel_by_unique_key() {
 }
 
 #[tokio::test]
+async fn test_admin_cancel_by_unique_key_tx_is_transactional() {
+    let _guard = test_lock().lock().await;
+    let client = setup().await;
+    let queue = "integ_cancel_by_unique_key_tx";
+    clean_queue(client.pool(), queue).await;
+
+    let args = SendEmail {
+        to: "cancel-by-key-tx@example.com".into(),
+        subject: "Cancel me by key in a tx".into(),
+    };
+    let job = insert_with(
+        client.pool(),
+        &args,
+        InsertOpts {
+            queue: queue.into(),
+            unique: Some(UniqueOpts {
+                by_queue: true,
+                by_args: true,
+                ..Default::default()
+            }),
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+    let args_value = serde_json::to_value(&args).unwrap();
+
+    // Rolled-back transaction: the cancel resolves the job but must NOT persist.
+    let mut tx = client.pool().begin().await.unwrap();
+    let cancelled = admin::cancel_by_unique_key_tx(
+        &mut tx,
+        SendEmail::kind(),
+        Some(queue),
+        Some(&args_value),
+        None,
+    )
+    .await
+    .unwrap();
+    assert_eq!(cancelled.expect("tx cancel should find the job").id, job.id);
+    tx.rollback().await.unwrap();
+
+    let after_rollback = client.get_job(job.id).await.unwrap();
+    assert_ne!(
+        after_rollback.state,
+        JobState::Cancelled,
+        "a rolled-back cancel_by_unique_key_tx must leave the job uncancelled"
+    );
+
+    // Committed transaction: the cancel takes effect.
+    let mut tx = client.pool().begin().await.unwrap();
+    let cancelled = admin::cancel_by_unique_key_tx(
+        &mut tx,
+        SendEmail::kind(),
+        Some(queue),
+        Some(&args_value),
+        None,
+    )
+    .await
+    .unwrap();
+    assert_eq!(cancelled.expect("tx cancel should find the job").id, job.id);
+    tx.commit().await.unwrap();
+
+    let after_commit = client.get_job(job.id).await.unwrap();
+    assert_eq!(after_commit.state, JobState::Cancelled);
+}
+
+#[tokio::test]
 async fn test_admin_cancel_by_unique_key_returns_none_when_not_found() {
     let _guard = test_lock().lock().await;
     let client = setup().await;


### PR DESCRIPTION
## Transactional admin cancel — `cancel_tx` / `cancel_by_unique_key_tx`

Adds transaction-accepting variants of the admin cancel APIs so a cancel can participate in the **caller's** transaction — atomic with surrounding work, and the cooperative `awa:cancel` NOTIFY fires only on the caller's commit. Motivated by a downstream consumer that cancels a unique job atomically with recording the event that obsoletes it (today's pool-based API forces a separate, non-atomic connection).

### Changes
- `admin::cancel_tx(&mut Transaction, job_id)` and `admin::cancel_by_unique_key_tx(&mut Transaction, …)`.
- New `pub(crate) QueueStorage::cancel_job_in_tx` wrapper over the existing `cancel_job_tx`; it skips the best-effort **post-commit** claim-cursor advance the pool variant performs (bounded transient over-count on queue-storage until later rows on the lane are claimed; **canonical counts unaffected**).
- Pool-based `cancel` / `cancel_by_unique_key` are unchanged in behavior; the candidate-lookup SQL is extracted into shared helpers so the pool and tx paths can't drift.
- Integration test: rollback leaves the job uncancelled; commit cancels.

### Verification
- `cargo fmt --all --check`, `clippy --all-targets --all-features -- -D warnings`, `build --workspace`: clean.
- `cargo test --test integration_test cancel`: 10/10 pass (incl. the existing pool-based tests).
- TLA+ `AwaSegmentedStorage`: *No error has been found* — additive API below the model abstraction; the cancel transitions/SQL are unchanged.

Cuts **0.6.0-rc.2**.
