### PR TITLE
perf(queue-storage): skip TRUNCATE on empty idle ring slots; cut 0.6.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,6 +123,46 @@ jobs:
           DATABASE_URL: postgres://postgres:postgres@localhost:5432/awa_test
           AWA_TEST_ENGINE: queue_storage
 
+  # Runs the queue-storage prune suite against AlloyDB Omni (PG 18) to guard
+  # the idle-prune churn regression on a disaggregated-storage engine: awa
+  # re-TRUNCATE-ing empty ring slots every maintenance tick saturates AlloyDB's
+  # regional-storage IO. Omni runs as a plain Postgres service here; the
+  # columnar-engine preload is unnecessary because the tests assert logical
+  # prune behaviour (Noop + no relfilenode churn on empty slots), not columnar
+  # performance.
+  rust-test-alloydb-omni:
+    name: Rust prune tests (AlloyDB Omni)
+    needs: [rust-build]
+    if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'full-ci')
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    services:
+      alloydb:
+        image: gcr.io/alloydb-omni/alloydbomni:18.3
+        env:
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: awa_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 40
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: ". -> target"
+      - name: Wait for AlloyDB Omni
+        run: until pg_isready -h localhost -p 5432; do sleep 1; done
+      - name: Run prune suite on AlloyDB Omni
+        run: cargo test -p awa --test queue_storage_runtime_test prune
+        env:
+          DATABASE_URL: postgres://postgres:postgres@localhost:5432/awa_test
+          AWA_TEST_ENGINE: queue_storage
+
   # ─── Rust bridge (tokio-postgres) ──────────────────────
   rust-bridge-tokio-pg:
     name: Rust bridge (tokio-postgres)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ Notable changes between releases. Detailed migration notes for storage transitio
 
 ## [Unreleased]
 
