### PR TITLE
fix(migrations): transaction-scoped advisory lock for cancellation-safe, atomic upgrades

### DIFF
--- a/awa-model/src/migrations.rs
+++ b/awa-model/src/migrations.rs
@@ -239,30 +239,58 @@ fn normalize_legacy_version(old_version: i32) -> i32 {
 ///
 /// Applies only migrations newer than the current schema version.
 /// V1 bootstraps the canonical schema from scratch; V2+ are incremental
-/// and use `IF NOT EXISTS` guards so they are safe to re-run.
+/// and use `IF NOT EXISTS` guards so they are safe to re-run. Legacy
+/// `schema_version` rows from pre-0.4 releases are normalized to the new
+/// numbering in [`current_version`] before the pending set is computed.
 ///
-/// by replacing the legacy `schema_version` rows with the new numbering.
+/// Safe to call concurrently from any number of processes against the same
+/// database: a transaction-scoped advisory lock serializes runners, and every
+/// step is idempotent, so concurrent runs converge on a single application.
 ///
 /// Takes `&PgPool` for ergonomic use from Rust.
 pub async fn run(pool: &PgPool) -> Result<(), AwaError> {
     let lock_key: i64 = 0x4157_415f_4d49_4752; // "AWA_MIGR"
-    let mut conn = pool.acquire().await?;
-    sqlx::query("SELECT pg_advisory_lock($1)")
+
+    // Run the version check, ADR-037 finalize gate, and every migration step
+    // inside a single transaction guarded by a *transaction-scoped* advisory
+    // lock. `pg_advisory_xact_lock` gives us two properties a session-scoped
+    // `pg_advisory_lock` did not:
+    //
+    //   1. Serialization: concurrent runners on the same database block on the
+    //      lock, then re-read `schema_version` inside it and no-op. Advisory
+    //      locks are per-database, so runners against different databases never
+    //      contend — the correct semantics on both counts.
+    //
+    //   2. Cancellation safety: the lock is released automatically when the
+    //      transaction ends. If this future is dropped mid-migration (e.g. a
+    //      Rust caller wraps `run` in `tokio::time::timeout`), the transaction
+    //      rolls back and the lock is freed immediately. A session-scoped lock
+    //      would instead ride the pooled connection back into the pool still
+    //      held — sqlx does not `DISCARD ALL` on release — and every later
+    //      migrate in any process would block until that connection happened
+    //      to close.
+    //
+    // Wrapping the steps in one transaction also makes a partial upgrade
+    // atomic: a failed or cancelled run leaves no half-applied step. This is
+    // only sound because every migration is transaction-safe (no
+    // `CREATE INDEX CONCURRENTLY`, `VACUUM`, or explicit transaction control).
+    let mut tx = pool.begin().await?;
+    sqlx::query("SELECT pg_advisory_xact_lock($1)")
         .bind(lock_key)
-        .execute(&mut *conn)
+        .execute(&mut *tx)
         .await?;
+    apply_migrations(&mut tx).await?;
+    tx.commit().await?;
 
-    let result = run_inner(&mut conn).await;
+    // Best-effort admin-metadata cache warmup, deliberately outside the
+    // migration transaction: it must not extend the lock hold, and a slow or
+    // timed-out refresh must not roll back the committed schema.
+    warm_admin_metadata_cache(pool).await;
 
-    let _ = sqlx::query("SELECT pg_advisory_unlock($1)")
-        .bind(lock_key)
-        .execute(&mut *conn)
-        .await;
-
-    result
+    Ok(())
 }
 
-async fn run_inner(conn: &mut PgConnection) -> Result<(), AwaError> {
+async fn apply_migrations(conn: &mut PgConnection) -> Result<(), AwaError> {
     let has_schema: bool =
         sqlx::query_scalar("SELECT EXISTS(SELECT 1 FROM pg_namespace WHERE nspname = 'awa')")
             .fetch_one(&mut *conn)
@@ -293,29 +321,38 @@ async fn run_inner(conn: &mut PgConnection) -> Result<(), AwaError> {
         info!(version = current, "Schema is up to date");
     }
 
-    // Ensure the admin metadata cache is warm. Since v006 removed the
-    // synchronous triggers on jobs_hot, the cache is only updated by the
-    // maintenance leader. Refreshing here guarantees queue_stats() and
-    // state_counts() return accurate data immediately after migrate().
-    let has_refresh: bool = sqlx::query_scalar(
+    Ok(())
+}
+
+/// Warm the admin-metadata cache after migrations commit.
+///
+/// Since v006 removed the synchronous triggers on `jobs_hot`, the cache is
+/// only updated by the maintenance leader. Refreshing here guarantees
+/// `queue_stats()` and `state_counts()` return accurate data immediately after
+/// `migrate()`. Best-effort: any failure is swallowed, since the schema is
+/// already committed and the leader will refresh the cache anyway.
+///
+/// Runs on its own pooled connection, outside the migration transaction, so it
+/// neither holds the migration advisory lock nor risks rolling back committed
+/// schema on a slow refresh.
+async fn warm_admin_metadata_cache(pool: &PgPool) {
+    let has_refresh: Result<bool, _> = sqlx::query_scalar(
         "SELECT EXISTS(SELECT 1 FROM pg_proc WHERE proname = 'refresh_admin_metadata' AND pronamespace = (SELECT oid FROM pg_namespace WHERE nspname = 'awa'))",
     )
-    .fetch_one(&mut *conn)
-    .await?;
-    if has_refresh {
-        // Best-effort cache warmup. Uses a short statement timeout to avoid
-        // blocking if a previous runtime's maintenance leader is still
-        // holding the cache advisory lock during a slow shutdown.
-        // Wrapped in an explicit transaction because SET LOCAL is only
-        // effective inside a transaction block (not in autocommit mode).
+    .fetch_one(pool)
+    .await;
+    if matches!(has_refresh, Ok(true)) {
+        // Uses a short statement timeout to avoid blocking if a previous
+        // runtime's maintenance leader is still holding the cache advisory
+        // lock during a slow shutdown. Wrapped in an explicit transaction
+        // because SET LOCAL is only effective inside a transaction block (not
+        // in autocommit mode).
         let _ = sqlx::raw_sql(
             "BEGIN; SET LOCAL statement_timeout = '5s'; SELECT awa.refresh_admin_metadata(); COMMIT;",
         )
-        .execute(&mut *conn)
+        .execute(pool)
         .await;
     }
-
-    Ok(())
 }
 
 /// The 0.7 migrate gate (#370 / ADR-037).

--- a/awa-model/src/migrations.rs
+++ b/awa-model/src/migrations.rs
@@ -341,17 +341,33 @@ async fn warm_admin_metadata_cache(pool: &PgPool) {
     )
     .fetch_one(pool)
     .await;
-    if matches!(has_refresh, Ok(true)) {
-        // Uses a short statement timeout to avoid blocking if a previous
-        // runtime's maintenance leader is still holding the cache advisory
-        // lock during a slow shutdown. Wrapped in an explicit transaction
-        // because SET LOCAL is only effective inside a transaction block (not
-        // in autocommit mode).
-        let _ = sqlx::raw_sql(
-            "BEGIN; SET LOCAL statement_timeout = '5s'; SELECT awa.refresh_admin_metadata(); COMMIT;",
-        )
-        .execute(pool)
-        .await;
+    if !matches!(has_refresh, Ok(true)) {
+        return;
+    }
+
+    // Use a *managed* transaction (not raw `BEGIN; … COMMIT;`): the SET LOCAL
+    // scopes a short statement timeout so a maintenance leader still holding
+    // the cache advisory lock during a slow shutdown can't block us — but if
+    // that timeout fires, the batch aborts and a raw trailing COMMIT would
+    // never run, leaving the pooled connection "idle in transaction (aborted)"
+    // for the next borrower (sqlx doesn't track transactions it didn't open).
+    // pool.begin()'s guard rolls back on drop, keeping the connection clean.
+    let Ok(mut tx) = pool.begin().await else {
+        return;
+    };
+    let refreshed =
+        sqlx::raw_sql("SET LOCAL statement_timeout = '5s'; SELECT awa.refresh_admin_metadata();")
+            .execute(&mut *tx)
+            .await;
+    match refreshed {
+        Ok(_) => {
+            let _ = tx.commit().await;
+        }
+        // Explicit rollback (rather than relying on the Drop guard) so the
+        // connection is returned clean immediately, not on its next use.
+        Err(_) => {
+            let _ = tx.rollback().await;
+        }
     }
 }
 

--- a/awa-python/tests/test_migration_concurrency.py
+++ b/awa-python/tests/test_migration_concurrency.py
@@ -1,0 +1,77 @@
+"""Concurrent-migration safety for the Python client.
+
+Races several ``client.migrate()`` calls from separate OS threads — each with
+its own client and connection pool — against a freshly dropped schema. This is
+the Python mirror of the Rust ``test_concurrent_runs_apply_once_and_converge``:
+the migration advisory lock must serialize the runners so every call succeeds
+and the schema converges on the build's version, with each migration recorded
+exactly once.
+
+``migrate()`` maps to ``migrate_sync`` on the raw client, which releases the
+GIL for the duration of the migration, so the threads contend for real on the
+Postgres advisory lock rather than serializing behind the interpreter.
+
+Requires Postgres running at localhost:15432.
+"""
+
+import concurrent.futures
+import os
+
+import awa
+
+DATABASE_URL = os.environ.get(
+    "DATABASE_URL", "postgres://postgres:test@localhost:15432/awa_test"
+)
+
+RACERS = 8
+
+
+def _drop_schema() -> None:
+    client = awa.Client(DATABASE_URL, max_connections=2)
+    tx = client.transaction()
+    tx.execute("DROP SCHEMA IF EXISTS awa CASCADE")
+    tx.commit()
+    client.close()
+
+
+def test_concurrent_migrate_converges():
+    _drop_schema()
+
+    def migrate_once() -> None:
+        # A distinct client per thread => a distinct connection pool => the
+        # racers genuinely contend on the Postgres advisory lock.
+        client = awa.Client(DATABASE_URL, max_connections=2)
+        try:
+            client.migrate()
+        finally:
+            client.close()
+
+    errors: list[BaseException] = []
+    with concurrent.futures.ThreadPoolExecutor(max_workers=RACERS) as pool:
+        futures = [pool.submit(migrate_once) for _ in range(RACERS)]
+        for future in concurrent.futures.as_completed(futures):
+            try:
+                future.result()
+            except BaseException as exc:  # noqa: BLE001
+                errors.append(exc)
+
+    assert not errors, f"concurrent migrate() calls failed: {errors}"
+
+    # Converged: schema at the build's version, no torn/duplicate application.
+    client = awa.Client(DATABASE_URL, max_connections=2)
+    tx = client.transaction()
+    max_version = tx.fetch_one("SELECT max(version) AS v FROM awa.schema_version")["v"]
+    recorded = tx.fetch_one("SELECT count(*) AS n FROM awa.schema_version")["n"]
+    duplicates = tx.fetch_one(
+        "SELECT count(*) AS n FROM ("
+        "  SELECT version FROM awa.schema_version GROUP BY version HAVING count(*) > 1"
+        ") AS d"
+    )["n"]
+    tx.commit()
+    client.close()
+
+    assert max_version == awa.current_migration_version()
+    assert duplicates == 0, "schema_version has duplicate rows"
+    # One row per known migration; len(migrations()) accounts for the reserved
+    # v008 gap, so it is the migration count rather than CURRENT_VERSION.
+    assert recorded == len(awa.migrations())

--- a/awa/tests/migration_test.rs
+++ b/awa/tests/migration_test.rs
@@ -3107,3 +3107,145 @@ async fn test_auto_finalize_refuses_when_runtime_is_live() {
     let after = storage::status(&pool).await.unwrap();
     assert_eq!(after.state, "canonical");
 }
+
+// ── Concurrency & cancellation safety (migration advisory lock) ───
+
+/// Build a dedicated pool with a specific connection ceiling — the shared
+/// `pool()` caps at 2, too few to genuinely race several runners at once.
+async fn pool_with_max_connections(max: u32) -> PgPool {
+    ensure_migration_database().await;
+    PgPoolOptions::new()
+        .max_connections(max)
+        .acquire_timeout(std::time::Duration::from_secs(10))
+        .connect(&migration_database_url())
+        .await
+        .expect("Failed to connect to migration test database — is Postgres running?")
+}
+
+/// Race N concurrent `run()` calls against a fresh database and assert they
+/// converge: every run succeeds, the schema reaches CURRENT_VERSION, and each
+/// migration version is recorded exactly once. Without the migration advisory
+/// lock the interleaved DDL would collide ("relation already exists", "tuple
+/// concurrently updated"); the lock serializes the runners so all converge on
+/// a single application.
+#[tokio::test]
+async fn test_concurrent_runs_apply_once_and_converge() {
+    let _guard = acquire_migration_guard().await;
+
+    const RACERS: usize = 8;
+    let pool = pool_with_max_connections(RACERS as u32 + 2).await;
+    reset_schema(&pool).await;
+
+    // `migrations::run` is `!Send` (it holds a pooled connection / transaction
+    // across awaits), so the racers run on a LocalSet rather than tokio::spawn.
+    // Cooperative scheduling is enough to exercise lock contention: while one
+    // run holds the lock and awaits Postgres, the others park inside
+    // pg_advisory_xact_lock.
+    let local = tokio::task::LocalSet::new();
+    let results: Vec<Result<(), awa::AwaError>> = local
+        .run_until(async {
+            let mut handles = Vec::with_capacity(RACERS);
+            for _ in 0..RACERS {
+                let pool = pool.clone();
+                handles.push(tokio::task::spawn_local(async move {
+                    migrations::run(&pool).await
+                }));
+            }
+            let mut out = Vec::with_capacity(RACERS);
+            for handle in handles {
+                out.push(handle.await.expect("run task should not panic"));
+            }
+            out
+        })
+        .await;
+
+    for (index, result) in results.iter().enumerate() {
+        if let Err(err) = result {
+            panic!("concurrent run {index} failed: {err}");
+        }
+    }
+
+    let version = migrations::current_version(&pool).await.unwrap();
+    assert_eq!(version, migrations::CURRENT_VERSION);
+
+    // No version applied more than once — a torn/interleaved application would
+    // leave duplicate rows (or would have errored above).
+    let duplicate_versions: i64 = sqlx::query_scalar(
+        "SELECT count(*) FROM (SELECT version FROM awa.schema_version GROUP BY version HAVING count(*) > 1) AS d",
+    )
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(duplicate_versions, 0, "schema_version has duplicate rows");
+
+    // Exactly one row per known migration (v008 is a reserved gap, so this is
+    // the migration count, not CURRENT_VERSION).
+    let recorded: i64 = sqlx::query_scalar("SELECT count(*) FROM awa.schema_version")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert_eq!(
+        recorded,
+        migrations::migration_sql().len() as i64,
+        "every migration version should be recorded exactly once"
+    );
+
+    pool.close().await;
+}
+
+/// A `run()` cancelled while it holds the migration lock must not strand the
+/// lock. Because the lock is transaction-scoped, dropping the future rolls the
+/// transaction back and frees the lock, so a subsequent `run()` proceeds
+/// promptly. With the old session-scoped lock the cancelled run left the lock
+/// held on the pooled connection and every later migrate blocked until that
+/// connection happened to close — this test would then hang on the final run.
+#[tokio::test]
+async fn test_cancelled_run_does_not_strand_migration_lock() {
+    let _guard = acquire_migration_guard().await;
+
+    let pool = pool_with_max_connections(4).await;
+    reset_schema(&pool).await;
+    migrations::run(&pool).await.expect("initial migrate");
+
+    // Hold ACCESS EXCLUSIVE on awa.schema_version so a racing run parks *while
+    // holding the migration advisory lock*: run() acquires the xact lock, then
+    // blocks on its early `SELECT MAX(version) FROM awa.schema_version`.
+    let mut blocker = PgConnection::connect(&migration_database_url())
+        .await
+        .expect("blocker connection should open");
+    let mut blocker_tx = blocker.begin().await.expect("blocker begin");
+    sqlx::raw_sql("LOCK TABLE awa.schema_version IN ACCESS EXCLUSIVE MODE")
+        .execute(&mut *blocker_tx)
+        .await
+        .expect("blocker should lock schema_version");
+
+    // Start a run and cancel it: the timeout drops the future while it is
+    // parked on the held table lock, holding the migration advisory lock.
+    let cancelled = tokio::time::timeout(
+        std::time::Duration::from_millis(500),
+        migrations::run(&pool),
+    )
+    .await;
+    assert!(
+        cancelled.is_err(),
+        "run should still be blocked on the held table lock when the timeout fires"
+    );
+
+    // Release the table lock. The cancelled run's rollback must have already
+    // freed the migration advisory lock.
+    blocker_tx.rollback().await.expect("blocker rollback");
+    drop(blocker);
+
+    // A fresh run must acquire the migration lock and finish. If the cancelled
+    // run had stranded a session-scoped lock, this would block until the
+    // timeout and fail.
+    tokio::time::timeout(std::time::Duration::from_secs(30), migrations::run(&pool))
+        .await
+        .expect("subsequent run must not block on a stranded migration lock")
+        .expect("subsequent migrate should succeed");
+
+    let version = migrations::current_version(&pool).await.unwrap();
+    assert_eq!(version, migrations::CURRENT_VERSION);
+
+    pool.close().await;
+}


### PR DESCRIPTION
## Problem

`migrations::run` guarded the version check, ADR-037 finalize gate, and every migration step with a **session-scoped** `pg_advisory_lock` acquired on a pooled connection and released manually. sqlx does not `DISCARD ALL` when a connection returns to the pool, so if the `run` future is cancelled mid-migration — e.g. a Rust embedder wraps `migrate` in `tokio::time::timeout` — the connection goes back to the pool **with the advisory lock still held**. Every subsequent migrate in any process then blocks until that pooled connection happens to close.

Python callers were immune (their `block_on` runs to completion regardless of asyncio cancellation); Rust callers were not. The advisory-lock behaviour also had **no direct test** — `migration_test.rs` covered stepping/gate/re-runs, but nothing raced two `run()`s to prove mutual exclusion + idempotent convergence, and nothing exercised cancellation.

## Fix

Take a **transaction-scoped** `pg_advisory_xact_lock` inside a single transaction that wraps the whole upgrade:

- **Serialization** is unchanged — concurrent runners block on the lock, then re-read `schema_version` inside it and no-op. (Advisory locks are per-database, so runners against different databases never contend.)
- **Cancellation safety** — the lock is released when the transaction ends. Dropping the future rolls it back and frees the lock immediately; nothing is stranded on the pooled connection.
- **Atomicity** — a failed or cancelled run leaves no half-applied step. This is sound because every migration is transaction-safe (verified: no `CREATE INDEX CONCURRENTLY`, `VACUUM`, or top-level transaction control across all 39 migrations).

The best-effort admin-metadata cache warmup moves out of the migration transaction onto its own connection, so it neither extends the lock hold nor risks rolling back committed schema on a slow/timed-out refresh.

## Tests

- **`test_concurrent_runs_apply_once_and_converge`** — races 8 `run()`s on a fresh database (via `LocalSet`, since `run` is `!Send`); asserts every run succeeds, the schema reaches `CURRENT_VERSION`, and each migration version is recorded exactly once.
- **`test_cancelled_run_does_not_strand_migration_lock`** — deterministically parks a run *while it holds the lock* (a blocker holds `ACCESS EXCLUSIVE` on `schema_version`, so the run blocks on its early `SELECT MAX(version)`), cancels it via `timeout`, then asserts a subsequent run completes. Verified to **fail against the old session-scoped lock** (subsequent run times out on the stranded lock) and **pass with the fix**.
- **`awa-python/tests/test_migration_concurrency.py`** — races 8 threaded `client.migrate()` calls (each its own pool; `migrate_sync` releases the GIL) and asserts the same convergence, covering the Python leg.

## Verification

- `cargo fmt --all`, `cargo clippy -p awa-model -p awa --all-targets --all-features -- -D warnings` — clean
- Full migration suite (serialized): **51 passed, 0 failed**
- Python concurrency test: **passed**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved migration reliability when multiple clients run upgrades at the same time.
  * Reduced the chance of migrations getting stuck after a cancelled or timed-out run.
  * Made post-migration metadata refreshes more tolerant of temporary failures.

* **Tests**
  * Added coverage for concurrent migration runs.
  * Added coverage to confirm migrations complete cleanly after a blocked or cancelled attempt.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->