### PR TITLE
review followups for #398: JSON contract on missing rows, refresh-cadence floor, ADR wording

### DIFF
--- a/awa-cli/src/main.rs
+++ b/awa-cli/src/main.rs
@@ -1269,105 +1269,106 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
                     }
                 },
 
-                Commands::Queue { command } => {
-                    match command {
-                        QueueCommands::Pause { queue } => {
-                            awa_model::admin::pause_queue(&pool, &queue, Some("cli")).await?;
-                            println!("Paused queue '{queue}'");
+                Commands::Queue { command } => match command {
+                    QueueCommands::Pause { queue } => {
+                        awa_model::admin::pause_queue(&pool, &queue, Some("cli")).await?;
+                        println!("Paused queue '{queue}'");
+                    }
+                    QueueCommands::Resume { queue } => {
+                        awa_model::admin::resume_queue(&pool, &queue).await?;
+                        println!("Resumed queue '{queue}'");
+                    }
+                    QueueCommands::Drain { queue } => {
+                        let count = awa_model::admin::drain_queue(&pool, &queue).await?;
+                        println!("Drained {count} jobs from queue '{queue}'");
+                    }
+                    QueueCommands::Overrides { command } => match command {
+                        OverrideCommands::Set {
+                            queue,
+                            poll_interval_ms,
+                            claim_batch_size,
+                            rate_limit,
+                            deadline_ms,
+                        } => {
+                            let overrides = awa_model::admin::QueueRuntimeOverrides {
+                                poll_interval_ms,
+                                claim_batch_size,
+                                rate_limit,
+                                deadline_ms,
+                            };
+                            awa_model::admin::set_queue_runtime_overrides(
+                                &pool, &queue, &overrides,
+                            )
+                            .await?;
+                            println!(
+                                "Overrides set for queue '{queue}': {}",
+                                serde_json::to_string(&overrides)?
+                            );
+                            println!("Workers apply them within their refresh cadence (~10s).");
                         }
-                        QueueCommands::Resume { queue } => {
-                            awa_model::admin::resume_queue(&pool, &queue).await?;
-                            println!("Resumed queue '{queue}'");
+                        OverrideCommands::Clear { queue } => {
+                            awa_model::admin::clear_queue_runtime_overrides(&pool, &queue).await?;
+                            println!("Overrides cleared for queue '{queue}' — workers revert to builder values.");
                         }
-                        QueueCommands::Drain { queue } => {
-                            let count = awa_model::admin::drain_queue(&pool, &queue).await?;
-                            println!("Drained {count} jobs from queue '{queue}'");
-                        }
-                        QueueCommands::Overrides { command } => {
-                            match command {
-                                OverrideCommands::Set {
-                                    queue,
-                                    poll_interval_ms,
-                                    claim_batch_size,
-                                    rate_limit,
-                                    deadline_ms,
-                                } => {
-                                    let overrides = awa_model::admin::QueueRuntimeOverrides {
-                                        poll_interval_ms,
-                                        claim_batch_size,
-                                        rate_limit,
-                                        deadline_ms,
-                                    };
-                                    awa_model::admin::set_queue_runtime_overrides(
-                                        &pool, &queue, &overrides,
-                                    )
-                                    .await?;
-                                    println!(
-                                        "Overrides set for queue '{queue}': {}",
-                                        serde_json::to_string(&overrides)?
-                                    );
-                                    println!(
-                                        "Workers apply them within their refresh cadence (~10s)."
-                                    );
-                                }
-                                OverrideCommands::Clear { queue } => {
-                                    awa_model::admin::clear_queue_runtime_overrides(&pool, &queue)
-                                        .await?;
-                                    println!("Overrides cleared for queue '{queue}' — workers revert to builder values.");
-                                }
-                                OverrideCommands::Show { queue, json } => {
-                                    let overrides =
-                                        awa_model::admin::queue_runtime_overrides(&pool, &queue)
-                                            .await?;
-                                    match overrides {
+                        OverrideCommands::Show { queue, json } => {
+                            let overrides =
+                                awa_model::admin::queue_runtime_overrides(&pool, &queue).await?;
+                            match overrides {
                                 Some(overrides) if json => {
                                     println!("{}", serde_json::to_string_pretty(&overrides)?)
                                 }
                                 Some(overrides) => {
                                     println!("queue '{queue}' overrides:");
-                                    println!("  poll_interval_ms:  {:?}", overrides.poll_interval_ms);
-                                    println!("  claim_batch_size:  {:?}", overrides.claim_batch_size);
+                                    println!(
+                                        "  poll_interval_ms:  {:?}",
+                                        overrides.poll_interval_ms
+                                    );
+                                    println!(
+                                        "  claim_batch_size:  {:?}",
+                                        overrides.claim_batch_size
+                                    );
                                     println!("  rate_limit:        {:?}", overrides.rate_limit);
                                     println!("  deadline_ms:       {:?}", overrides.deadline_ms);
                                 }
-                                None => println!("queue '{queue}' has no control-plane row (no overrides)."),
-                            }
-                                }
+                                None if json => println!("null"),
+                                None => println!(
+                                    "queue '{queue}' has no control-plane row (no overrides)."
+                                ),
                             }
                         }
-                        QueueCommands::Stats => {
-                            let stats = awa_model::admin::queue_overviews(&pool).await?;
-                            if stats.is_empty() {
-                                println!("No queues found.");
-                            } else {
+                    },
+                    QueueCommands::Stats => {
+                        let stats = awa_model::admin::queue_overviews(&pool).await?;
+                        if stats.is_empty() {
+                            println!("No queues found.");
+                        } else {
+                            println!(
+                                "{:<15} {:<10} {:<10} {:<10} {:<15} {:<10} {:<8}",
+                                "QUEUE",
+                                "AVAIL",
+                                "RUNNING",
+                                "FAILED",
+                                "COMPLETED/1H",
+                                "LAG(s)",
+                                "PAUSED"
+                            );
+                            for stat in &stats {
                                 println!(
                                     "{:<15} {:<10} {:<10} {:<10} {:<15} {:<10} {:<8}",
-                                    "QUEUE",
-                                    "AVAIL",
-                                    "RUNNING",
-                                    "FAILED",
-                                    "COMPLETED/1H",
-                                    "LAG(s)",
-                                    "PAUSED"
+                                    stat.queue,
+                                    stat.available,
+                                    stat.running,
+                                    stat.failed,
+                                    stat.completed_last_hour,
+                                    stat.lag_seconds
+                                        .map(|s| format!("{:.1}", s))
+                                        .unwrap_or_else(|| "-".to_string()),
+                                    if stat.paused { "yes" } else { "no" },
                                 );
-                                for stat in &stats {
-                                    println!(
-                                        "{:<15} {:<10} {:<10} {:<10} {:<15} {:<10} {:<8}",
-                                        stat.queue,
-                                        stat.available,
-                                        stat.running,
-                                        stat.failed,
-                                        stat.completed_last_hour,
-                                        stat.lag_seconds
-                                            .map(|s| format!("{:.1}", s))
-                                            .unwrap_or_else(|| "-".to_string()),
-                                        if stat.paused { "yes" } else { "no" },
-                                    );
-                                }
                             }
                         }
                     }
-                }
+                },
             }
         }
     }

--- a/awa-worker/src/dispatcher.rs
+++ b/awa-worker/src/dispatcher.rs
@@ -318,7 +318,9 @@ fn override_refresh_interval() -> Duration {
         std::env::var("AWA_OVERRIDE_REFRESH_MS")
             .ok()
             .and_then(|raw| raw.parse::<u64>().ok())
-            .map(Duration::from_millis)
+            // Floor at 50ms: zero would turn the poll sleep into a busy
+            // loop and make every wake refresh.
+            .map(|ms| Duration::from_millis(ms.max(50)))
             .unwrap_or(Duration::from_secs(10))
     })
 }

--- a/docs/adr/038-queue-runtime-overrides.md
+++ b/docs/adr/038-queue-runtime-overrides.md
@@ -53,8 +53,9 @@ Two guard rails, both logged when they bite:
 
 **Negative / limits**
 
-- Changes take up to one refresh cadence to apply; the cadence is deliberately not
-  configurable in Tier 1.
+- Changes take up to one refresh cadence to apply. The cadence has a process-wide
+  escape hatch (`AWA_OVERRIDE_REFRESH_MS`, floored at 50ms) but is deliberately not
+  configurable per queue in Tier 1.
 - Per-claimer application means a brief window where claimers of one queue disagree.
 - Live concurrency (`max_workers`), correctness-coupled cadences (heartbeat/rescue), and
   Python/UI parity are explicitly Tier 2 ([#397](https://github.com/hardbyte/awa/issues/397)).


### PR DESCRIPTION
Post-merge CodeRabbit findings on #398, all three applied:

- `awa queue overrides show --json` now emits `null` (valid JSON) when the queue has no control-plane row, instead of prose.
- `AWA_OVERRIDE_REFRESH_MS=0` no longer turns the poll sleep into a busy loop — the cadence is floored at 50ms.
- ADR-038 acknowledges the env escape hatch ("deliberately not configurable per queue in Tier 1") instead of claiming the cadence is fixed.

Overrides regression test green; clippy clean.