### PR TITLE
ci: automate release candidate validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [main, "release/**"]
   pull_request:
   workflow_dispatch:
 
@@ -17,9 +17,26 @@ env:
 
 # PRs default to a low-minute gate so AWA does not monopolize shared Actions
 # capacity across repositories. Add the `full-ci` label, dispatch CI manually,
-# or merge to main to run the expensive DB/Python/E2E/smoke matrix.
+# or merge to main or a release branch to run the expensive DB/Python/E2E/smoke matrix.
 
 jobs:
+  # The release workflow requires a successful branch-push CI run on the exact
+  # tagged SHA. Keep the storage models here so that gate covers the executable
+  # tests and their formal concurrency model together.
+  tla-storage:
+    name: TLA+ storage model checking
+    if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'full-ci')
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - name: Show Docker version
+        run: docker --version
+      - name: Run TLC model suite
+        run: ./correctness/run-tlc-suite.sh
+
   # ─── Rust ───────────────────────────────────────────────
   rust-lint:
     name: Rust lint (fmt + clippy)
@@ -368,7 +385,7 @@ jobs:
         run: until pg_isready -h localhost -p 5432; do sleep 1; done
         working-directory: .
       - name: Run migrations
-        run: ../../target/debug/awa --database-url $DATABASE_URL migrate
+        run: ../../target/debug/awa --database-url "$DATABASE_URL" migrate
       - name: Install Playwright browsers
         run: npx playwright install chromium
       - name: Run E2E tests

--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -2,12 +2,10 @@
 # must pass on the exact release-candidate SHA before artifacts publish.
 #
 # Two entry points:
-#   * workflow_dispatch — run manually against a candidate ref BEFORE
-#     tagging (the required pre-tag check in the release process).
-#   * workflow_call — invoked by release.yml on tag push, so even a tag
-#     created without the manual pre-check cannot publish until the same
-#     rehearsal passes on the tagged commit. Publishing is gated, not
-#     merely observed.
+#   * workflow_dispatch — optionally rehearse early against a candidate ref.
+#   * workflow_call — invoked by release.yml on tag push after exact-SHA CI is
+#     verified, so publication still waits for the rehearsal on the tagged
+#     commit. Publishing is gated, not merely observed.
 #
 # Evidence: each rehearsal cell writes a machine-readable JSON report
 # (phases with elapsed-ms watermarks, census counts, flip status, exact

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,7 @@ env:
   SQLX_OFFLINE: "true"
 
 permissions:
+  actions: read
   contents: write
   packages: write
   id-token: write
@@ -88,14 +89,41 @@ jobs:
           sys.exit(fail)
           PY
 
+  # ─── Exact-candidate gate ────────────────────────────────────────
+  # Require the complete CI workflow triggered by the merge push to have
+  # passed on this exact commit before the release rehearsal or publication.
+  candidate-ci:
+    name: Verify exact-candidate CI
+    needs: [version-check]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require successful branch-push CI on this SHA
+        env:
+          GH_TOKEN: ${{ github.token }}
+          EXPECTED_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          count=$(gh api -X GET \
+            "repos/${GITHUB_REPOSITORY}/actions/workflows/ci.yml/runs" \
+            -f head_sha="${EXPECTED_SHA}" \
+            -f event=push \
+            -f status=success \
+            -f per_page=100 \
+            --jq '.total_count')
+          if [ "$count" -lt 1 ]; then
+            echo "::error::No successful branch-push CI run exists for ${EXPECTED_SHA}."
+            echo "Merge the release-prep PR, wait for the automatically triggered full CI run on the release branch, then tag that exact commit."
+            exit 1
+          fi
+          echo "Found ${count} successful exact-SHA branch-push CI run(s) for ${EXPECTED_SHA}."
+
   # ─── Cross-compile CLI binaries ──────────────────────────────────────
   # ─── Adversarial upgrade rehearsal gate (#427 / #383) ───────────────
-  # The mixed-version rehearsal must pass on the exact tagged commit
-  # before anything publishes. Tagging without the manual pre-tag
-  # dispatch of release-gate.yml therefore cannot ship artifacts.
+  # The mixed-version rehearsal must pass on the exact tagged commit before
+  # anything publishes. It runs after exact-candidate CI has been verified.
   release-gate:
     name: Release gate — upgrade rehearsal
-    needs: [version-check]
+    needs: [version-check, candidate-ci]
     uses: ./.github/workflows/release-gate.yml
 
   build-binaries:
@@ -173,8 +201,8 @@ jobs:
             exit 1
           fi
           test -d awa-ui/static/assets
-          ls awa-ui/static/assets/ | grep -q '\.js$'
-          ls awa-ui/static/assets/ | grep -q '\.css$'
+          compgen -G 'awa-ui/static/assets/*.js' >/dev/null
+          compgen -G 'awa-ui/static/assets/*.css' >/dev/null
 
       - name: Build (native)
         if: matrix.target != 'aarch64-unknown-linux-musl'
@@ -419,11 +447,12 @@ jobs:
           TAGS: ${{ steps.meta.outputs.tags }}
           DIGEST: ${{ steps.build-and-push.outputs.digest }}
         run: |
-          images=""
-          for tag in ${TAGS}; do
-            images+="${tag}@${DIGEST} "
+          read -r -a tags <<< "$TAGS"
+          images=()
+          for tag in "${tags[@]}"; do
+            images+=("${tag}@${DIGEST}")
           done
-          cosign sign --yes ${images}
+          cosign sign --yes "${images[@]}"
 
       - name: Attest build provenance
         uses: actions/attest@v4
@@ -573,8 +602,8 @@ jobs:
             exit 1
           fi
           test -d awa-ui/static/assets
