### PR TITLE
fix(migrations): discover substrate schemas without superuser

### DIFF
--- a/awa-model/migrations/v024_receipt_plane_fillfactor.sql
+++ b/awa-model/migrations/v024_receipt_plane_fillfactor.sql
@@ -126,10 +126,14 @@ BEGIN
     FOR v_schema IN
         SELECT n.nspname
         FROM pg_namespace AS n
-        WHERE to_regprocedure(format(
-            '%I.claim_ready_runtime(text,bigint,double precision,double precision)',
-            n.nspname
-        )) IS NOT NULL
+        WHERE has_schema_privilege(current_user, n.oid, 'USAGE')
+          AND EXISTS (
+              SELECT 1 FROM pg_proc AS awa_p
+              WHERE awa_p.pronamespace = n.oid
+                AND awa_p.proname = 'claim_ready_runtime'
+                AND oidvectortypes(awa_p.proargtypes)
+                    = 'text, bigint, double precision, double precision'
+          )
     LOOP
         -- The helper itself re-checks the sentinel and verifies the
         -- partitioned `leases` / `lease_claims` exist before doing

--- a/awa-model/migrations/v025_drop_leases_state_hb_index.sql
+++ b/awa-model/migrations/v025_drop_leases_state_hb_index.sql
@@ -37,10 +37,14 @@ BEGIN
     FOR v_schema IN
         SELECT n.nspname
         FROM pg_namespace AS n
-        WHERE to_regprocedure(format(
-            '%I.claim_ready_runtime(text,bigint,double precision,double precision)',
-            n.nspname
-        )) IS NOT NULL
+        WHERE has_schema_privilege(current_user, n.oid, 'USAGE')
+          AND EXISTS (
+              SELECT 1 FROM pg_proc AS awa_p
+              WHERE awa_p.pronamespace = n.oid
+                AND awa_p.proname = 'claim_ready_runtime'
+                AND oidvectortypes(awa_p.proargtypes)
+                    = 'text, bigint, double precision, double precision'
+          )
     LOOP
         IF to_regclass(format('%I.leases', v_schema)) IS NULL THEN
             CONTINUE;

--- a/awa-model/migrations/v027_sequence_lane_cursors.sql
+++ b/awa-model/migrations/v027_sequence_lane_cursors.sql
@@ -29,10 +29,14 @@ BEGIN
     FOR v_schema IN
         SELECT n.nspname
         FROM pg_namespace AS n
-        WHERE to_regprocedure(format(
-            '%I.claim_ready_runtime(text,bigint,double precision,double precision)',
-            n.nspname
-        )) IS NOT NULL
+        WHERE has_schema_privilege(current_user, n.oid, 'USAGE')
+          AND EXISTS (
+              SELECT 1 FROM pg_proc AS awa_p
+              WHERE awa_p.pronamespace = n.oid
+                AND awa_p.proname = 'claim_ready_runtime'
+                AND oidvectortypes(awa_p.proargtypes)
+                    = 'text, bigint, double precision, double precision'
+          )
     LOOP
         IF to_regclass(format('%I.queue_ring_state', v_schema)) IS NULL
            OR to_regclass(format('%I.lease_ring_state', v_schema)) IS NULL

--- a/awa-model/migrations/v028_ready_tombstones.sql
+++ b/awa-model/migrations/v028_ready_tombstones.sql
@@ -18,10 +18,14 @@ BEGIN
     FOR v_schema IN
         SELECT n.nspname
         FROM pg_namespace AS n
-        WHERE to_regprocedure(format(
-            '%I.claim_ready_runtime(text,bigint,double precision,double precision)',
-            n.nspname
-        )) IS NOT NULL
+        WHERE has_schema_privilege(current_user, n.oid, 'USAGE')
+          AND EXISTS (
+              SELECT 1 FROM pg_proc AS awa_p
+              WHERE awa_p.pronamespace = n.oid
+                AND awa_p.proname = 'claim_ready_runtime'
+                AND oidvectortypes(awa_p.proargtypes)
+                    = 'text, bigint, double precision, double precision'
+          )
     LOOP
         IF to_regclass(format('%I.queue_ring_state', v_schema)) IS NULL
            OR to_regclass(format('%I.lease_ring_state', v_schema)) IS NULL

