### PR TITLE
ci: shard the Rust tests job; nextest-partition the migration suite

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,21 @@
+# Used by the CI migration shards (scripts/ci-test-shard.sh); harmless for
+# local `cargo nextest run`.
+#
+# The slow-timeout only FLAGS tests, it never kills them — it is the durable
+# per-run list of >60s tests that #335's real-time-window audit works from.
+#
+# migration_test runs one test process at a time: most of its tests already
+# serialize through a Postgres advisory lock, but a few schema-bootstrap
+# tests predate the guard and race on CREATE SCHEMA under concurrent
+# processes. Serial execution costs nothing — the advisory lock was already
+# the effective concurrency limit — and shard-level parallelism comes from
+# each CI shard owning its own Postgres.
+[profile.default]
+slow-timeout = { period = "60s" }
+
+[test-groups]
+migrations = { max-threads = 1 }
+
+[[profile.default.overrides]]
+filter = 'binary(migration_test)'
+test-group = 'migrations'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,8 @@ jobs:
         run: cargo fmt --all -- --check
       - name: cargo clippy
         run: cargo clippy --workspace --all-targets --all-features -- -D warnings
+      - name: Check CI test-shard membership
+        run: ./scripts/ci-test-shard.sh check
 
   rust-build:
     name: Rust build
@@ -53,13 +55,27 @@ jobs:
         run: cargo build --workspace
 
   rust-test:
-    name: Rust tests
+    name: Rust tests (${{ matrix.shard }})
     needs: [rust-build]
     if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'full-ci')
     runs-on: ubuntu-latest
-    # Migration replay tests are intentionally exhaustive for queue-storage
-    # upgrade safety and can take ~25m on GitHub-hosted runners by themselves.
-    timeout-minutes: 60
+    # Sharded per #335: the migration replay suite alone took ~22 minutes as
+    # one binary, so it is partitioned per-test across four shards with
+    # cargo-nextest, the other slow binaries form `heavy`, and everything
+    # else (including new test files, automatically) lands in `rest`.
+    # Shard membership lives in scripts/ci-test-shard.sh; the lint job runs
+    # its `check` mode so renames can't silently drop coverage.
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        shard:
+          - migrations-1
+          - migrations-2
+          - migrations-3
+          - migrations-4
+          - heavy
+          - rest
     services:
       postgres:
         image: postgres:17-alpine
@@ -76,13 +92,16 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-nextest
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: ". -> target"
       - name: Wait for Postgres
         run: until pg_isready -h localhost -p 5432; do sleep 1; done
