### PR TITLE
chore: prepare 0.6.7 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,16 @@ Notable changes between releases. Detailed migration notes for storage transitio
 
 ## [Unreleased]
 
+## [0.6.7] — 2026-08-31
+
+Patch release: CLI help credential redaction and dependency security updates. No migrations, schema changes, or public API changes.
+
 ### Fixed
 
 - **CLI help no longer prints credential-bearing environment values.** `awa --help` hides the resolved `DATABASE_URL`, while `awa serve --help` and `awa callbacks serve --help` hide `AWA_CALLBACK_HMAC_SECRET`. The CLI still accepts those environment variables and help still identifies their names, but their current values are never rendered.
+  - If help output containing either value was captured in CI logs, support bundles, or another shared location, remove that output where possible and rotate the exposed credential.
+- **The bundled admin UI no longer resolves the vulnerable `seroval` 1.5.1 transitive dependency.** The lockfile now selects 1.5.6, which contains the fix for [GHSA-mv8w-475r-vwqw](https://github.com/advisories/GHSA-mv8w-475r-vwqw).
+- **Rust transitive dependencies with published advisories are updated.** Both Rust lockfiles now select `h2` 0.4.16, fixing [RUSTSEC-2026-0258](https://rustsec.org/advisories/RUSTSEC-2026-0258), and the main workspace selects `crossbeam-epoch` 0.9.20, fixing [RUSTSEC-2026-0204](https://rustsec.org/advisories/RUSTSEC-2026-0204).
 
 ## [0.6.6] — 2026-08-14
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -383,7 +383,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "awa"
-version = "0.6.6"
+version = "0.6.7"
 dependencies = [
  "async-trait",
  "awa-macros",
@@ -408,7 +408,7 @@ dependencies = [
 
 [[package]]
 name = "awa-cli"
-version = "0.6.6"
+version = "0.6.7"
 dependencies = [
  "assert_cmd",
  "awa-model",
@@ -430,7 +430,7 @@ dependencies = [
 
 [[package]]
 name = "awa-macros"
-version = "0.6.6"
+version = "0.6.7"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -440,7 +440,7 @@ dependencies = [
 
 [[package]]
 name = "awa-metrics"
-version = "0.6.6"
+version = "0.6.7"
 dependencies = [
  "awa-model",
  "opentelemetry",
@@ -448,7 +448,7 @@ dependencies = [
 
 [[package]]
 name = "awa-model"
-version = "0.6.6"
+version = "0.6.7"
 dependencies = [
  "awa-macros",
  "blake3",
@@ -469,7 +469,7 @@ dependencies = [
 
 [[package]]
 name = "awa-seaorm"
-version = "0.6.6"
+version = "0.6.7"
 dependencies = [
  "awa",
  "awa-testing",
@@ -482,7 +482,7 @@ dependencies = [
 
 [[package]]
 name = "awa-testing"
-version = "0.6.6"
+version = "0.6.7"
 dependencies = [
  "async-trait",
  "awa-model",
@@ -497,7 +497,7 @@ dependencies = [
 
 [[package]]
 name = "awa-ui"
-version = "0.6.6"
+version = "0.6.7"
 dependencies = [
  "awa-metrics",
  "awa-model",
@@ -520,7 +520,7 @@ dependencies = [
 
 [[package]]
 name = "awa-worker"
-version = "0.6.6"
+version = "0.6.7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1023,9 +1023,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -1494,9 +1494,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.13"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ members = [
 exclude = ["awa-python", "spike"]
 
 [workspace.package]
-version = "0.6.6"
+version = "0.6.7"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "Postgres-native background job queue — transactional enqueue, heartbeat crash recovery, SKIP LOCKED dispatch"
@@ -25,11 +25,11 @@ categories = ["database", "asynchronous", "web-programming"]
 
 [workspace.dependencies]
 # Internal crates
-awa-model = { path = "awa-model", version = "0.6.6" }
-awa-macros = { path = "awa-macros", version = "0.6.6" }
-awa-metrics = { path = "awa-metrics", version = "0.6.6" }
-awa-worker = { path = "awa-worker", version = "0.6.6" }
-awa = { path = "awa", version = "0.6.6" }
+awa-model = { path = "awa-model", version = "0.6.7" }
+awa-macros = { path = "awa-macros", version = "0.6.7" }
+awa-metrics = { path = "awa-metrics", version = "0.6.7" }
+awa-worker = { path = "awa-worker", version = "0.6.7" }
+awa = { path = "awa", version = "0.6.7" }
 
 # Database
 sea-orm = { version = "=2.0.0-rc.38", default-features = false, features = ["sqlx-postgres", "runtime-tokio-rustls", "with-chrono", "with-json"] }

--- a/awa-cli/Cargo.toml
+++ b/awa-cli/Cargo.toml
@@ -14,7 +14,7 @@ path = "src/main.rs"
 [dependencies]
 awa-model.workspace = true
 awa-worker.workspace = true
-awa-ui = { path = "../awa-ui", version = "0.6.6" }
+awa-ui = { path = "../awa-ui", version = "0.6.7" }
 axum.workspace = true
 sqlx.workspace = true
 tokio.workspace = true
@@ -28,5 +28,5 @@ hex.workspace = true
 uuid.workspace = true
 
 [dev-dependencies]
-awa-testing = { path = "../awa-testing", version = "0.6.6" }
+awa-testing = { path = "../awa-testing", version = "0.6.7" }
 assert_cmd = "2"

--- a/awa-cli/pyproject.toml
+++ b/awa-cli/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "awa-cli"
-version = "0.6.6"
+version = "0.6.7"
 description = "CLI for the Awa Postgres-native job queue (migrations, admin, serve)"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/awa-python/Cargo.lock
+++ b/awa-python/Cargo.lock
@@ -95,7 +95,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "awa-macros"
-version = "0.6.6"
+version = "0.6.7"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -105,7 +105,7 @@ dependencies = [
 
 [[package]]
 name = "awa-metrics"
-version = "0.6.6"
+version = "0.6.7"
 dependencies = [
  "awa-model",
  "opentelemetry",
@@ -113,7 +113,7 @@ dependencies = [
 
 [[package]]
 name = "awa-model"
-version = "0.6.6"
+version = "0.6.7"
 dependencies = [
  "awa-macros",
  "blake3",
@@ -133,7 +133,7 @@ dependencies = [
 
 [[package]]
 name = "awa-python"
-version = "0.6.6"
+version = "0.6.7"
 dependencies = [
  "async-trait",
  "awa-model",
@@ -156,7 +156,7 @@ dependencies = [
 
 [[package]]
 name = "awa-worker"
-version = "0.6.6"
+version = "0.6.7"
 dependencies = [
  "async-trait",
  "awa-macros",
@@ -667,9 +667,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.13"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",

--- a/awa-python/Cargo.toml
+++ b/awa-python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "awa-python"
-version = "0.6.6"
+version = "0.6.7"
 edition = "2021"
 
 [lib]
@@ -12,8 +12,8 @@ default = ["cel"]
 cel = ["awa-model/cel"]
 
 [dependencies]
-awa-model = { path = "../awa-model", version = "0.6.6" }
-awa-worker = { path = "../awa-worker", version = "0.6.6", features = ["__python-bridge"] }
+awa-model = { path = "../awa-model", version = "0.6.7" }
+awa-worker = { path = "../awa-worker", version = "0.6.7", features = ["__python-bridge"] }
 pyo3 = { version = "0.29", features = ["macros", "abi3-py310", "chrono"] }
 pyo3-async-runtimes = { version = "0.29", features = ["tokio-runtime"] }
 sqlx = { version = "0.8", features = ["runtime-tokio-rustls", "postgres", "chrono", "json"] }

--- a/awa-python/pyproject.toml
+++ b/awa-python/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "maturin"
 [project]
 name = "awa-pg"
 requires-python = ">=3.10"
-version = "0.6.6"
+version = "0.6.7"
 description = "Postgres-native background job queue — Python SDK with async/sync workers, transactional enqueue, and progress tracking. Install awa-pg[ui] to add the bundled web dashboard."
 readme = "README.md"
 license = {text = "MIT OR Apache-2.0"}
@@ -32,7 +32,7 @@ classifiers = [
 #
 # Kept opt-in so the default `awa-pg` install stays small — workers and
 # producers don't need the ~10 MB UI bundle.
-ui = ["awa-cli==0.6.6"]
+ui = ["awa-cli==0.6.7"]
 
 [project.urls]
 Homepage = "https://github.com/hardbyte/awa"

--- a/awa-python/uv.lock
+++ b/awa-python/uv.lock
@@ -88,12 +88,12 @@ wheels = [
 
 [[package]]
 name = "awa-cli"
-version = "0.6.6"
+version = "0.6.7"
 source = { directory = "../awa-cli" }
 
 [[package]]
 name = "awa-pg"
-version = "0.6.6"
+version = "0.6.7"
 source = { editable = "." }
 
 [package.optional-dependencies]

--- a/awa-seaorm/Cargo.toml
+++ b/awa-seaorm/Cargo.toml
@@ -14,6 +14,6 @@ serde_json.workspace = true
 sqlx.workspace = true
 
 [dev-dependencies]
-awa-testing = { path = "../awa-testing", version = "0.6.6" }
+awa-testing = { path = "../awa-testing", version = "0.6.7" }
 serde = { workspace = true, features = ["derive"] }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/awa-ui/frontend/package-lock.json
+++ b/awa-ui/frontend/package-lock.json
@@ -4860,9 +4860,9 @@
       }
     },
     "node_modules/seroval": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/seroval/-/seroval-1.5.1.tgz",
-      "integrity": "sha512-OwrZRZAfhHww0WEnKHDY8OM0U/Qs8OTfIDWhUD4BLpNJUfXK4cGmjiagGze086m+mhI+V2nD0gfbHEnJjb9STA==",
+      "version": "1.5.6",
+      "resolved": "https://registry.npmjs.org/seroval/-/seroval-1.5.6.tgz",
+      "integrity": "sha512-rVQVWjjSvlINzaQPZH5JFqsqEsIWdTxY3iJZCnTL/5gQbXIRooVZKI60tVCkOVfzcRPejboxO2t0P89dg5mQaA==",
       "license": "MIT",
       "engines": {
         "node": ">=10"

--- a/awa/Cargo.toml
+++ b/awa/Cargo.toml
@@ -20,7 +20,7 @@ awa-macros.workspace = true
 awa-worker.workspace = true
 
 [dev-dependencies]
-awa-testing = { path = "../awa-testing", version = "0.6.6" }
+awa-testing = { path = "../awa-testing", version = "0.6.7" }
 sqlx.workspace = true
 serde.workspace = true
 serde_json.workspace = true


### PR DESCRIPTION
## Summary

Prepare the 0.6 maintenance line for v0.6.7.

- bump all Rust and Python package versions, internal pins, and generated locks to 0.6.7
- publish the credential-redaction fix already merged in #477
- update the bundled UI lockfile from vulnerable `seroval` 1.5.1 to patched 1.5.6 (the same scoped update as #453)
- update `h2` to 0.4.16 in both Rust lockfiles and `crossbeam-epoch` to 0.9.20 in the main lockfile, resolving the current RustSec advisories
- add focused release notes, including credential-rotation guidance when old help output was captured or shared

This patch has no migrations, schema changes, or public API changes.

## Validation

- `cargo fmt --all -- --check`
- `SQLX_OFFLINE=true cargo clippy --all-targets --all-features -- -D warnings`
- `SQLX_OFFLINE=true cargo build --workspace`
- `cargo test -p awa-cli --test help_cli_test` (3 passed)
- `cd awa-python && SQLX_OFFLINE=true cargo check --all-targets --all-features`
- `cd awa-python && uv lock --check`
- release version-consistency check reproduced locally: all 32 checked surfaces match 0.6.7
- `cargo deny check advisories` in both Rust workspaces (clean)
- `cd awa-ui/frontend && npm ci && npm run lint && npm run build`
- `cd awa-ui/frontend && npm audit --omit=dev` (0 vulnerabilities)
- rebuilt `awa-cli` after the production frontend build; `awa --version` reports 0.6.7

## Release gate

After merge, wait for the automatically triggered full `CI` branch-push run on the exact `release/0.6.6` merge commit. Tag that exact commit `v0.6.7` only after it passes; the release workflow enforces this exact-SHA gate.