--- a/awa-model/migrations/v030_terminal_count_deltas.sql
+++ b/awa-model/migrations/v030_terminal_count_deltas.sql
@@ -16,10 +16,14 @@ BEGIN
     FOR v_schema IN
         SELECT n.nspname
         FROM pg_namespace AS n
-        WHERE to_regprocedure(format(
-            '%I.claim_ready_runtime(text,bigint,double precision,double precision)',
-            n.nspname
-        )) IS NOT NULL
+        WHERE has_schema_privilege(current_user, n.oid, 'USAGE')
+          AND EXISTS (
+              SELECT 1 FROM pg_proc AS awa_p
+              WHERE awa_p.pronamespace = n.oid
+                AND awa_p.proname = 'claim_ready_runtime'
+                AND oidvectortypes(awa_p.proargtypes)
+                    = 'text, bigint, double precision, double precision'
+          )
     LOOP
         IF to_regclass(format('%I.queue_ring_state', v_schema)) IS NULL
            OR to_regclass(format('%I.lease_ring_state', v_schema)) IS NULL

--- a/awa-model/migrations/v031_queue_storage_failed_done_indexes.sql
+++ b/awa-model/migrations/v031_queue_storage_failed_done_indexes.sql
@@ -15,12 +15,22 @@ BEGIN
     FOR v_schema IN
         SELECT n.nspname
         FROM pg_namespace AS n