-      - name: Run tests
-        run: cargo test --workspace
+      - name: Run test shard
+        run: ./scripts/ci-test-shard.sh "${{ matrix.shard }}"
         env:
           DATABASE_URL: postgres://postgres:postgres@localhost:5432/awa_test
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ Notable changes between releases. Detailed migration notes for storage transitio
 - **Worker health & readiness endpoints ([#368](https://github.com/hardbyte/awa/issues/368)).** Opt-in HTTP listener in the worker runtime (`AWA_HEALTH_ADDR` or `ClientBuilder::health_addr`): `GET /healthz` (process liveness, stays `200` through graceful drain) and `GET /readyz` (`503` + JSON reasons when Postgres is unreachable, the schema is older than the binary, a claim loop stalls, heartbeat/maintenance die, or shutdown starts). No new dependencies in `awa-worker`. Kubernetes probe examples in `docs/deployment.md`.
 - **`awa health` CLI probe.** Cluster-level readiness from the database alone (reachable, schema migrated for this binary, storage state, fleet heartbeat counts) with `--json` output and exit codes for probe-less environments.
 
+### Internal
+
+- **CI: the Rust tests job is sharded ([#335](https://github.com/hardbyte/awa/issues/335)).** One `cargo test --workspace` run took ~31 minutes, ~22 of them the migration replay binary alone. The job is now a six-way matrix: the migration suite partitioned per-test across four shards with `cargo-nextest` (safe because those tests already serialize through a Postgres advisory lock), the other slow binaries in a `heavy` shard, and everything else — including any new test file, automatically — in `rest`. Shard membership lives in `scripts/ci-test-shard.sh`; the lint job validates it so renames can't drop coverage, and the nextest profile flags any test slower than 60s as the standing worklist for shrinking real-time fixture windows.
+
 ## [0.6.1] — 2026-07-07
 
 Patch release: one canonical-engine bug fix, no migrations, no API changes.

--- a/awa/tests/migration_test.rs
+++ b/awa/tests/migration_test.rs
@@ -1,8 +1,9 @@
 //! Migration tests: step-through upgrade, data survival, idempotency,
 //! and migration_sql() consistency.
 //!
-//! **Must run with `--test-threads=1`** — these tests drop and recreate
-//! the `awa` schema, which would break concurrent tests.
+//! Tests serialize through a Postgres advisory lock (plus a process-local
+//! mutex), so they are safe under parallel threads and under per-test
+//! processes — CI shards this binary with `cargo nextest --partition`.
 //!
 //! Set DATABASE_URL=postgres://postgres:test@localhost:15432/awa_test
 
@@ -86,10 +87,19 @@ async fn ensure_migration_database() {
     .await
     .expect("Failed to check migration database existence");
     if !exists {
-        sqlx::raw_sql("CREATE DATABASE awa_migration_test")
+        // Tolerate the duplicate-database race: under per-test processes
+        // (cargo-nextest CI shards) another test can create it between the
+        // existence check and this statement.
+        if let Err(err) = sqlx::raw_sql("CREATE DATABASE awa_migration_test")
             .execute(&mut admin)
             .await
-            .expect("Failed to create migration test database");
+        {
+            let duplicate = matches!(
+                &err,
+                sqlx::Error::Database(db_err) if db_err.code().as_deref() == Some("42P04")
+            );
+            assert!(duplicate, "Failed to create migration test database: {err}");
+        }
     }
 }
 

--- a/docs/test-plan.md
+++ b/docs/test-plan.md
@@ -304,6 +304,14 @@ Planned test matrix for the 0.7 cycle, mapped to the roadmap ([`0.7-roadmap.md`]
 
 ## Running Tests
 
+CI runs the Rust suite as a sharded matrix (`scripts/ci-test-shard.sh`): the
+migration replay binary is partitioned per-test with `cargo-nextest`, the
+other slow binaries form a `heavy` shard, and every remaining test target —
+including newly added files, automatically — runs in `rest`. Locally,
+`cargo test --workspace` remains the equivalent single command; individual
+shards can be reproduced with e.g. `./scripts/ci-test-shard.sh heavy`.
+
+
 ```bash
 # Start Postgres
 docker run -d --name awa-pg -e POSTGRES_PASSWORD=test -e POSTGRES_DB=awa_test -p 15432:5432 postgres:18-alpine

--- a/scripts/ci-test-shard.sh
+++ b/scripts/ci-test-shard.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# CI sharding for the `Rust tests` job (#335).
+#
+# The suite is split into parallel CI shards so wall-clock cost is the
+# slowest shard, not the sum. Timing basis (main run 28783383104):
+# migration_test alone was 1339s of the ~31-minute job, so it is
+# partitioned per-test with cargo-nextest (each test in its own process;
+# the suite's Postgres advisory locks already serialize schema access
+# across processes). The other named binaries form the `heavy` shard;
+# EVERYTHING ELSE is the `rest` shard, computed by subtraction — a new
+# test file lands in `rest` automatically and can never be forgotten.
+#
+# `check` mode (run by the lint job) fails when a named binary disappears,
+# so renames can't silently drop coverage.
+set -euo pipefail
+
+MIGRATION_PARTITIONS=4
+
+HEAVY_TESTS=(
+  executor_guard_test
+  lifecycle_hook_test
+  queue_storage_runtime_test
+  external_wait_test
+  cel_callback_test
+)
+
+ASSIGNED_ELSEWHERE=(
+  migration_test
+  "${HEAVY_TESTS[@]}"
+)
+
+list_awa_test_files() {
+  for f in awa/tests/*.rs; do
+    basename "$f" .rs
+  done
+}
+
+rest_test_args() {
+  local name assigned
+  for name in $(list_awa_test_files); do
+    assigned=false
+    for a in "${ASSIGNED_ELSEWHERE[@]}"; do
+      if [ "$name" = "$a" ]; then
+        assigned=true
+        break
+      fi
+    done
+    $assigned || printf -- '--test %s ' "$name"
+  done
+}
+
+check() {
+  local missing=0
+  for a in "${ASSIGNED_ELSEWHERE[@]}"; do
+    if [ ! -f "awa/tests/${a}.rs" ]; then
+      echo "ci-test-shard.sh: shard references missing test file awa/tests/${a}.rs" >&2
+      missing=1
+    fi
+  done
+  if [ "$missing" -ne 0 ]; then
+    echo "Update HEAVY_TESTS / ASSIGNED_ELSEWHERE in scripts/ci-test-shard.sh" >&2
+    exit 1
+  fi
+  echo "shard membership OK: $(list_awa_test_files | wc -l) awa test files," \
+    "${#ASSIGNED_ELSEWHERE[@]} explicitly assigned, rest-shard covers the remainder"
+}
+
+shard="${1:?usage: ci-test-shard.sh <check|migrations-K|heavy|rest>}"
+
+case "$shard" in
+  check)
+    check
+    ;;
+  migrations-*)
+    part="${shard#migrations-}"
+    cargo nextest run -p awa --test migration_test \
+      --partition "count:${part}/${MIGRATION_PARTITIONS}"
+    ;;
+  heavy)
+    args=()
+    for t in "${HEAVY_TESTS[@]}"; do args+=(--test "$t"); done
+    cargo test -p awa "${args[@]}"
+    ;;
+  rest)
+    # awa unit tests + every test binary not assigned elsewhere, then the
+    # rest of the workspace (tests + doctests), then awa's own doctests.
+    # Together with the other shards this mirrors `cargo test --workspace`.
+    # shellcheck disable=SC2046
+    cargo test -p awa --lib --bins $(rest_test_args)
+    cargo test --workspace --exclude awa
+    cargo test -p awa --doc
+    ;;
+  *)
+    echo "unknown shard: $shard" >&2
+    exit 2
+    ;;
+esac


### PR DESCRIPTION
Closes #335 (roadmap WS-1, P0 — "do first, it multiplies every later item").

## Data

From main run 28783383104: the single `cargo test --workspace` job took **~31 minutes**, of which `migration_test` alone was **1,339s (~22 min)** — its tests serialize through a Postgres advisory lock, so within-binary thread parallelism never helped. Next: `executor_guard` 131s, `lifecycle_hook` 110s, `queue_storage_runtime` 98s, `external_wait`/`cel_callback` ~34s each; everything else ≈ 90s combined.

## Design

Six-way matrix, each shard with its own Postgres service (`timeout-minutes: 20`, down from 60):

- **migrations-1..4** — `cargo nextest run --partition count:K/4` over `migration_test`. Per-test processes are what makes the dominant binary divisible at all. A nextest **test-group (`max-threads = 1`)** runs the binary one process at a time within a shard: a few schema-bootstrap tests predate the advisory-lock guard and race on `CREATE SCHEMA` under concurrent processes — and serial execution costs nothing, because the advisory lock was already the effective concurrency limit. `ensure_migration_database` tolerates the cross-process duplicate-database race (42P04).
- **heavy** — the other slow binaries, plain `cargo test` (same thread semantics as today).
- **rest** — awa unit tests + **every test binary not assigned elsewhere, computed by subtraction** + `--workspace --exclude awa` + doctests. New test files are covered automatically and can never be forgotten; together the shards mirror `cargo test --workspace` exactly.

**Coverage guard:** shard membership lives in one place (`scripts/ci-test-shard.sh`); the lint job runs its `check` mode, so renaming/removing a named test file fails fast instead of silently dropping coverage.

**Timing visibility** (issue item 2): the nextest profile flags every >60s test in output — the durable slowest-tests list the issue asked for, feeding the real-time-window audit (item 3), which is deliberately left as follow-up with this instrumentation in place.

## Validation

- `./scripts/ci-test-shard.sh check`: 36 test files, 6 explicitly assigned, rest covers the remainder.
- Local isolated runs: **migrations-1: 13/13 in 293s (~4.9 min)**; **heavy: all green (~4.5 min)**; **rest: all green**. Worst projected CI shard ≈ setup + ~6 min — under the 8-minute target.
- A cautionary local finding worth recording: running two shards against **one** Postgres produced cross-shard flakes (shared `max_connections`); the design depends on per-shard services, which the matrix provides.
- This PR's own `full-ci` run is the end-to-end validation of the matrix itself — please eyeball the per-shard durations on it.

## Not in scope

Shrinking the >60s real-time windows themselves (issue item 3) and per-binary DB-setup dedup (item 4) — both now have standing instrumentation to work from.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * CI now runs Rust tests in parallel shards for faster, more scalable execution.
  * Migration tests are split and run safely with serialized database access where needed.

* **Bug Fixes**
  * Improved handling of duplicate test database creation to avoid flaky failures.
  * Added safeguards to keep shard coverage accurate when tests are renamed or added.

* **Documentation**
  * Updated test-running docs to explain how to reproduce the CI shard setup locally.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->