### PR TITLE
test: nightly binary/schema compat matrix with pinned release artifacts

### DIFF
--- a/.github/workflows/nightly-chaos.yml
+++ b/.github/workflows/nightly-chaos.yml
@@ -30,6 +30,39 @@ jobs:
       - name: Run TLC model suite
         run: ./correctness/run-tlc-suite.sh
 
+  compat-matrix:
+    name: Binary/schema compat matrix
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    services:
+      postgres:
+        image: postgres:17-alpine
+        env:
+          POSTGRES_PASSWORD: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: ". -> target"
+      - uses: astral-sh/setup-uv@v5
+      - name: Build current awa CLI
+        run: cargo build -p awa-cli
+      - name: Run compat matrix (pinned release artifacts vs newest schema)
+        run: ./scripts/compat-matrix.sh
+        env:
+          PGHOST: localhost
+          PGPORT: "5432"
+          PGUSER: postgres
+          PGPASSWORD: postgres
+
   postgres-failover-smoke:
     name: Postgres failover smoke
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ correctness/**/*_TTrace_*.tla
 # Benchmark run artifacts
 /benchmarks/portable/results/
 /benchmarks/portable/awa-bench/target/
+.compat-venv-*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ Notable changes between releases. Detailed migration notes for storage transitio
 
 ### Internal
 