-        WHERE to_regclass(format('%I.queue_ring_state', n.nspname)) IS NOT NULL
-          AND to_regclass(format('%I.done_entries', n.nspname)) IS NOT NULL
-          AND to_regprocedure(format(
-              '%I.claim_ready_runtime(text,bigint,double precision,double precision)',
-              n.nspname
-          )) IS NOT NULL
+        WHERE has_schema_privilege(current_user, n.oid, 'USAGE')
+          AND EXISTS (
+              SELECT 1 FROM pg_class AS awa_c
+              WHERE awa_c.relnamespace = n.oid AND awa_c.relname = 'queue_ring_state'
+          )
+          AND EXISTS (
+              SELECT 1 FROM pg_class AS awa_c
+              WHERE awa_c.relnamespace = n.oid AND awa_c.relname = 'done_entries'
+          )
+          AND EXISTS (
+              SELECT 1 FROM pg_proc AS awa_p
+              WHERE awa_p.pronamespace = n.oid
+                AND awa_p.proname = 'claim_ready_runtime'
+                AND oidvectortypes(awa_p.proargtypes)
+                    = 'text, bigint, double precision, double precision'
+          )
     LOOP
         EXECUTE format(
             'SELECT slot_count FROM %I.queue_ring_state WHERE singleton = TRUE',

--- a/awa-model/migrations/v032_failed_terminal_retention.sql
+++ b/awa-model/migrations/v032_failed_terminal_retention.sql
@@ -14,12 +14,22 @@ BEGIN
     FOR v_schema IN
         SELECT n.nspname
         FROM pg_namespace AS n
-        WHERE to_regclass(format('%I.queue_ring_state', n.nspname)) IS NOT NULL
-          AND to_regclass(format('%I.queue_terminal_rollups', n.nspname)) IS NOT NULL
-          AND to_regprocedure(format(
-              '%I.claim_ready_runtime(text,bigint,double precision,double precision)',
-              n.nspname
-          )) IS NOT NULL
+        WHERE has_schema_privilege(current_user, n.oid, 'USAGE')
+          AND EXISTS (
+              SELECT 1 FROM pg_class AS awa_c
+              WHERE awa_c.relnamespace = n.oid AND awa_c.relname = 'queue_ring_state'
+          )
+          AND EXISTS (
+              SELECT 1 FROM pg_class AS awa_c
+              WHERE awa_c.relnamespace = n.oid AND awa_c.relname = 'queue_terminal_rollups'
+          )
+          AND EXISTS (
+              SELECT 1 FROM pg_proc AS awa_p
+              WHERE awa_p.pronamespace = n.oid
+                AND awa_p.proname = 'claim_ready_runtime'
+                AND oidvectortypes(awa_p.proargtypes)
+                    = 'text, bigint, double precision, double precision'
+          )
     LOOP
         IF NOT EXISTS (
             SELECT 1

--- a/awa-model/migrations/v033_receipt_rescue_cursors.sql
+++ b/awa-model/migrations/v033_receipt_rescue_cursors.sql
@@ -17,10 +17,14 @@ BEGIN
     FOR v_schema IN
         SELECT n.nspname
         FROM pg_namespace AS n
-        WHERE to_regprocedure(format(
-            '%I.claim_ready_runtime(text,bigint,double precision,double precision)',
-            n.nspname
-        )) IS NOT NULL
+        WHERE has_schema_privilege(current_user, n.oid, 'USAGE')
+          AND EXISTS (
+              SELECT 1 FROM pg_proc AS awa_p
+              WHERE awa_p.pronamespace = n.oid
+                AND awa_p.proname = 'claim_ready_runtime'
+                AND oidvectortypes(awa_p.proargtypes)
+                    = 'text, bigint, double precision, double precision'
+          )
     LOOP
         IF to_regclass(format('%I.queue_ring_state', v_schema)) IS NULL
            OR to_regclass(format('%I.lease_ring_state', v_schema)) IS NULL

--- a/awa-model/migrations/v035_receipt_deadline_rescue_cursors.sql
+++ b/awa-model/migrations/v035_receipt_deadline_rescue_cursors.sql
@@ -21,10 +21,14 @@ BEGIN
     FOR v_schema IN
         SELECT n.nspname
         FROM pg_namespace AS n
-        WHERE to_regprocedure(format(
-            '%I.claim_ready_runtime(text,bigint,double precision,double precision)',
-            n.nspname
-        )) IS NOT NULL
+        WHERE has_schema_privilege(current_user, n.oid, 'USAGE')
+          AND EXISTS (
+              SELECT 1 FROM pg_proc AS awa_p
+              WHERE awa_p.pronamespace = n.oid
+                AND awa_p.proname = 'claim_ready_runtime'
+                AND oidvectortypes(awa_p.proargtypes)
+                    = 'text, bigint, double precision, double precision'
+          )
     LOOP
         IF to_regclass(format('%I.queue_ring_state', v_schema)) IS NULL
            OR to_regclass(format('%I.lease_ring_state', v_schema)) IS NULL

--- a/awa-model/migrations/v036_compact_receipt_completions.sql
+++ b/awa-model/migrations/v036_compact_receipt_completions.sql
@@ -20,10 +20,14 @@ BEGIN
     FOR v_schema IN
         SELECT n.nspname
         FROM pg_namespace AS n
-        WHERE to_regprocedure(format(
-            '%I.claim_ready_runtime(text,bigint,double precision,double precision)',
-            n.nspname
-        )) IS NOT NULL
+        WHERE has_schema_privilege(current_user, n.oid, 'USAGE')
+          AND EXISTS (
+              SELECT 1 FROM pg_proc AS awa_p
+              WHERE awa_p.pronamespace = n.oid
+                AND awa_p.proname = 'claim_ready_runtime'
+                AND oidvectortypes(awa_p.proargtypes)
+                    = 'text, bigint, double precision, double precision'
+          )
     LOOP
         IF to_regclass(format('%I.queue_ring_state', v_schema)) IS NULL
            OR to_regclass(format('%I.lease_ring_state', v_schema)) IS NULL

--- a/awa-model/migrations/v037_ready_segments.sql
+++ b/awa-model/migrations/v037_ready_segments.sql
@@ -21,10 +21,14 @@ BEGIN
     FOR v_schema IN
         SELECT n.nspname
         FROM pg_namespace AS n
-        WHERE to_regprocedure(format(
-            '%I.claim_ready_runtime(text,bigint,double precision,double precision)',
-            n.nspname
-        )) IS NOT NULL
+        WHERE has_schema_privilege(current_user, n.oid, 'USAGE')
+          AND EXISTS (
+              SELECT 1 FROM pg_proc AS awa_p
+              WHERE awa_p.pronamespace = n.oid
+                AND awa_p.proname = 'claim_ready_runtime'
+                AND oidvectortypes(awa_p.proargtypes)
+                    = 'text, bigint, double precision, double precision'
+          )
     LOOP
         IF to_regclass(format('%I.queue_ring_state', v_schema)) IS NULL
            OR to_regclass(format('%I.lease_ring_state', v_schema)) IS NULL

--- a/awa-model/migrations/v039_claim_head_cold_routing.sql
+++ b/awa-model/migrations/v039_claim_head_cold_routing.sql
@@ -28,10 +28,14 @@ BEGIN
     FOR v_schema IN
         SELECT n.nspname
         FROM pg_namespace AS n
-        WHERE to_regprocedure(format(
-            '%I.claim_ready_runtime(text,bigint,double precision,double precision)',
-            n.nspname
-        )) IS NOT NULL
+        WHERE has_schema_privilege(current_user, n.oid, 'USAGE')
+          AND EXISTS (
+              SELECT 1 FROM pg_proc AS awa_p
+              WHERE awa_p.pronamespace = n.oid
+                AND awa_p.proname = 'claim_ready_runtime'
+                AND oidvectortypes(awa_p.proargtypes)
+                    = 'text, bigint, double precision, double precision'
+          )
     LOOP
         IF to_regclass(format('%I.queue_ring_state', v_schema)) IS NULL
            OR to_regclass(format('%I.lease_ring_state', v_schema)) IS NULL

--- a/awa-model/migrations/v042_compact_deadline_claims.sql
+++ b/awa-model/migrations/v042_compact_deadline_claims.sql
@@ -40,10 +40,14 @@ BEGIN
     FOR v_schema IN
         SELECT n.nspname
         FROM pg_namespace AS n
-        WHERE to_regprocedure(format(
-            '%I.claim_ready_runtime(text,bigint,double precision,double precision)',
-            n.nspname
-        )) IS NOT NULL
+        WHERE has_schema_privilege(current_user, n.oid, 'USAGE')
+          AND EXISTS (
+              SELECT 1 FROM pg_proc AS awa_p
+              WHERE awa_p.pronamespace = n.oid
+                AND awa_p.proname = 'claim_ready_runtime'
+                AND oidvectortypes(awa_p.proargtypes)
+                    = 'text, bigint, double precision, double precision'
+          )
     LOOP
         IF to_regclass(format('%I.queue_ring_state', v_schema)) IS NULL
            OR to_regclass(format('%I.lease_ring_state', v_schema)) IS NULL

--- a/awa-model/migrations/v043_ring_rotation_ledger.sql
+++ b/awa-model/migrations/v043_ring_rotation_ledger.sql
@@ -65,10 +65,14 @@ BEGIN
     FOR v_schema IN
         SELECT n.nspname
         FROM pg_namespace AS n
-        WHERE to_regprocedure(format(
-            '%I.claim_ready_runtime(text,bigint,double precision,double precision)',
-            n.nspname
-        )) IS NOT NULL
+        WHERE has_schema_privilege(current_user, n.oid, 'USAGE')
+          AND EXISTS (
+              SELECT 1 FROM pg_proc AS awa_p
+              WHERE awa_p.pronamespace = n.oid
+                AND awa_p.proname = 'claim_ready_runtime'
+                AND oidvectortypes(awa_p.proargtypes)
+                    = 'text, bigint, double precision, double precision'
+          )
     LOOP
         IF to_regclass(format('%I.queue_ring_state', v_schema)) IS NULL
            OR to_regclass(format('%I.lease_ring_state', v_schema)) IS NULL

--- a/awa-model/tests/least_privilege_migration_test.rs
+++ b/awa-model/tests/least_privilege_migration_test.rs
@@ -1,0 +1,115 @@
+//! Regression test: the full migration chain must apply under a
+//! least-privilege *owner* role, not only under a superuser.
+//!
+//! The queue-storage migrations discover substrate schemas by scanning
+//! `pg_namespace`. The old idiom probed every schema with
+//! `to_regprocedure()` / `to_regclass()`, which raise
+//! `permission denied for schema X` for any schema the current role lacks
+//! `USAGE` on — most notably `pg_toast`. That made the whole migration set
+//! apply cleanly only as a superuser (which bypasses schema ACLs), so on
+//! managed Postgres — where the migration role owns the `awa` schema but is
+//! deliberately not a superuser — provisioning failed at the first such
+//! migration.
+//!
+//! This test provisions a fresh database owned by a `NOSUPERUSER` role and
+//! asserts `migrations::run` reaches `CURRENT_VERSION`. It fails against the
+//! old scan idiom (with `permission denied for schema pg_toast`) and passes
+//! once discovery uses catalog lookups gated on `has_schema_privilege()`.
+
+use sqlx::postgres::{PgConnectOptions, PgPoolOptions};
+use std::str::FromStr;
+
+fn database_url() -> String {
+    std::env::var("DATABASE_URL")
+        .unwrap_or_else(|_| "postgres://postgres:test@localhost:15432/awa_test".to_string())
+}
+
+#[tokio::test]
+async fn migrations_apply_as_non_superuser_owner() {
+    let admin = PgPoolOptions::new()
+        .max_connections(2)
+        .connect(&database_url())
+        .await
+        .expect("admin connect");
+
+    // Unique names so concurrent test runs don't collide.
+    let suffix = uuid::Uuid::new_v4().simple().to_string();
+    let role = format!("awa_lp_{suffix}");
+    let db = format!("awa_lp_{suffix}");
+    let password = "awa_lp_test_pw";
+
+    // A least-privilege login role: explicitly NOSUPERUSER so it is subject
+    // to the same schema ACLs (pg_toast etc.) a managed-Postgres owner hits.
+    sqlx::query(&format!(
+        "CREATE ROLE \"{role}\" LOGIN NOSUPERUSER NOCREATEDB NOCREATEROLE PASSWORD '{password}'"
+    ))
+    .execute(&admin)
+    .await
+    .expect("create least-privilege role");
+
+    // A fresh database owned by that role: it can CREATE the awa schema, and
+    // every object it creates is owned by it — matching the real deployment.
+    // (CREATE DATABASE cannot run inside a transaction.)
+    sqlx::query(&format!("CREATE DATABASE \"{db}\" OWNER \"{role}\""))
+        .execute(&admin)
+        .await
+        .expect("create owned database");
+
+    let result = run_migrations_as(&database_url(), &db, &role, password).await;
+
+    // Always tear down, regardless of the outcome.
+    let _ = sqlx::query(&format!("DROP DATABASE IF EXISTS \"{db}\" WITH (FORCE)"))
+        .execute(&admin)
+        .await;
+    let _ = sqlx::query(&format!("DROP ROLE IF EXISTS \"{role}\""))
+        .execute(&admin)
+        .await;
+    admin.close().await;
+
+    result.expect("migrations must apply cleanly as a non-superuser owner");
+}
+
+async fn run_migrations_as(
+    admin_url: &str,
+    db: &str,
+    role: &str,
+    password: &str,
+) -> Result<(), String> {
+    let opts = PgConnectOptions::from_str(admin_url)
+        .map_err(|e| format!("parse DATABASE_URL: {e}"))?
+        .database(db)
+        .username(role)
+        .password(password);
+    let pool = PgPoolOptions::new()
+        .max_connections(2)
+        .connect_with(opts)
+        .await
+        .map_err(|e| format!("connect as {role}: {e}"))?;
+
+    // The test only proves something if the role really is non-superuser.
+    let is_super: bool =
+        sqlx::query_scalar("SELECT rolsuper FROM pg_roles WHERE rolname = current_user")
+            .fetch_one(&pool)
+            .await
+            .map_err(|e| format!("check rolsuper: {e}"))?;
+    if is_super {
+        return Err("test role unexpectedly has SUPERUSER".into());
+    }
+
+    awa_model::migrations::run(&pool)
+        .await
+        .map_err(|e| format!("run migrations: {e}"))?;
+
+    let version = awa_model::migrations::current_version(&pool)
+        .await
+        .map_err(|e| format!("current_version: {e}"))?;
+    pool.close().await;
+
+    if version != awa_model::migrations::CURRENT_VERSION {
+        return Err(format!(
+            "expected schema version {}, reached {version}",
+            awa_model::migrations::CURRENT_VERSION
+        ));
+    }
+    Ok(())
+}


### PR DESCRIPTION
## Problem

The queue-storage migrations discover substrate schemas by scanning every schema in `pg_namespace` and probing each with `to_regprocedure()` / `to_regclass()`:

```sql
FOR v_schema IN
    SELECT n.nspname
    FROM pg_namespace AS n
    WHERE to_regprocedure(format(
        '%I.claim_ready_runtime(text,bigint,double precision,double precision)',
        n.nspname
    )) IS NOT NULL
LOOP ...
```

`to_regprocedure()` / `to_regclass()` raise `permission denied for schema X` for any schema the current role lacks `USAGE` on — most notably `pg_toast`, but also another application's schema on a shared database. Because the scan touches *every* schema, the entire migration set only applies cleanly under a **superuser** (which bypasses schema ACLs).

On managed Postgres — where the migration role *owns* the `awa` schema but is deliberately **not** a superuser — provisioning fails at the first migration that runs this scan (v24), with:

```
Error: awa migrations failed
    permission denied for schema pg_toast
```

The failure *looks* like it comes from the DDL in that migration (e.g. v24's fillfactor `ALTER`), but it's the discovery scan — the DDL itself works fine as the schema owner.

## Fix

Replace the `to_regprocedure()` / `to_regclass()` probes with lookups against the shared catalogs (`pg_proc` / `pg_class`), which never trigger a per-schema permission check, and gate discovery on `has_schema_privilege()` so a role only operates on substrates it can actually access:

```sql
FROM pg_namespace AS n
WHERE has_schema_privilege(current_user, n.oid, 'USAGE')
  AND EXISTS (
      SELECT 1 FROM pg_proc AS awa_p
      WHERE awa_p.pronamespace = n.oid
        AND awa_p.proname = 'claim_ready_runtime'
        AND oidvectortypes(awa_p.proargtypes)
            = 'text, bigint, double precision, double precision'
  )
```

Applied to every migration that used the scan (14 files, both the single-`claim_ready_runtime` and the compound `to_regclass` + `to_regprocedure` variants).

- **No behavioural change** for a superuser or a single-schema install — discovery returns the same substrate set.
- **Correct for multi-tenant databases**: with the old scan working (no longer erroring), discovery could surface another tenant's substrate and then fail on the inner ops; `has_schema_privilege()` restricts it to substrates the role can use.
- The Rust runtime already uses known-schema lookups, so no changes there.

## Validation

- Every rewritten discovery query verified on Postgres 17 as a **non-superuser owner role**: returns the substrate schema with no permission error (the old form errors on `pg_toast`).
- `oidvectortypes(proargtypes)` matches the exact `claim_ready_runtime(text, bigint, double precision, double precision)` signature the old probe used.

## Regression test

Includes `awa-model/tests/least_privilege_migration_test.rs`: provisions a fresh database owned by a **`NOSUPERUSER` role**, runs the full migration chain as that role, and asserts it reaches `CURRENT_VERSION`. It asserts the role is genuinely non-superuser first so it can't pass vacuously, and tears down the role and database afterward. Fails against the old scan (`permission denied for schema pg_toast`), passes with the catalog-based discovery — guarding against the scan idiom creeping back in.
