### PR TITLE
test(upgrade): fix cron double-fire flake in the mixed-version rehearsal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ correctness/**/*_TTrace_*.tla
 /benchmarks/portable/results/
 /benchmarks/portable/awa-bench/target/
 .compat-venv-*
+rehearsal-repro-logs/

--- a/awa/tests/rolling_upgrade_rehearsal_test.rs
+++ b/awa/tests/rolling_upgrade_rehearsal_test.rs
@@ -1316,10 +1316,12 @@ async fn test_migrate_first_full_workload_reconciles_designed_outcomes() {
     // `*/5 * * * *` looks inert but can coincide with a real wall-clock
     // boundary on a slow/contended run, and the periodic dispatcher fires
     // independently of manual triggers, producing an uncounted third
-    // completion that overshoots `expectations` by one. Pausing right
-    // after registration blocks *automatic* fires while leaving
-    // trigger_cron_job() — which works on paused schedules by design —
-    // fully functional for the two intentional fires.
+    // completion that overshoots `expectations` by one. Registering and
+    // pausing in the same transaction closes the window entirely: the
+    // periodic dispatcher only ever observes the committed (paused) row,
+    // never an intermediate unpaused one. trigger_cron_job() keeps working
+    // on a paused schedule by design ("manual trigger is an explicit
+    // operator action"), so the two intentional fires are unaffected.
     let cron_name = format!("upgrade_rehearsal_cron_{run_id}");
     let cron_job = PeriodicJob::builder(cron_name.clone(), "*/5 * * * *")
         .queue(workload_queue.clone())
@@ -1328,12 +1330,17 @@ async fn test_migrate_first_full_workload_reconciles_designed_outcomes() {
             mode: "complete".to_string(),
         })
         .expect("build cron job");
-    upsert_cron_job(&pool, &cron_job)
+    let mut cron_setup_tx = pool.begin().await.expect("begin cron registration");
+    upsert_cron_job(cron_setup_tx.as_mut(), &cron_job)
         .await
         .expect("upsert cron job");
-    pause_cron_job(&pool, &cron_name, Some("rehearsal-test"))
+    pause_cron_job(cron_setup_tx.as_mut(), &cron_name, Some("rehearsal-test"))
         .await
         .expect("pause cron schedule so only explicit triggers fire it");
+    cron_setup_tx
+        .commit()
+        .await
+        .expect("commit paused cron registration");
     let pre_flip_fire = trigger_cron_job(&pool, &cron_name)
         .await
         .expect("trigger cron before flip");

--- a/awa/tests/rolling_upgrade_rehearsal_test.rs
+++ b/awa/tests/rolling_upgrade_rehearsal_test.rs
@@ -7,7 +7,7 @@
 use async_trait::async_trait;
 use awa::model::{
     admin,
-    cron::{trigger_cron_job, upsert_cron_job, PeriodicJob},
+    cron::{pause_cron_job, trigger_cron_job, upsert_cron_job, PeriodicJob},
     dlq, insert_with, migrations, storage, InsertOpts, JobState, QueueStorage, QueueStorageConfig,
 };
 use awa::{Client, JobArgs, JobContext, JobError, JobResult, QueueConfig, Worker};
