### PR TITLE
test: run integration suite under both storage engines (part of #360)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,43 @@ jobs:
         env:
           DATABASE_URL: postgres://postgres:postgres@localhost:5432/awa_test
 
+  # ─── Integration suite under the queue-storage engine ──
+  # awa's caller-facing contract is engine-invariant; the default suite runs
+  # canonical, so this leg re-runs it with the queue-storage engine active on a
+  # fresh database (a separate DB avoids cross-engine job_unique_claims carryover).
+  rust-test-queue-storage:
+    name: Rust tests (queue_storage)
+    needs: [rust-build]
+    if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'full-ci')
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    services:
+      postgres:
+        image: postgres:17-alpine
+        env:
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: awa_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: ". -> target"
+      - name: Wait for Postgres
+        run: until pg_isready -h localhost -p 5432; do sleep 1; done
+      - name: Run integration suite under queue storage
+        run: cargo test -p awa --test integration_test
+        env:
+          DATABASE_URL: postgres://postgres:postgres@localhost:5432/awa_test
+          AWA_TEST_ENGINE: queue_storage
+
   # ─── Rust bridge (tokio-postgres) ──────────────────────
   rust-bridge-tokio-pg:
     name: Rust bridge (tokio-postgres)

--- a/awa-testing/src/lib.rs
+++ b/awa-testing/src/lib.rs
@@ -261,7 +261,7 @@ impl TestClient {
         };
 
         let claimed = store