-          ls awa-ui/static/assets/ | grep -q '\.js$'
-          ls awa-ui/static/assets/ | grep -q '\.css$'
+          compgen -G 'awa-ui/static/assets/*.js' >/dev/null
+          compgen -G 'awa-ui/static/assets/*.css' >/dev/null
 
       - name: Build CLI wheels
         uses: PyO3/maturin-action@v1
@@ -682,8 +711,8 @@ jobs:
             exit 1
           fi
           test -d awa-ui/static/assets
-          ls awa-ui/static/assets/ | grep -q '\.js$'
-          ls awa-ui/static/assets/ | grep -q '\.css$'
+          compgen -G 'awa-ui/static/assets/*.js' >/dev/null
+          compgen -G 'awa-ui/static/assets/*.css' >/dev/null
 
       - name: Publish awa-macros
         run: cargo publish --package awa-macros --no-verify

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -447,7 +447,7 @@ jobs:
           TAGS: ${{ steps.meta.outputs.tags }}
           DIGEST: ${{ steps.build-and-push.outputs.digest }}
         run: |
-          read -r -a tags <<< "$TAGS"
+          mapfile -t tags <<< "$TAGS"
           images=()
           for tag in "${tags[@]}"; do
             images+=("${tag}@${DIGEST}")

--- a/docs/development.md
+++ b/docs/development.md
@@ -40,8 +40,8 @@ Use pre-release tags before publishing a final version. Both crates.io and PyPI 
 6. The Release workflow reruns the rolling-upgrade rehearsal on the tagged
    commit, builds wheels, publishes to crates.io and PyPI, and creates a GitHub
    Release with binary assets.
-7. When ready for final: bump version to `0.x.0`, repeat the exact-SHA CI gate,
-   merge to the branch being released, and tag `v0.x.0`.
+7. When ready for final: bump the version to `0.x.0`, repeat steps 2–4 for the
+   final release preparation, then tag the validated commit as `v0.x.0`.
 
 ### Why pre-releases matter
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -28,11 +28,20 @@ Use pre-release tags before publishing a final version. Both crates.io and PyPI 
    - `awa-cli/pyproject.toml` (`[project].version` — controls CLI wheel version on PyPI)
    - `awa-python/Cargo.toml` (`version`, `awa-model`, `awa-worker` dep versions)
    - `awa-python/pyproject.toml` (`[project].version` — controls SDK wheel version on PyPI)
-2. Commit: `Bump version to 0.x.0-alpha.1`
-3. Push to a branch, wait for CI green.
-4. Tag and push: `git tag v0.x.0-alpha.1 && git push origin v0.x.0-alpha.1`
-5. The Release workflow builds wheels, publishes to crates.io and PyPI, and creates a GitHub Release with binary assets.
-6. When ready for final: bump version to `0.x.0`, merge to main, tag `v0.x.0`.
+2. Finalize the matching changelog section and commit the release preparation.
+3. Push a branch and open a PR against the branch being released. Apply the
+   `full-ci` label and wait for every check, including the TLA+ storage models.
+4. After merge, record the release branch's exact commit SHA and wait for the
+   automatically triggered **CI** workflow to pass completely. The Release
+   workflow refuses to publish unless this exact-SHA branch-push run succeeded;
+   a PR run against a pre-merge SHA is not sufficient.
+5. Tag and push the validated commit, for example:
+   `git tag v0.x.0-alpha.1 && git push origin v0.x.0-alpha.1`.
+6. The Release workflow reruns the rolling-upgrade rehearsal on the tagged
+   commit, builds wheels, publishes to crates.io and PyPI, and creates a GitHub
+   Release with binary assets.
+7. When ready for final: bump version to `0.x.0`, repeat the exact-SHA CI gate,
+   merge to the branch being released, and tag `v0.x.0`.
 
 ### Why pre-releases matter
 


### PR DESCRIPTION
## Purpose

Remove the required manual CI dispatch from the release process while preserving the stronger invariant: the exact commit being tagged must have passed the complete CI matrix.

## What changed

- Run full CI automatically for pushes to main and release branches.
- Add the TLA+ storage-model suite to full and exact-candidate CI.
- Require a successful push-event CI run for the exact tagged SHA before the release rehearsal or publication can proceed.
- Keep the rolling-upgrade rehearsal as a separate tag-time publication gate; its manual dispatch remains available only as an optional early rehearsal.
- Update the release documentation to wait for the automatic post-merge run instead of manually dispatching CI.
- Carry forward the existing workflow ShellCheck fixes for quoted arguments, frontend asset globs, and cosign arrays so actionlint is clean.

## Why

PR CI validates a pre-merge head, which may differ from the eventual merge commit. Previously, release branches did not trigger CI on push, so the release workflow required an operator to dispatch CI manually after merge. Automatically running CI on release-branch pushes proves the same exact-SHA property without that extra ceremony.

## Validation

- actionlint, including embedded ShellCheck
- git diff --check
- exact-SHA Actions API probe: a successful push run is found for current main, while a PR-only head is rejected
- TLC storage suite locally — all 24 expectations passed
- Exact-head full CI `a00aa308` — all 18 jobs passed: https://github.com/hardbyte/awa/actions/runs/31848332459


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Release Process**
  * Releases now verify that the exact tagged commit has passed CI before publication.
  * Release workflows include an optional rolling-upgrade rehearsal.
  * Package, container, and GitHub Release publishing checks have been strengthened.

* **Documentation**
  * Updated release guidance covers changelog finalization, labeled pull requests, commit validation, tagging, and publication steps.

* **CI**
  * CI now runs for release branches and includes additional gated validation checks.
  * Frontend end-to-end checks now handle database connection settings more reliably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->