### PR TITLE
fix(python): satisfy rustc 1.97 Send inference in async bridge paths

### DIFF
--- a/awa-python/src/client.rs
+++ b/awa-python/src/client.rs
@@ -33,7 +33,10 @@ use uuid::Uuid;
 /// transaction across awaits), so it cannot be awaited directly inside the
 /// `future_into_py` bridge, whose future must be `Send`. We drive it on a
 /// throwaway `current_thread` runtime inside `spawn_blocking` — this keeps the
-/// asyncio loop free and lets `asyncio.wait_for()` cancel the outer call.
+/// asyncio loop free. Note that `asyncio.wait_for()` cancellation only detaches
+/// the outer await: a `spawn_blocking` task cannot be interrupted, so the
+/// migration keeps running to completion in the background. The migration
+/// itself stays crash/cancel-safe through its transaction-scoped advisory lock.
 ///
 /// This lives in a dedicated `async fn` (taking the pool *by value*) rather
 /// than inline in each caller on purpose: the `!Send` migration future is

--- a/awa-python/src/client.rs
+++ b/awa-python/src/client.rs
@@ -27,6 +27,36 @@ use std::sync::{Arc, Mutex, RwLock};
 use std::time::Duration;
 use uuid::Uuid;
 
+/// Run schema migrations off the asyncio event loop.
+///
+/// `migrations::run` is `!Send` (it holds a pooled connection / open
+/// transaction across awaits), so it cannot be awaited directly inside the
+/// `future_into_py` bridge, whose future must be `Send`. We drive it on a
+/// throwaway `current_thread` runtime inside `spawn_blocking` — this keeps the
+/// asyncio loop free and lets `asyncio.wait_for()` cancel the outer call.
+///
+/// This lives in a dedicated `async fn` (taking the pool *by value*) rather
+/// than inline in each caller on purpose: the `!Send` migration future is
+/// confined to this function's concrete, named future, so it never leaks into
+/// the caller's `future_into_py` block where rustc's auto-trait solver would
+/// otherwise have to reason about it. Awaiting the `!Send` `block_on` result
+/// inline (via `spawn_blocking(..).await`) trips a higher-ranked
+/// `Send`/`Executor is not general enough` inference error on some rustc
+/// versions (observed on 1.97); routing through this helper keeps the outer
+/// future unambiguously `Send` across toolchains.
+async fn run_migrations_offthread(pool: PgPool) -> PyResult<()> {
+    tokio::task::spawn_blocking(move || {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("failed to build current_thread runtime for migrate");
+        rt.block_on(awa_model::migrations::run(&pool))
+    })
+    .await
+    .map_err(|e| state_error(format!("migration task failed: {e}")))?
+    .map_err(map_awa_error)
+}
+
 fn validate_timeout_seconds(timeout_seconds: f64) -> PyResult<Duration> {
     if !timeout_seconds.is_finite() || timeout_seconds.is_sign_negative() {
         return Err(map_awa_error(awa_model::AwaError::Validation(
@@ -570,20 +600,8 @@ impl PyClient {
 
     fn migrate<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
         let pool = self.pool.clone();
-        // migrations::run() is !Send (holds PoolConnection across awaits).
-        // We bridge it via spawn_blocking + a current_thread runtime so the
-        // asyncio event loop stays free and asyncio.wait_for() can cancel.
         pyo3_async_runtimes::tokio::future_into_py(py, async move {
-            tokio::task::spawn_blocking(move || {
-                let rt = tokio::runtime::Builder::new_current_thread()
-                    .enable_all()
-                    .build()
-                    .expect("failed to build current_thread runtime for migrate");
-                rt.block_on(awa_model::migrations::run(&pool))
-            })
-            .await
-            .map_err(|e| state_error(format!("migration task failed: {e}")))?
-            .map_err(map_awa_error)?;
+            run_migrations_offthread(pool).await?;
             Ok(())
         })
     }
@@ -658,23 +676,12 @@ impl PyClient {
                     // schema is configured to a non-`awa` name this is
                     // just a quick idempotent no-op.
                     //
-                    // `migrations::run` is `!Send` (holds a
-                    // `PoolConnection` across awaits), and this async
-                    // block goes through `future_into_py` which
-                    // requires `Send`. Bridge via spawn_blocking +
-                    // current_thread runtime, the same pattern
-                    // `Self::migrate` uses.
-                    let pool_for_migrate = pool.clone();
-                    tokio::task::spawn_blocking(move || {
-                        let rt = tokio::runtime::Builder::new_current_thread()
-                            .enable_all()
-                            .build()
-                            .expect("failed to build current_thread runtime for migrate");
-                        rt.block_on(awa_model::migrations::run(&pool_for_migrate))
-                    })
-                    .await
-                    .map_err(|e| state_error(format!("migration task failed: {e}")))?
-                    .map_err(map_awa_error)?;
+                    // Re-run the control-plane migrations off-thread (they are
+                    // `!Send`), the same pattern `Self::migrate` uses. Routed
+                    // through the shared helper so the `!Send` migration future
+                    // stays out of this `future_into_py` block — see
+                    // `run_migrations_offthread`.
+                    run_migrations_offthread(pool.clone()).await?;
                     store.prepare_schema(&pool).await.map_err(map_awa_error)?;
                     store.reset(&pool).await.map_err(map_awa_error)?;
                     store.activate_backend(&pool).await.map_err(map_awa_error)?;


### PR DESCRIPTION
## Summary

GitHub's `stable` runners are rolling from rustc **1.96.1 → 1.97.0** (released 2026-07-07). On 1.97 the `awa-python` extension no longer compiles: the `future_into_py` bridge paths in `AsyncClient.migrate()` and `install_queue_storage` trip five *"implementation of `Send`/`Executor` is not general enough"* errors, failing the CI **Python build + test** job (and, transitively, chaos-smoke / telemetry-OTLP which need the wheel).

This is the **rustc half** of the 1.97 rollout; the **clippy half** (`useless_borrows_in_formatting`) is #411, cherry-picked here so this branch's own CI is green.

## Evidence it's the 1.97 rollout

From the failed CI Python job log (run 29119252893):

```
stable-x86_64-unknown-linux-gnu updated - rustc 1.97.0 (2d8144b78 2026-07-07) (from rustc 1.96.1 ...)
...
error: implementation of `Executor` is not general enough
   --> src/client.rs:586:9
error: implementation of `Send` is not general enough
   --> src/client.rs:650:9
```

The same source compiled green on 1.96.1 the day before (#407 run). Reproduced locally on rustc 1.97.0; 1.96.1/1.95.0 accept the pre-fix code, so it is a 1.97 auto-trait/HRTB inference regression, in the family of rust-lang/rust [#96865](https://github.com/rust-lang/rust/issues/96865) / [#110339](https://github.com/rust-lang/rust/issues/110339) ("implementation not general enough" with async + lifetimed impls, whose standard remedy is to confine the offending future behind a concrete boundary). No provider-specific upstream issue is filed yet (1.97 is days old); the code fix stands regardless of whether rustc later reverts the regression, since it compiles on both toolchains.

## Root cause

Both bridge paths drive the `!Send` `migrations::run` on a throwaway `current_thread` runtime inside `spawn_blocking`, then `.await` the `JoinHandle` **inline** within the `future_into_py` async block (whose future must be `Send`). On 1.97 rustc can no longer prove the outer future `Send` while the `!Send` migration future — which holds `&mut PgConnection` across awaits — is inlined into it.

## Fix

Extract the throwaway-runtime migration into a dedicated

```rust
async fn run_migrations_offthread(pool: PgPool) -> PyResult<()>
```

(taking the pool by value). Its concrete, named future keeps the `!Send` migration out of each caller's `future_into_py` block, so the outer future is unambiguously `Send`. The two call sites (`migrate()` and the `install_queue_storage` reset path) now just `run_migrations_offthread(pool).await?`. No behaviour change — the runtime bridging, error mapping, and `asyncio.wait_for()` cancellation are identical.

## Verification (both toolchains, actual output)

- `cargo +1.95.0 build -p awa-python --features pyo3/extension-module,pyo3/abi3-py310` → **Finished** (clean).
- `cargo +1.97.0 build ...` (fresh isolated target) → **Finished** (clean). Pre-fix this produced the 5 errors.
- `cargo fmt --all --check` clean; `cargo +1.97.0 clippy --workspace --all-targets --all-features -- -D warnings` → **Finished** (clean, incl. the cherry-picked CLI fix).
- `maturin develop` on 1.97 builds and installs the wheel; `awa.migrate()` runs (1.9s). `tests/test_awa.py` non-fixture tests pass.

## Note for #413 (pool-leak fix)

#413 (`fix(python): run admin-metadata warmup on the ambient runtime`) touches these same two functions. I verified that **#413 as currently written does NOT compile on 1.97** when composed with this fix: splitting the migration into `run_migration_steps` on the throwaway runtime **plus a second `warm_admin_metadata_cache(...).await`** reintroduces the same HRTB error, because rustc 1.97 rejects any bridge future that awaits `spawn_blocking(!Send).await` *and* has a further await. The whole migrate-plus-warmup must stay a single combined future run inside one `block_on` (which is what this PR's `run_migrations_offthread` → `migrations::run` does). So #413 needs to be reworked to fix the leak *without* a trailing ambient-runtime await — e.g. keep the warmup inside `migrations::run` but have it acquire a **detached** connection and `close().await` it inline (no pool return-to-pool to strand when the throwaway runtime drops). I have a working sketch of that and will fold it into #413 once this lands; flagging here so #413 isn't merged in its current shape onto a 1.97 runner.

Relation: rustc half of the 1.97 rollout (clippy half = #411, cherry-picked here). Adjacent to #413.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved migration handling to keep asynchronous cancellation responsive.
  * Increased reliability when installing or resetting queue storage by using consistent migration processing.
  * Preserved existing error reporting behavior for migration failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->