### PR TITLE
fix(migrations): detach the admin-metadata warmup connection (#408 follow-up)

### DIFF
--- a/awa-model/src/migrations.rs
+++ b/awa-model/src/migrations.rs
@@ -1,6 +1,6 @@
 use crate::error::AwaError;
 use sqlx::postgres::PgConnection;
-use sqlx::PgPool;
+use sqlx::{Connection, PgPool};
 use tracing::info;
 
 /// Current schema version.
@@ -332,43 +332,70 @@ async fn apply_migrations(conn: &mut PgConnection) -> Result<(), AwaError> {
 /// `migrate()`. Best-effort: any failure is swallowed, since the schema is
 /// already committed and the leader will refresh the cache anyway.
 ///
-/// Runs on its own pooled connection, outside the migration transaction, so it
+/// Runs on a *detached* connection, outside the migration transaction, so it
 /// neither holds the migration advisory lock nor risks rolling back committed
 /// schema on a slow refresh.
+///
+/// ## Why a detached connection, not `pool.begin()`
+///
+/// `migrations::run` may be driven on a short-lived runtime that is dropped the
+/// instant it returns — the Python bridge builds a throwaway `current_thread`
+/// runtime and `block_on`s the whole migration on it (see awa-python's
+/// `run_migrations_offthread`). A *pooled* connection returns to the pool via
+/// an async step on its owning runtime; if that runtime is torn down before the
+/// return completes, the return is guillotined and the connection's pool
+/// semaphore permit is leaked — one leaked permit eventually deadlocks every
+/// later `acquire`, poisoning the client's whole pool. (This was #408's
+/// regression: the warmup's `pool.begin()` was the last pool op before the
+/// throwaway runtime dropped.)
+///
+/// `acquire().detach()` hands us a `PgConnection` the pool no longer tracks:
+/// there is no return-to-pool step to race and no permit to strand. We close it
+/// explicitly with `close().await`, which completes inline before the runtime
+/// goes away. The pool is one connection smaller afterwards; it re-opens a
+/// replacement lazily on the next `acquire`. This runs once per `migrate()`, so
+/// the extra connect is negligible.
 async fn warm_admin_metadata_cache(pool: &PgPool) {
+    // Detach immediately so nothing borrowed from the pool outlives this
+    // function on a runtime that may be about to be dropped.
+    let Ok(conn) = pool.acquire().await else {
+        return;
+    };
+    let mut conn = conn.detach();
+
     let has_refresh: Result<bool, _> = sqlx::query_scalar(
         "SELECT EXISTS(SELECT 1 FROM pg_proc WHERE proname = 'refresh_admin_metadata' AND pronamespace = (SELECT oid FROM pg_namespace WHERE nspname = 'awa'))",
     )
-    .fetch_one(pool)
+    .fetch_one(&mut conn)
     .await;
-    if !matches!(has_refresh, Ok(true)) {
-        return;
-    }
 
-    // Use a *managed* transaction (not raw `BEGIN; … COMMIT;`): the SET LOCAL
-    // scopes a short statement timeout so a maintenance leader still holding
-    // the cache advisory lock during a slow shutdown can't block us — but if
-    // that timeout fires, the batch aborts and a raw trailing COMMIT would
-    // never run, leaving the pooled connection "idle in transaction (aborted)"
-    // for the next borrower (sqlx doesn't track transactions it didn't open).
-    // pool.begin()'s guard rolls back on drop, keeping the connection clean.
-    let Ok(mut tx) = pool.begin().await else {
-        return;
-    };
-    let refreshed =
-        sqlx::raw_sql("SET LOCAL statement_timeout = '5s'; SELECT awa.refresh_admin_metadata();")
+    if matches!(has_refresh, Ok(true)) {
+        // Managed transaction (not raw `BEGIN; … COMMIT;`): the SET LOCAL scopes
+        // a short statement timeout so a maintenance leader still holding the
+        // cache advisory lock during a slow shutdown can't block us — but if
+        // that timeout fires the batch aborts and a raw trailing COMMIT would
+        // never run, leaving the connection "idle in transaction (aborted)". A
+        // managed transaction's guard rolls back on drop, keeping it clean.
+        if let Ok(mut tx) = conn.begin().await {
+            let refreshed = sqlx::raw_sql(
+                "SET LOCAL statement_timeout = '5s'; SELECT awa.refresh_admin_metadata();",
+            )
             .execute(&mut *tx)
             .await;
-    match refreshed {
-        Ok(_) => {
-            let _ = tx.commit().await;
-        }
-        // Explicit rollback (rather than relying on the Drop guard) so the
-        // connection is returned clean immediately, not on its next use.
-        Err(_) => {
-            let _ = tx.rollback().await;
+            match refreshed {
+                Ok(_) => {
+                    let _ = tx.commit().await;
+                }
+                Err(_) => {
+                    let _ = tx.rollback().await;
+                }
+            }
         }
     }
+
+    // Detached: nothing returns this to the pool, so close it explicitly (inline,
+    // before any short-lived runtime is dropped) rather than leaking the socket.
+    let _ = conn.close().await;
 }
 
 /// The 0.7 migrate gate (#370 / ADR-037).


### PR DESCRIPTION
## Summary

Fixes the #408 pool-permit leak in `AsyncClient.migrate()` that poisons the client's connection pool and makes every later DB op hang 30s then fail with `pool timed out while waiting for an open connection`. This is the root cause of CI's **chaos-smoke** and **telemetry-OTLP** failures (the helper's `client.start()` hangs, so `READY mode=worker_chaos_probe` never prints and the Rust harness times out) and the local `awa-python` pytest fixture errors.

**Stacked on #414** (`fix(python): satisfy rustc 1.97 Send inference…`). Base branch is `fix/rustc-197-python-send-inference`, so the diff here is only the leak fix. Merge order: **#411 → #414 → #413**.

## Root cause

`migrations::run` ends with a best-effort `warm_admin_metadata_cache`, which opened a **pooled** connection (`pool.begin()`). A pooled connection returns to the pool via an async step on the runtime awaiting it. The Python bridge drives the whole migration on a **throwaway `current_thread` runtime** built inside `spawn_blocking` and drops it the instant `block_on` returns — so the warmup's pooled connection was the last pool op before teardown, and its return **raced the runtime drop**. Losing that race stranded the connection and leaked its pool **semaphore permit**; with a small `max_connections`, one leaked permit eventually deadlocks every later `acquire`. `migrate()` returns "successfully" (~2s) but the pool is dead.

Evidence: reverting the migration change makes all post-migrate acquires succeed; removing just the warmup call also fixes it; `pg_stat_activity` shows exactly one connection stranded `idle` after each poisoned migrate.

## Fix

Run the warmup on a **detached** connection: `pool.acquire().detach()` yields a `PgConnection` the pool no longer tracks, so there is no return-to-pool step to race and no permit to strand. Close it explicitly with `close().await`, which completes inline before any short-lived runtime is dropped.

**Pool accounting:** detach removes one connection from the pool; the pool re-opens a replacement lazily on the next `acquire`. This runs once per `migrate()`, so the extra connect is negligible and there is no steady-state size change.

## Why not the earlier "warmup on the ambient runtime" approach

The first cut of this PR split the migration into `run_migration_steps` on the throwaway runtime **plus a second `warm_admin_metadata_cache(...).await`** on the ambient pyo3 runtime. That reintroduces the **rustc 1.97** higher-ranked `Send`/`Executor is not general enough` error (#414's territory): 1.97 rejects any `future_into_py` bridge future that awaits `spawn_blocking(!Send).await` *and* has a further await. Keeping migrate-plus-warmup a **single combined future** run inside one `block_on` (which #414's `run_migrations_offthread` → `migrations::run` does) stays 1.97-safe, and fixing the leak at the **connection level** (detach + close) needs no change to the async-bridge shape. No `client.rs` change is required in this PR.

## Verification

- `cargo build -p awa-model` on **1.95 and 1.97**: clean. Full extension (`awa-python`) composed with #414 builds clean on **1.97** (fresh isolated target).
- Wheel built on **rustc 1.97** via maturin; `tests/test_awa.py` run **twice** against a fresh DB: **37 passed, 1 skipped** each time (37.4s / 37.1s). The fixture tests that error on `main` (the poisoned-pool path) now pass.
- On #414 alone (no leak fix), CI chaos-smoke builds the wheel but still fails with `Timed out waiting for python helper output: READY mode=worker_chaos_probe` — the leak symptom this PR removes.

Closes the #408 regression; unblocks #409/#410.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved administrative metadata cache refresh reliability.
  * Prevented connection and pool resources from remaining stranded when the calling runtime stops unexpectedly.
  * Ensured refresh operations use a short timeout and fail gracefully when the refresh cannot be completed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->