@@ -1310,7 +1310,16 @@ async fn test_migrate_first_full_workload_reconciles_designed_outcomes() {
     .await;
     report.phase("migrated_mixed_fleet_completing");
 
-    // Cron work fires while both fleets are live, before any flip.
+    // Cron work fires while both fleets are live, before any flip. The
+    // schedule itself must never fire on its own — the test wants exactly
+    // the two explicit trigger_cron_job() calls below and nothing else.
+    // `*/5 * * * *` looks inert but can coincide with a real wall-clock
+    // boundary on a slow/contended run, and the periodic dispatcher fires
+    // independently of manual triggers, producing an uncounted third
+    // completion that overshoots `expectations` by one. Pausing right
+    // after registration blocks *automatic* fires while leaving
+    // trigger_cron_job() — which works on paused schedules by design —
+    // fully functional for the two intentional fires.
     let cron_name = format!("upgrade_rehearsal_cron_{run_id}");
     let cron_job = PeriodicJob::builder(cron_name.clone(), "*/5 * * * *")
         .queue(workload_queue.clone())
@@ -1322,6 +1331,9 @@ async fn test_migrate_first_full_workload_reconciles_designed_outcomes() {
     upsert_cron_job(&pool, &cron_job)
         .await
         .expect("upsert cron job");
+    pause_cron_job(&pool, &cron_name, Some("rehearsal-test"))
+        .await
+        .expect("pause cron schedule so only explicit triggers fire it");
     let pre_flip_fire = trigger_cron_job(&pool, &cron_name)
         .await
         .expect("trigger cron before flip");

--- a/scripts/repro-rehearsal-contention.sh
+++ b/scripts/repro-rehearsal-contention.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# Reproduce timing-sensitive rolling_upgrade_rehearsal_test.rs (#427) flakes
+# locally by loop-running it under a constrained CPU set.
+#
+# The rehearsal races live traffic against a real schema migration and, in
+# the mixed-fleet cells, against a hard-killed released worker. On a
+# many-core dev box those races basically never land: everything finishes
+# well inside the staleness/timeout margins. GitHub's hosted runners give
+# the job 2 vCPUs, which widens the same windows enough to occasionally lose
+# them — that gap is why flakes like the cron double-fire and the
+# simple-queue terminal-count mismatch showed up in CI but not locally.
+# `taskset -c 0,1` closes that gap by pinning this shell to 2 cores too.
+#
+# Usage:
+#   scripts/repro-rehearsal-contention.sh [iterations] [test-name-filter]
+#
+#   iterations         default 20
+#   test-name-filter   default: run every #[ignore]'d test in the file
+#                       (pass a substring, e.g. "full_workload", to narrow it)
+#
+# Env:
+#   DATABASE_URL          default postgres://postgres:test@localhost:15432/awa_test
+#   AWA_N_MINUS_ONE_VER   released N-1 awa-pg version to rehearse against, default 0.6.3
+#   AWA_N_MINUS_ONE_PYTHON  path to an existing interpreter; skips venv setup if set
+#
+# On a failure, the full test output is kept under
+# ./rehearsal-repro-logs/run-<N>.log for post-mortem (grep for "panicked at",
+# then cross-reference job ids / timestamps against the database — see the
+# cron double-fire and simple-queue investigations for the pattern).
+set -euo pipefail
+
+ITERATIONS=${1:-20}
+TEST_FILTER=${2:-}
+DATABASE_URL=${DATABASE_URL:-postgres://postgres:test@localhost:15432/awa_test}
+AWA_N_MINUS_ONE_VER=${AWA_N_MINUS_ONE_VER:-0.6.3}
+LOG_DIR=rehearsal-repro-logs
+
+if ! psql "$DATABASE_URL" -c "SELECT 1" >/dev/null 2>&1; then
+  echo "error: cannot reach DATABASE_URL=$DATABASE_URL" >&2
+  echo "  start it, e.g.: docker run -d --name awa-pg -e POSTGRES_PASSWORD=test -e POSTGRES_DB=awa_test -p 15432:5432 postgres:17-alpine" >&2
+  exit 1
+fi
+
+if [ -z "${AWA_N_MINUS_ONE_PYTHON:-}" ]; then
+  VENV=.compat-venv-repro
+  echo "── setup: released awa-pg==${AWA_N_MINUS_ONE_VER} in ${VENV}"
+  uv venv --quiet --clear "$VENV"
+  uv pip install --quiet --python "$VENV" "awa-pg==${AWA_N_MINUS_ONE_VER}"
+  AWA_N_MINUS_ONE_PYTHON="$(pwd)/${VENV}/bin/python"
+fi
+export AWA_N_MINUS_ONE_PYTHON
+export DATABASE_URL
+export SQLX_OFFLINE=true
+
+TASKSET=()
+if command -v taskset >/dev/null 2>&1; then
+  TASKSET=(taskset -c 0,1)
+else
+  echo "warning: taskset not found — running unconstrained; reproduction is much less likely" >&2
+fi
+
+echo "── build"
+cargo build --package awa --test rolling_upgrade_rehearsal_test
+
+mkdir -p "$LOG_DIR"
+rm -f "$LOG_DIR"/run-*.log
+
+pass=0
+fail=0
+for i in $(seq 1 "$ITERATIONS"); do
+  log="$LOG_DIR/run-${i}.log"
+  echo "── iteration $i/$ITERATIONS"
+  if "${TASKSET[@]}" cargo test --package awa --test rolling_upgrade_rehearsal_test \
+      ${TEST_FILTER:+"$TEST_FILTER"} -- --ignored --nocapture >"$log" 2>&1; then
+    pass=$((pass + 1))
+    rm -f "$log"
+  else
+    fail=$((fail + 1))
+    echo "   FAILED — see $log"
+    grep -A2 "panicked at" "$log" | sed 's/^/   /' || true
+  fi
+done
+
+echo
+echo "── summary: ${pass} passed, ${fail} failed (of ${ITERATIONS})"
+if [ "$fail" -gt 0 ]; then
+  echo "   failing logs kept in ${LOG_DIR}/"
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- The `#427` rolling-upgrade rehearsal's `test_migrate_first_full_workload_reconciles_designed_outcomes` cell has been intermittently failing in nightly CI with `expected=N counts=... terminal: N+1` — one extra completion beyond what the test tracked.
- Root-caused via a local reproduction (see below): the test's cron job runs on a live `*/5 * * * *` schedule and expects exactly two completions, from its two explicit `trigger_cron_job()` calls. On a slow/contended run, the periodic dispatcher can independently fire on a real wall-clock boundary — confirmed directly against a failing run's database: `cron_jobs.last_enqueued_at = 22:50:00+00` exactly matched a third, unaccounted-for `terminal_jobs` row completed at `22:50:00.25`, alongside the two manual triggers at `22:49:53` and `22:49:58`.
- Fix: pause the cron schedule immediately after registering it. `pause_cron_job()` blocks the periodic dispatcher's automatic fires; `trigger_cron_job()` is explicitly designed to keep working on paused schedules ("manual trigger is an explicit operator action"), so the test's two intentional fires are unaffected.
- Adds `scripts/repro-rehearsal-contention.sh`, a loop-and-`taskset`-pin harness for reproducing this class of timing-sensitive rehearsal flake locally. The race barely opens on a many-core dev box; pinning to 2 CPUs (matching GitHub's hosted runners) is what actually surfaced it (0/14 reproductions unconstrained vs 2/14 pinned).

## Note
This fixes one confirmed source of the `#434`-tracked nightly flakiness. The original two nightly failures (`expected=33`/`terminal=34`) were on the simple-queue drain earlier in the same test, before the cron job even exists — a separate, still-unconfirmed issue. I was not able to reproduce that one locally in this pass; `scripts/repro-rehearsal-contention.sh` is meant to make chasing it down (and future flakes like it) cheaper going forward.

## Test plan
- [x] `cargo build --package awa --test rolling_upgrade_rehearsal_test` (offline, compiles clean)
- [x] `scripts/repro-rehearsal-contention.sh 15 full_workload` — 15/15 passed under 2-CPU contention (previously reproduced the cron-fire bug within ~14 runs under the same conditions)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved rolling-upgrade rehearsal reliability by pausing scheduled cron jobs and triggering them deterministically.
  * Added a repeatable test runner for reproducing timing-sensitive rehearsal failures, with configurable iterations and failure logs.

* **Chores**
  * Excluded rehearsal reproduction logs from version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->