+- **Nightly binary/schema compat matrix ([#367](https://github.com/hardbyte/awa/issues/367)).** Pinned release artifacts (`awa-pg` 0.6.0 and 0.5.7 wheels from PyPI) run against the newest schema every night: the 0.6.0 leg asserts the full job lifecycle on a finalized cluster; the 0.5.7 leg asserts the documented asymmetry (producers route through the compat layer to the active engine, workers are inert); the backward-guard leg asserts the newest `awa migrate` refuses an old unfinalized schema with the exact finalize-steps message and a non-zero exit. The support statement lives in `docs/stability.md`.
+
 - **CI: the Rust tests job is sharded ([#335](https://github.com/hardbyte/awa/issues/335)).** One `cargo test --workspace` run took ~31 minutes, ~22 of them the migration replay binary alone. The job is now a six-way matrix: the migration suite partitioned per-test across four shards with `cargo-nextest` (safe because those tests already serialize through a Postgres advisory lock), the other slow binaries in a `heavy` shard, and everything else — including any new test file, automatically — in `rest`. Shard membership lives in `scripts/ci-test-shard.sh`; the lint job validates it so renames can't drop coverage, and the nextest profile flags any test slower than 60s as the standing worklist for shrinking real-time fixture windows.
 
 ## [0.6.1] — 2026-07-07

--- a/awa-cli/src/main.rs
+++ b/awa-cli/src/main.rs
@@ -468,7 +468,17 @@ struct RetryFailedArgs {
 }
 
 #[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
+async fn main() {
+    // Errors render through Display, not the derive(Debug) shape: operator
+    // guidance (e.g. the ADR-037 migrate-gate message naming the finalize
+    // steps) lives in the Display impls and must reach the terminal.
+    if let Err(err) = run().await {
+        eprintln!("error: {err}");
+        std::process::exit(1);
+    }
+}
+
+async fn run() -> Result<(), Box<dyn std::error::Error>> {
     tracing_subscriber::fmt()
         .with_env_filter(
             tracing_subscriber::EnvFilter::try_from_default_env()

--- a/docs/stability.md
+++ b/docs/stability.md
@@ -42,11 +42,21 @@ changelog will say so explicitly.
 ## What "supported" means for binary/schema skew
 
 Rolling deploys create windows where an older binary runs against a newer schema. The support
-statement (maintained with [#367](https://github.com/hardbyte/awa/issues/367)):
+statement, asserted nightly by `scripts/compat-matrix.sh` against **pinned release
+artifacts** ([#367](https://github.com/hardbyte/awa/issues/367)):
 
-- A binary one minor version behind the schema must either work correctly or fail loudly and
-  legibly — never silently misbehave.
-- A newer binary against an older schema refuses to run and names the migration step.
+- **One minor behind (0.6.x binary, 0.7 schema):** full lifecycle supported — enqueue,
+  claim, complete, cancel — on a finalized cluster. Asserted with the published
+  `awa-pg==0.6.0` wheel.
+- **Two minors behind (0.5.x binary, finalized schema):** asymmetric. *Producers* keep
+  working — the `awa.jobs` compatibility routing sends their inserts to the active engine.
+  *Workers* are inert: they claim from the canonical hot table, which is empty on a
+  finalized cluster. Upgrade workers before or with the finalize step.
+- **Newer binary, older unfinalized schema:** `awa migrate` refuses loudly (exit non-zero,
+  message names the exact finalize steps) rather than upgrading over live canonical work —
+  the [ADR-037](adr/037-canonical-engine-deprecation.md) gate. Asserted against a 0.5.7-era
+  schema carrying a canonical job; the pre-migrate-0.6 variant of this leg activates
+  automatically once the 0.7 line ships its first migration.
 - The 0.7 boundary additionally requires a finalized queue-storage transition (ADR-037).
 
 ## Relationship to release notes

--- a/docs/test-plan.md
+++ b/docs/test-plan.md
@@ -254,9 +254,9 @@ Planned test matrix for the 0.7 cycle, mapped to the roadmap ([`0.7-roadmap.md`]
 | --- | --- | --- | --- | --- |
 | V1 | Broad integration suite green under `AWA_TEST_ENGINE=queue_storage` | ✓ | ✓ | #360 |
 | V2 | Engine guard rejects canonical-only raw-SQL helpers under queue_storage | ✓ |  | #360 |
-| V3 | Pinned 0.6.0 binary: enqueue→claim→complete→cancel against 0.7 schema | ✓ | ✓ | #367 |
-| V4 | 0.7 binary against pre-migrate 0.6 schema fails loudly (message + exit code asserted) | ✓ |  | #367 |
-| V5 | `awa migrate` refuses non-`active` storage state, names finalize steps | ✓ |  | #370 |
+| V3 | Pinned 0.6.0 binary: enqueue→claim→complete→cancel against 0.7 schema | | ✓ | #367 — nightly `scripts/compat-matrix.sh` (awa-pg 0.6.0 wheel; a pinned native-binary leg can extend it) |
+| V4 | Newest binary against a pre-migrate old schema fails loudly (message + exit code asserted) | ✓ |  | #367 — asserted against a 0.5.7 schema with canonical work; the 0.6-schema variant activates with the first 0.7 migration |
+| V5 | `awa migrate` refuses non-`active` storage state, names finalize steps | ✓ |  | #370 — `migration_test` gate tests + the nightly backward-guard leg |
 
 ### Deployment & operations
 

--- a/scripts/compat-matrix.sh
+++ b/scripts/compat-matrix.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# Binary/schema compatibility matrix (#367), run nightly.
+#
+# Rolling deploys guarantee old binaries run against the newest schema and
+# the newest binary meets not-yet-migrated schemas. This harness exercises
+# those skews with PINNED RELEASE ARTIFACTS (awa-pg wheels from PyPI — the
+# compiled runtime, not a source build of an old tag):
+#
+#   forward-0.6.0   full lifecycle (enqueue/claim/complete/cancel) against
+#                   the newest schema, finalized to queue storage.
+#   forward-0.5.7   producers still route through the compat layer to the
+#                   active engine; workers are inert (canonical hot table is
+#                   empty on a finalized cluster). Asserted, not assumed.
+#   backward-guard  the newest `awa migrate` against a 0.5.7-era schema with
+#                   live canonical work refuses loudly (ADR-037 gate) —
+#                   message content and exit code asserted.
+#
+# A second backward sub-leg (newest binary vs pre-migrate 0.6 schema)
+# activates automatically once the 0.7 line ships its first migration:
+# today both binaries share CURRENT_VERSION so there is nothing pending to
+# gate. The support statement lives in docs/stability.md.
+set -euo pipefail
+
+PGHOST=${PGHOST:-localhost}
+PGPORT=${PGPORT:-5432}
+PGUSER=${PGUSER:-postgres}
+PGPASSWORD=${PGPASSWORD:-postgres}
+export PGPASSWORD
+BASE_URL="postgres://${PGUSER}:${PGPASSWORD}@${PGHOST}:${PGPORT}"
+FWD_DB=awa_compat_forward
+BACK_DB=awa_compat_backward
+SCRIPT_DIR=$(cd -- "$(dirname -- "$0")" && pwd)
+AWA_BIN=${AWA_BIN:-target/debug/awa}
+
+psql_admin() { psql "${BASE_URL}/postgres" -v ON_ERROR_STOP=1 -qAt -c "$1"; }
+
+echo "── setup: fresh databases"
+psql_admin "DROP DATABASE IF EXISTS ${FWD_DB} WITH (FORCE)"
+psql_admin "DROP DATABASE IF EXISTS ${BACK_DB} WITH (FORCE)"
+psql_admin "CREATE DATABASE ${FWD_DB}"
+psql_admin "CREATE DATABASE ${BACK_DB}"
+
+echo "── setup: newest schema on ${FWD_DB}, finalized to queue storage"
+"$AWA_BIN" --database-url "${BASE_URL}/${FWD_DB}" migrate
+# Fresh-install finalize, exactly what a first worker's
+# awa.storage_auto_finalize_if_fresh would do (valid because the database
+# has no jobs and no runtimes).
+psql "${BASE_URL}/${FWD_DB}" -v ON_ERROR_STOP=1 -q <<'SQL'
+UPDATE awa.storage_transition_state
+SET state = 'active',
+    current_engine = 'queue_storage',
+    prepared_engine = NULL,
+    details = jsonb_build_object('schema', 'awa', 'auto_finalized', true),
+    transition_epoch = transition_epoch + 1,
+    updated_at = now(),
+    finalized_at = now()
+WHERE singleton;
+INSERT INTO awa.runtime_storage_backends (backend, schema_name, updated_at)
+VALUES ('queue_storage', 'awa', now())
+ON CONFLICT (backend) DO UPDATE
+SET schema_name = EXCLUDED.schema_name, updated_at = EXCLUDED.updated_at;
+SQL
+
+echo "── setup: pinned release artifacts (PyPI wheels)"
+uv venv --quiet --clear .compat-venv-060
+uv pip install --quiet --python .compat-venv-060 "awa-pg==0.6.0"
+uv venv --quiet --clear .compat-venv-057
+uv pip install --quiet --python .compat-venv-057 "awa-pg==0.5.7"
+
+echo "── leg: forward-0.6.0 (full lifecycle on newest schema)"
+DATABASE_URL="${BASE_URL}/${FWD_DB}" .compat-venv-060/bin/python "${SCRIPT_DIR}/compat/forward_060.py"
+
+echo "── leg: forward-0.5.7 (producer routes, worker inert)"
+DATABASE_URL="${BASE_URL}/${FWD_DB}" .compat-venv-057/bin/python "${SCRIPT_DIR}/compat/forward_057.py"
+routed=$(psql "${BASE_URL}/${FWD_DB}" -qAt -c \
+  "SELECT count(*) FROM awa.jobs WHERE queue = 'compat_legacy'")
+hot=$(psql "${BASE_URL}/${FWD_DB}" -qAt -c \
+  "SELECT count(*) FROM awa.jobs_hot WHERE queue = 'compat_legacy'")
+if [ "$routed" != "1" ] || [ "$hot" != "0" ]; then
+  echo "FAIL: 0.5.7 insert should route to the active engine (view=$routed, jobs_hot=$hot)" >&2
+  exit 1
+fi
+echo "0.5.7 insert routed to queue storage (visible in view, absent from jobs_hot)"
+
+echo "── leg: backward guard (newest migrate refuses old unfinalized schema)"
+DATABASE_URL="${BASE_URL}/${BACK_DB}" .compat-venv-057/bin/python "${SCRIPT_DIR}/compat/backward_prepare_057.py"
+set +e
+gate_output=$("$AWA_BIN" --database-url "${BASE_URL}/${BACK_DB}" migrate 2>&1)
+gate_rc=$?
+set -e
+if [ "$gate_rc" -eq 0 ]; then
+  echo "FAIL: newest migrate must refuse a 0.5.7 schema with canonical work" >&2
+  echo "$gate_output"
+  exit 1
+fi
+case "$gate_output" in
+  *"storage transition not finalized"*"awa storage prepare"*) ;;
+  *)
+    echo "FAIL: refusal must name the finalize steps; got:" >&2
+    echo "$gate_output"
+    exit 1
+    ;;
+esac
+echo "newest migrate refused legibly (exit ${gate_rc}, names the finalize steps)"
+
+echo
+echo "compat matrix: all legs behaved as documented"

--- a/scripts/compat/backward_prepare_057.py
+++ b/scripts/compat/backward_prepare_057.py
@@ -1,0 +1,26 @@
+"""Create a genuinely old (0.5.7-era) schema with live canonical work, as
+the backward-guard fixture: the newest binary's `awa migrate` must refuse
+it loudly (ADR-037 gate) rather than upgrade over live canonical jobs."""
+
+import asyncio
+import os
+import sys
+from dataclasses import dataclass
+
+import awa
+
+
+@dataclass
+class LegacyJob:
+    marker: str
+
+
+async def main() -> int:
+    client = awa.AsyncClient(os.environ["DATABASE_URL"])
+    await client.migrate()
+    inserted = await client.insert(LegacyJob(marker="stranded"), queue="compat_backward")
+    print(f"0.5.7 schema prepared with canonical job {inserted.id}")
+    return 0
+
+
+sys.exit(asyncio.run(main()))

--- a/scripts/compat/forward_057.py
+++ b/scripts/compat/forward_057.py
@@ -1,0 +1,42 @@
+"""Forward-compat leg for the 0.5.x line against the newest (finalized)
+schema. The supported statement is asymmetric: 0.5.7 *producers* keep
+working (the compat routing on `awa.jobs` sends their inserts to the
+active engine), while 0.5.7 *workers* are inert — they claim from the
+canonical hot table, which is empty on a finalized cluster. This leg
+asserts both halves. Runs under the awa-pg 0.5.7 wheel from PyPI."""
+
+import asyncio
+import os
+import sys
+from dataclasses import dataclass
+
+import awa
+
+
+@dataclass
+class LegacyProducerJob:
+    marker: str
+
+
+async def main() -> int:
+    client = awa.AsyncClient(os.environ["DATABASE_URL"])
+
+    inserted = await client.insert(
+        LegacyProducerJob(marker="from-0.5.7"), queue="compat_legacy"
+    )
+    print(f"0.5.7 producer inserted job {inserted.id}")
+
+    @client.task(LegacyProducerJob, queue="compat_legacy")
+    async def handle(job: LegacyProducerJob):
+        # Reaching here would falsify the documented worker inertness.
+        print("FAIL: 0.5.7 worker claimed a job on a finalized cluster", file=sys.stderr)
+        os._exit(1)
+
+    await client.start([("compat_legacy", 2)])
+    await asyncio.sleep(10)
+    await client.shutdown()
+    print("FORWARD-0.5.7 PASS (producer routed, worker inert)")
+    return 0
+
+
+sys.exit(asyncio.run(main()))

--- a/scripts/compat/forward_060.py
+++ b/scripts/compat/forward_060.py
@@ -1,0 +1,60 @@
+"""Forward-compat leg: a pinned awa-pg 0.6.x release runs the full job
+lifecycle against the newest schema (enqueue -> claim -> complete, plus
+cancel). Runs under the 0.6.0 wheel from PyPI — a real release artifact,
+not a source build. Exits non-zero on any contract violation."""
+
+import asyncio
+import os
+import sys
+from dataclasses import dataclass
+
+import awa
+
+
+@dataclass
+class CompatJob:
+    marker: str
+
+
+async def main() -> int:
+    client = awa.AsyncClient(os.environ["DATABASE_URL"])
+    done = asyncio.Event()
+
+    @client.task(CompatJob, queue="compat_forward")
+    async def handle(job: CompatJob):
+        if job.args.marker == "lifecycle":
+            done.set()
+
+    inserted = await client.insert(CompatJob(marker="lifecycle"), queue="compat_forward")
+    print(f"inserted job {inserted.id}")
+
+    # A parked job to exercise admin cancel against the new schema.
+    import datetime
+
+    parked = await client.insert(
+        CompatJob(marker="parked"),
+        queue="compat_forward_parked",
+        run_at=datetime.datetime.now(datetime.timezone.utc)
+        + datetime.timedelta(hours=1),
+    )
+
+    await client.start([("compat_forward", 2)])
+    try:
+        await asyncio.wait_for(done.wait(), timeout=60)
+    except asyncio.TimeoutError:
+        print("FAIL: 0.6.0 worker never completed the job", file=sys.stderr)
+        return 1
+    print("lifecycle job completed by 0.6.0 worker")
+
+    cancelled = await client.cancel(parked.id)
+    if cancelled is None or str(cancelled.state) not in ("JobState.CANCELLED", "cancelled"):
+        print(f"FAIL: cancel returned {cancelled}", file=sys.stderr)
+        return 1
+    print("parked job cancelled")
+
+    await client.shutdown()
+    print("FORWARD-0.6.0 PASS")
+    return 0
+
+
+sys.exit(asyncio.run(main()))


### PR DESCRIPTION
Closes #367 (roadmap WS-1, P0 — the safety net #360 identified as missing: no test ran a genuinely old binary against the newest schema).

## Design

`scripts/compat-matrix.sh`, run as a new nightly job, exercises the supported skews with **pinned PyPI wheels** (`awa-pg` 0.6.0 and 0.5.7 — compiled release artifacts containing the Rust core, not source builds of old tags):

| Leg | Asserts |
| --- | --- |
| **forward-0.6.0** | Full lifecycle — enqueue → claim → complete → cancel — on the newest schema, finalized to queue storage (the fresh-install-equivalent SQL finalize a first worker would perform). |
| **forward-0.5.7** | The documented asymmetry, from both sides: the 0.5.7 *producer* insert routes through the `awa.jobs` compat layer to the active engine (asserted visible in the view **and** absent from `jobs_hot`), while the 0.5.7 *worker* is inert on a finalized cluster (a handler invocation fails the leg). |
| **backward guard** | The newest `awa migrate` against a 0.5.7-era schema carrying live canonical work refuses — non-zero exit **and** message naming the finalize steps, both asserted (the ADR-037 gate from #386). The pre-migrate-0.6 sub-leg activates automatically once the 0.7 line ships its first migration; today both lines share `CURRENT_VERSION`, so there is nothing pending to gate. |

## Found by the harness on its first run

`awa-cli` rendered fatal errors through the default `Result`-in-`main` **Debug** path — operators saw `Error: StorageNotFinalized { state: "canonical" }` instead of the Display message with the finalize steps. Every operator-guidance string in the error types was unreachable from the CLI. `main()` now prints Display and exits 1 (all `awa-cli` suites re-verified: 13/13 across the four test files).

## Docs

`docs/stability.md`'s skew section is now the concrete support statement (one-minor-behind: full lifecycle; two-minors: producers work, workers inert — upgrade workers with the finalize step; newer-binary-vs-unfinalized: legible refusal). Test-plan rows V3–V5 annotated with how each is covered; CHANGELOG entry under Internal.

## Validation

Full matrix green locally against Postgres 18 (all three legs, output above each assertion). The nightly job needs one CI run — dispatching `nightly-chaos.yml` on this branch alongside the regular `full-ci` run.

## Follow-ups

- A pinned **native-binary** leg (the release Docker image driving `awa` CLI operations against the newest schema) would extend V3's Rust column; the wheel already pins the compiled core.
- When v40 lands, flip the backward guard's second sub-leg from dormant to asserted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added nightly compatibility checks to validate older and newer versions against the latest database schema.
  * Expanded compatibility coverage for job lifecycle, inactive workers on finalized clusters, and upgrade-time schema rejection.

* **Bug Fixes**
  * Improved command-line error handling so failures are reported more clearly and exit with a non-zero status.

* **Documentation**
  * Updated support and test-plan guidance to describe the compatibility expectations more precisely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->