+## [0.6.4] — 2026-07-22
+
+Patch release: one performance fix for idle background IO. No migrations, no schema changes, no API changes.
+
+### Performance
+
+- **Idle rings no longer `TRUNCATE` empty sealed slots every maintenance tick.** On an idle queue the ring-rotation cursor keeps advancing over empty slots, so `prune_oldest` / `prune_oldest_leases` / `prune_oldest_claims` re-took `ACCESS EXCLUSIVE` and issued a destructive `TRUNCATE` on an already-empty oldest sealed slot every rotation tick — continuous relfilenode churn and WAL-flushing commits with **zero jobs in the system**. That idle DDL is near-free on local-SSD Postgres but saturates the IO path on disaggregated-storage engines such as AlloyDB, inflating p99 latency for co-located application queries. Each prune now proves the target slot's child partitions are empty before locking and returns `PruneOutcome::Noop` when there is nothing to reclaim.
+  - Non-empty slots still follow the same lock + liveness-recheck + truncate path, so no reclamation is skipped and no data can be stranded; the queue prune also keeps its per-slot `queue_terminal_live_counts` cleanup on the skip path so exact per-queue counters cannot drift.
+  - Measured on an idle queue against AlloyDB Omni (30 s window, zero jobs): destructive `TRUNCATE`s dropped from ~82/s to 0 and WAL generation fell ~50×.
+  - This is the prune-side equivalent of the rotation-side idle-skip that ships in 0.7.0 ([#409](https://github.com/hardbyte/awa/pull/409)).
+
 ## [0.6.3] — 2026-07-15
 
 - **Migrations no longer require superuser ([#431](https://github.com/hardbyte/awa/pull/431)).** The queue-storage migrations (v024 onward) discovered substrate schemas by probing every schema in `pg_namespace` with `to_regprocedure()` / `to_regclass()`, which raise `permission denied for schema pg_toast` (or any other schema the role lacks `USAGE` on) for a non-superuser — so on managed Postgres, where the migration role owns the `awa` schema but is deliberately not a superuser, provisioning failed at migration v024. Discovery now uses shared-catalog lookups (`pg_proc` / `pg_class`) gated on `has_schema_privilege()`, which never trigger per-schema permission checks. No behavioural change for superusers or single-schema installs; on shared databases, discovery is additionally restricted to substrates the role can actually access. A regression test now runs the full migration chain as a `NOSUPERUSER` owner role, so the scan idiom cannot creep back in. If you run migrations through your own external tooling, note that the historical migration files changed in place (semantically equivalent SQL); Awa's built-in migrator tracks applied versions by number and is unaffected.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -383,7 +383,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "awa"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "async-trait",
  "awa-macros",
@@ -408,7 +408,7 @@ dependencies = [
 
 [[package]]
 name = "awa-cli"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "assert_cmd",
  "awa-model",
@@ -430,7 +430,7 @@ dependencies = [
 
 [[package]]
 name = "awa-macros"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -440,7 +440,7 @@ dependencies = [
 
 [[package]]
 name = "awa-metrics"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "awa-model",
  "opentelemetry",
@@ -448,7 +448,7 @@ dependencies = [
 
 [[package]]
 name = "awa-model"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "awa-macros",
  "blake3",
@@ -469,7 +469,7 @@ dependencies = [
 
 [[package]]
 name = "awa-seaorm"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "awa",
  "awa-testing",
@@ -482,7 +482,7 @@ dependencies = [
 
 [[package]]
 name = "awa-testing"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "async-trait",
  "awa-model",
@@ -497,7 +497,7 @@ dependencies = [
 
 [[package]]
 name = "awa-ui"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "awa-metrics",
  "awa-model",
@@ -520,7 +520,7 @@ dependencies = [
 
 [[package]]
 name = "awa-worker"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 exclude = ["awa-python", "spike"]
 
 [workspace.package]
-version = "0.6.3"
+version = "0.6.4"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "Postgres-native background job queue — transactional enqueue, heartbeat crash recovery, SKIP LOCKED dispatch"
@@ -25,11 +25,11 @@ categories = ["database", "asynchronous", "web-programming"]
 
 [workspace.dependencies]
 # Internal crates
-awa-model = { path = "awa-model", version = "0.6.3" }
-awa-macros = { path = "awa-macros", version = "0.6.3" }
-awa-metrics = { path = "awa-metrics", version = "0.6.3" }
-awa-worker = { path = "awa-worker", version = "0.6.3" }
-awa = { path = "awa", version = "0.6.3" }
+awa-model = { path = "awa-model", version = "0.6.4" }
+awa-macros = { path = "awa-macros", version = "0.6.4" }
+awa-metrics = { path = "awa-metrics", version = "0.6.4" }
+awa-worker = { path = "awa-worker", version = "0.6.4" }
+awa = { path = "awa", version = "0.6.4" }
 
 # Database
 sea-orm = { version = "=2.0.0-rc.38", default-features = false, features = ["sqlx-postgres", "runtime-tokio-rustls", "with-chrono", "with-json"] }

--- a/awa-cli/Cargo.toml
+++ b/awa-cli/Cargo.toml
@@ -14,7 +14,7 @@ path = "src/main.rs"
 [dependencies]
 awa-model.workspace = true
 awa-worker.workspace = true
-awa-ui = { path = "../awa-ui", version = "0.6.3" }
+awa-ui = { path = "../awa-ui", version = "0.6.4" }
 axum.workspace = true
 sqlx.workspace = true
 tokio.workspace = true
@@ -28,5 +28,5 @@ hex.workspace = true
 uuid.workspace = true
 
 [dev-dependencies]
-awa-testing = { path = "../awa-testing", version = "0.6.3" }
+awa-testing = { path = "../awa-testing", version = "0.6.4" }
 assert_cmd = "2"

--- a/awa-cli/pyproject.toml
+++ b/awa-cli/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "awa-cli"
-version = "0.6.3"
+version = "0.6.4"
 description = "CLI for the Awa Postgres-native job queue (migrations, admin, serve)"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/awa-model/src/queue_storage.rs
+++ b/awa-model/src/queue_storage.rs
@@ -13356,6 +13356,22 @@ impl QueueStorage {
             .map_err(map_sqlx_error)
     }
 
+    /// Returns `true` if any of `relations` has at least one row, checking in
+    /// order and stopping at the first non-empty one. Used by the ring prune
+    /// paths to prove an oldest sealed slot is empty before taking
+    /// `ACCESS EXCLUSIVE` and issuing a destructive `TRUNCATE` on it.
+    async fn any_relation_has_rows_tx(
+        tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+        relations: &[&str],
+    ) -> Result<bool, AwaError> {
+        for relation in relations {
+            if Self::relation_has_rows_tx(tx, relation).await? {
+                return Ok(true);
+            }
+        }
+        Ok(false)
+    }
+
     #[tracing::instrument(skip(self, pool), name = "queue_storage.rotate")]
     pub async fn rotate(&self, pool: &PgPool) -> Result<RotateOutcome, AwaError> {
         let schema = self.schema();
@@ -14129,11 +14145,60 @@ impl QueueStorage {
         let receipt_tomb_child = receipt_completion_tombstone_child_name(schema, slot as usize);
         let delta_child = terminal_delta_child_name(schema, slot as usize);
 
-        // Queue prune has three common skip gates. Check them before
-        // taking ACCESS EXCLUSIVE on the ready/terminal child tables so
-        // a known-busy slot does not block hot claim reads behind a
-        // doomed truncate attempt. These are only MVCC snapshots; the
-        // same gates are checked again after the exclusive locks.
+        // Idle-prune churn guard: on an idle queue the rotation cursor keeps
+        // sealing empty slots, so without this gate the prune would re-take
+        // ACCESS EXCLUSIVE and re-issue TRUNCATE on an already-empty sealed
+        // slot every maintenance tick — continuous relfilenode churn and
+        // WAL-flushing commits with zero jobs in the system. That idle DDL is
+        // near-free on local-SSD Postgres but saturates the IO path on
+        // disaggregated-storage engines such as AlloyDB, inflating p99 latency
+        // for co-located application queries. If every child partition this
+        // prune would truncate is already empty there is nothing to reclaim,
+        // so commit and report Noop instead of truncating. The slot is sealed
+        // (slot <> current_slot) and its ring-state and slot rows are held FOR
+        // UPDATE above, so the emptiness snapshot cannot race a writer.
+        let slot_has_reclaimable_rows = Self::any_relation_has_rows_tx(
+            &mut tx,
+            &[
+                &ready_child,
+                &claim_attempt_child,
+                &done_child,
+                &tomb_child,
+                &segment_child,
+                &receipt_batch_child,
+                &receipt_tomb_child,
+                &delta_child,
+            ],
+        )
+        .await?;
+        if !slot_has_reclaimable_rows {
+            // The destructive prune path also deletes this slot's
+            // queue_terminal_live_counts rows alongside the TRUNCATE. Those
+            // rows are a materialized per-slot aggregate of done_entries, so an
+            // empty done partition normally means none exist. Counter drift
+            // (possible during a rolling upgrade from a pre-counter binary) can
+            // nonetheless leave orphan rows for a slot whose ring children are
+            // already empty. Preserve that cleanup on the skip path so avoiding
+            // the (no-op) TRUNCATE does not strand counter rows and let the
+            // exact per-queue counters drift indefinitely. This is a cheap
+            // 0-row DELETE in the steady state and needs no ACCESS EXCLUSIVE.
+            sqlx::query(&format!(
+                "DELETE FROM {schema}.queue_terminal_live_counts WHERE ready_slot = $1"
+            ))
+            .bind(slot)
+            .execute(tx.as_mut())
+            .await
+            .map_err(map_sqlx_error)?;
+            tx.commit().await.map_err(map_sqlx_error)?;
+            return Ok(PruneOutcome::Noop);
+        }
+
+        // Beyond the emptiness gate above, queue prune has three liveness
+        // skip gates. Check them before taking ACCESS EXCLUSIVE on the
+        // ready/terminal child tables so a known-busy slot does not block hot
+        // claim reads behind a doomed truncate attempt. These are only MVCC
+        // snapshots; the same gates are checked again after the exclusive
+        // locks.
         let active_leases =
             queue_prune_has_active_leases_tx(&mut tx, schema, slot, generation).await?;
 
@@ -14543,6 +14608,18 @@ impl QueueStorage {
 
         let lease_child = lease_child_name(schema, slot as usize);
 
+        // Idle-prune churn guard (see `prune_oldest`): skip the destructive
+        // ACCESS EXCLUSIVE + TRUNCATE when the sealed lease slot is already
+        // empty, turning a per-tick truncate of an empty slot into a Noop and
+        // eliminating the relfilenode/WAL churn that disaggregated-storage
+        // engines such as AlloyDB amplify into application p99 latency. The
+        // slot is sealed and its ring-state and slot rows are held FOR UPDATE
+        // above, so the emptiness snapshot cannot race a writer.
+        if !Self::relation_has_rows_tx(&mut tx, &lease_child).await? {
+            tx.commit().await.map_err(map_sqlx_error)?;
+            return Ok(PruneOutcome::Noop);
+        }
+
         set_prune_lock_timeout_tx(&mut tx, self.prune_lock_timeout).await?;
 
         let lock_table = sqlx::query(&format!(
@@ -14798,6 +14875,29 @@ impl QueueStorage {
         let claim_batch_child = claim_batch_child_name(schema, slot as usize);
         let closure_child = closure_child_name(schema, slot as usize);
         let closure_batch_child = claim_closure_batch_child_name(schema, slot as usize);
+
+        // Idle-prune churn guard (see `prune_oldest`): if every claim-ring
+        // child partition for this sealed slot is already empty there is
+        // nothing to reclaim, so commit a Noop instead of re-truncating an
+        // empty slot every maintenance tick, eliminating the relfilenode/WAL
+        // churn that disaggregated-storage engines such as AlloyDB amplify
+        // into application p99 latency. The slot is sealed and its ring-state
+        // and slot rows are held FOR UPDATE above, so the emptiness snapshot
+        // cannot race a writer.
+        let slot_has_reclaimable_rows = Self::any_relation_has_rows_tx(
+            &mut tx,
+            &[
+                &claim_child,
+                &claim_batch_child,
+                &closure_child,
+                &closure_batch_child,
+            ],
+        )
+        .await?;
+        if !slot_has_reclaimable_rows {
+            tx.commit().await.map_err(map_sqlx_error)?;
+            return Ok(PruneOutcome::Noop);
+        }
 
         // Before taking ACCESS EXCLUSIVE on the child partitions, prove
         // the sealed slot is actually reclaimable. This optimistic proof

--- a/awa-python/Cargo.lock
+++ b/awa-python/Cargo.lock
@@ -95,7 +95,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "awa-macros"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -105,7 +105,7 @@ dependencies = [
 
 [[package]]
 name = "awa-metrics"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "awa-model",
  "opentelemetry",
@@ -113,7 +113,7 @@ dependencies = [
 
 [[package]]
 name = "awa-model"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "awa-macros",
  "blake3",
@@ -133,7 +133,7 @@ dependencies = [
 
 [[package]]
 name = "awa-python"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "async-trait",
  "awa-model",
@@ -156,7 +156,7 @@ dependencies = [
 
 [[package]]
 name = "awa-worker"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "async-trait",
  "awa-macros",

--- a/awa-python/Cargo.toml
+++ b/awa-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "awa-python"
-version = "0.6.3"
+version = "0.6.4"
 edition = "2021"
 
 [lib]
@@ -12,8 +12,8 @@ default = ["cel"]
 cel = ["awa-model/cel"]
 
 [dependencies]
-awa-model = { path = "../awa-model", version = "0.6.3" }
-awa-worker = { path = "../awa-worker", version = "0.6.3", features = ["__python-bridge"] }
+awa-model = { path = "../awa-model", version = "0.6.4" }
+awa-worker = { path = "../awa-worker", version = "0.6.4", features = ["__python-bridge"] }
 pyo3 = { version = "0.29", features = ["macros", "abi3-py310", "chrono"] }
 pyo3-async-runtimes = { version = "0.29", features = ["tokio-runtime"] }
 sqlx = { version = "0.8", features = ["runtime-tokio-rustls", "postgres", "chrono", "json"] }

--- a/awa-python/pyproject.toml
+++ b/awa-python/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "maturin"
 [project]
 name = "awa-pg"
 requires-python = ">=3.10"
-version = "0.6.3"
+version = "0.6.4"
 description = "Postgres-native background job queue — Python SDK with async/sync workers, transactional enqueue, and progress tracking. Install awa-pg[ui] to add the bundled web dashboard."
 readme = "README.md"
 license = {text = "MIT OR Apache-2.0"}
@@ -32,7 +32,7 @@ classifiers = [
 #
 # Kept opt-in so the default `awa-pg` install stays small — workers and
 # producers don't need the ~10 MB UI bundle.
-ui = ["awa-cli==0.6.3"]
+ui = ["awa-cli==0.6.4"]
 
 [project.urls]
 Homepage = "https://github.com/hardbyte/awa"

--- a/awa-seaorm/Cargo.toml
+++ b/awa-seaorm/Cargo.toml
@@ -14,6 +14,6 @@ serde_json.workspace = true
 sqlx.workspace = true
 
 [dev-dependencies]
-awa-testing = { path = "../awa-testing", version = "0.6.3" }
+awa-testing = { path = "../awa-testing", version = "0.6.4" }
 serde = { workspace = true, features = ["derive"] }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/awa/Cargo.toml
+++ b/awa/Cargo.toml
@@ -20,7 +20,7 @@ awa-macros.workspace = true
 awa-worker.workspace = true
 
 [dev-dependencies]
-awa-testing = { path = "../awa-testing", version = "0.6.3" }
+awa-testing = { path = "../awa-testing", version = "0.6.4" }
 sqlx.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/awa/tests/queue_storage_benchmark_test.rs
+++ b/awa/tests/queue_storage_benchmark_test.rs
@@ -801,10 +801,14 @@ async fn test_queue_storage_round_trip_smoke() {
         .prune_oldest_leases(&pool)
         .await
         .expect("Failed to prune smoke lease slot");
-    assert!(matches!(
-        pruned_leases,
-        PruneOutcome::Pruned { slot: 0, .. }
-    ));
+    // The legacy complete path DELETEs each lease row in `complete_batch`, so
+    // after draining, sealed lease slot 0 is already empty. The idle-prune
+    // guard therefore skips the (no-op) TRUNCATE and reports Noop; a Pruned
+    // outcome would mean the slot still held rows.
+    assert!(
+        matches!(pruned_leases, PruneOutcome::Noop),
+        "drained (empty) lease slot 0 should report Noop, got {pruned_leases:?}"
+    );
 
     let final_counts = store
         .queue_counts(&pool, "smoke")

--- a/awa/tests/queue_storage_runtime_test.rs
+++ b/awa/tests/queue_storage_runtime_test.rs
@@ -2517,9 +2517,12 @@ async fn test_prune_oldest_leases_does_not_reset_claim_rescue_cursor() {
         .prune_oldest_leases(&pool)
         .await
         .expect("prune_oldest_leases");
+    // Lease slot 0 is empty, so the idle-prune guard reports Noop instead of
+    // truncating. Either way the independent claim ring's rescue cursor must
+    // remain untouched.
     assert!(
-        matches!(prune, PruneOutcome::Pruned { slot: 0, .. }),
-        "lease prune should truncate empty lease slot 0, got {prune:?}"
+        matches!(prune, PruneOutcome::Noop),
+        "empty lease slot 0 should skip the TRUNCATE and report Noop, got {prune:?}"
     );
 
     let cursor: (bool, i64, i64) = sqlx::query_as(&format!(
@@ -2621,14 +2624,12 @@ async fn test_prune_oldest_claims_refuses_to_truncate_open_claim() {
     assert_eq!(survived, 1, "open claim must survive SkippedActive prune");
 }
 
-/// Regression for the post-lock claim-prune proof. The claim row is
-/// inserted but left uncommitted while prune performs its optimistic
-/// pre-lock proof, so the proof sees an empty slot. The writer transaction
-/// keeps a relation lock that makes prune wait for `ACCESS EXCLUSIVE`; once
-/// the writer commits, the post-lock proof must see the now-visible open
-/// claim and skip instead of truncating it.
+/// The idle-prune emptiness guard must not over-skip: a sealed claim slot
+/// holding a committed open claim (no matching closure) is non-empty, so
+/// prune falls through the guard to the open-claim liveness gate, returns
+/// `SkippedActive`, and does not truncate — the claim survives.
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-async fn test_prune_oldest_claims_rechecks_open_claim_after_lock_wait() {
+async fn test_prune_oldest_claims_does_not_skip_committed_open_claim() {
     let (_db_guard, pool) = setup_pool(8).await;
     let schema = "awa_qs_claim_ring_post_lock";
     let store = Arc::new(
@@ -2653,7 +2654,12 @@ async fn test_prune_oldest_claims_rechecks_open_claim_after_lock_wait() {
         .await
         .expect("rotate away from claim slot 0");
 
-    let mut writer_tx = pool.begin().await.expect("begin claim writer tx");
+    // Seed a committed open claim (no matching closure) into the sealed slot;
+    // the empty-slot skip direction is covered by
+    // `test_queue_storage_idle_prune_is_noop_and_does_not_churn_relfilenodes`.
+    // The post-lock re-check is unreachable from an empty slot now that the
+    // emptiness guard precedes lock acquisition; a committed live claim is
+    // caught by the pre-lock liveness gate instead.
     sqlx::query(&format!(
         r#"
         INSERT INTO {schema}.lease_claims (
@@ -2662,52 +2668,13 @@ async fn test_prune_oldest_claims_rechecks_open_claim_after_lock_wait() {
         ) VALUES (0, 1001, 1, 0, 0, 'synthetic', 2, 1, 25, 1001)
         "#
     ))
-    .execute(writer_tx.as_mut())
+    .execute(&pool)
     .await
-    .expect("seed uncommitted open claim");
+    .expect("seed committed open claim");
 
-    let prune_store = Arc::clone(&store);
-    let prune_pool = pool.clone();
-    let prune_task =
-        tokio::spawn(async move { prune_store.prune_oldest_claims(&prune_pool).await });
-
-    let needle = format!("{schema}.lease_claims_0");
-    let wait_deadline = Instant::now() + Duration::from_secs(1);
-    let mut saw_lock_wait = false;
-    while Instant::now() < wait_deadline {
-        let waiting: bool = sqlx::query_scalar(
-            r#"
-            SELECT EXISTS (
-                SELECT 1
-                FROM pg_stat_activity
-                WHERE datname = current_database()
-                  AND pid <> pg_backend_pid()
-                  AND wait_event_type = 'Lock'
-                  AND position($1 in query) > 0
-            )
-            "#,
-        )
-        .bind(&needle)
-        .fetch_one(&pool)
+    let outcome = store
+        .prune_oldest_claims(&pool)
         .await
-        .expect("poll prune lock wait");
-        if waiting {
-            saw_lock_wait = true;
-            break;
-        }
-        tokio::time::sleep(Duration::from_millis(1)).await;
-    }
-    assert!(
-        saw_lock_wait,
-        "prune should wait on the claim child before the writer commits"
-    );
-
-    writer_tx.commit().await.expect("commit open claim");
-
-    let outcome = tokio::time::timeout(Duration::from_secs(3), prune_task)
-        .await
-        .expect("prune task timed out")
-        .expect("prune task panicked")
         .expect("prune_oldest_claims");
     assert!(
         matches!(
@@ -2718,7 +2685,7 @@ async fn test_prune_oldest_claims_rechecks_open_claim_after_lock_wait() {
                 count: 1
             }
         ),
-        "post-lock proof must see the committed open claim, got {outcome:?}"
+        "open claim must force SkippedActive past the emptiness guard, got {outcome:?}"
     );
 
     let survived: i64 = sqlx::query_scalar(&format!(
@@ -2726,15 +2693,16 @@ async fn test_prune_oldest_claims_rechecks_open_claim_after_lock_wait() {
     ))
     .fetch_one(&pool)
     .await
-    .expect("count post-lock survivor");
-    assert_eq!(
-        survived, 1,
-        "claim committed during the lock wait must survive SkippedActive prune"
-    );
+    .expect("count open-claim survivor");
+    assert_eq!(survived, 1, "committed open claim must survive the prune");
 }
 
+/// The idle-prune emptiness guard must not over-skip: a sealed queue slot
+/// holding a committed pending ready row is non-empty, so prune falls
+/// through the guard to the pending-ready liveness gate, returns
+/// `SkippedActive`, and does not truncate — the row survives.
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-async fn test_prune_oldest_rechecks_pending_ready_after_lock_wait() {
+async fn test_prune_oldest_does_not_skip_committed_pending_ready() {
     let (_db_guard, pool) = setup_pool(8).await;
     let queue = "qs_ready_ring_post_lock";
     let schema = "awa_qs_ready_ring_post_lock";
@@ -2780,8 +2748,13 @@ async fn test_prune_oldest_rechecks_pending_ready_after_lock_wait() {
         "unexpected rotate outcome: {rotated:?}"
     );
 
-    let post_lock_job_id = 1_000_091_i64;
-    let mut writer_tx = pool.begin().await.expect("begin ready writer tx");
+    // Seed a committed pending ready row + segment into the sealed slot; the
+    // empty-slot skip direction is covered by
+    // `test_queue_storage_idle_prune_is_noop_and_does_not_churn_relfilenodes`.
+    // The post-lock re-check is unreachable from an empty slot now that the
+    // emptiness guard precedes lock acquisition; a committed pending row is
+    // caught by the pre-lock liveness gate instead.
+    let pending_job_id = 1_000_091_i64;
     sqlx::query(&format!(
         r#"
         INSERT INTO {schema}.ready_entries (
@@ -2795,11 +2768,11 @@ async fn test_prune_oldest_rechecks_pending_ready_after_lock_wait() {
         )
         "#
     ))
-    .bind(post_lock_job_id)
+    .bind(pending_job_id)
     .bind(queue)
-    .execute(writer_tx.as_mut())
+    .execute(&pool)
     .await
-    .expect("seed uncommitted ready row");
+    .expect("seed committed pending ready row");
     sqlx::query(&format!(
         r#"
         INSERT INTO {schema}.ready_segments (
@@ -2811,52 +2784,13 @@ async fn test_prune_oldest_rechecks_pending_ready_after_lock_wait() {
         "#
     ))
     .bind(queue)
-    .execute(writer_tx.as_mut())
+    .execute(&pool)
     .await
-    .expect("seed uncommitted ready segment");
+    .expect("seed committed ready segment");
 
-    let prune_store = Arc::clone(&store);
-    let prune_pool = pool.clone();
-    let prune_task =
-        tokio::spawn(async move { prune_store.prune_oldest(&prune_pool, Duration::ZERO).await });
-
-    let needle = format!("{schema}.ready_entries_0");
-    let wait_deadline = Instant::now() + Duration::from_secs(1);
-    let mut saw_lock_wait = false;
-    while Instant::now() < wait_deadline {
-        let waiting: bool = sqlx::query_scalar(
-            r#"
-            SELECT EXISTS (
-                SELECT 1
-                FROM pg_stat_activity
-                WHERE datname = current_database()
-                  AND pid <> pg_backend_pid()
-                  AND wait_event_type = 'Lock'
-                  AND position($1 in query) > 0
-            )
-            "#,
-        )
-        .bind(&needle)
-        .fetch_one(&pool)
+    let outcome = store
+        .prune_oldest(&pool, Duration::ZERO)
         .await
-        .expect("poll ready prune lock wait");
-        if waiting {
-            saw_lock_wait = true;
-            break;
-        }
-        tokio::time::sleep(Duration::from_millis(1)).await;
-    }
-    assert!(
-        saw_lock_wait,
-        "queue prune should wait on the ready child before the writer commits"
-    );
-
-    writer_tx.commit().await.expect("commit pending ready row");
-
-    let outcome = tokio::time::timeout(Duration::from_secs(3), prune_task)
-        .await
-        .expect("queue prune task timed out")
-        .expect("queue prune task panicked")
         .expect("prune_oldest");
     assert!(
         matches!(
@@ -2867,19 +2801,19 @@ async fn test_prune_oldest_rechecks_pending_ready_after_lock_wait() {
                 count: 1
             }
         ),
-        "post-lock proof must see the committed pending ready row, got {outcome:?}"
+        "pending ready row must force SkippedActive past the emptiness guard, got {outcome:?}"
     );
 
     let survived: i64 = sqlx::query_scalar(&format!(
         "SELECT count(*)::bigint FROM {schema}.ready_entries_0 WHERE job_id = $1"
     ))
-    .bind(post_lock_job_id)
+    .bind(pending_job_id)
     .fetch_one(&pool)
     .await
-    .expect("count post-lock ready survivor");
+    .expect("count pending ready survivor");
     assert_eq!(
         survived, 1,
-        "ready row committed during the lock wait must survive SkippedActive prune"
+        "committed pending ready row must survive the prune"
     );
 }
 
@@ -7417,6 +7351,116 @@ async fn test_queue_storage_prune_skips_live_ready_slot_until_completion() {
     );
 
     client.shutdown(Duration::from_secs(5)).await;
+}
+
+/// Idle-prune churn regression.
+///
+/// On an idle queue the rotation cursor keeps advancing over empty slots, so
+/// every maintenance tick `prune_oldest`/`_leases`/`_claims` selects an
+/// already-empty sealed slot. Before the fix each such prune took
+/// `ACCESS EXCLUSIVE` and issued a `TRUNCATE` that swapped the child
+/// relfilenodes — continuous destructive DDL and WAL-flushing commits with zero
+/// jobs in the system, which saturated regional-storage IO on AlloyDB. The fix
+/// short-circuits an all-empty target slot to `PruneOutcome::Noop` and leaves
+/// the relations untouched. This test asserts both: the outcome is `Noop` and
+/// the ring child relfilenodes do not change across repeated idle prunes.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn test_queue_storage_idle_prune_is_noop_and_does_not_churn_relfilenodes() {
+    let (_db_guard, pool) = setup_pool(6).await;
+    let schema = "awa_qs_runtime_idle_prune_noop";
+    let store = create_store(&pool, schema).await;
+
+    // Snapshot of every ring child relfilenode; a TRUNCATE would change these.
+    let filenode_sql = format!(
+        r#"
+        SELECT coalesce(
+            string_agg(c.relname || '=' || pg_relation_filenode(c.oid)::text, ',' ORDER BY c.relname),
+            ''
+        )
+        FROM pg_class c
+        JOIN pg_namespace n ON n.oid = c.relnamespace
+        WHERE n.nspname = '{schema}'
+          AND c.relkind = 'r'
+          AND (
+            c.relname LIKE 'ready_entries_%'
+            OR c.relname LIKE 'done_entries_%'
+            OR c.relname LIKE 'lease_claims_%'
+            OR c.relname LIKE 'leases_%'
+          )
+        "#
+    );
+    let snapshot = |pool: sqlx::PgPool, sql: String| async move {
+        sqlx::query_scalar::<_, String>(&sql)
+            .fetch_one(&pool)
+            .await
+            .expect("read ring child relfilenodes")
+    };
+
+    // Advance every ring's cursor across empty slots so each has an oldest
+    // *sealed* slot to prune — all empty, since nothing was enqueued.
+    for _ in 0..3 {
+        let queue = store.rotate(&pool).await.expect("rotate idle queue ring");
+        assert!(
+            matches!(queue, RotateOutcome::Rotated { .. }),
+            "idle queue rotate should advance over the empty next slot: {queue:?}"
+        );
+        let lease = store
+            .rotate_leases(&pool)
+            .await
+            .expect("rotate idle lease ring");
+        assert!(
+            matches!(lease, RotateOutcome::Rotated { .. }),
+            "idle lease rotate should advance: {lease:?}"
+        );
+        let claim = store
+            .rotate_claims(&pool)
+            .await
+            .expect("rotate idle claim ring");
+        assert!(
+            matches!(claim, RotateOutcome::Rotated { .. }),
+            "idle claim rotate should advance: {claim:?}"
+        );
+    }
+
+    let before = snapshot(pool.clone(), filenode_sql.clone()).await;
+    assert!(
+        !before.is_empty(),
+        "expected ring child partitions to exist for schema {schema}"
+    );
+
+    // Repeated idle prunes must all be Noop and must not truncate anything.
+    for round in 0..4 {
+        let queue = store
+            .prune_oldest(&pool, Duration::ZERO)
+            .await
+            .expect("idle queue prune");
+        assert!(
+            matches!(queue, PruneOutcome::Noop),
+            "round {round}: idle queue prune must be Noop (empty sealed slot), got {queue:?}"
+        );
+        let lease = store
+            .prune_oldest_leases(&pool)
+            .await
+            .expect("idle lease prune");
+        assert!(
+            matches!(lease, PruneOutcome::Noop),
+            "round {round}: idle lease prune must be Noop, got {lease:?}"
+        );
+        let claim = store
+            .prune_oldest_claims(&pool)
+            .await
+            .expect("idle claim prune");
+        assert!(
+            matches!(claim, PruneOutcome::Noop),
+            "round {round}: idle claim prune must be Noop, got {claim:?}"
+        );
+    }
+
+    let after = snapshot(pool.clone(), filenode_sql).await;
+    assert_eq!(
+        before, after,
+        "idle prune must not TRUNCATE ring children (relfilenodes changed)"
+    );
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]


### PR DESCRIPTION
## 0.6.4 hotfix: stop idle rings from re-`TRUNCATE`-ing empty sealed slots

Backport of the 0.7 rotation-side idle-skip (#409) to the 0.6.x line, addressing an AlloyDB p99/IO-wait regression traced to awa's **background** processes (no enqueued jobs in the window).

### Root cause
On an idle queue the ring-rotation cursor keeps advancing over empty slots, so `prune_oldest` / `prune_oldest_leases` / `prune_oldest_claims` selected an already-empty oldest sealed slot and re-took `ACCESS EXCLUSIVE` + issued a destructive `TRUNCATE` on it **every maintenance tick** — continuous relfilenode churn + WAL-flushing commits with zero jobs in the system. Near-free on local-SSD Postgres; on disaggregated-storage engines (AlloyDB) each such commit forces a regional-WAL flush and the churn evicts hot application pages, inflating p99 for co-located queries.

### Fix
Each prune proves the target slot's child partitions are empty before locking and returns `PruneOutcome::Noop` when there is nothing to reclaim. Non-empty slots follow the identical lock + liveness-recheck + truncate path (no reclamation skipped, no data stranded); the queue prune keeps its per-slot `queue_terminal_live_counts` cleanup on the skip path so exact counters can't drift.

### Validation (local, AlloyDB Omni vs vanilla PG 17, idle 30 s window, zero jobs)
| build | WAL/s | `TRUNCATE` relfilenode churn |
| --- | --: | :--: |
| 0.6.3 (pre-fix) | 72–124 KB/s | yes (~82 creates/s) |
| 0.6.4 (this PR) | 1–27 KB/s | none |

- `cargo test -p awa --test queue_storage_runtime_test` — 114 passed (incl. new `test_queue_storage_idle_prune_is_noop_and_does_not_churn_relfilenodes` + updated guard tests).
- `cargo fmt --all --check`, `cargo clippy --all-targets --all-features -D warnings` — clean.
- New CI job `rust-test-alloydb-omni` runs the prune suite against AlloyDB Omni 18.3 (`full-ci` label).


