### PR TITLE
docs: add awa agent skills

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,29 @@ jobs:
       - name: Check CI test-shard membership
         run: ./scripts/ci-test-shard.sh check
 
+  agent-skills:
+    name: Agent Skills validate
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v6
+      - uses: astral-sh/setup-uv@v8.2.0
+      - name: Validate every published skill
+        run: |
+          shopt -s nullglob
+          skills=(skills/*/)
+          if [ ${#skills[@]} -eq 0 ]; then
+            echo "::error::no skills found under skills/"
+            exit 1
+          fi
+          for dir in "${skills[@]}"; do
+            test -f "${dir}SKILL.md" || {
+              echo "::error::${dir} has no SKILL.md"; exit 1;
+            }
+            echo "Validating ${dir%/}"
+            uvx --from skills-ref==0.1.1 agentskills validate "${dir%/}"
+          done
+
   rust-build:
     name: Rust build
     needs: [rust-lint]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,8 +44,12 @@ jobs:
     name: Agent Skills validate
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: astral-sh/setup-uv@v8.2.0
       - name: Validate every published skill
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -260,6 +260,7 @@ jobs:
           mkdir -p "${ARCHIVE}"
           cp "target/${{ matrix.target }}/release/awa" "${ARCHIVE}/"
           cp README.md LICENSE* "${ARCHIVE}/" 2>/dev/null || true
+          cp -r skills "${ARCHIVE}/skills"
           tar czf "${ARCHIVE}.tar.gz" "${ARCHIVE}"
           echo "ARCHIVE=${ARCHIVE}.tar.gz" >> "$GITHUB_ENV"
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,56 @@
+# AGENTS.md
+
+Guidance for AI coding agents working in this repository. See
+[`docs/development.md`](docs/development.md) for the full contributor workflow;
+this file records the always-on rules.
+
+## Build, Lint, Test
+
+The workspace is Rust; the Python bindings (`awa-python`) are a separate
+workspace. Always run the pre-commit checks before committing Rust changes:
+
+```bash
+cargo fmt --all
+SQLX_OFFLINE=true cargo clippy --all-targets --all-features -- -D warnings
+SQLX_OFFLINE=true cargo build --workspace
+```
+
+Tests need a live PostgreSQL:
+
+```bash
+docker run -d --name awa-pg -e POSTGRES_PASSWORD=test -e POSTGRES_DB=awa_test \
+  -p 15432:5432 postgres:17-alpine
+DATABASE_URL=postgres://postgres:test@localhost:15432/awa_test cargo test --workspace
+
+cd awa-python && uv run maturin develop
+DATABASE_URL=postgres://postgres:test@localhost:15432/awa_test uv run pytest tests/ -v
+```
+
+Read the redirected log and check the real exit status; do not trust a green
+exit code from a piped or backgrounded command.
+
+## Schema Migrations
+
+Migrations are forward-only and must stay rolling-upgrade compatible. Follow the
+migration checklist and rolling-upgrade policy in
+[`docs/development.md`](docs/development.md#authoring-schema-migrations) and
+[ADR-041](docs/adr/041-rolling-upgrade-policy.md) before opening a migration PR.
+Version floors, exclusive migrations, and the newer-schema fail-safe live in
+`awa-model/src/migrations.rs`.
+
+## Agent Skills
+
+Canonical, portable [Agent Skills](https://agentskills.io/) live under
+`skills/<name>/SKILL.md` and follow the Agent Skills specification.
+
+- Keep product workflows and version-aware semantics in skills. Keep always-on
+  repository contribution rules in this file.
+- `awa-jobs` covers authoring jobs and workers (Rust and Python); `awa-operations`
+  covers deploying and operating the fleet.
+- Validate every skill locally with
+  `uvx --from skills-ref==0.1.1 agentskills validate skills/<name>`; CI runs the
+  same check.
+- Skills ship in the release binary archives. Do not copy them into crates,
+  runtime images, or the container build.
+- Update the affected skill when public behavior or a documented workflow
+  changes, and avoid duplicating skill content elsewhere.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,7 +50,10 @@ Canonical, portable [Agent Skills](https://agentskills.io/) live under
 - Validate every skill locally with
   `uvx --from skills-ref==0.1.1 agentskills validate skills/<name>`; CI runs the
   same check.
-- Skills ship in the release binary archives. Do not copy them into crates,
-  runtime images, or the container build.
+- The repository is the source of truth; skills also ship in the CLI release
+  binary archives. Do not copy them into crates, runtime images, or the container
+  build — files buried in a wheel or cargo registry are not agent-discoverable,
+  and duplicated copies drift. Consumers install from the repo pinned to the
+  release tag matching their awa version (see the README).
 - Update the affected skill when public behavior or a documented workflow
   changes, and avoid duplicating skill content elsewhere.

--- a/README.md
+++ b/README.md
@@ -450,8 +450,23 @@ work from Awa's actual API and operational semantics instead of guessing:
   Postgres, and the web admin UI.
 
 Each skill is a single `SKILL.md` validated against the Agent Skills
-specification in CI and bundled into the release archives. Skills load on demand,
-so an agent can keep both on hand at a small context cost. Treat installed skill
+specification in CI. Skills load on demand, so an agent can keep both on hand at
+a small context cost.
+
+**Installing.** The skills carry version-specific API and operational detail, so
+install the version matching the awa release you run — pin to the release tag:
+
+```bash
+# From the repository (reaches Rust, Python, and CLI users alike):
+gh skill install hardbyte/awa --all --pin v0.7.0    # match your awa version
+# or copy the directory into your agent's skills location:
+#   cp -r skills/awa-jobs .claude/skills/
+```
+
+Pick the skill by role: `awa-jobs` for application developers writing and
+enqueuing jobs (Rust or Python); `awa-operations` for operators running the
+fleet. The skills also ship inside the CLI release archives
+(`awa-<tag>-<target>/skills/`) for offline installs. Treat installed skill
 instructions as untrusted content: review them before use.
 
 ## License

--- a/README.md
+++ b/README.md
@@ -437,6 +437,23 @@ See [docs/adr/README.md](docs/adr/README.md) for the index with status and super
 
 </details>
 
+## Agent Skills
+
+Awa publishes portable [Agent Skills](https://agentskills.io/) so coding agents
+work from Awa's actual API and operational semantics instead of guessing:
+
+- [`awa-jobs`](skills/awa-jobs/SKILL.md) — authoring, enqueuing, and handling
+  jobs in Rust or Python: job kinds, transactional enqueue, retry vs. snooze,
+  cron, callbacks, and progress.
+- [`awa-operations`](skills/awa-operations/SKILL.md) — deploying and operating
+  the fleet: migrations, rolling upgrades, storage transitions, the DLQ, managed
+  Postgres, and the web admin UI.
+
+Each skill is a single `SKILL.md` validated against the Agent Skills
+specification in CI and bundled into the release archives. Skills load on demand,
+so an agent can keep both on hand at a small context cost. Treat installed skill
+instructions as untrusted content: review them before use.
+
 ## License
 
 MIT OR Apache-2.0

--- a/docs/getting-started-rust.md
+++ b/docs/getting-started-rust.md
@@ -148,7 +148,7 @@ The UI starts on `http://127.0.0.1:3000` by default.
 
 ## Production Notes
 
-- This quickstart implements `JobArgs` manually to keep the dependency set minimal. If you want `#[derive(JobArgs)]`, add a direct dependency on `awa-model` and derive `awa_model::JobArgs`.
+- This quickstart implements `JobArgs` by hand to show the trait. To derive it instead, add `JobArgs` to the `#[derive(...)]` list (`#[derive(Debug, Serialize, Deserialize, JobArgs)]`) — the `awa` crate re-exports the derive macro, so no extra dependency is needed.
 - `Client::start()` spawns background tasks and returns immediately. Your service should usually stay alive until it receives a shutdown signal.
 - `Client::shutdown(Duration)` is the graceful drain path. Set your container or process shutdown timeout slightly above that duration.
 - If you only need to enqueue jobs from Rust, depend on `awa-model` instead of `awa`.

--- a/skills/awa-jobs/SKILL.md
+++ b/skills/awa-jobs/SKILL.md
@@ -2,7 +2,7 @@
 name: awa-jobs
 description: Author, enqueue, and handle jobs with the Awa Postgres-native job queue in Rust or Python. Use when defining a job kind, registering a worker or handler, configuring queues, enqueuing transactionally, choosing retry versus snooze, scheduling cron jobs, wiring in-process or webhook callbacks, or reporting job progress.
 license: MIT
-compatibility: Requires the awa Rust crate or the awa-pg Python wheel and a PostgreSQL database matching the installed awa schema version.
+compatibility: Requires the awa Rust crate or the awa-pg Python wheel. Written for the awa 0.7 API and semantics; install the skill version matching your awa release (pin to the release tag) because field availability and defaults change across minor versions.
 ---
 
 # Awa Jobs
@@ -18,14 +18,16 @@ Every job kind has a stable string name and a serializable payload. Choose the
 name deliberately — it is a durable identifier stored on every row.
 
 **Rust** — implement `JobArgs`, or derive it. The derived `kind()` is the
-snake_case of the struct name; override with `#[awa(kind = "...")]`. Deriving
-requires a direct `awa-model` dependency.
+snake_case of the struct name; override with `#[awa(kind = "...")]`. The `awa`
+facade re-exports both the trait and the derive macro, so depending on `awa`
+alone is enough — no separate `awa-model` dependency is needed. (If you only
+enqueue and never run a worker, depend on `awa-model` directly instead.)
 
 ```rust
-use awa::{JobArgs, JobResult};
+use awa::JobArgs;
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Serialize, Deserialize, awa_model::JobArgs)]
+#[derive(Debug, Serialize, Deserialize, JobArgs)]
 struct SendEmail { to: String, subject: String } // kind() == "send_email"
 ```
 
@@ -101,9 +103,15 @@ awa::insert_with(&mut *tx, &SendEmail { to, subject },
 ```
 
 **Python** — `await client.insert(args, queue=..., priority=..., run_at=..., ...)`.
-For transactional enqueue use `async with await client.transaction() as tx:
-await tx.insert(...)`, or `awa.bridge.insert_job(session, args, ...)` to enqueue
-inside an existing asyncpg / psycopg3 / SQLAlchemy / Django transaction.
+For transactional enqueue:
+
+```python
+async with await client.transaction() as tx:
+    await tx.insert(args)
+```
+
+Or use `awa.bridge.insert_job(session, args, ...)` to enqueue inside an existing
+asyncpg / psycopg3 / SQLAlchemy / Django transaction.
 
 `InsertOpts` / keyword options: `queue`, `priority`, `max_attempts`, `run_at`
 (a future time starts the job `Scheduled` rather than `Available`),
@@ -113,9 +121,13 @@ a waiting job's effective priority one level per aging interval (default 60s) so
 low-priority work cannot starve indefinitely.
 
 **Unique jobs** deduplicate on a BLAKE3 key over kind + optionally queue + args +
-a time-period bucket. Defaults: dedup by args, not by queue. A duplicate insert
-is silently skipped. Cancel without storing the id via `cancel_by_unique_key(kind,
-queue=, args=, period_bucket=)` — the components must match those used at insert.
+a time-period bucket. Defaults: dedup by args, not by queue. Conflict handling
+depends on the API: a single-row `insert` / `insert_with` and the row-by-row
+`insert_many` **raise `AwaError::UniqueConflict`** (Python raises the
+corresponding error) on a duplicate — you must handle it, do not assume a silent
+no-op. Only the COPY bulk path (`insert_many_copy`) silently skips duplicates.
+Cancel without storing the id via `cancel_by_unique_key(kind, queue=, args=,
+period_bucket=)` — the components must match those used at insert.
 Args-based uniqueness relies on canonical (sorted-key) JSON, pinned by
 cross-language golden tests; the default state set includes `completed`, so a
 still-retained completed job suppresses a re-insert with the same args. Scope
@@ -149,7 +161,9 @@ cannot double-fire an occurrence.
 
 ```rust
 let job = PeriodicJob::builder("nightly-report", "0 0 * * *")
-    .timezone("Pacific/Auckland").queue("reports").build(&ReportArgs { .. })?;
+    .timezone("Pacific/Auckland")
+    .queue("reports")
+    .build(&ReportArgs { region: "nz".into() })?;
 // .periodic(job) on the client builder
 ```
 
@@ -213,9 +227,21 @@ Rust exposes two hook families on the client builder:
   `Rescued`, `WaitingForCallback`. They are **not** a durable workflow — they can
   be lost on crash and `shutdown()` does not wait for them.
 - **Durable follow-up hooks** (`on_completed_enqueue`, `on_exhausted_enqueue`,
-  and the other `on_*_enqueue`) INSERT a follow-up job in the **same transaction**
-  as the triggering transition, so they survive a crash. Use these for side
-  effects that must not be lost.
+  and the other `on_*_enqueue`) INSERT a follow-up job for side effects that must
+  survive a crash. Atomicity depends on what triggered them:
+  - Worker-driven outcomes (a handler returning `Ok`/`Err`) and callback
+    resolution on the `Client` (`complete_external`, `resolve_callback`, …) commit
+    the follow-up in the **same transaction** as the transition — exactly-once per
+    committed outcome.
+  - **`on_rescued_enqueue` is the exception: it is best-effort, not atomic.**
+    Maintenance rescue (stale-heartbeat / deadline / expired-callback) commits the
+    rescue first, then dispatches the follow-up in a separate transaction; a
+    failure there leaves the rescue applied and is only logged. Do not build a
+    rescue-notification workflow that assumes the follow-up cannot be lost — use an
+    outbox/sweeper if you need zero-loss rescue signals.
+
+  Every follow-up, once enqueued, is delivered at-least-once, so its handler must
+  be safe to re-run.
 
 Enqueues capture the current trace span into reserved metadata
 (`awa:traceparent`) automatically; disable with `AWA_TRACE_CAPTURE=off`. To

--- a/skills/awa-jobs/SKILL.md
+++ b/skills/awa-jobs/SKILL.md
@@ -1,0 +1,233 @@
+---
+name: awa-jobs
+description: Author, enqueue, and handle jobs with the Awa Postgres-native job queue in Rust or Python. Use when defining a job kind, registering a worker or handler, configuring queues, enqueuing transactionally, choosing retry versus snooze, scheduling cron jobs, wiring in-process or webhook callbacks, or reporting job progress.
+license: MIT
+compatibility: Requires the awa Rust crate or the awa-pg Python wheel and a PostgreSQL database matching the installed awa schema version.
+---
+
+# Awa Jobs
+
+Use the awa version the project depends on and match its documentation. Awa is
+Postgres-only: a job is a typed payload stored in Postgres and run by a worker
+that claims it. Defaults across both languages: queue `"default"`, priority `2`
+(1 = highest … 4 = lowest), `max_attempts` 25.
+
+## Define A Job Kind
+
+Every job kind has a stable string name and a serializable payload. Choose the
+name deliberately — it is a durable identifier stored on every row.
+
+**Rust** — implement `JobArgs`, or derive it. The derived `kind()` is the
+snake_case of the struct name; override with `#[awa(kind = "...")]`. Deriving
+requires a direct `awa-model` dependency.
+
+```rust
+use awa::{JobArgs, JobResult};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize, awa_model::JobArgs)]
+struct SendEmail { to: String, subject: String } // kind() == "send_email"
+```
+
+snake_case derivation splits acronyms in non-obvious ways (`SMTPEmail` →
+`smtp_email`, `HTMLToPDF` → `html_to_pdf`). If the exact kind string matters,
+set it explicitly.
+
+**Python** — define a `@dataclass` (or Pydantic model) and register a handler
+with `@client.task`. The kind defaults to the snake_cased class name.
+
+```python
+@dataclass
+class SendEmail:
+    to: str
+    subject: str
+
+@client.task(SendEmail, queue="email")
+async def handle_email(job):
+    ...  # job.args is a reconstructed SendEmail
+```
+
+`client.worker(...)` is the deprecated alias for `client.task(...)`; it emits a
+`DeprecationWarning`.
+
+Regardless of language, job args and metadata must not contain NUL bytes (`\u0000`) in string values
+or keys — they are rejected before reaching Postgres JSONB.
+
+## Run A Worker
+
+**Rust** uses a builder; `start()` spawns background tasks and returns
+immediately, `shutdown(timeout)` drains gracefully.
+
+```rust
+let client = Client::builder(pool.clone())
+    .queue("email", QueueConfig { max_workers: 2, ..Default::default() })
+    .register::<SendEmail, _, _>(|args, _ctx| async move {
+        Ok(JobResult::Completed)
+    })
+    .build()?;
+client.start().await?;
+```
+
+`QueueConfig` defaults worth knowing: `max_workers` 50, `poll_interval` 200ms,
+`deadline_duration` 300s, `claimers` 1, `claim_batch_size` 512. The trait form
+(`impl Worker` + `.register_worker(w)`) is equivalent to the typed closure.
+
+**Python** passes a queue list to `start`:
+
+```python
+client = awa.AsyncClient(DATABASE_URL)
+# handlers registered via @client.task above
+await client.start([("email", 2)])        # (name, max_workers)
+```
+
+Concurrency has two modes. **Hard-reserved** (the default) gives each queue its
+own fixed `max_workers`. **Weighted** shares one pool: call `.global_max_workers(N)`
+(Rust) or pass `global_max_workers=N` with dict-form queues (Python), then use
+`min_workers` as a floor and `weight` to split overflow. Per-queue rate limiting
+is a token bucket (`RateLimit { max_rate, burst }` / `rate_limit=(rate, burst)`).
+Enabling a rate limit live is not supported — you can only retune a queue that
+was built with one.
+
+## Enqueue
+
+**Rust** — `insert(executor, &args)` or `insert_with(executor, &args, InsertOpts)`.
+The executor is any `PgExecutor`, so pass `&pool` for a standalone enqueue or
+`&mut *tx` to enqueue inside your own transaction — the job commits or rolls back
+with your data. Batch inserts use `insert_many` / `insert_many_copy`.
+
+```rust
+awa::insert_with(&mut *tx, &SendEmail { to, subject },
+    InsertOpts { queue: "email".into(), priority: 1, ..Default::default() }).await?;
+```
+
+**Python** — `await client.insert(args, queue=..., priority=..., run_at=..., ...)`.
+For transactional enqueue use `async with await client.transaction() as tx:
+await tx.insert(...)`, or `awa.bridge.insert_job(session, args, ...)` to enqueue
+inside an existing asyncpg / psycopg3 / SQLAlchemy / Django transaction.
+
+`InsertOpts` / keyword options: `queue`, `priority`, `max_attempts`, `run_at`
+(a future time starts the job `Scheduled` rather than `Available`),
+`deadline_duration`, `metadata`, `tags`, `unique`, `ordering_key`. Dispatch
+order is strict `priority ASC, run_at ASC, id ASC`. Priority aging then improves
+a waiting job's effective priority one level per aging interval (default 60s) so
+low-priority work cannot starve indefinitely.
+
+**Unique jobs** deduplicate on a BLAKE3 key over kind + optionally queue + args +
+a time-period bucket. Defaults: dedup by args, not by queue. A duplicate insert
+is silently skipped. Cancel without storing the id via `cancel_by_unique_key(kind,
+queue=, args=, period_bucket=)` — the components must match those used at insert.
+Args-based uniqueness relies on canonical (sorted-key) JSON, pinned by
+cross-language golden tests; the default state set includes `completed`, so a
+still-retained completed job suppresses a re-insert with the same args. Scope
+uniqueness with `by_period`, or drop `completed` from the state set, if that is
+not what you want.
+
+## Retry, Snooze, Cancel
+
+A handler's return value decides the outcome:
+
+- **Completed** — Rust `Ok(JobResult::Completed)`; Python return `None`.
+- **Retry after a delay** — `JobResult::RetryAfter(dur)` / `awa.RetryAfter(secs)`.
+  This **consumes an attempt** and exhausts into the DLQ on the final one.
+- **Snooze** — `JobResult::Snooze(dur)` / `awa.Snooze(secs)`. Reschedules
+  **without** consuming an attempt and fires no lifecycle event.
+- **Cancel** — `JobResult::Cancel(reason)` / `awa.Cancel(reason)`. Terminal, no
+  DLQ, no failure event.
+
+An uncaught error is retryable by default. Make it terminal with
+`JobError::terminal(msg)` (Rust) or by raising a subclass of `awa.TerminalError`
+(Python). Automatic backoff is `min(2^attempt seconds + up to 25% jitter, 24h)`.
+
+**The key gotcha:** use `Snooze` — not `RetryAfter` — for "not ready yet" polling
+or rate-limit waits, so `max_attempts` bounds genuine failures only.
+
+## Cron / Periodic Jobs
+
+Declare the schedule in code. It is UPSERT-synced to the database and evaluated
+by the single elected maintenance leader; enqueue is atomic, so leader failover
+cannot double-fire an occurrence.
+
+```rust
+let job = PeriodicJob::builder("nightly-report", "0 0 * * *")
+    .timezone("Pacific/Auckland").queue("reports").build(&ReportArgs { .. })?;
+// .periodic(job) on the client builder
+```
+
+```python
+client.periodic("nightly-report", "0 0 * * *", ReportArgs, ReportArgs(...),
+                timezone="Pacific/Auckland", queue="reports")
+```
+
+Timezone is an IANA name (default UTC), validated eagerly. `missed_fire_policy`
+is `coalesce` (default — enqueue only the latest missed fire after a delay) or
+`catch_up` (enqueue each missed fire in order). Pause, resume, and trigger are
+admin operations (the web UI and admin API, and the Python client), not part of
+the code-defined builder; a paused schedule leaves `last_enqueued_at` untouched,
+so `missed_fire_policy` governs catch-up on resume. Cron pause and queue pause
+are independent. To purge in-flight cron work, pause the schedule, then
+bulk-cancel jobs filtered by `metadata.cron_name`.
+
+## Callbacks
+
+**In-process callbacks** park a job on an external event and resume the same
+handler when it arrives.
+
+- `ctx.register_callback(timeout)` (Rust) / `job.register_callback(timeout_seconds=)`
+  (Python) writes the callback id to the database. Register it **before** handing
+  the id to the external system, or the completion can race ahead of registration.
+- For a long wait, return `JobResult::WaitForCallback(guard)` /
+  `awa.WaitForCallback(token)` — this releases the worker permit while parked.
+- `ctx.wait_for_callback(guard).await` suspends the handler in place but **holds
+  the worker permit** while polling; use it only for short waits.
+- Resolve from a process holding the worker client so hooks fire:
+  `resolve_callback(id, payload, default_action)`, or `complete_external` /
+  `fail_external` / `retry_external` / `resume_external`. Resolving through the
+  bare admin/CLI path transitions the job correctly but fires no hooks.
+
+**Webhook callbacks** (Rust `http-worker` feature) dispatch a job to a serverless
+function over HTTP and park it for an async callback. The receiver exposes
+`POST {prefix}/{callback_id}/{complete,fail,heartbeat}`. The `X-Awa-Signature`
+header is a BLAKE3 keyed hash of the callback-id string (not RFC HMAC, not over
+the body); the secret is 32 bytes / 64 hex chars. Function responses map 2xx →
+park, 5xx → retryable, 4xx → terminal. The HTTP `complete` endpoint completes the
+job; it does not resume an in-process `wait_for_callback` handler.
+
+**CEL filtering** (feature `cel`) gates and reshapes callback payloads via
+`CallbackConfig` expressions (`filter`, `on_fail`, `on_complete`, `transform`),
+with `DefaultAction` when nothing matches. Only the `payload` variable is
+available; any other variable is rejected at registration rather than failing
+open at resolve time.
+
+## Progress And Lifecycle Hooks
+
+Report progress from inside a handler: `set_progress(percent, message)` and
+`update_metadata(obj)` buffer in memory; `flush_progress().await` writes durably
+(only while the job is `running` with a matching run lease). Progress metadata
+survives retries and snoozes, so read it back at the start of a handler to resume
+from a checkpoint. Flush periodically, not every iteration.
+
+Rust exposes two hook families on the client builder:
+
+- **Observation hooks** (`.on_event` / `.on_event_kind`) fire best-effort in
+  process for `Started`, `Completed`, `Retried`, `Exhausted`, `Cancelled`,
+  `Rescued`, `WaitingForCallback`. They are **not** a durable workflow — they can
+  be lost on crash and `shutdown()` does not wait for them.
+- **Durable follow-up hooks** (`on_completed_enqueue`, `on_exhausted_enqueue`,
+  and the other `on_*_enqueue`) INSERT a follow-up job in the **same transaction**
+  as the triggering transition, so they survive a crash. Use these for side
+  effects that must not be lost.
+
+Enqueues capture the current trace span into reserved metadata
+(`awa:traceparent`) automatically; disable with `AWA_TRACE_CAPTURE=off`. To
+propagate a trace onward from inside a handler, use the current span
+(`awa_model::trace::current_traceparent()`), not the stored enqueue-site value.
+
+## Version-Aware Notes
+
+- The canonical (row-mutating) storage engine is deprecated in 0.7 and removed in
+  0.8; queue-storage is the default. Coordinate storage transitions and upgrades
+  with the operator — see the `awa-operations` skill.
+- Partitioned FIFO (`enqueue_shards`, `ordering_key`) landed in 0.6; `ordering_key`
+  is ignored while a queue's shard count is 1.
+- Read the CHANGELOG for the exact version that introduced any field before using
+  it against an older deployment.

--- a/skills/awa-operations/SKILL.md
+++ b/skills/awa-operations/SKILL.md
@@ -2,7 +2,7 @@
 name: awa-operations
 description: Deploy, upgrade, and operate the Awa Postgres-native job queue and its worker fleet. Use when running database migrations, planning a rolling upgrade, sizing connection pools on managed Postgres, operating the dead-letter queue or cron schedules, driving a storage-engine transition, configuring the awa CLI, or serving the web admin UI.
 license: MIT
-compatibility: Requires an awa CLI matching the deployed runtime version and PostgreSQL access. Storage and health workflows require a live worker fleet.
+compatibility: Requires an awa CLI matching the deployed runtime version and PostgreSQL access. Written for awa 0.7; pin to the release tag matching your deployment. The CLI, `awa health`, and `awa storage status` work against the database alone; the runtime `/readyz` probe and the fleet-liveness fields require a live worker fleet.
 ---
 
 # Awa Operations

--- a/skills/awa-operations/SKILL.md
+++ b/skills/awa-operations/SKILL.md
@@ -1,0 +1,235 @@
+---
+name: awa-operations
+description: Deploy, upgrade, and operate the Awa Postgres-native job queue and its worker fleet. Use when running database migrations, planning a rolling upgrade, sizing connection pools on managed Postgres, operating the dead-letter queue or cron schedules, driving a storage-engine transition, configuring the awa CLI, or serving the web admin UI.
+license: MIT
+compatibility: Requires an awa CLI matching the deployed runtime version and PostgreSQL access. Storage and health workflows require a live worker fleet.
+---
+
+# Awa Operations
+
+Use the awa CLI version that matches the deployed runtime and schema. A binary
+refuses a database schema newer than it understands, so operate every database
+from a CLI at least as new as the fleet. Read the upgrade note for the exact
+version pair before changing anything (`docs/upgrade-0.6-to-0.7.md`,
+`docs/upgrade-0.5-to-0.6.md`).
+
+## Connect Safely
+
+`awa` resolves a target in this order: `--database-url` > `--context`
+(`AWA_CONTEXT`) > `DATABASE_URL` env > `default_context` in
+`~/.config/awa/config.toml`. Every command echoes the resolved target with the
+password stripped before acting; confirm it.
+
+Read-only commands may fall back to `DATABASE_URL` or the default context.
+Mutating commands refuse to run against an implicit target whenever more than
+one context is defined — pass an explicit `--context` or `--database-url`. A
+context marked `production = true` prompts for confirmation on a mutating
+command; `--yes` skips the prompt, and a non-interactive shell without `--yes`
+refuses rather than hanging. An explicit `--database-url` is never treated as
+production.
+
+Prefer `url_env` over an inline `url` in config so credentials never sit in the
+file. Never print database URLs or passwords in logs or issues.
+
+## Migrations
+
+Migrations are forward-only and transactional; there are no down migrations.
+Roll back with a database snapshot or reverse SQL, not with the CLI.
+
+```bash
+awa migrate --pending                 # apply from current DB version to latest
+awa migrate --sql --pending           # print the SQL instead of applying
+awa migrate --extract-to ./out        # write SQL files for an external runner
+```
+
+The migrator runs pre-flight gates before touching the schema: it refuses a
+schema newer than the binary understands, refuses to apply while the storage
+transition is unfinalized where a gate requires it, enforces per-migration
+minimum runtime versions, and enforces exclusive (no-live-runtime) windows for
+non-rolling migrations. `--allow-live-runtimes` overrides the live-runtime
+checks — use it only after independently verifying compatibility.
+
+Extracted or printed SQL does **not** run the Rust pre-flights. An external
+runner must enforce version floors and exclusive windows itself. Do not append
+`storage prepare`/`enter-mixed-transition`/`finalize` to extracted migration
+files; those are not migration DDL.
+
+Do not skip a major version. 0.5 → 0.7 is unsupported; step through 0.6.
+
+## Rolling Upgrades
+
+Awa runs mixed-version fleets during a rollout; the constraints are version
+specific, so follow the matching upgrade doc. The 0.6 → 0.7 upgrade is the
+current worked example and its shape generalizes:
+
+1. **Stepping stone first.** Roll the entire fleet to 0.6.2+ before applying the
+   0.7 (v043) ring-rotation migration. 0.6.0/0.6.1 misclassify a newer schema
+   destructively (#392).
+2. **Finalize storage.** A 0.7 binary refuses `awa migrate` unless the storage
+   transition is finalized (`storage status` shows `state=active`,
+   `current_engine=queue_storage`) or the install is fresh.
+3. **Roll binaries and migrate in either order.** Mixed 0.6.2/0.7 is safe in
+   compatibility mode. If binaries roll first, a 0.7 worker refuses to start on
+   the old schema and crash-loops harmlessly until the migration commits.
+4. **Promote ring authority only after the fleet is fully 0.7.** Use
+   `awa storage flip-ring-authority`, or let maintenance auto-flip once every
+   worker has been 0.7 for a stable period.
+
+Crash-safety facts to respect:
+
+- After the flip, roll back only to another 0.7 build. The flip poisons the
+  compatibility cursor fields and a database trigger rejects old-style cursor
+  advances, so a returning pre-flip binary fails loudly.
+- While a v043 fleet is still all-0.6.2, deadline-based rescue resumes only once
+  a 0.7 runtime takes maintenance leadership. Roll the maintenance leader
+  promptly.
+
+The `flip-ring-authority` step itself has a hard guard — see Storage
+Transitions below.
+
+## Health And The Fleet
+
+Workers are stateless; all state is in Postgres, and scaling means running more
+processes. Exactly one worker per database is the elected maintenance leader
+(session-scoped advisory lock — if it dies, another is elected on the next
+tick). The leader alone runs cluster-wide scans: deferred→ready promotion, the
+three rescue paths (stale-heartbeat, hard-deadline, callback-timeout), ring
+rotation and prune, DLQ and descriptor cleanup, and cron evaluation. Every
+worker dispatches and heartbeats its own attempts. There is no `pg_cron` or
+external scheduler.
+
+Late completions from a rescued attempt lose against the newer attempt via the
+`run_lease` guard, so rescue never double-commits. Set `heartbeat_staleness`
+(default 90s) to at least 3× the heartbeat interval; detection latency is
+roughly `heartbeat_staleness + heartbeat_rescue_interval`.
+
+Health signals:
+
+- Runtime listener (opt in via `AWA_HEALTH_ADDR`): `GET /healthz` liveness (200
+  even while draining) and `GET /readyz` (503 with failing checks:
+  postgres_connected, schema_version, schema_compatible, poll/heartbeat/
+  maintenance loops, shutting_down). `leader` is informational and never gates.
+  The listener has no TLS or auth — keep it off public ingress.
+- `awa health [--json]`: database-only readiness (reachable, schema migrated for
+  this binary, fleet heartbeat counts). Exit 0 ready, 1 unreachable or
+  unmigrated.
+
+On Kubernetes, set `terminationGracePeriodSeconds` above the shutdown drain
+timeout (e.g. 40s for a 30s drain) so a leader finishes draining before SIGKILL.
+
+## Dead-Letter Queue
+
+The DLQ is a separate physical table, not a job state; a DLQ'd job cannot be
+claimed until retried out. It is per-queue opt-in (`dlq_enabled`) with a
+default 30-day retention pruned by the maintenance leader. `dlq_reason` is
+`max_attempts`, `manual`, or `deadline_expired`.
+
+```bash
+awa dlq depth --queue emails
+awa dlq list --queue emails --limit 20
+awa dlq retry <id>                       # resets attempt/lease, re-runs
+awa dlq retry-bulk --queue emails        # bulk; --all required with no filter
+awa dlq purge --kind SendEmail           # destructive; --all required if unfiltered
+```
+
+- Retry resets the job to `attempt=0`, `run_lease=0` on the runnable path with
+  its stored queue/priority and immediate `run_at`. Use the programmatic retry
+  APIs to override those.
+- `retry-bulk`, `purge`, and `move` require `--all` when no filter is given —
+  the guard against reviving or wiping the whole DLQ. Purge is unrecoverable;
+  prefer `retry-bulk` if you might want the data back.
+- Enabling `dlq_enabled` does not retroactively move existing `failed` rows.
+  Move them explicitly with `awa dlq move --reason ... [--all]`.
+
+## Cron
+
+The CLI cron surface is `list` and `remove <name>` only. Pause, resume, and
+trigger are admin operations (the web UI and admin API, and the Python client),
+not the CLI. Only the maintenance leader evaluates due schedules; enqueue is
+atomic and re-checks `paused_at` inside the same statement, so a pause races
+cleanly against a fire — a pause takes effect even if it lands between the
+evaluator's read and the enqueue. Schedules are declared in application code;
+for timezone and missed-fire (`coalesce`/`catch_up`) semantics, see the
+`awa-jobs` skill.
+
+## Storage Transitions
+
+`awa storage status` is the source of truth: it reports the transition state
+(`canonical` → `prepared` → `mixed_transition` → `active`), current/active/
+prepared engine, backlog, blockers, and `can_finalize`. Drive transitions with
+the storage commands so routing, drain, readiness, and interlocks move
+together — never by swapping which workers you run.
+
+```bash
+awa storage status
+awa storage prepare --engine queue_storage
+awa storage enter-mixed-transition        # needs a live queue_storage runtime
+awa storage finalize --check              # dry run: exit 0 ready, exit 2 blocked
+awa storage finalize --wait               # poll until gates stay clear
+```
+
+Dangerous operations:
+
+- `prepare-queue-storage-schema --reset --schema awa` is refused — it would drop
+  the migration-owned `awa` schema (schema_version, runtime_instances, …) and
+  leave the database unrecoverable. `DROP SCHEMA awa CASCADE` is not a supported
+  operator action.
+- The transition is a one-way door once queue-storage work is accepted:
+  `storage abort` is rejected once rows exist in the new tables. Recovery is
+  `finalize` or database restore.
+- `flip-ring-authority` is one-way; it refuses without `--force` while any
+  fresh-heartbeat runtime is not known to be flip-aware (an unknown or
+  unparseable runtime version counts as not flip-aware).
+- `rebuild-terminal-counters` is for counter-drift incidents and is best run on
+  a quiesced fleet.
+
+Rings rotate only when active — a frozen generation on an idle queue is healthy.
+The condition to alert on is a frozen generation *with* accumulating rows
+(`skipped_busy`): a pinned ring, almost always caused by a long-held snapshot.
+
+## Managed Postgres
+
+Prefer PostgreSQL 18 where available; PG17 on some managed platforms caps
+throughput because readers queue behind the ring-rotation `ACCESS EXCLUSIVE`
+lock. Size for steady-state completion rate, not burst.
+
+- **MVCC discipline is the biggest footgun.** Any long-held snapshot — `idle in
+  transaction`, a BI tool, `pg_dump`, a stuck migration — pins the database-wide
+  horizon and blocks vacuum *and* Awa ring prune across every table. Keep
+  analytical readers on a replica; bound roles with
+  `idle_in_transaction_session_timeout` and `statement_timeout`; alert on
+  `pg_stat_activity.xact_start` age.
+- **Pool sizing.** `max_connections >= sum(queue claimers) + 5`, plus headroom
+  for handler SQL, producers, and admin. Each claimer holds a LISTEN connection;
+  the leader holds one advisory-lock connection.
+- **DDL creds.** Migrations and custom-schema prep need DDL-capable credentials.
+  Cloud SQL IAM service accounts need a one-shot manual `cloudsqlsuperuser`
+  grant; AlloyDB grants `alloydbsuperuser` automatically.
+- **Role model.** `awa_owner` owns the schema (NOLOGIN); `awa_migrator` runs
+  `awa migrate`; `awa_runtime` (least privilege, cannot alter schema) runs
+  workers, producers, `awa serve`, and CLI admin.
+
+## Web Admin UI
+
+`awa serve` is a read/write admin console, not the worker runtime. It has **no
+built-in authentication** — treat it like a database admin console and restrict
+access with ingress policy, firewall, or private networking. It binds
+`127.0.0.1:3000` by default; set `--host 0.0.0.0` in containers.
+
+Run one `awa serve` per database (single-backend by design; `--peer` links are
+navigation only, no shared data plane). Use `--read-only` / `AWA_READ_ONLY=1`
+for incident read-outs or against a replica — mutation endpoints return 503 and
+the UI hides its buttons; read-only is auto-detected against a read-only
+connection. Set `--callback-hmac-secret` to verify callback signatures; for
+externally reachable callbacks with a private admin surface, run
+`awa callbacks serve` instead, whose router has no admin routes.
+
+## Before You Finish A Change
+
+1. Confirm the resolved target and that you are on the intended context.
+2. For a schema change, run `awa migrate --sql --pending` and read the plan.
+3. For a storage or upgrade step, run `awa storage status` (and `finalize
+   --check`) before and after.
+4. Verify `awa health` and `/readyz` across the fleet, not just one worker.
+5. Read the matching-version upgrade doc for gates, rollback limits, and
+   ordering specific to the pair you are moving between.


### PR DESCRIPTION
## Summary

Adds two portable [Agent Skills](https://agentskills.io/) so coding agents work from awa's actual API and operational semantics instead of guessing. Split across awa's two personas:

- **`awa-jobs`** — authoring, enqueuing, and handling jobs in Rust and Python: job kinds, transactional enqueue, priorities and aging, retry vs. snooze, unique jobs, cron, in-process and webhook callbacks, and progress/lifecycle hooks.
- **`awa-operations`** — deploying and operating the fleet: CLI reference, migrations and rolling upgrades, storage transitions, the DLQ, the maintenance/leader model, managed Postgres, and the web admin UI.

Also:

- **CI** — a new `agent-skills` job validates every `skills/<name>/SKILL.md` against the Agent Skills specification.
- **Release** — skills ship inside the release binary archives (`awa-<tag>-<target>/skills/`).
- **README** — an Agent Skills section linking both skills.
- **AGENTS.md** (new) — always-on build/lint/test rules, the migration-policy pointer, and skill-authoring governance.

## Design notes

- Skills are dense, version-aware operational references, not tutorials. They front-load the rule, then the gotcha (e.g. use `Snooze` not `RetryAfter` for polling waits; `flip-ring-authority` is a one-way door; a long-held snapshot pins the MVCC horizon and blocks ring prune).
- Product workflows and version-specific semantics live in skills; always-on contribution rules live in `AGENTS.md`. Cross-cutting facts (cron, ring flip) are stated once and cross-referenced rather than duplicated across the two skills.

## Validation

- `uvx --from skills-ref==0.1.1 agentskills validate skills/awa-jobs`
- `uvx --from skills-ref==0.1.1 agentskills validate skills/awa-operations`
- Both workflow files parse as valid YAML; both skill bodies are under the spec's 500-line recommendation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Published “Agent Skills” documentation, including `awa-jobs` and `awa-operations` usage guidance.
  * Bundled Agent Skills assets into shipped CLI/binary release archives for offline installs.

* **CI**
  * Added automated validation to ensure every published skill is documented and conforms to the Agent Skills specification.

* **Documentation**
  * Added always-on agent guidance for testing, migrations, and skill validation.
  * Expanded README with install instructions and safety guidance for reviewing downloaded skill instructions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->