-            .claim_runtime_batch(&self.pool, &target_queue, 1, Duration::from_secs(300))
+            .claim_runtime_batch(&self.pool, &target_queue, 1, Duration::from_secs(60))
             .await?;
         let claimed = match claimed.into_iter().next() {
             Some(claimed) => claimed,
@@ -291,14 +291,17 @@ impl TestClient {
                 Ok(WorkResult::Retryable(job))
             }
             Err(JobError::Retryable(_)) => {
-                // A retryable error reschedules the job; the store takes an
-                // explicit delay, whose value does not affect the WorkResult.
+                // A retryable error reschedules the job. Canonical leaves it in
+                // a finalized `retryable` state (not re-claimable by a later
+                // `work_one`); the store needs an explicit delay, so use a long
+                // one rather than a near-immediate reschedule that would let the
+                // same job be re-claimed within a test or accumulate across runs.
                 store
                     .retry_after(
                         &self.pool,
                         job.id,
                         job.run_lease,
-                        Duration::from_secs(1),
+                        Duration::from_secs(3600),
                         progress_snapshot,
                     )
                     .await?;
@@ -316,9 +319,14 @@ impl TestClient {
                 // canonical path.
                 match self.get_job(job.id).await?.callback_id {
                     Some(callback_id) => {
-                        store
+                        let entered = store
                             .enter_callback_wait(&self.pool, job.id, job.run_lease, callback_id)
                             .await?;
+                        assert!(
+                            entered,
+                            "enter_callback_wait did not transition job {} to waiting_external",
+                            job.id
+                        );
                         Ok(WorkResult::WaitingExternal(self.get_job(job.id).await?))
                     }
                     None => {

--- a/awa-testing/src/lib.rs
+++ b/awa-testing/src/lib.rs
@@ -64,11 +64,21 @@ impl TestClient {
     }
 
     /// Claim and execute a single job, optionally filtered by queue.
+    ///
+    /// Routes through the active storage engine: under queue storage it claims
+    /// and records the outcome via the runtime store API; under canonical it
+    /// drives the `awa.jobs` view directly.
     pub async fn work_one_in_queue<W: Worker>(
         &self,
         worker: &W,
         queue: Option<&str>,
     ) -> Result<WorkResult, AwaError> {
+        if let Some(schema) =
+            awa_model::queue_storage::QueueStorage::active_schema(&self.pool).await?
+        {
+            return self.work_one_queue_storage(worker, queue, &schema).await;
+        }
+
         // Claim one job
         let jobs: Vec<JobRow> = sqlx::query_as::<_, JobRow>(
             r#"
@@ -102,27 +112,7 @@ impl TestClient {
             None => return Ok(WorkResult::NoJob),
         };
 
-        let cancel = Arc::new(AtomicBool::new(false));
-        let state: Arc<HashMap<std::any::TypeId, Box<dyn Any + Send + Sync>>> =
-            Arc::new(HashMap::new());
-        let progress = Arc::new(std::sync::Mutex::new(ProgressState::new(
-            job.progress.clone(),
-        )));
-        let ctx = JobContext::new_for_testing(
-            job.clone(),
-            cancel,
-            state,
-            self.pool.clone(),
-            progress.clone(),
-        );
-
-        let result = worker.perform(&ctx).await;
-
-        // Snapshot progress from the buffer after handler execution
-        let progress_snapshot: Option<serde_json::Value> = {
-            let guard = progress.lock().expect("progress lock poisoned");
-            guard.clone_latest()
-        };
+        let (result, progress_snapshot) = self.run_handler(&job, worker).await;
 
         // Update job state based on result
         match &result {
@@ -207,6 +197,149 @@ impl TestClient {
                 .bind(&progress_snapshot)
                 .execute(&self.pool)
                 .await?;
+                Ok(WorkResult::Failed(job, msg.clone()))
+            }
+        }
+    }
+
+    /// Build a testing `JobContext`, run the worker, and snapshot any progress
+    /// it buffered. Shared by the canonical and queue-storage work paths.
+    async fn run_handler<W: Worker>(
+        &self,
+        job: &JobRow,
+        worker: &W,
+    ) -> (Result<JobResult, JobError>, Option<serde_json::Value>) {
+        let cancel = Arc::new(AtomicBool::new(false));
+        let state: Arc<HashMap<std::any::TypeId, Box<dyn Any + Send + Sync>>> =
+            Arc::new(HashMap::new());
+        let progress = Arc::new(std::sync::Mutex::new(ProgressState::new(
+            job.progress.clone(),
+        )));
+        let ctx = JobContext::new_for_testing(
+            job.clone(),
+            cancel,
+            state,
+            self.pool.clone(),
+            progress.clone(),
+        );
+        let result = worker.perform(&ctx).await;
+        let snapshot = {
+            let guard = progress.lock().expect("progress lock poisoned");
+            guard.clone_latest()
+        };
+        (result, snapshot)
+    }
+
+    /// Queue-storage variant of [`Self::work_one_in_queue`]: claim, run the
+    /// handler, and record the outcome through the runtime store API rather
+    /// than writing the `awa.jobs` view (which the engine rejects).
+    async fn work_one_queue_storage<W: Worker>(
+        &self,
+        worker: &W,
+        queue: Option<&str>,
+        schema: &str,
+    ) -> Result<WorkResult, AwaError> {
+        use std::time::Duration;
+        let store = awa_model::queue_storage::QueueStorage::from_existing_schema(schema)?;
+
+        // The store claims per queue; when the caller did not pin one, resolve a
+        // queue carrying a ready job of this worker's kind.
+        let target_queue = match queue {
+            Some(queue) => queue.to_string(),
+            None => {
+                let resolved: Option<String> = sqlx::query_scalar(&format!(
+                    "SELECT queue FROM {schema}.ready_entries WHERE kind = $1 ORDER BY job_id ASC LIMIT 1"
+                ))
+                .bind(worker.kind())
+                .fetch_optional(&self.pool)
+                .await?;
+                match resolved {
+                    Some(queue) => queue,
+                    None => return Ok(WorkResult::NoJob),
+                }
+            }
+        };
+
+        let claimed = store
+            .claim_runtime_batch(&self.pool, &target_queue, 1, Duration::from_secs(300))
+            .await?;
+        let claimed = match claimed.into_iter().next() {
+            Some(claimed) => claimed,
+            None => return Ok(WorkResult::NoJob),
+        };
+        let job = claimed.job.clone();
+
+        let (result, progress_snapshot) = self.run_handler(&job, worker).await;
+
+        match &result {
+            Ok(JobResult::Completed) => {
+                store
+                    .complete_runtime_batch(&self.pool, std::slice::from_ref(&claimed))
+                    .await?;
+                Ok(WorkResult::Completed(job))
+            }
+            Ok(JobResult::Cancel(reason)) => {
+                store
+                    .cancel_running(&self.pool, job.id, job.run_lease, reason, progress_snapshot)
+                    .await?;
+                Ok(WorkResult::Cancelled(job, reason.clone()))
+            }
+            Ok(JobResult::RetryAfter(delay)) => {
+                store
+                    .retry_after(&self.pool, job.id, job.run_lease, *delay, progress_snapshot)
+                    .await?;
+                Ok(WorkResult::Retryable(job))
+            }
+            Err(JobError::Retryable(_)) => {
+                // A retryable error reschedules the job; the store takes an
+                // explicit delay, whose value does not affect the WorkResult.
+                store
+                    .retry_after(
+                        &self.pool,
+                        job.id,
+                        job.run_lease,
+                        Duration::from_secs(1),
+                        progress_snapshot,
+                    )
+                    .await?;
+                Ok(WorkResult::Retryable(job))
+            }
+            Ok(JobResult::Snooze(delay)) => {
+                store
+                    .snooze(&self.pool, job.id, job.run_lease, *delay, progress_snapshot)
+                    .await?;
+                Ok(WorkResult::Snoozed(job))
+            }
+            Ok(JobResult::WaitForCallback(_)) => {
+                // The handler registers the callback via the context; park to
+                // waiting_external when it did, otherwise fail like the
+                // canonical path.
+                match self.get_job(job.id).await?.callback_id {
+                    Some(callback_id) => {
+                        store
+                            .enter_callback_wait(&self.pool, job.id, job.run_lease, callback_id)
+                            .await?;
+                        Ok(WorkResult::WaitingExternal(self.get_job(job.id).await?))
+                    }
+                    None => {
+                        let msg = "WaitForCallback returned without calling register_callback";
+                        store
+                            .fail_terminal(
+                                &self.pool,
+                                job.id,
+                                job.run_lease,
+                                msg,
+                                progress_snapshot,
+                            )
+                            .await?;
+                        Ok(WorkResult::Failed(job, msg.to_string()))
+                    }
+                }
+            }
+            Err(JobError::Terminal(msg)) => {
+                store
+                    .fail_terminal(&self.pool, job.id, job.run_lease, msg, progress_snapshot)
+                    .await?;
                 Ok(WorkResult::Failed(job, msg.clone()))
             }
         }

--- a/awa-testing/src/setup.rs
+++ b/awa-testing/src/setup.rs
@@ -49,10 +49,20 @@ pub async fn setup(max_connections: u32) -> PgPool {
     pool
 }
 
-/// Clear any previously-activated runtime backend so legacy integration tests
-/// start from the canonical compatibility surface unless they opt into a
-/// queue-storage runtime explicitly.
+/// Initialise the active storage engine to the one selected by the
+/// `AWA_TEST_ENGINE` env var: `canonical` (default) or `queue_storage`. awa's
+/// caller-facing contract is engine-invariant, so running the same suite under
+/// both values exercises both backends. Tests that pin a specific engine call
+/// [`reset_to_canonical`] / [`activate_queue_storage`] directly.
 pub async fn reset_runtime_backend(pool: &PgPool) {
+    match std::env::var("AWA_TEST_ENGINE").as_deref() {
+        Ok("queue_storage") => activate_queue_storage(pool).await,
+        _ => reset_to_canonical(pool).await,
+    }
+}
+
+/// Force the canonical engine and clear any queue-storage runtime registration.
+pub async fn reset_to_canonical(pool: &PgPool) {
     let mut tx = pool
         .begin()
         .await
@@ -85,6 +95,84 @@ pub async fn reset_runtime_backend(pool: &PgPool) {
     tx.commit()
         .await
         .expect("Failed to commit runtime backend reset transaction");
+}
+
+/// Activate the queue-storage engine against the substrate installed in the
+/// `awa` schema (mirrors a fresh-install auto-finalize).
+pub async fn activate_queue_storage(pool: &PgPool) {
+    let mut tx = pool
+        .begin()
+        .await
+        .expect("Failed to start queue-storage activation transaction");
+
+    sqlx::query(
+        r#"
+        UPDATE awa.storage_transition_state
+        SET state = 'active',
+            current_engine = 'queue_storage',
+            prepared_engine = NULL,
+            details = jsonb_build_object('schema', 'awa'),
+            transition_epoch = transition_epoch + 1,
+            updated_at = now(),
+            finalized_at = now()
+        WHERE singleton
+        "#,
+    )
+    .execute(&mut *tx)
+    .await
+    .expect("Failed to activate queue-storage transition state for test setup");
+    sqlx::query(
+        r#"
+        INSERT INTO awa.runtime_storage_backends (backend, schema_name, updated_at)
+        VALUES ('queue_storage', 'awa', now())
+        ON CONFLICT (backend) DO UPDATE
+        SET schema_name = EXCLUDED.schema_name, updated_at = EXCLUDED.updated_at
+        "#,
+    )
+    .execute(&mut *tx)
+    .await
+    .expect("Failed to register queue-storage backend for test setup");
+    sqlx::query("DELETE FROM awa.runtime_instances")
+        .execute(&mut *tx)
+        .await
+        .expect("Failed to reset runtime instances for test setup");
+    tx.commit()
+        .await
+        .expect("Failed to commit queue-storage activation transaction");
+}
+
+/// The storage engine the suite is running against, selected by `AWA_TEST_ENGINE`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TestEngine {
+    Canonical,
+    QueueStorage,
+}
+
+/// The engine selected for this test run (`canonical` unless `AWA_TEST_ENGINE=queue_storage`).
+pub fn test_engine() -> TestEngine {
+    match std::env::var("AWA_TEST_ENGINE").as_deref() {
+        Ok("queue_storage") => TestEngine::QueueStorage,
+        _ => TestEngine::Canonical,
+    }
+}
+
+/// Guard for tests whose assertions are specific to the canonical engine —
+/// e.g. admin-metadata caches maintained by canonical row triggers, or the
+/// canonical running-cancel notification. Returns `true` (with a skip notice)
+/// when the run is under another engine, so the test can early-return:
+///
+/// ```ignore
+/// if awa_testing::setup::skip_unless_canonical("my_test") { return; }
+/// ```
+pub fn skip_unless_canonical(test: &str) -> bool {
+    if test_engine() != TestEngine::Canonical {
+        eprintln!(
+            "[skip] {test}: canonical-only assertions; running under AWA_TEST_ENGINE=queue_storage"
+        );
+        true
+    } else {
+        false
+    }
 }
 
 /// Delete all jobs, queue metadata, and admin caches for a specific queue.

--- a/awa-testing/src/setup.rs
+++ b/awa-testing/src/setup.rs
@@ -182,11 +182,19 @@ pub fn skip_unless_canonical(test: &str) -> bool {
 /// this, but concurrent test runs against a shared DB can cause small delta
 /// errors that compound over time.
 pub async fn clean_queue(pool: &PgPool, queue: &str) {
-    sqlx::query("DELETE FROM awa.jobs WHERE queue = $1")
-        .bind(queue)
-        .execute(pool)
+    match awa_model::queue_storage::QueueStorage::active_schema(pool)
         .await
-        .expect("Failed to clean queue jobs");
+        .expect("active_schema lookup for clean_queue")
+    {
+        Some(schema) => clean_queue_substrate(pool, &schema, queue).await,
+        None => {
+            sqlx::query("DELETE FROM awa.jobs WHERE queue = $1")
+                .bind(queue)
+                .execute(pool)
+                .await
+                .expect("Failed to clean queue jobs");
+        }
+    }
     sqlx::query("DELETE FROM awa.queue_meta WHERE queue = $1")
         .bind(queue)
         .execute(pool)
@@ -197,6 +205,41 @@ pub async fn clean_queue(pool: &PgPool, queue: &str) {
         .execute(pool)
         .await
         .expect("Failed to clean queue state counts");
+}
+
+/// Drain every job-bearing plane of the queue-storage substrate for one queue
+/// and release its unique claims, so a queue name can be reused across tests
+/// and re-runs against the same database. The canonical `awa.jobs` view only
+/// surfaces a queue's head under queue storage, so a single view `DELETE`
+/// leaves the rest of the lane (and its `job_unique_claims`) behind.
+async fn clean_queue_substrate(pool: &PgPool, schema: &str, queue: &str) {
+    // Release unique claims first, while the rows that carry the job ids exist.
+    sqlx::query(&format!(
+        "DELETE FROM awa.job_unique_claims WHERE job_id IN (
+             SELECT job_id FROM {schema}.ready_entries WHERE queue = $1
+             UNION SELECT job_id FROM {schema}.deferred_jobs WHERE queue = $1
+             UNION SELECT job_id FROM {schema}.leases WHERE queue = $1
+             UNION SELECT job_id FROM {schema}.done_entries WHERE queue = $1
+             UNION SELECT job_id FROM {schema}.dlq_entries WHERE queue = $1)"
+    ))
+    .bind(queue)
+    .execute(pool)
+    .await
+    .expect("Failed to release queue unique claims");
+
+    for plane in [
+        "ready_entries",
+        "deferred_jobs",
+        "leases",
+        "done_entries",
+        "dlq_entries",
+    ] {
+        sqlx::query(&format!("DELETE FROM {schema}.{plane} WHERE queue = $1"))
+            .bind(queue)
+            .execute(pool)
+            .await
+            .unwrap_or_else(|err| panic!("Failed to clean {plane} for queue {queue}: {err}"));
+    }
 }
 
 /// Query job state counts for a queue, returning a map of state -> count.

--- a/awa/tests/integration_test.rs
+++ b/awa/tests/integration_test.rs
@@ -752,6 +752,12 @@ async fn test_work_one_no_job() {
 
 #[tokio::test]
 async fn test_admin_retry() {
+    // Manufactures a failed job via a raw `UPDATE awa.jobs`; queue storage
+    // rejects view writes. The queue-storage retry path is covered by
+    // queue_storage_runtime_test.
+    if awa_testing::setup::skip_unless_canonical("test_admin_retry") {
+        return;
+    }
     let _guard = test_lock().lock().await;
     let client = setup().await;
     let queue = "integ_admin_retry";
@@ -816,6 +822,11 @@ async fn test_admin_cancel() {
 
 #[tokio::test]
 async fn test_admin_cancel_by_unique_key_emits_canonical_running_cancel_notification() {
+    if awa_testing::setup::skip_unless_canonical(
+        "test_admin_cancel_by_unique_key_emits_canonical_running_cancel_notification",
+    ) {
+        return;
+    }
     let _guard = test_lock().lock().await;
     let client = setup_with_connections(4).await;
     let queue = "integ_cancel_by_unique_key_notify";
@@ -1013,6 +1024,14 @@ async fn test_admin_cancel_by_unique_key_returns_none_when_not_found() {
 
 #[tokio::test]
 async fn test_admin_cancel_by_unique_key_noop_when_already_completed() {
+    // Manufactures a completed job via a raw `UPDATE awa.jobs`; queue storage
+    // rejects view writes. The queue-storage cancel-by-unique-key candidate
+    // query is covered by test_admin_cancel_by_unique_key_queue_storage_active.
+    if awa_testing::setup::skip_unless_canonical(
+        "test_admin_cancel_by_unique_key_noop_when_already_completed",
+    ) {
+        return;
+    }
     let _guard = test_lock().lock().await;
     let client = setup().await;
     let queue = "integ_cancel_by_key_completed";
@@ -1117,6 +1136,14 @@ async fn test_admin_cancel_by_unique_key_scheduled_job() {
 
 #[tokio::test]
 async fn test_admin_cancel_by_unique_key_cancels_oldest_when_multiple_exist() {
+    // Relies on multiple non-terminal jobs sharing a unique key (canonical
+    // unique_states semantics) and a raw `UPDATE awa.jobs`; not a queue-storage
+    // scenario.
+    if awa_testing::setup::skip_unless_canonical(
+        "test_admin_cancel_by_unique_key_cancels_oldest_when_multiple_exist",
+    ) {
+        return;
+    }
     let _guard = test_lock().lock().await;
     let client = setup().await;
     let queue = "integ_cancel_by_key_multi";
@@ -1249,43 +1276,6 @@ async fn test_admin_cancel_by_unique_key_mismatched_queue_returns_none() {
     );
 }
 
-/// Force the engine onto the queue-storage substrate the way a fresh install
-/// auto-finalizes onto it — the inverse of `awa_testing::reset_runtime_backend`.
-/// The substrate already exists in the `awa` schema (installed by the
-/// migrations); flipping the transition state and registering the backend is
-/// enough for the admin paths to route there.
-async fn activate_queue_storage(pool: &sqlx::PgPool) {
-    let mut tx = pool.begin().await.unwrap();
-    sqlx::query(
-        r#"
-        UPDATE awa.storage_transition_state
-        SET state = 'active',
-            current_engine = 'queue_storage',
-            prepared_engine = NULL,
-            details = jsonb_build_object('schema', 'awa'),
-            transition_epoch = transition_epoch + 1,
-            updated_at = now(),
-            finalized_at = now()
-        WHERE singleton
-        "#,
-    )
-    .execute(&mut *tx)
-    .await
-    .expect("activate queue-storage transition state");
-    sqlx::query(
-        r#"
-        INSERT INTO awa.runtime_storage_backends (backend, schema_name, updated_at)
-        VALUES ('queue_storage', 'awa', now())
-        ON CONFLICT (backend) DO UPDATE
-        SET schema_name = EXCLUDED.schema_name, updated_at = EXCLUDED.updated_at
-        "#,
-    )
-    .execute(&mut *tx)
-    .await
-    .expect("register queue-storage backend");
-    tx.commit().await.unwrap();
-}
-
 /// `cancel_by_unique_key` and its `_tx` variant must run against the
 /// queue-storage substrate, not only the canonical tables. The queue-storage
 /// candidate query spans the available, deferred, and running-job lookups (the
@@ -1295,7 +1285,7 @@ async fn activate_queue_storage(pool: &sqlx::PgPool) {
 async fn test_admin_cancel_by_unique_key_queue_storage_active() {
     let _guard = test_lock().lock().await;
     let client = setup().await;
-    activate_queue_storage(client.pool()).await;
+    awa_testing::setup::activate_queue_storage(client.pool()).await;
 
     let pool_result = admin::cancel_by_unique_key(
         client.pool(),
@@ -1454,6 +1444,11 @@ async fn test_admin_queue_stats() {
 
 #[tokio::test]
 async fn test_admin_metadata_caches_track_state_and_catalog_changes() {
+    if awa_testing::setup::skip_unless_canonical(
+        "test_admin_metadata_caches_track_state_and_catalog_changes",
+    ) {
+        return;
+    }
     let _guard = test_lock().lock().await;
     let client = setup().await;
     let queue_a = "integ_admin_meta_a";
@@ -1688,6 +1683,11 @@ async fn drain_dirty_for(
 
 #[tokio::test]
 async fn test_admin_metadata_tracks_scheduled_promotion_path() {
+    if awa_testing::setup::skip_unless_canonical(
+        "test_admin_metadata_tracks_scheduled_promotion_path",
+    ) {
+        return;
+    }
     let _guard = test_lock().lock().await;
     let client = setup().await;
     let queue = "integ_admin_meta_promote";
@@ -1872,6 +1872,11 @@ async fn test_heartbeat_progress_updates_do_not_dirty_admin_metadata() {
 /// one 100-key batch.
 #[tokio::test]
 async fn test_flush_dirty_admin_metadata_drains_full_backlog() {
+    if awa_testing::setup::skip_unless_canonical(
+        "test_flush_dirty_admin_metadata_drains_full_backlog",
+    ) {
+        return;
+    }
     let _guard = test_lock().lock().await;
     let client = setup().await;
 

--- a/awa/tests/integration_test.rs
+++ b/awa/tests/integration_test.rs
@@ -51,21 +51,9 @@ async fn setup() -> TestClient {
 /// concurrent test runs against a shared DB can cause small delta errors that
 /// compound over time).
 async fn clean_queue(pool: &sqlx::PgPool, queue: &str) {
-    sqlx::query("DELETE FROM awa.jobs WHERE queue = $1")
-        .bind(queue)
-        .execute(pool)
-        .await
-        .expect("Failed to clean queue jobs");
-    sqlx::query("DELETE FROM awa.queue_meta WHERE queue = $1")
-        .bind(queue)
-        .execute(pool)
-        .await
-        .expect("Failed to clean queue meta");
-    sqlx::query("DELETE FROM awa.queue_state_counts WHERE queue = $1")
-        .bind(queue)
-        .execute(pool)
-        .await
-        .expect("Failed to clean queue state counts");
+    // Engine-aware cleanup lives in the shared harness so a queue name can be
+    // reused across tests and re-runs under either storage engine.
+    awa_testing::setup::clean_queue(pool, queue).await;
 }
 
 async fn run_batch_operation_to_completion(


### PR DESCRIPTION
Part of #360.

## Motivation

awa's caller-facing contract is engine-invariant, but the default test harness forces the **canonical** engine (`reset_runtime_backend`), so the **queue-storage** implementations of that contract were never exercised by the broad integration suite. That blind spot is how the queue-storage `cancel_by_unique_key` candidate query (`{schema}.leases.unique_key`, a column that doesn't exist) shipped — it was dead code to CI until #359.

## Changes

- **`awa-testing`**: `reset_runtime_backend` now honours `AWA_TEST_ENGINE` (`canonical` default | `queue_storage`). Split into `reset_to_canonical` / `activate_queue_storage`, and add `TestEngine` / `test_engine()` / `skip_unless_canonical()`.
- **`awa-testing`**: `work_one_in_queue` is **engine-aware** — under queue storage it claims, runs the handler, and records the outcome through the runtime store API (`claim_runtime_batch` → `complete_runtime_batch` / `retry_after` / `snooze` / `cancel_running` / `fail_terminal` / `enter_callback_wait`) instead of raw `UPDATE awa.jobs` (which the engine rejects). The handler-run is factored into a shared `run_handler`.
- **`integration_test`**: gate the genuinely canonical-only tests with `skip_unless_canonical` — the admin-metadata caches (canonical-trigger bookkeeping), the canonical running-cancel notification, and three tests that manufacture job state via raw `UPDATE awa.jobs` / rely on multiple non-terminal same-key jobs. Their queue-storage equivalents are covered by `queue_storage_runtime_test` + the cancel regression test.

## Result

`cargo test -p awa --test integration_test` is **44/44 under both** `AWA_TEST_ENGINE=canonical` and `AWA_TEST_ENGINE=queue_storage` (verified locally). `fmt` / `clippy -D warnings` clean.

## Remaining for #360

- Forward-compatibility test: version-pinned 0.5.7 enqueue→claim→complete against a V39-migrated DB.
- CI engine-matrix dimension (`engine: [canonical, queue_storage]`) for the correctness suites.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved job execution so tasks are routed correctly when an alternate runtime is active.
  * Added more reliable handling for retries, waiting states, and terminal failures during processing.
  * Reduced test flakiness by skipping incompatible admin/metadata checks in non-default runtime mode.

* **Tests**
  * Updated integration coverage to support both runtime modes and use the shared test setup flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->