### PR TITLE
ci: make draft release repository explicit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -253,6 +253,7 @@ jobs:
       - name: Create or verify draft release
         env:
           GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
           tag="${GITHUB_REF_NAME}"


### PR DESCRIPTION
## Root cause

The tag-triggered release job creates the draft without checking out the repository. `gh release` therefore could not infer a repository and failed with `fatal: not a git repository`.

## Fix

Set `GH_REPO` from `github.repository` for the draft-release step, keeping the job checkout-free while making `gh release view/create` repository-explicit.

## Validation

- `actionlint` passes
- `git diff --check` passes
- From a temporary non-Git directory, `GH_REPO=hardbyte/awa gh release view v0.6.6` reaches GitHub and returns the expected `release not found`
- Failed release run 31862901899 was cancelled; no GitHub Release exists and registry publication was gated/skipped