### PR TITLE
fix(queue-storage): fold whole partition on queue-ring prune (terminal-count defense-in-depth)

### DIFF
--- a/awa-model/src/queue_storage.rs
+++ b/awa-model/src/queue_storage.rs
@@ -14239,6 +14239,13 @@ impl QueueStorage {
                 FROM {done_child}
                 GROUP BY queue, priority
             ),
+            -- Scan the entire partition being truncated (all generations),
+            -- mirroring done_counts' whole-child scan above. The rotate guard
+            -- keeps a partition to one generation at prune time, so this is the
+            -- same set today; counting the whole child keeps the rollup fold
+            -- conservative even if that invariant is ever weakened (a stray
+            -- generation's batches would otherwise be truncated without being
+            -- folded into the rollup -> terminal-count undercount).
             batch_rows AS (
                 SELECT
                     batch.ready_generation,
@@ -14251,7 +14258,6 @@ impl QueueStorage {
                     batch.job_ids,
                     batch.run_leases
                 ) AS item(job_id, run_lease)
-                WHERE batch.ready_generation = $3
             ),
             batch_counts AS (
                 SELECT
@@ -14288,7 +14294,6 @@ impl QueueStorage {
         ))
         .bind(failed_retention_secs)
         .bind(retention_floor)
-        .bind(generation)
         .fetch_all(tx.as_mut())
         .await
         .map_err(map_sqlx_error)?;


### PR DESCRIPTION
## Context

Follow-up from the terminal-count accounting audit (which otherwise found the accounting **fully symmetric** — no drift bugs). This hardens one inert fragility.

## The fragility

`prune_oldest`'s rollup fold counts the about-to-be-truncated partition into the permanent `queue_terminal_rollups`. It scanned the **entire** `done_entries` partition (`done_counts`, no generation filter) but filtered `receipt_completion_batches` to the current generation (`batch.ready_generation = $3`).

`TRUNCATE` drops the **whole** partition child, so the fold must count the whole child to conserve the terminal total. Today the rotate guard refuses to reuse a slot whose children are non-empty, so a partition holds exactly one generation at prune time → both scans return the same set and there's no drift. But if that ring invariant were ever weakened, a stray generation's compact batches would be truncated **without** being folded → terminal-count **under**count (the `live_terminal` loses a row the rollup never gains).

## Change

Drop the generation filter from `batch_rows` so it mirrors `done_counts`' whole-child scan (and remove the now-unused `$3` bind). This is the conserving direction — *not* adding the filter to `done_counts`, which would make the already-correct done side undercount.

- No behavior change under the current invariant (one generation per partition at prune).
- Defense-in-depth so the rollup fold conserves regardless of how many generations a partition holds at truncate time.

## Validation

`fmt` / `clippy -D warnings` clean. Ran the queue-ring prune + compact-completion + count tests:
`..._closes_via_batch_and_queue_prunes` (rescued + cancelled), `prune_carries_failed_rows_inside_retention_floor`, `sql_compat_delete_tombstones_compact_receipt_completion`, `queue_counts_fast_matches_exact_on_steady_state`, and the stripe/legacy-rollup count tests — **8/8 pass**.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved retention cleanup so completed items are counted more accurately across all batches, reducing the chance of incorrect carryover during pruning.
  * Fixed an issue where terminal counts could be miscalculated in some edge cases, helping queue storage stay consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->