### PR TITLE
fix(admin): include un-materialized receipt claims in job listings and queue overviews

### DIFF
--- a/awa-model/src/admin.rs
+++ b/awa-model/src/admin.rs
@@ -321,6 +321,118 @@ fn queue_storage_current_jobs_cte(schema: &str) -> String {
              AND ready.enqueue_shard = leases.enqueue_shard
              AND ready.lane_seq = leases.lane_seq
             UNION ALL
+            -- Receipt-plane claims that have not (yet) materialized into a
+            -- mutable lease are still running. Mirror load_job's and
+            -- queue_counts_exact's lease_claims branch: report each open
+            -- claim as running, anti-joined against every durable closure
+            -- evidence shape and against the materialized lease (which the
+            -- branch above already reports).
+            SELECT
+                claims.job_id,
+                ready.kind,
+                claims.queue,
+                'running'::awa.job_state AS state,
+                ready.created_at,
+                ready.run_at,
+                NULL::timestamptz AS finalized_at
+            FROM {schema}.lease_claims AS claims
+            JOIN {schema}.ready_entries AS ready
+              ON ready.ready_slot = claims.ready_slot
+             AND ready.ready_generation = claims.ready_generation
+             AND ready.queue = claims.queue
+             AND ready.priority = claims.priority
+             AND ready.enqueue_shard = claims.enqueue_shard
+             AND ready.lane_seq = claims.lane_seq
+            WHERE claims.closed_at IS NULL
+              AND NOT EXISTS (
+                  SELECT 1 FROM {schema}.lease_claim_closures AS closures
+                  WHERE closures.claim_slot = claims.claim_slot
+                    AND closures.job_id = claims.job_id
+                    AND closures.run_lease = claims.run_lease
+              )
+              AND NOT EXISTS (
+                  SELECT 1 FROM {schema}.lease_claim_closure_batches AS closure_batches
+                  WHERE closure_batches.receipt_ranges @> claims.receipt_id
+              )
+              AND NOT EXISTS (
+                  SELECT 1 FROM {schema}.done_entries AS done
+                  WHERE done.job_id = claims.job_id
+                    AND done.run_lease = claims.run_lease
+              )
+              AND NOT EXISTS (
+                  SELECT 1 FROM {schema}.deferred_jobs AS deferred
+                  WHERE deferred.job_id = claims.job_id
+                    AND deferred.run_lease = claims.run_lease
+              )
+              AND NOT EXISTS (
+                  SELECT 1 FROM {schema}.dlq_entries AS dlq
+                  WHERE dlq.job_id = claims.job_id
+                    AND dlq.run_lease = claims.run_lease
+              )
+              AND NOT EXISTS (
+                  SELECT 1 FROM {schema}.leases AS lease
+                  WHERE lease.job_id = claims.job_id
+                    AND lease.run_lease = claims.run_lease
+              )
+            UNION ALL
+            -- Zero-deadline compact receipt claims live in
+            -- lease_claim_batches until a cold path materializes them.
+            -- Expand the batch members and report each still-open item as
+            -- running, mirroring load_job's lease_claim_batch branch.
+            SELECT
+                items.job_id,
+                ready.kind,
+                claim_batches.queue,
+                'running'::awa.job_state AS state,
+                ready.created_at,
+                ready.run_at,
+                NULL::timestamptz AS finalized_at
+            FROM {schema}.lease_claim_batches AS claim_batches
+            CROSS JOIN LATERAL unnest(
+                claim_batches.job_ids,
+                claim_batches.run_leases,
+                claim_batches.receipt_ids,
+                claim_batches.lane_seqs
+            ) AS items(job_id, run_lease, receipt_id, lane_seq)
+            JOIN {schema}.ready_entries AS ready
+              ON ready.ready_slot = claim_batches.ready_slot
+             AND ready.ready_generation = claim_batches.ready_generation
+             AND ready.queue = claim_batches.queue
+             AND ready.enqueue_shard = claim_batches.enqueue_shard
+             AND ready.lane_seq = items.lane_seq
+             AND ready.job_id = items.job_id
+            WHERE NOT EXISTS (
+                  SELECT 1 FROM {schema}.lease_claim_closures AS closures
+                  WHERE closures.claim_slot = claim_batches.claim_slot
+                    AND closures.job_id = items.job_id
+                    AND closures.run_lease = items.run_lease
+              )
+              AND NOT EXISTS (
+                  SELECT 1 FROM {schema}.lease_claim_closure_batches AS closure_batches
+                  WHERE closure_batches.claim_slot = claim_batches.claim_slot
+                    AND closure_batches.receipt_ranges @> items.receipt_id
+              )
+              AND NOT EXISTS (
+                  SELECT 1 FROM {schema}.leases AS lease
+                  WHERE lease.job_id = items.job_id
+                    AND lease.run_lease = items.run_lease
+              )
+              AND NOT EXISTS (
+                  SELECT 1 FROM {schema}.done_entries AS done
+                  WHERE done.job_id = items.job_id
+                    AND done.run_lease = items.run_lease
+              )
+              AND NOT EXISTS (
+                  SELECT 1 FROM {schema}.deferred_jobs AS deferred
+                  WHERE deferred.job_id = items.job_id
+                    AND deferred.run_lease = items.run_lease
+              )
+              AND NOT EXISTS (
+                  SELECT 1 FROM {schema}.dlq_entries AS dlq
+                  WHERE dlq.job_id = items.job_id
+                    AND dlq.run_lease = items.run_lease
+              )
+            UNION ALL
             SELECT job_id, kind, queue, state, created_at, run_at, finalized_at
             FROM {schema}.terminal_jobs
             UNION ALL

--- a/awa/tests/queue_storage_runtime_test.rs
+++ b/awa/tests/queue_storage_runtime_test.rs
@@ -2119,6 +2119,241 @@ async fn test_claim_ring_rotates_and_prunes_empty() {
         .expect("prepare_schema should be idempotent");
 }
 
+/// Running count for `queue` as reported by the admin `/queues` overview.
+async fn queue_overview_running(pool: &sqlx::PgPool, queue: &str) -> i64 {
+    let overviews = admin::queue_overviews(pool)
+        .await
+        .expect("queue_overviews should succeed");
+    overviews
+        .into_iter()
+        .find(|overview| overview.queue == queue)
+        .map(|overview| overview.running)
+        .unwrap_or(0)
+}
+
+/// #416 regression: a receipt-plane claim that has not (yet) materialized
+/// into a mutable lease must still appear as `running` in the admin job
+/// listing and the `/queues` overview — the two paths that back the admin
+/// UI and `awa queue stats`. Before the fix, `queue_storage_current_jobs_cte`
+/// enumerated running jobs from `leases` only, so an open receipt claim was
+/// invisible to `list_jobs`/`queue_overviews` even though `load_job` (and
+/// the authoritative `queue_counts_exact`) reported it correctly.
+///
+/// This exercises the zero-deadline compact path (claim lands in
+/// `lease_claim_batches`) to lock in the `unnest(lease_claim_batches)`
+/// branch of the CTE. It is #410-independent: the same union naturally
+/// covers row-local `lease_claims` too.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn test_admin_lists_unmaterialized_receipt_claim_as_running() {
+    let (_db_guard, pool) = setup_pool(8).await;
+    let queue = "qs_admin_receipt_visibility";
+    let schema = "awa_qs_admin_receipt_visibility";
+    let store = create_store_with_config(
+        &pool,
+        QueueStorageConfig {
+            schema: schema.to_string(),
+            queue_slot_count: 4,
+            lease_slot_count: 2,
+            claim_slot_count: 2,
+            lease_claim_receipts: true,
+            ..Default::default()
+        },
+    )
+    .await;
+
+    let job_id = enqueue_job(
+        &pool,
+        &store,
+        &CompleteJob { id: 7 },
+        InsertOpts {
+            queue: queue.to_string(),
+            ..Default::default()
+        },
+    )
+    .await;
+
+    // Zero-deadline claim: routes through the compact receipt ledger and
+    // does NOT materialize a mutable lease row.
+    let claimed = store
+        .claim_runtime_batch(&pool, queue, 1, Duration::ZERO)
+        .await
+        .expect("claim receipt-backed job");
+    assert_eq!(claimed.len(), 1);
+    assert!(
+        claimed[0].claim.lease_claim_receipt,
+        "test must exercise the receipt-backed compact claim path"
+    );
+
+    // Precondition that makes the regression meaningful: the claim is real
+    // receipt-plane evidence with no materialized lease behind it.
+    assert_eq!(
+        lease_count(&pool, &store).await,
+        0,
+        "receipt claim must not have materialized a lease"
+    );
+    assert_eq!(
+        lease_claim_batch_count(&pool, &store).await,
+        1,
+        "zero-deadline receipt claim should land in lease_claim_batches"
+    );
+    assert_eq!(
+        open_receipt_claim_count(&pool, &store).await,
+        1,
+        "exactly one open receipt claim should be derivable"
+    );
+
+    // load_job has always been batch-aware; assert the inconsistency the
+    // fix removes was specifically in the list/overview path.
+    let loaded = store
+        .load_job(&pool, job_id)
+        .await
+        .expect("load_job should succeed")
+        .expect("load_job should see the open claim");
+    assert_eq!(loaded.state, JobState::Running);
+
+    // The fix: list_jobs and queue_overviews now agree with load_job.
+    let listed = admin::list_jobs(
+        &pool,
+        &admin::ListJobsFilter {
+            queue: Some(queue.to_string()),
+            ..Default::default()
+        },
+    )
+    .await
+    .expect("list_jobs should succeed");
+    let listed_job = listed
+        .iter()
+        .find(|job| job.id == job_id)
+        .expect("open receipt claim must appear in list_jobs");
+    assert_eq!(
+        listed_job.state,
+        JobState::Running,
+        "open receipt claim must list as running"
+    );
+    assert_eq!(
+        listed.iter().filter(|job| job.id == job_id).count(),
+        1,
+        "the claimed job must appear exactly once"
+    );
+
+    // The running filter alone must surface it too.
+    let running_only = admin::list_jobs(
+        &pool,
+        &admin::ListJobsFilter {
+            queue: Some(queue.to_string()),
+            state: Some(JobState::Running),
+            ..Default::default()
+        },
+    )
+    .await
+    .expect("list_jobs(running) should succeed");
+    assert!(
+        running_only.iter().any(|job| job.id == job_id),
+        "running-state filter must include the open receipt claim"
+    );
+
+    assert_eq!(
+        queue_overview_running(&pool, queue).await,
+        1,
+        "queue overview must count the open receipt claim as running"
+    );
+
+    // Once the claim completes, it must leave the running listing/overview.
+    store
+        .complete_runtime_batch(&pool, &claimed)
+        .await
+        .expect("complete receipt-backed job");
+
+    assert_eq!(
+        open_receipt_claim_count(&pool, &store).await,
+        0,
+        "completion must close the receipt claim"
+    );
+    assert_eq!(
+        queue_overview_running(&pool, queue).await,
+        0,
+        "completed job must not count as running in the overview"
+    );
+    let after_complete = admin::list_jobs(
+        &pool,
+        &admin::ListJobsFilter {
+            queue: Some(queue.to_string()),
+            state: Some(JobState::Running),
+            ..Default::default()
+        },
+    )
+    .await
+    .expect("list_jobs(running) after completion should succeed");
+    assert!(
+        !after_complete.iter().any(|job| job.id == job_id),
+        "completed job must not list as running"
+    );
+}
+
+/// #416 dedupe guard: a claim that HAS materialized into a mutable lease
+/// must be reported exactly once. The lease-backed branch and the new
+/// receipt-claim branches of `queue_storage_current_jobs_cte` both anti-join
+/// against materialized leases, so a materialized job appears via the leases
+/// branch only — never double-counted in the running total or listed twice.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn test_admin_materialized_lease_appears_once() {
+    let (_db_guard, pool) = setup_pool(8).await;
+    let queue = "qs_admin_materialized_dedupe";
+    let schema = "awa_qs_admin_materialized_dedupe";
+    // Legacy (non-receipts) mode materializes a lease immediately on claim,
+    // giving us a deterministic materialized-lease fixture.
+    let store = create_store(&pool, schema).await;
+
+    let job_id = enqueue_job(
+        &pool,
+        &store,
+        &CompleteJob { id: 9 },
+        InsertOpts {
+            queue: queue.to_string(),
+            ..Default::default()
+        },
+    )
+    .await;
+
+    let claimed = store
+        .claim_runtime_batch(&pool, queue, 1, Duration::from_secs(30))
+        .await
+        .expect("claim job into a materialized lease");
+    assert_eq!(claimed.len(), 1);
+    assert_eq!(
+        lease_count(&pool, &store).await,
+        1,
+        "legacy claim should materialize exactly one lease"
+    );
+
+    let listed = admin::list_jobs(
+        &pool,
+        &admin::ListJobsFilter {
+            queue: Some(queue.to_string()),
+            ..Default::default()
+        },
+    )
+    .await
+    .expect("list_jobs should succeed");
+    assert_eq!(
+        listed.iter().filter(|job| job.id == job_id).count(),
+        1,
+        "a materialized-lease job must appear exactly once in list_jobs"
+    );
+    assert_eq!(
+        listed
+            .iter()
+            .find(|job| job.id == job_id)
+            .map(|job| job.state),
+        Some(JobState::Running),
+    );
+    assert_eq!(
+        queue_overview_running(&pool, queue).await,
+        1,
+        "a materialized-lease job must be counted once as running"
+    );
+}
+
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn test_queue_storage_reset_truncates_compact_receipt_evidence() {
     let (_db_guard, pool) = setup_pool(8).await;


### PR DESCRIPTION
## Problem

`queue_storage_current_jobs_cte` (`awa-model/src/admin.rs`) enumerated running jobs from `{schema}.leases` **only**. A receipt-plane claim that has not (yet) materialized into a mutable lease was therefore invisible to everything the CTE backs:

- `list_jobs` / `list_queue_storage_jobs`
- `queue_overviews` and the kind overviews
- the admin UI `/jobs` and `/queues` pages
- `awa queue stats` / the job-list CLI

Meanwhile `QueueStorage::load_job` **is** batch-aware, so the same running claim showed up in `get_job` but not in `list_jobs` — an observable inconsistency between the two admin reads.

## Scope (pre-existing, worse under #246)

This blind spot is pre-existing on `main`. Today it covers **zero-deadline compact claims** (stored in `lease_claim_batches`). Once #246 (PR #410) lands and deadline-backed claims also route through `lease_claim_batches`, a saturated queue would **under-report running jobs** in the admin UI until claims materialize.

Found while fixing the #410 telemetry-test visibility bug.

## Fix

Give the admin CTE the same `lease_claims ∪ unnest(lease_claim_batches)` expansion that `load_job` and the authoritative `queue_counts_exact` (`queue_storage.rs`) already use:

- Add a `lease_claims` branch: report each open claim as `running`, anti-joined against every durable closure-evidence shape (`closed_at`, per-child `lease_claim_closures`, compact `lease_claim_closure_batches`, and `done`/`deferred`/`dlq` terminal rows) **and** against the materialized lease.
- Add an `unnest(lease_claim_batches)` branch with the identical anti-joins for compact zero-deadline claims.

Both new branches anti-join against `{schema}.leases`, and the existing leases branch is unchanged — so a materialized job is reported via the leases branch **only** and appears **exactly once** (dedupe).

The output column contract of the CTE is unchanged. This is **#410-independent**: the same union naturally covers both the current era (deadline claims as `lease_claims` rows, zero-deadline as compact batches) and the post-#246 era, because both tables are unioned.

## Tests

Added to `awa/tests/queue_storage_runtime_test.rs`:

- `test_admin_lists_unmaterialized_receipt_claim_as_running` — enqueue -> receipt claim (zero-deadline compact path, **no lease materialization**, asserted) -> the job appears in `list_jobs` (all-state and `running`-filtered) as `running` and `queue_overviews` running count is 1; then complete -> it leaves the running listing/overview. Verified this test **fails without the fix** (panics at "open receipt claim must appear in list_jobs") and passes with it.
- `test_admin_materialized_lease_appears_once` — dedupe guard: a materialized-lease job (legacy claim path) appears exactly once in `list_jobs` and is counted once as running.

Local verification (Postgres `awa_test`):

- `cargo fmt --all --check` clean
- `SQLX_OFFLINE=true cargo clippy --all-targets --all-features -- -D warnings` clean
- `SQLX_OFFLINE=true cargo build --workspace` clean
- `cargo test -p awa --test queue_storage_runtime_test admin_` — 8 passed (the 2 new tests + 6 pre-existing admin tests)

> Note: the `awa-ui/tests/admin_api_test.rs` suite currently fails in the shared local `awa_test` DB due to a pre-existing migration-state collision (stale `awa.queue_ring_state` missing `current_slot`/`generation` from the #415 rotation-ledger renumber) — it fails during migration setup before any admin CTE code runs, and those tests exercise the legacy `awa.jobs` path, not the queue_storage receipt plane this change touches. Unrelated to this fix; CI runs against a fresh DB.

## Notes

Confined to `admin.rs`'s CTE — does **not** touch `queue_storage.rs`, so no conflict with PR #410 is expected.

Closes #416

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Admin job listings now correctly show queue-storage jobs as **running** when receipt claims have not yet been materialized into leases.
  * Prevented duplicate running-job entries when a job is represented by both receipt and lease data.
  * Queue overviews now report running jobs accurately across these claim states.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->