### PR TITLE
fix(cli): drop redundant references in println args (clippy 1.97)

### DIFF
--- a/awa-cli/src/main.rs
+++ b/awa-cli/src/main.rs
@@ -848,8 +848,8 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
                                 println!(
                                     "{:<8} {:<25} {:<10} {:<10} {:<5} {:<5}",
                                     job.id,
-                                    &job.kind,
-                                    &job.queue,
+                                    job.kind,
+                                    job.queue,
                                     job.state,
                                     job.attempt,
                                     job.max_attempts,


### PR DESCRIPTION
CI's `dtolnay/rust-toolchain@stable` picked up Rust 1.97, whose clippy adds `useless_borrows_in_formatting`. `cargo clippy -D warnings` now fails on two pre-existing `&job.field` args in `awa-cli` — main's own CI went red on the #408 merge run, and every open PR inherits the failure (#409, #410).

Two-character fix, `cargo fmt` clean, clippy green on 1.97 semantics.

Merging this first unblocks lint CI for the open perf PRs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal formatting behavior for job list output without changing the displayed information or user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->