### PR TITLE
Backport Python shutdown and storage upgrade fixes to 0.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ Notable changes between releases. Detailed migration notes for storage transitio
 
 ## [Unreleased]
 
+- Emit a stderr diagnostic after five seconds of stalled native Python shutdown,
+  while retaining the join required for safe interpreter finalization.
+
 - Rejected Python bridge operations preserve client lifecycle state; canonical
   callback retries notify dispatchers only when their transaction commits.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,12 @@ Notable changes between releases. Detailed migration notes for storage transitio
 
 ## [Unreleased]
 
-- Fence and join Rust-to-Python completion callbacks before interpreter
-  finalization, preventing the reproduced exit-time CPython 3.12 SIGSEGV after
+- Cancel and join native Python async operations and join completion callbacks
+  before interpreter finalization, preventing the reproduced exit-time CPython 3.12 SIGSEGV after
   `await client.close()`. Worker shutdown and pool close remain explicit.
 
 - Preserve canonical callback resolution during mixed storage transitions (#462),
-  including lease fencing and transaction rollback.
+  including handler registration, polling, lease fencing, and transaction rollback.
 - Add `storage enter-mixed-transition --quiesced` for a stopped fleet, refusing
   fresh runtime snapshots and retaining canonical backlog/finalize gates (#457).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Notable changes between releases. Detailed migration notes for storage transitio
 
 ## [Unreleased]
 
+- Fence and join Rust-to-Python completion callbacks before interpreter
+  finalization, preventing the reproduced exit-time CPython 3.12 SIGSEGV after
+  `await client.close()`. Worker shutdown and pool close remain explicit.
+
 - Preserve canonical callback resolution during mixed storage transitions (#462),
   including lease fencing and transaction rollback.
 - Add `storage enter-mixed-transition --quiesced` for a stopped fleet, refusing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ Notable changes between releases. Detailed migration notes for storage transitio
 
 ## [Unreleased]
 
+- Rejected Python bridge operations preserve client lifecycle state; canonical
+  callback retries notify dispatchers only when their transaction commits.
+
 - Cancel and join native Python async operations and join completion callbacks
   before interpreter finalization, preventing the reproduced exit-time CPython 3.12 SIGSEGV after
   `await client.close()`. Worker shutdown and pool close remain explicit.
@@ -11,7 +14,8 @@ Notable changes between releases. Detailed migration notes for storage transitio
 - Preserve canonical callback resolution during mixed storage transitions (#462),
   including handler registration, polling, lease fencing, and transaction rollback.
 - Add `storage enter-mixed-transition --quiesced` for a stopped fleet, refusing
-  fresh runtime snapshots and retaining canonical backlog/finalize gates (#457).
+  fresh runtime snapshots with millisecond precision, checking the complete target
+  substrate, and retaining canonical backlog/finalize gates (#457).
 
 ## [0.6.7] — 2026-08-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ Notable changes between releases. Detailed migration notes for storage transitio
 
 ## [Unreleased]
 
+- Preserve canonical callback resolution during mixed storage transitions (#462),
+  including lease fencing and transaction rollback.
+- Add `storage enter-mixed-transition --quiesced` for a stopped fleet, refusing
+  fresh runtime snapshots and retaining canonical backlog/finalize gates (#457).
+
 ## [0.6.7] — 2026-08-31
 
 Patch release: CLI help credential redaction and dependency security updates. No migrations, schema changes, or public API changes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ Notable changes between releases. Detailed migration notes for storage transitio
 
 ## [Unreleased]
 
+- Python `Transaction`/`SyncTransaction` handles released without commit or
+  rollback now roll back on the shared Tokio runtime. Previously garbage
+  collection on a thread without a runtime, including interpreter exit,
+  panicked inside sqlx's pool return with "this functionality requires a
+  Tokio context".
+
 - Emit a stderr diagnostic after five seconds of stalled native Python shutdown,
   while retaining the join required for safe interpreter finalization.
 

--- a/awa-cli/src/main.rs
+++ b/awa-cli/src/main.rs
@@ -411,7 +411,12 @@ enum StorageCommands {
     /// Abort a prepared or mixed-transition storage rollout before final activation
     Abort,
     /// Enter mixed transition and begin routing new writes to the prepared engine
-    EnterMixedTransition,
+    EnterMixedTransition {
+        /// Flip with all workers stopped; refuse any fresh runtime heartbeat.
+        /// Keep workers stopped until this command returns, then restart them.
+        #[arg(long)]
+        quiesced: bool,
+    },
     /// Finalize the storage transition once drain and capability gates pass
     Finalize {
         /// Dry-run: print the readiness report and exit. Exits 0 when
@@ -1100,8 +1105,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                         let report = awa_model::storage::status_report(&pool).await?;
                         println!("{}", serde_json::to_string_pretty(&report)?);
                     }
-                    StorageCommands::EnterMixedTransition => {
-                        awa_model::storage::enter_mixed_transition(&pool).await?;
+                    StorageCommands::EnterMixedTransition { quiesced } => {
+                        if quiesced {
+                            awa_model::storage::enter_mixed_transition_quiesced(&pool).await?;
+                        } else {
+                            awa_model::storage::enter_mixed_transition(&pool).await?;
+                        }
                         let report = awa_model::storage::status_report(&pool).await?;
                         println!("{}", serde_json::to_string_pretty(&report)?);
                     }

--- a/awa-model/src/admin.rs
+++ b/awa-model/src/admin.rs
@@ -295,6 +295,34 @@ async fn callback_queue_storage_in_tx(
     Ok(Some(store))
 }
 
+/// A drain handler keeps its canonical job ID across the routing flip. Job
+/// IDs are global; migrated successors get fresh IDs, so an existing canonical
+/// row identifies this handler's store without searching the queue view.
+async fn callback_job_queue_storage_in_tx(
+    tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+    job_id: i64,
+) -> Result<Option<QueueStorage>, AwaError> {
+    let state: Option<String> = sqlx::query_scalar(
+        "SELECT state FROM awa.storage_transition_state WHERE singleton FOR SHARE",
+    )
+    .fetch_optional(tx.as_mut())
+    .await?;
+    let Some(store) = active_queue_storage_in_tx(tx).await? else {
+        return Ok(None);
+    };
+    if state.as_deref() == Some("mixed_transition") {
+        let canonical: bool =
+            sqlx::query_scalar("SELECT EXISTS(SELECT 1 FROM awa.jobs_hot WHERE id=$1)")
+                .bind(job_id)
+                .fetch_one(tx.as_mut())
+                .await?;
+        if canonical {
+            return Ok(None);
+        }
+    }
+    Ok(Some(store))
+}
+
 fn queue_storage_current_jobs_cte(schema: &str) -> String {
     format!(
         r#"
@@ -3042,7 +3070,9 @@ pub async fn register_callback(
     run_lease: i64,
     timeout: std::time::Duration,
 ) -> Result<Uuid, AwaError> {
-    if let Some(store) = active_queue_storage(pool).await? {
+    let mut tx = pool.begin().await?;
+    if let Some(store) = callback_job_queue_storage_in_tx(&mut tx, job_id).await? {
+        tx.commit().await?;
         return store
             .register_callback(pool, job_id, run_lease, timeout)
             .await;
@@ -3051,7 +3081,7 @@ pub async fn register_callback(
     let callback_id = Uuid::new_v4();
     let timeout_secs = timeout.as_secs_f64();
     let result = sqlx::query(
-        r#"UPDATE awa.jobs
+        r#"UPDATE awa.jobs_hot
            SET callback_id = $2,
                callback_timeout_at = now() + make_interval(secs => $3),
                callback_filter = NULL,
@@ -3064,11 +3094,12 @@ pub async fn register_callback(
     .bind(callback_id)
     .bind(timeout_secs)
     .bind(run_lease)
-    .execute(pool)
+    .execute(tx.as_mut())
     .await?;
     if result.rows_affected() == 0 {
         return Err(AwaError::Validation("job is not in running state".into()));
     }
+    tx.commit().await?;
     Ok(callback_id)
 }
 
@@ -3384,13 +3415,15 @@ pub async fn heartbeat_callback(
 /// `Ok(false)` if no match (already resolved, rescued, or wrong lease).
 /// Callers should not treat `false` as an error.
 pub async fn cancel_callback(pool: &PgPool, job_id: i64, run_lease: i64) -> Result<bool, AwaError> {
-    if let Some(store) = active_queue_storage(pool).await? {
+    let mut tx = pool.begin().await?;
+    if let Some(store) = callback_job_queue_storage_in_tx(&mut tx, job_id).await? {
+        tx.commit().await?;
         return store.cancel_callback(pool, job_id, run_lease).await;
     }
 
     let result = sqlx::query(
         r#"
-        UPDATE awa.jobs
+        UPDATE awa.jobs_hot
         SET callback_id = NULL,
             callback_timeout_at = NULL,
             callback_filter = NULL,
@@ -3402,9 +3435,10 @@ pub async fn cancel_callback(pool: &PgPool, job_id: i64, run_lease: i64) -> Resu
     )
     .bind(job_id)
     .bind(run_lease)
-    .execute(pool)
+    .execute(tx.as_mut())
     .await?;
 
+    tx.commit().await?;
     Ok(result.rows_affected() > 0)
 }
 
@@ -3443,7 +3477,9 @@ pub async fn enter_callback_wait(
     run_lease: i64,
     callback_id: Uuid,
 ) -> Result<bool, AwaError> {
-    if let Some(store) = active_queue_storage(pool).await? {
+    let mut tx = pool.begin().await?;
+    if let Some(store) = callback_job_queue_storage_in_tx(&mut tx, job_id).await? {
+        tx.commit().await?;
         return store
             .enter_callback_wait(pool, job_id, run_lease, callback_id)
             .await;
@@ -3451,7 +3487,7 @@ pub async fn enter_callback_wait(
 
     let result = sqlx::query(
         r#"
-        UPDATE awa.jobs
+        UPDATE awa.jobs_hot
         SET state = 'waiting_external',
             heartbeat_at = NULL,
             deadline_at = NULL
@@ -3461,9 +3497,10 @@ pub async fn enter_callback_wait(
     .bind(job_id)
     .bind(run_lease)
     .bind(callback_id)
-    .execute(pool)
+    .execute(tx.as_mut())
     .await?;
 
+    tx.commit().await?;
     Ok(result.rows_affected() > 0)
 }
 
@@ -3477,21 +3514,33 @@ pub async fn check_callback_state(
     job_id: i64,
     callback_id: Uuid,
 ) -> Result<CallbackPollResult, AwaError> {
-    if let Some(store) = active_queue_storage(pool).await? {
+    let mut tx = pool.begin().await?;
+    if let Some(store) = callback_job_queue_storage_in_tx(&mut tx, job_id).await? {
+        tx.commit().await?;
         return store.check_callback_state(pool, job_id, callback_id).await;
     }
 
-    let row: Option<(JobState, Option<Uuid>, serde_json::Value)> =
-        sqlx::query_as("SELECT state, callback_id, metadata FROM awa.jobs WHERE id = $1")
-            .bind(job_id)
-            .fetch_optional(pool)
-            .await?;
+    let row: Option<(JobState, Option<Uuid>, serde_json::Value)> = sqlx::query_as(
+        "SELECT state, callback_id, metadata FROM awa.jobs_hot WHERE id = $1 FOR UPDATE",
+    )
+    .bind(job_id)
+    .fetch_optional(tx.as_mut())
+    .await?;
 
-    match row {
+    let result = match row {
         Some((JobState::Running, None, metadata))
             if metadata.get("_awa_callback_result").is_some() =>
         {
-            let payload = take_callback_payload(pool, job_id, metadata).await?;
+            let payload = metadata
+                .get("_awa_callback_result")
+                .cloned()
+                .unwrap_or(serde_json::Value::Null);
+            sqlx::query(
+                "UPDATE awa.jobs_hot SET metadata=metadata-'_awa_callback_result' WHERE id=$1",
+            )
+            .bind(job_id)
+            .execute(tx.as_mut())
+            .await?;
             Ok(CallbackPollResult::Resolved(payload))
         }
         Some((state, Some(current_callback_id), _)) if current_callback_id != callback_id => {
@@ -3509,7 +3558,9 @@ pub async fn check_callback_state(
             state,
         }),
         None => Ok(CallbackPollResult::NotFound),
-    }
+    };
+    tx.commit().await?;
+    result
 }
 
 /// Extract the `_awa_callback_result` key from metadata and clean it up.
@@ -3523,10 +3574,12 @@ pub async fn take_callback_payload(
         .cloned()
         .unwrap_or(serde_json::Value::Null);
 
-    sqlx::query("UPDATE awa.jobs SET metadata = metadata - '_awa_callback_result' WHERE id = $1")
-        .bind(job_id)
-        .execute(pool)
-        .await?;
+    sqlx::query(
+        "UPDATE awa.jobs_hot SET metadata = metadata - '_awa_callback_result' WHERE id = $1",
+    )
+    .bind(job_id)
+    .execute(pool)
+    .await?;
 
     Ok(payload)
 }
@@ -3653,7 +3706,9 @@ pub async fn register_callback_with_config(
         }
     }
 
-    if let Some(store) = active_queue_storage(pool).await? {
+    let mut tx = pool.begin().await?;
+    if let Some(store) = callback_job_queue_storage_in_tx(&mut tx, job_id).await? {
+        tx.commit().await?;
         return store
             .register_callback_with_config(pool, job_id, run_lease, timeout, config)
             .await;
@@ -3663,7 +3718,7 @@ pub async fn register_callback_with_config(
     let timeout_secs = timeout.as_secs_f64();
 
     let result = sqlx::query(
-        r#"UPDATE awa.jobs
+        r#"UPDATE awa.jobs_hot
            SET callback_id = $2,
                callback_timeout_at = now() + make_interval(secs => $3),
                callback_filter = $4,
@@ -3680,12 +3735,13 @@ pub async fn register_callback_with_config(
     .bind(&config.on_fail)
     .bind(&config.transform)
     .bind(run_lease)
-    .execute(pool)
+    .execute(tx.as_mut())
     .await?;
 
     if result.rows_affected() == 0 {
         return Err(AwaError::Validation("job is not in running state".into()));
     }
+    tx.commit().await?;
     Ok(callback_id)
 }
 

--- a/awa-model/src/admin.rs
+++ b/awa-model/src/admin.rs
@@ -3365,9 +3365,16 @@ pub async fn retry_external_in_tx(
     .fetch_optional(tx.as_mut())
     .await?;
 
-    row.ok_or(AwaError::CallbackNotFound {
+    let row = row.ok_or(AwaError::CallbackNotFound {
         callback_id: callback_id.to_string(),
-    })
+    })?;
+    // jobs_hot only notifies on INSERT. This direct UPDATE must wake the
+    // canonical dispatcher itself; PostgreSQL delivers it only on commit.
+    sqlx::query("SELECT pg_notify('awa:' || $1, '')")
+        .bind(&row.queue)
+        .execute(tx.as_mut())
+        .await?;
+    Ok(row)
 }
 
 /// Reset the callback timeout for a long-running external operation.

--- a/awa-model/src/admin.rs
+++ b/awa-model/src/admin.rs
@@ -269,6 +269,32 @@ async fn active_queue_storage_in_tx(
         .transpose()
 }
 
+/// Callback ownership can remain canonical while new jobs route to queue storage.
+/// Lock transition state through the caller's transaction so finalize cannot
+/// change the fallback boundary halfway through a callback operation (#462).
+async fn callback_queue_storage_in_tx(
+    tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+    callback_id: Uuid,
+) -> Result<Option<QueueStorage>, AwaError> {
+    let state: Option<String> = sqlx::query_scalar(
+        "SELECT state FROM awa.storage_transition_state WHERE singleton FOR SHARE",
+    )
+    .fetch_optional(tx.as_mut())
+    .await?;
+    let Some(store) = active_queue_storage_in_tx(tx).await? else {
+        return Ok(None);
+    };
+    if state.as_deref() == Some("mixed_transition")
+        && store
+            .callback_job_in_tx(tx, callback_id, None, false)
+            .await?
+            .is_none()
+    {
+        return Ok(None);
+    }
+    Ok(Some(store))
+}
+
 fn queue_storage_current_jobs_cte(schema: &str) -> String {
     format!(
         r#"
@@ -3122,7 +3148,7 @@ async fn complete_external_in_tx_inner(
     run_lease: Option<i64>,
     resume: bool,
 ) -> Result<JobRow, AwaError> {
-    if let Some(store) = active_queue_storage_in_tx(tx).await? {
+    if let Some(store) = callback_queue_storage_in_tx(tx, callback_id).await? {
         return store
             .complete_external_in_tx(tx, callback_id, payload, run_lease, resume)
             .await;
@@ -3134,7 +3160,7 @@ async fn complete_external_in_tx_inner(
         let payload_json = payload.unwrap_or(serde_json::Value::Null);
         sqlx::query_as::<_, JobRow>(
             r#"
-            UPDATE awa.jobs
+            UPDATE awa.jobs_hot
             SET state = 'running',
                 callback_id = NULL,
                 callback_timeout_at = NULL,
@@ -3158,7 +3184,7 @@ async fn complete_external_in_tx_inner(
         // Complete: terminal state, clear everything.
         sqlx::query_as::<_, JobRow>(
             r#"
-            UPDATE awa.jobs
+            UPDATE awa.jobs_hot
             SET state = 'completed',
                 finalized_at = now(),
                 callback_id = NULL,
@@ -3208,7 +3234,7 @@ pub async fn fail_external_in_tx(
     error: &str,
     run_lease: Option<i64>,
 ) -> Result<JobRow, AwaError> {
-    if let Some(store) = active_queue_storage_in_tx(tx).await? {
+    if let Some(store) = callback_queue_storage_in_tx(tx, callback_id).await? {
         return store
             .fail_external_with_error_entry_in_tx(
                 tx,
@@ -3221,7 +3247,7 @@ pub async fn fail_external_in_tx(
 
     let row = sqlx::query_as::<_, JobRow>(
         r#"
-        UPDATE awa.jobs
+        UPDATE awa.jobs_hot
         SET state = 'failed',
             finalized_at = now(),
             callback_id = NULL,
@@ -3279,13 +3305,13 @@ pub async fn retry_external_in_tx(
     callback_id: Uuid,
     run_lease: Option<i64>,
 ) -> Result<JobRow, AwaError> {
-    if let Some(store) = active_queue_storage_in_tx(tx).await? {
+    if let Some(store) = callback_queue_storage_in_tx(tx, callback_id).await? {
         return store.retry_external_in_tx(tx, callback_id, run_lease).await;
     }
 
     let row = sqlx::query_as::<_, JobRow>(
         r#"
-        UPDATE awa.jobs
+        UPDATE awa.jobs_hot
         SET state = 'available',
             attempt = 0,
             run_at = now(),
@@ -3326,14 +3352,16 @@ pub async fn heartbeat_callback(
     callback_id: Uuid,
     timeout: std::time::Duration,
 ) -> Result<JobRow, AwaError> {
-    if let Some(store) = active_queue_storage(pool).await? {
+    let mut tx = pool.begin().await?;
+    if let Some(store) = callback_queue_storage_in_tx(&mut tx, callback_id).await? {
+        tx.commit().await?;
         return store.heartbeat_callback(pool, callback_id, timeout).await;
     }
 
     let timeout_secs = timeout.as_secs_f64();
     let row = sqlx::query_as::<_, JobRow>(
         r#"
-        UPDATE awa.jobs
+        UPDATE awa.jobs_hot
         SET callback_timeout_at = now() + make_interval(secs => $2)
         WHERE callback_id = $1 AND state = 'waiting_external'
         RETURNING *
@@ -3341,9 +3369,10 @@ pub async fn heartbeat_callback(
     )
     .bind(callback_id)
     .bind(timeout_secs)
-    .fetch_optional(pool)
+    .fetch_optional(tx.as_mut())
     .await?;
 
+    tx.commit().await?;
     row.ok_or(AwaError::CallbackNotFound {
         callback_id: callback_id.to_string(),
     })
@@ -3709,7 +3738,7 @@ pub async fn resolve_callback_in_tx(
     default_action: DefaultAction,
     run_lease: Option<i64>,
 ) -> Result<ResolveOutcome, AwaError> {
-    if let Some(store) = active_queue_storage_in_tx(tx).await? {
+    if let Some(store) = callback_queue_storage_in_tx(tx, callback_id).await? {
         let job = store
             .callback_job_in_tx(tx, callback_id, run_lease, true)
             .await?
@@ -3776,7 +3805,7 @@ pub async fn resolve_callback_in_tx(
         ResolveAction::Complete(transformed_payload) => {
             let completed_job = sqlx::query_as::<_, JobRow>(
                 r#"
-                UPDATE awa.jobs
+                UPDATE awa.jobs_hot
                 SET state = 'completed',
                     finalized_at = now(),
                     callback_id = NULL,
@@ -3813,7 +3842,7 @@ pub async fn resolve_callback_in_tx(
 
             let failed_job = sqlx::query_as::<_, JobRow>(
                 r#"
-                UPDATE awa.jobs
+                UPDATE awa.jobs_hot
                 SET state = 'failed',
                     finalized_at = now(),
                     callback_id = NULL,

--- a/awa-model/src/storage.rs
+++ b/awa-model/src/storage.rs
@@ -126,13 +126,7 @@ pub async fn enter_mixed_transition_quiesced(pool: &PgPool) -> Result<StorageSta
         .and_then(serde_json::Value::as_str)
         .filter(|s| !s.is_empty())
         .unwrap_or("awa");
-    let ready: bool = sqlx::query_scalar(
-        "SELECT bool_and(to_regclass(format('%I.%I', $1::text, name)) IS NOT NULL)
-         FROM unnest(ARRAY['queue_ring_state','ready_entries','leases']) AS name",
-    )
-    .bind(schema)
-    .fetch_one(tx.as_mut())
-    .await?;
+    let ready = queue_storage_schema_ready(tx.as_mut(), schema).await?;
     if !ready {
         return Err(AwaError::Validation(format!(
             "queue storage schema {schema:?} is not prepared"
@@ -140,8 +134,8 @@ pub async fn enter_mixed_transition_quiesced(pool: &PgPool) -> Result<StorageSta
     }
     let live: i64 = sqlx::query_scalar(
         "SELECT count(*) FROM awa.runtime_instances
-         WHERE last_seen_at + make_interval(secs =>
-             GREATEST(((GREATEST(snapshot_interval_ms, 1000) / 1000) * 3)::int, 30)
+         WHERE last_seen_at + GREATEST(
+             snapshot_interval_ms * INTERVAL '3 milliseconds', INTERVAL '30 seconds'
          ) >= clock_timestamp()",
     )
     .fetch_one(tx.as_mut())
@@ -209,7 +203,10 @@ fn queue_storage_schema_from_status(status: &StorageStatus) -> Option<String> {
 /// for custom schemas. If you change a required substrate object or the
 /// `claim_ready_runtime` signature there, update this check at the same
 /// time.
-pub async fn queue_storage_schema_ready(pool: &PgPool, schema: &str) -> Result<bool, AwaError> {
+pub async fn queue_storage_schema_ready<'e, E>(executor: E, schema: &str) -> Result<bool, AwaError>
+where
+    E: PgExecutor<'e>,
+{
     sqlx::query_scalar::<_, bool>(
         r#"
         SELECT
@@ -265,7 +262,7 @@ pub async fn queue_storage_schema_ready(pool: &PgPool, schema: &str) -> Result<b
         "#,
     )
     .bind(schema)
-    .fetch_one(pool)
+    .fetch_one(executor)
     .await
     .map_err(AwaError::from)
 }

--- a/awa-model/src/storage.rs
+++ b/awa-model/src/storage.rs
@@ -95,6 +95,82 @@ where
         .map_err(AwaError::from)
 }
 
+/// Enter mixed transition after the operator has stopped the entire fleet.
+/// Unlike the live transition, this does not require a queue-storage target.
+/// Fresh runtime snapshots refuse the operation, including unhealthy or
+/// shutting-down runtimes. Stale snapshots are evidence of absence, not a
+/// process fence: the operator must keep workers stopped until this returns.
+/// Canonical backlog is preserved and still blocks finalization.
+///
+/// Implemented without DDL so this works on an unfinalized 0.6 schema (#457).
+pub async fn enter_mixed_transition_quiesced(pool: &PgPool) -> Result<StorageStatus, AwaError> {
+    let mut tx = pool.begin().await?;
+    // Serialize snapshot writes with the liveness check and routing flip. Do
+    // not take the snapshot protocol advisory lock after this table lock: a
+    // writer may already hold it while waiting to insert its snapshot.
+    sqlx::query("LOCK TABLE awa.runtime_instances IN SHARE MODE")
+        .execute(tx.as_mut())
+        .await?;
+    sqlx::query("SELECT singleton FROM awa.storage_transition_state WHERE singleton FOR UPDATE")
+        .fetch_one(tx.as_mut())
+        .await?;
+    let before = status(tx.as_mut()).await?;
+    if before.state != "prepared" || before.prepared_engine.as_deref() != Some("queue_storage") {
+        return Err(AwaError::Validation(
+            "quiesced transition requires prepared queue storage".into(),
+        ));
+    }
+    let schema = before
+        .details
+        .get("schema")
+        .and_then(serde_json::Value::as_str)
+        .filter(|s| !s.is_empty())
+        .unwrap_or("awa");
+    let ready: bool = sqlx::query_scalar(
+        "SELECT bool_and(to_regclass(format('%I.%I', $1::text, name)) IS NOT NULL)
+         FROM unnest(ARRAY['queue_ring_state','ready_entries','leases']) AS name",
+    )
+    .bind(schema)
+    .fetch_one(tx.as_mut())
+    .await?;
+    if !ready {
+        return Err(AwaError::Validation(format!(
+            "queue storage schema {schema:?} is not prepared"
+        )));
+    }
+    let live: i64 = sqlx::query_scalar(
+        "SELECT count(*) FROM awa.runtime_instances
+         WHERE last_seen_at + make_interval(secs =>
+             GREATEST(((GREATEST(snapshot_interval_ms, 1000) / 1000) * 3)::int, 30)
+         ) >= clock_timestamp()",
+    )
+    .fetch_one(tx.as_mut())
+    .await?;
+    if live != 0 {
+        return Err(AwaError::Validation(format!(
+            "cannot enter quiesced transition while {live} fresh runtime snapshot(s) exist; stop all workers and wait for their heartbeats to expire",
+        )));
+    }
+    sqlx::query(
+        "INSERT INTO awa.runtime_storage_backends(backend,schema_name,updated_at)
+         VALUES ('queue_storage',$1,now()) ON CONFLICT(backend)
+         DO UPDATE SET schema_name=EXCLUDED.schema_name,updated_at=EXCLUDED.updated_at",
+    )
+    .bind(schema)
+    .execute(tx.as_mut())
+    .await?;
+    sqlx::query(
+        "UPDATE awa.storage_transition_state SET state='mixed_transition',
+         transition_epoch=transition_epoch+1,entered_at=now(),updated_at=now(),finalized_at=NULL
+         WHERE singleton",
+    )
+    .execute(tx.as_mut())
+    .await?;
+    let after = status(tx.as_mut()).await?;
+    tx.commit().await?;
+    Ok(after)
+}
+
 pub async fn finalize<'e, E>(executor: E) -> Result<StorageStatus, AwaError>
 where
     E: PgExecutor<'e>,

--- a/awa-model/tests/quiesced_transition_test.rs
+++ b/awa-model/tests/quiesced_transition_test.rs
@@ -1,0 +1,143 @@
+//! The role-free transition must work on an unfinalized 0.6 schema, without DDL.
+use awa_model::{migrations, storage};
+use serde_json::json;
+use sqlx::PgPool;
+
+async fn prepared(pool: &PgPool) {
+    // Stop at the 0.6 migration ceiling: neither fix may require a 0.7 migration.
+    for (_, _, sql) in migrations::migration_sql_range(0, 40) {
+        sqlx::raw_sql(&sql).execute(pool).await.unwrap();
+    }
+    storage::prepare(pool, "queue_storage", json!({"schema": "awa"}))
+        .await
+        .unwrap();
+}
+
+#[sqlx::test(migrations = false)]
+async fn quiesced_transition_observes_inflight_snapshot(pool: PgPool) {
+    prepared(&pool).await;
+    let mut writer = pool.begin().await.unwrap();
+    let writer_pid: i32 = sqlx::query_scalar("SELECT pg_backend_pid()")
+        .fetch_one(writer.as_mut())
+        .await
+        .unwrap();
+    sqlx::query("INSERT INTO awa.runtime_instances(instance_id,pid,version,started_at,last_seen_at,snapshot_interval_ms,healthy,postgres_connected,poll_loop_alive,heartbeat_alive,maintenance_alive,shutting_down,leader,storage_capability,transition_role) VALUES ($1,1,'0.6.6',now(),now(),1000,true,true,true,true,true,false,false,'queue_storage','auto')")
+        .bind(uuid::Uuid::new_v4()).execute(writer.as_mut()).await.unwrap();
+    let flip_pool = pool.clone();
+    let flip =
+        tokio::spawn(async move { storage::enter_mixed_transition_quiesced(&flip_pool).await });
+    tokio::time::timeout(std::time::Duration::from_secs(10), async {
+        loop {
+            let blocked: bool = sqlx::query_scalar(
+                "SELECT EXISTS(SELECT 1 FROM pg_stat_activity WHERE $1=ANY(pg_blocking_pids(pid)))",
+            )
+            .bind(writer_pid)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+            if blocked {
+                break;
+            }
+            assert!(!flip.is_finished(), "flip passed an uncommitted snapshot");
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .unwrap();
+    writer.commit().await.unwrap();
+    let error = flip.await.unwrap().unwrap_err();
+    assert!(error.to_string().contains("fresh runtime"), "{error}");
+    assert_eq!(storage::status(&pool).await.unwrap().state, "prepared");
+}
+
+#[sqlx::test(migrations = false)]
+async fn quiesced_transition_requires_materialized_schema(pool: PgPool) {
+    prepared(&pool).await;
+    // prepare records the target but does not install a custom substrate.
+    storage::prepare(
+        &pool,
+        "queue_storage",
+        json!({"schema":"missing_substrate"}),
+    )
+    .await
+    .unwrap();
+    assert!(storage::enter_mixed_transition_quiesced(&pool)
+        .await
+        .unwrap_err()
+        .to_string()
+        .contains("not prepared"));
+    assert_eq!(storage::status(&pool).await.unwrap().state, "prepared");
+}
+
+#[sqlx::test(migrations = false)]
+async fn quiesced_transition_without_witness(pool: PgPool) {
+    prepared(&pool).await;
+    assert!(storage::enter_mixed_transition(&pool).await.is_err());
+    let before = storage::status(&pool).await.unwrap();
+    let after = storage::enter_mixed_transition_quiesced(&pool)
+        .await
+        .unwrap();
+    assert_eq!(after.state, "mixed_transition");
+    assert_eq!(after.active_engine, "queue_storage");
+    assert_eq!(after.current_engine, "canonical");
+    assert_eq!(after.transition_epoch, before.transition_epoch + 1);
+    assert!(storage::enter_mixed_transition_quiesced(&pool)
+        .await
+        .is_err());
+    assert_eq!(storage::status(&pool).await.unwrap(), after);
+    assert_eq!(storage::finalize(&pool).await.unwrap().state, "active");
+}
+
+#[sqlx::test(migrations = false)]
+async fn quiesced_transition_refuses_every_fresh_runtime(pool: PgPool) {
+    prepared(&pool).await;
+    let id = uuid::Uuid::new_v4();
+    sqlx::query("INSERT INTO awa.runtime_instances(instance_id,pid,version,started_at,last_seen_at,snapshot_interval_ms,healthy,postgres_connected,poll_loop_alive,heartbeat_alive,maintenance_alive,shutting_down,leader,storage_capability,transition_role) VALUES ($1,1,'0.6.6',now(),now(),1000,false,false,false,false,false,true,false,'queue_storage','auto')")
+        .bind(id).execute(&pool).await.unwrap();
+    let before = storage::status(&pool).await.unwrap();
+    for capability in ["canonical", "canonical_drain_only", "queue_storage"] {
+        sqlx::query("UPDATE awa.runtime_instances SET storage_capability=$1")
+            .bind(capability)
+            .execute(&pool)
+            .await
+            .unwrap();
+        let error = storage::enter_mixed_transition_quiesced(&pool)
+            .await
+            .unwrap_err();
+        assert!(error.to_string().contains("fresh runtime"), "{error}");
+        assert_eq!(storage::status(&pool).await.unwrap(), before);
+    }
+    sqlx::query("UPDATE awa.runtime_instances SET last_seen_at=now()-interval '1 hour'")
+        .execute(&pool)
+        .await
+        .unwrap();
+    assert_eq!(
+        storage::enter_mixed_transition_quiesced(&pool)
+            .await
+            .unwrap()
+            .state,
+        "mixed_transition"
+    );
+}
+
+#[sqlx::test(migrations = false)]
+async fn quiesced_transition_preserves_backlog_and_finalize_gate(pool: PgPool) {
+    prepared(&pool).await;
+    sqlx::query(
+        "INSERT INTO awa.jobs(kind,args,queue) VALUES ('upgrade_probe','{}','upgrade_probe')",
+    )
+    .execute(&pool)
+    .await
+    .unwrap();
+    storage::enter_mixed_transition_quiesced(&pool)
+        .await
+        .unwrap();
+    assert_eq!(
+        sqlx::query_scalar::<_, i64>("SELECT awa.canonical_live_backlog()")
+            .fetch_one(&pool)
+            .await
+            .unwrap(),
+        1
+    );
+    assert!(storage::finalize(&pool).await.is_err());
+}

--- a/awa-model/tests/quiesced_transition_test.rs
+++ b/awa-model/tests/quiesced_transition_test.rs
@@ -141,3 +141,39 @@ async fn quiesced_transition_preserves_backlog_and_finalize_gate(pool: PgPool) {
     );
     assert!(storage::finalize(&pool).await.is_err());
 }
+
+#[sqlx::test(migrations = false)]
+async fn quiesced_transition_rejects_partial_substrate(pool: PgPool) {
+    prepared(&pool).await;
+    sqlx::raw_sql("CREATE SCHEMA partial_substrate; CREATE TABLE partial_substrate.queue_ring_state(id int); CREATE TABLE partial_substrate.ready_entries(id int); CREATE TABLE partial_substrate.leases(id int)")
+        .execute(&pool).await.unwrap();
+    storage::prepare(
+        &pool,
+        "queue_storage",
+        json!({"schema":"partial_substrate"}),
+    )
+    .await
+    .unwrap();
+    assert!(
+        !storage::queue_storage_schema_ready(&pool, "partial_substrate")
+            .await
+            .unwrap()
+    );
+    let before = storage::status(&pool).await.unwrap();
+    assert!(storage::enter_mixed_transition_quiesced(&pool)
+        .await
+        .is_err());
+    assert_eq!(storage::status(&pool).await.unwrap(), before);
+}
+
+#[sqlx::test(migrations = false)]
+async fn quiesced_transition_preserves_snapshot_milliseconds(pool: PgPool) {
+    prepared(&pool).await;
+    // 91 seconds is stale with integer truncation (90s), but fresh at 92.997s.
+    sqlx::query("INSERT INTO awa.runtime_instances(instance_id,pid,version,started_at,last_seen_at,snapshot_interval_ms,healthy,postgres_connected,poll_loop_alive,heartbeat_alive,maintenance_alive,shutting_down,leader,storage_capability,transition_role) VALUES ($1,1,'0.6.6',now(),clock_timestamp()-interval '91 seconds',30999,true,true,true,true,true,false,false,'queue_storage','auto')")
+        .bind(uuid::Uuid::new_v4()).execute(&pool).await.unwrap();
+    assert!(storage::enter_mixed_transition_quiesced(&pool)
+        .await
+        .is_err());
+    assert_eq!(storage::status(&pool).await.unwrap().state, "prepared");
+}

--- a/awa-python/src/async_bridge.rs
+++ b/awa-python/src/async_bridge.rs
@@ -17,9 +17,11 @@ use pyo3_async_runtimes::generic::{self, ContextExt, Runtime};
 use pyo3_async_runtimes::TaskLocals;
 use std::collections::BTreeMap;
 use std::future::Future;
+use std::io::Write;
 use std::pin::Pin;
 use std::sync::{Condvar, Mutex};
 use std::task::{Context, Poll};
+use std::time::{Duration, Instant};
 
 #[derive(Default)]
 struct State {
@@ -178,8 +180,33 @@ pub(crate) fn _shutdown_async_bridge(py: Python<'_>) {
             task.abort();
         }
         let mut state = STATE.lock().unwrap_or_else(|e| e.into_inner());
+        let started = Instant::now();
+        let mut warned = false;
         while state.callbacks != 0 || !state.tasks.is_empty() {
-            state = IDLE.wait(state).unwrap_or_else(|e| e.into_inner());
+            if warned {
+                state = IDLE.wait(state).unwrap_or_else(|e| e.into_inner());
+                continue;
+            }
+            let remaining = Duration::from_secs(5).saturating_sub(started.elapsed());
+            if remaining.is_zero() {
+                let tasks = state.tasks.len();
+                let callbacks = state.callbacks;
+                drop(state);
+                // Do not attach to Python for diagnostics, or let a closed
+                // stderr panic. A deadline cannot safely permit finalization:
+                // synchronous Python code may still be using the interpreter.
+                let _ = writeln!(
+                    std::io::stderr().lock(),
+                    "Awa shutdown is still waiting for {tasks} native task(s) and {callbacks} completion callback(s) after 5 seconds. Python code may be blocked; interpreter finalization remains paused to prevent unsafe access."
+                );
+                warned = true;
+                state = STATE.lock().unwrap_or_else(|e| e.into_inner());
+            } else {
+                state = IDLE
+                    .wait_timeout(state, remaining)
+                    .unwrap_or_else(|e| e.into_inner())
+                    .0;
+            }
         }
     });
 }

--- a/awa-python/src/async_bridge.rs
+++ b/awa-python/src/async_bridge.rs
@@ -1,0 +1,141 @@
+//! Join Python-facing completion callbacks before interpreter finalization.
+//!
+//! `future_into_py` schedules the asyncio result before its blocking callback
+//! releases all Python objects. An awaited result is therefore not a native
+//! join. CPython 3.12 can terminate that thread during GIL reacquisition and
+//! unwind Rust destructors without a thread state (the captured wheel SIGSEGV).
+//!
+//! Count callbacks before enqueueing them, fence new callbacks at atexit, and
+//! wait with the GIL released until every accepted callback has returned. This
+//! owns only the Rust -> Python completion boundary, not the Tokio runtime or
+//! worker shutdown. Applications must still shut down workers and close pools.
+
+use pyo3::exceptions::PyRuntimeError;
+use pyo3::prelude::*;
+use pyo3_async_runtimes::generic::{self, ContextExt, Runtime};
+use pyo3_async_runtimes::TaskLocals;
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::{Condvar, Mutex};
+
+#[derive(Default)]
+struct State {
+    closing: bool,
+    callbacks: usize,
+}
+
+static STATE: Mutex<State> = Mutex::new(State {
+    closing: false,
+    callbacks: 0,
+});
+static IDLE: Condvar = Condvar::new();
+
+struct Completion;
+
+impl Completion {
+    fn enter() -> Option<Self> {
+        let mut state = STATE.lock().unwrap_or_else(|e| e.into_inner());
+        if state.closing {
+            return None;
+        }
+        state.callbacks += 1;
+        Some(Self)
+    }
+}
+
+impl Drop for Completion {
+    fn drop(&mut self) {
+        let mut state = STATE.lock().unwrap_or_else(|e| e.into_inner());
+        state.callbacks -= 1;
+        if state.callbacks == 0 {
+            IDLE.notify_all();
+        }
+    }
+}
+
+struct BridgeRuntime;
+
+tokio::task_local! {
+    static LOCALS: TaskLocals;
+}
+
+impl Runtime for BridgeRuntime {
+    type JoinError = tokio::task::JoinError;
+    type JoinHandle = tokio::task::JoinHandle<()>;
+
+    fn spawn<F>(future: F) -> Self::JoinHandle
+    where
+        F: Future<Output = ()> + Send + 'static,
+    {
+        pyo3_async_runtimes::tokio::get_runtime().spawn(future)
+    }
+
+    fn spawn_blocking<F>(callback: F) -> Self::JoinHandle
+    where
+        F: FnOnce() + Send + 'static,
+    {
+        let Some(completion) = Completion::enter() else {
+            // A Rust future may finish after shutdown starts. Dropping its
+            // owned Py handles detached is supported by PyO3; do not attach to
+            // a finalizing interpreter just to report a result nobody can use.
+            drop(callback);
+            return Self::spawn(async {});
+        };
+        pyo3_async_runtimes::tokio::get_runtime().spawn_blocking(move || {
+            let _completion = completion;
+            callback();
+        })
+    }
+}
+
+impl ContextExt for BridgeRuntime {
+    fn scope<F, R>(locals: TaskLocals, future: F) -> Pin<Box<dyn Future<Output = R> + Send>>
+    where
+        F: Future<Output = R> + Send + 'static,
+    {
+        Box::pin(LOCALS.scope(locals, future))
+    }
+
+    fn get_task_locals() -> Option<TaskLocals> {
+        LOCALS.try_with(Clone::clone).ok()
+    }
+}
+
+pub(crate) fn future_into_py<F, T>(py: Python<'_>, future: F) -> PyResult<Bound<'_, PyAny>>
+where
+    F: Future<Output = PyResult<T>> + Send + 'static,
+    T: for<'py> IntoPyObject<'py> + Send + 'static,
+{
+    if STATE.lock().unwrap_or_else(|e| e.into_inner()).closing {
+        return Err(PyRuntimeError::new_err("Awa async bridge is shutting down"));
+    }
+    let locals = get_current_locals(py)?;
+    generic::future_into_py_with_locals::<BridgeRuntime, _, _>(py, locals, future)
+}
+
+pub(crate) fn get_current_locals(py: Python<'_>) -> PyResult<TaskLocals> {
+    match BridgeRuntime::get_task_locals() {
+        Some(locals) => Ok(locals),
+        None => pyo3_async_runtimes::tokio::get_current_locals(py),
+    }
+}
+
+#[pyfunction]
+pub(crate) fn _shutdown_async_bridge(py: Python<'_>) {
+    py.detach(|| {
+        let mut state = STATE.lock().unwrap_or_else(|e| e.into_inner());
+        state.closing = true;
+        while state.callbacks != 0 {
+            state = IDLE.wait(state).unwrap_or_else(|e| e.into_inner());
+        }
+    });
+}
+
+pub(crate) fn register_shutdown(m: &Bound<'_, PyModule>) -> PyResult<()> {
+    let shutdown = wrap_pyfunction!(_shutdown_async_bridge, m)?;
+    m.py()
+        .import("atexit")?
+        .call_method1("register", (&shutdown,))?;
+    m.add_function(shutdown)?;
+    Ok(())
+}

--- a/awa-python/src/async_bridge.rs
+++ b/awa-python/src/async_bridge.rs
@@ -1,32 +1,39 @@
-//! Join Python-facing completion callbacks before interpreter finalization.
+//! Join Python-facing native work before interpreter finalization.
 //!
 //! `future_into_py` schedules the asyncio result before its blocking callback
 //! releases all Python objects. An awaited result is therefore not a native
 //! join. CPython 3.12 can terminate that thread during GIL reacquisition and
 //! unwind Rust destructors without a thread state (the captured wheel SIGSEGV).
 //!
-//! Count callbacks before enqueueing them, fence new callbacks at atexit, and
-//! wait with the GIL released until every accepted callback has returned. This
-//! owns only the Rust -> Python completion boundary, not the Tokio runtime or
-//! worker shutdown. Applications must still shut down workers and close pools.
+//! Track async bodies as well as completion callbacks: argument conversion and
+//! result construction can acquire the GIL before completion. At atexit, fence
+//! new work, cancel async tasks, and join all accepted work with the GIL released.
+//! This does not own worker shutdown or the shared Tokio runtime. Applications
+//! must still shut down workers and close pools.
 
 use pyo3::exceptions::PyRuntimeError;
 use pyo3::prelude::*;
 use pyo3_async_runtimes::generic::{self, ContextExt, Runtime};
 use pyo3_async_runtimes::TaskLocals;
+use std::collections::BTreeMap;
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::{Condvar, Mutex};
+use std::task::{Context, Poll};
 
 #[derive(Default)]
 struct State {
     closing: bool,
     callbacks: usize,
+    next_task: u64,
+    tasks: BTreeMap<u64, tokio::task::AbortHandle>,
 }
 
 static STATE: Mutex<State> = Mutex::new(State {
     closing: false,
     callbacks: 0,
+    next_task: 0,
+    tasks: BTreeMap::new(),
 });
 static IDLE: Condvar = Condvar::new();
 
@@ -55,6 +62,31 @@ impl Drop for Completion {
 
 struct BridgeRuntime;
 
+struct TaskCompletion(u64);
+
+impl Drop for TaskCompletion {
+    fn drop(&mut self) {
+        let mut state = STATE.lock().unwrap_or_else(|e| e.into_inner());
+        state.tasks.remove(&self.0);
+        IDLE.notify_all();
+    }
+}
+
+// Fields drop in declaration order, including cancellation and panic paths.
+// Release the future's Python handles before reporting that the task is joined.
+struct TrackedFuture<F> {
+    future: Pin<Box<F>>,
+    _completion: TaskCompletion,
+}
+
+impl<F: Future> Future for TrackedFuture<F> {
+    type Output = F::Output;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        self.get_mut().future.as_mut().poll(cx)
+    }
+}
+
 tokio::task_local! {
     static LOCALS: TaskLocals;
 }
@@ -67,7 +99,22 @@ impl Runtime for BridgeRuntime {
     where
         F: Future<Output = ()> + Send + 'static,
     {
-        pyo3_async_runtimes::tokio::get_runtime().spawn(future)
+        let mut state = STATE.lock().unwrap_or_else(|e| e.into_inner());
+        if state.closing {
+            drop(state);
+            drop(future);
+            return pyo3_async_runtimes::tokio::get_runtime().spawn(async {});
+        }
+        let id = state.next_task;
+        state.next_task += 1;
+        // Hold the lock through registration so a fast task cannot remove its
+        // entry before it is inserted, or escape the shutdown snapshot.
+        let task = pyo3_async_runtimes::tokio::get_runtime().spawn(TrackedFuture {
+            future: Box::pin(future),
+            _completion: TaskCompletion(id),
+        });
+        state.tasks.insert(id, task.abort_handle());
+        task
     }
 
     fn spawn_blocking<F>(callback: F) -> Self::JoinHandle
@@ -125,7 +172,13 @@ pub(crate) fn _shutdown_async_bridge(py: Python<'_>) {
     py.detach(|| {
         let mut state = STATE.lock().unwrap_or_else(|e| e.into_inner());
         state.closing = true;
-        while state.callbacks != 0 {
+        let tasks: Vec<_> = state.tasks.values().cloned().collect();
+        drop(state);
+        for task in tasks {
+            task.abort();
+        }
+        let mut state = STATE.lock().unwrap_or_else(|e| e.into_inner());
+        while state.callbacks != 0 || !state.tasks.is_empty() {
             state = IDLE.wait(state).unwrap_or_else(|e| e.into_inner());
         }
     });

--- a/awa-python/src/client.rs
+++ b/awa-python/src/client.rs
@@ -494,7 +494,7 @@ impl PyClient {
     ) -> PyResult<Bound<'py, PyAny>> {
         let pool = self.pool.clone();
 
-        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+        crate::async_bridge::future_into_py(py, async move {
             let (kind_str, args_json, metadata_json, run_at, unique, ordering_key) =
                 Python::attach(|py| {
                     let args_bound = args.bind(py);
@@ -562,7 +562,7 @@ impl PyClient {
     /// If workers are running, call `shutdown()` first.
     fn close<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
         let pool = self.pool.clone();
-        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+        crate::async_bridge::future_into_py(py, async move {
             pool.close().await;
             Ok(())
         })
@@ -573,7 +573,7 @@ impl PyClient {
         // migrations::run() is !Send (holds PoolConnection across awaits).
         // We bridge it via spawn_blocking + a current_thread runtime so the
         // asyncio event loop stays free and asyncio.wait_for() can cancel.
-        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+        crate::async_bridge::future_into_py(py, async move {
             tokio::task::spawn_blocking(move || {
                 let rt = tokio::runtime::Builder::new_current_thread()
                     .enable_all()
@@ -607,7 +607,7 @@ impl PyClient {
         lease_slot_count: u32,
     ) -> PyResult<Bound<'py, PyAny>> {
         let pool = self.pool.clone();
-        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+        crate::async_bridge::future_into_py(py, async move {
             let store = QueueStorage::new(QueueStorageConfig {
                 schema,
                 queue_slot_count: queue_slot_count as usize,
@@ -631,7 +631,7 @@ impl PyClient {
         begin_queue_storage_install(&self.lifecycle)?;
         let pool = self.pool.clone();
         let lifecycle = self.lifecycle.clone();
-        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+        crate::async_bridge::future_into_py(py, async move {
             let result = async {
                 let store = QueueStorage::new(QueueStorageConfig {
                     schema,
@@ -691,7 +691,7 @@ impl PyClient {
 
     fn transaction<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
         let pool = self.pool.clone();
-        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+        crate::async_bridge::future_into_py(py, async move {
             let tx = pool.begin().await.map_err(map_sqlx_error)?;
             Ok(PyTransaction::new(tx))
         })
@@ -730,7 +730,7 @@ impl PyClient {
                     handler: handler_py.clone_ref(py),
                     args_type: args_type.clone_ref(py),
                     queue: queue.clone(),
-                    task_locals: pyo3_async_runtimes::tokio::get_current_locals(py)?,
+                    task_locals: crate::async_bridge::get_current_locals(py)?,
                 };
 
                 let workers = workers.clone();
@@ -895,7 +895,7 @@ impl PyClient {
 
     fn retry<'py>(&self, py: Python<'py>, job_id: i64) -> PyResult<Bound<'py, PyAny>> {
         let pool = self.pool.clone();
-        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+        crate::async_bridge::future_into_py(py, async move {
             let row = awa_model::admin::retry(&pool, job_id)
                 .await
                 .map_err(map_awa_error)?;
@@ -905,7 +905,7 @@ impl PyClient {
 
     fn cancel<'py>(&self, py: Python<'py>, job_id: i64) -> PyResult<Bound<'py, PyAny>> {
         let pool = self.pool.clone();
-        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+        crate::async_bridge::future_into_py(py, async move {
             let row = awa_model::admin::cancel(&pool, job_id)
                 .await
                 .map_err(map_awa_error)?;
@@ -934,7 +934,7 @@ impl PyClient {
                 pyo3::exceptions::PyValueError::new_err(format!("Failed to serialize args: {e}"))
             })?;
         let pool = self.pool.clone();
-        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+        crate::async_bridge::future_into_py(py, async move {
             let row = awa_model::admin::cancel_by_unique_key(
                 &pool,
                 &kind,
@@ -964,7 +964,7 @@ impl PyClient {
             }
         }
         let pool = self.pool.clone();
-        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+        crate::async_bridge::future_into_py(py, async move {
             let outcome = match (kind, queue) {
                 (Some(kind), None) => awa_model::admin::retry_failed_by_kind(&pool, &kind).await,
                 (None, Some(queue)) => awa_model::admin::retry_failed_by_queue(&pool, &queue).await,
@@ -978,7 +978,7 @@ impl PyClient {
 
     fn discard_failed<'py>(&self, py: Python<'py>, kind: String) -> PyResult<Bound<'py, PyAny>> {
         let pool = self.pool.clone();
-        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+        crate::async_bridge::future_into_py(py, async move {
             let count = awa_model::admin::discard_failed(&pool, &kind)
                 .await
                 .map_err(map_awa_error)?;
@@ -994,7 +994,7 @@ impl PyClient {
         paused_by: Option<String>,
     ) -> PyResult<Bound<'py, PyAny>> {
         let pool = self.pool.clone();
-        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+        crate::async_bridge::future_into_py(py, async move {
             awa_model::admin::pause_queue(&pool, &queue, paused_by.as_deref())
                 .await
                 .map_err(map_awa_error)?;
@@ -1004,7 +1004,7 @@ impl PyClient {
 
     fn resume_queue<'py>(&self, py: Python<'py>, queue: String) -> PyResult<Bound<'py, PyAny>> {
         let pool = self.pool.clone();
-        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+        crate::async_bridge::future_into_py(py, async move {
             awa_model::admin::resume_queue(&pool, &queue)
                 .await
                 .map_err(map_awa_error)?;
@@ -1014,7 +1014,7 @@ impl PyClient {
 
     fn drain_queue<'py>(&self, py: Python<'py>, queue: String) -> PyResult<Bound<'py, PyAny>> {
         let pool = self.pool.clone();
-        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+        crate::async_bridge::future_into_py(py, async move {
             let count = awa_model::admin::drain_queue(&pool, &queue)
                 .await
                 .map_err(map_awa_error)?;
@@ -1027,7 +1027,7 @@ impl PyClient {
     /// maintenance leader to ensure the cache is fully fresh.
     fn flush_admin_metadata<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
         let pool = self.pool.clone();
-        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+        crate::async_bridge::future_into_py(py, async move {
             awa_model::admin::flush_dirty_admin_metadata(&pool)
                 .await
                 .map_err(map_awa_error)?;
@@ -1056,7 +1056,7 @@ impl PyClient {
 
     fn dump_job<'py>(&self, py: Python<'py>, job_id: i64) -> PyResult<Bound<'py, PyAny>> {
         let pool = self.pool.clone();
-        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+        crate::async_bridge::future_into_py(py, async move {
             let dump = awa_model::admin::dump_job(&pool, job_id)
                 .await
                 .map_err(map_awa_error)?;
@@ -1090,7 +1090,7 @@ impl PyClient {
         attempt: Option<i16>,
     ) -> PyResult<Bound<'py, PyAny>> {
         let pool = self.pool.clone();
-        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+        crate::async_bridge::future_into_py(py, async move {
             let dump = awa_model::admin::dump_run(&pool, job_id, attempt)
                 .await
                 .map_err(map_awa_error)?;
@@ -1121,7 +1121,7 @@ impl PyClient {
 
     fn storage_status<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
         let pool = self.pool.clone();
-        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+        crate::async_bridge::future_into_py(py, async move {
             let report = awa_model::storage::status_report(&pool)
                 .await
                 .map_err(map_awa_error)?;
@@ -1151,7 +1151,7 @@ impl PyClient {
 
     fn list_cron_jobs<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
         let pool = self.pool.clone();
-        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+        crate::async_bridge::future_into_py(py, async move {
             let rows = awa_model::cron::list_cron_jobs(&pool)
                 .await
                 .map_err(map_awa_error)?;
@@ -1181,7 +1181,7 @@ impl PyClient {
 
     fn delete_cron_job<'py>(&self, py: Python<'py>, name: String) -> PyResult<Bound<'py, PyAny>> {
         let pool = self.pool.clone();
-        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+        crate::async_bridge::future_into_py(py, async move {
             awa_model::cron::delete_cron_job(&pool, &name)
                 .await
                 .map_err(map_awa_error)
@@ -1201,7 +1201,7 @@ impl PyClient {
 
     fn queue_stats<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
         let pool = self.pool.clone();
-        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+        crate::async_bridge::future_into_py(py, async move {
             let stats = awa_model::admin::queue_overviews(&pool)
                 .await
                 .map_err(map_awa_error)?;
@@ -1241,7 +1241,7 @@ impl PyClient {
     ) -> PyResult<Bound<'py, PyAny>> {
         let pool = self.pool.clone();
         let parsed_state = state.as_deref().map(parse_job_state).transpose()?;
-        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+        crate::async_bridge::future_into_py(py, async move {
             let filter = ListJobsFilter {
                 state: parsed_state,
                 kind,
@@ -1265,7 +1265,7 @@ impl PyClient {
     /// Get a single job by ID.
     fn get_job<'py>(&self, py: Python<'py>, job_id: i64) -> PyResult<Bound<'py, PyAny>> {
         let pool = self.pool.clone();
-        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+        crate::async_bridge::future_into_py(py, async move {
             let job = awa_model::admin::get_job(&pool, job_id)
                 .await
                 .map_err(map_awa_error)?;
@@ -1289,7 +1289,7 @@ impl PyClient {
         limit: i64,
     ) -> PyResult<Bound<'py, PyAny>> {
         let pool = self.pool.clone();
-        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+        crate::async_bridge::future_into_py(py, async move {
             let filter =
                 crate::dlq::build_filter(kind, queue, tag, before_id, before_dlq_at, Some(limit));
             let rows = awa_model::dlq::list_dlq(&pool, &filter)
@@ -1318,7 +1318,7 @@ impl PyClient {
         let spec = parse_batch_operation_spec(py, &op_kind, &spec)?;
         let filter = parse_batch_operation_filter(py, filter.as_ref())?;
         let pool = self.pool.clone();
-        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+        crate::async_bridge::future_into_py(py, async move {
             let preview = awa_model::batch_operations::preview_batch_operation(&pool, spec, filter)
                 .await
                 .map_err(map_awa_error)?;
@@ -1340,7 +1340,7 @@ impl PyClient {
         let spec = parse_batch_operation_spec(py, &op_kind, &spec)?;
         let filter = parse_batch_operation_filter(py, filter.as_ref())?;
         let pool = self.pool.clone();
-        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+        crate::async_bridge::future_into_py(py, async move {
             let operation = awa_model::batch_operations::submit_batch_operation(
                 &pool,
                 SubmitBatchOperation {
@@ -1369,7 +1369,7 @@ impl PyClient {
             .map(parse_batch_operation_state)
             .transpose()?;
         let pool = self.pool.clone();
-        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+        crate::async_bridge::future_into_py(py, async move {
             let operations = awa_model::batch_operations::list_batch_operations(
                 &pool,
                 &ListBatchOperationsFilter {
@@ -1389,7 +1389,7 @@ impl PyClient {
             pyo3::exceptions::PyValueError::new_err(format!("invalid batch operation id: {err}"))
         })?;
         let pool = self.pool.clone();
-        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+        crate::async_bridge::future_into_py(py, async move {
             let operation = awa_model::batch_operations::get_batch_operation(&pool, id)
                 .await
                 .map_err(map_awa_error)?;
@@ -1407,7 +1407,7 @@ impl PyClient {
             pyo3::exceptions::PyValueError::new_err(format!("invalid batch operation id: {err}"))
         })?;
         let pool = self.pool.clone();
-        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+        crate::async_bridge::future_into_py(py, async move {
             let operation =
                 awa_model::batch_operations::request_batch_operation_cancellation(&pool, id)
                     .await
@@ -1425,7 +1425,7 @@ impl PyClient {
         limit: i64,
     ) -> PyResult<Bound<'py, PyAny>> {
         let pool = self.pool.clone();
-        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+        crate::async_bridge::future_into_py(py, async move {
             awa_model::batch_operations::purge_batch_operations_before(&pool, before, limit)
                 .await
                 .map_err(map_awa_error)
@@ -1435,7 +1435,7 @@ impl PyClient {
     /// Fetch a single DLQ entry by id. Returns `None` if the row isn't in the DLQ.
     fn get_dlq_job<'py>(&self, py: Python<'py>, job_id: i64) -> PyResult<Bound<'py, PyAny>> {
         let pool = self.pool.clone();
-        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+        crate::async_bridge::future_into_py(py, async move {
             let row = awa_model::dlq::get_dlq_job(&pool, job_id)
                 .await
                 .map_err(map_awa_error)?;
@@ -1459,7 +1459,7 @@ impl PyClient {
         queue: Option<String>,
     ) -> PyResult<Bound<'py, PyAny>> {
         let pool = self.pool.clone();
-        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+        crate::async_bridge::future_into_py(py, async move {
             let count = awa_model::dlq::dlq_depth(&pool, queue.as_deref())
                 .await
                 .map_err(map_awa_error)?;
@@ -1470,7 +1470,7 @@ impl PyClient {
     /// DLQ row counts grouped by queue (descending).
     fn dlq_depth_by_queue<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
         let pool = self.pool.clone();
-        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+        crate::async_bridge::future_into_py(py, async move {
             let rows = awa_model::dlq::dlq_depth_by_queue(&pool)
                 .await
                 .map_err(map_awa_error)?;
@@ -1492,7 +1492,7 @@ impl PyClient {
         let pool = self.pool.clone();
         let metrics = self.metrics.clone();
         let opts = crate::dlq::build_retry_opts(run_at, priority, queue);
-        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+        crate::async_bridge::future_into_py(py, async move {
             let job = awa_model::dlq::retry_from_dlq(&pool, job_id, &opts)
                 .await
                 .map_err(map_awa_error)?;
@@ -1523,7 +1523,7 @@ impl PyClient {
     ) -> PyResult<Bound<'py, PyAny>> {
         let pool = self.pool.clone();
         let metrics = self.metrics.clone();
-        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+        crate::async_bridge::future_into_py(py, async move {
             let queue_attr = queue.clone();
             let filter = crate::dlq::build_filter(kind, queue, tag, None, None, None);
             let count = awa_model::dlq::bulk_retry_from_dlq(&pool, &filter, allow_all)
@@ -1546,7 +1546,7 @@ impl PyClient {
     ) -> PyResult<Bound<'py, PyAny>> {
         let pool = self.pool.clone();
         let metrics = self.metrics.clone();
-        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+        crate::async_bridge::future_into_py(py, async move {
             let row = awa_model::dlq::move_failed_to_dlq(&pool, job_id, &reason)
                 .await
                 .map_err(map_awa_error)?;
@@ -1579,7 +1579,7 @@ impl PyClient {
     ) -> PyResult<Bound<'py, PyAny>> {
         let pool = self.pool.clone();
         let metrics = self.metrics.clone();
-        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+        crate::async_bridge::future_into_py(py, async move {
             let kind_attr = kind.clone();
             let queue_attr = queue.clone();
             let count = awa_model::dlq::bulk_move_failed_to_dlq(
@@ -1607,7 +1607,7 @@ impl PyClient {
     fn purge_dlq_job<'py>(&self, py: Python<'py>, job_id: i64) -> PyResult<Bound<'py, PyAny>> {
         let pool = self.pool.clone();
         let metrics = self.metrics.clone();
-        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+        crate::async_bridge::future_into_py(py, async move {
             let queue = awa_model::dlq::get_dlq_job(&pool, job_id)
                 .await
                 .map_err(map_awa_error)?
@@ -1640,7 +1640,7 @@ impl PyClient {
     ) -> PyResult<Bound<'py, PyAny>> {
         let pool = self.pool.clone();
         let metrics = self.metrics.clone();
-        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+        crate::async_bridge::future_into_py(py, async move {
             let queue_attr = queue.clone();
             let filter = crate::dlq::build_filter(kind, queue, tag, before_id, before_dlq_at, None);
             let count = awa_model::dlq::purge_dlq(&pool, &filter, allow_all)
@@ -1656,7 +1656,7 @@ impl PyClient {
     fn health_check<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
         let pool = self.pool.clone();
         let runtime = self.runtime.lock().expect("runtime mutex poisoned").clone();
-        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+        crate::async_bridge::future_into_py(py, async move {
             if let Some(runtime) = runtime {
                 let health = runtime.health_check().await;
                 return Ok(map_health_check(health));
@@ -1931,7 +1931,7 @@ impl PyClient {
         // Store the runtime BEFORE starting so shutdown() can find it
         // even if called concurrently. If start() fails, remove it.
         *runtime_store.lock().expect("runtime mutex poisoned") = Some(runtime);
-        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+        crate::async_bridge::future_into_py(py, async move {
             if let Err(e) = runtime_clone.start().await {
                 runtime_store.lock().expect("runtime mutex poisoned").take();
                 set_runtime_lifecycle(&lifecycle, RuntimeLifecycle::Idle);
@@ -1945,7 +1945,7 @@ impl PyClient {
     fn shutdown<'py>(&self, py: Python<'py>, timeout_ms: u64) -> PyResult<Bound<'py, PyAny>> {
         let runtime = self.runtime.lock().expect("runtime mutex poisoned").take();
         let lifecycle = self.lifecycle.clone();
-        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+        crate::async_bridge::future_into_py(py, async move {
             if let Some(runtime) = runtime {
                 runtime.shutdown(Duration::from_millis(timeout_ms)).await;
             }
@@ -1968,7 +1968,7 @@ impl PyClient {
             .as_ref()
             .map(|value| Python::attach(|py| py_to_json(py, value.bind(py))))
             .transpose()?;
-        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+        crate::async_bridge::future_into_py(py, async move {
             let uuid = uuid::Uuid::parse_str(&callback_id)
                 .map_err(|e| map_awa_error(awa_model::AwaError::Validation(e.to_string())))?;
             let row = awa_model::admin::complete_external(&pool, uuid, payload_json, None)
@@ -1985,7 +1985,7 @@ impl PyClient {
         error: String,
     ) -> PyResult<Bound<'py, PyAny>> {
         let pool = self.pool.clone();
-        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+        crate::async_bridge::future_into_py(py, async move {
             let uuid = uuid::Uuid::parse_str(&callback_id)
                 .map_err(|e| map_awa_error(awa_model::AwaError::Validation(e.to_string())))?;
             let row = awa_model::admin::fail_external(&pool, uuid, &error, None)
@@ -2001,7 +2001,7 @@ impl PyClient {
         callback_id: String,
     ) -> PyResult<Bound<'py, PyAny>> {
         let pool = self.pool.clone();
-        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+        crate::async_bridge::future_into_py(py, async move {
             let uuid = uuid::Uuid::parse_str(&callback_id)
                 .map_err(|e| map_awa_error(awa_model::AwaError::Validation(e.to_string())))?;
             let row = awa_model::admin::retry_external(&pool, uuid, None)
@@ -2027,7 +2027,7 @@ impl PyClient {
             .as_ref()
             .map(|value| Python::attach(|py| py_to_json(py, value.bind(py))))
             .transpose()?;
-        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+        crate::async_bridge::future_into_py(py, async move {
             let uuid = uuid::Uuid::parse_str(&callback_id)
                 .map_err(|e| map_awa_error(awa_model::AwaError::Validation(e.to_string())))?;
             let row = awa_model::admin::resume_external(&pool, uuid, payload_json, None)
@@ -2070,7 +2070,7 @@ impl PyClient {
         timeout_seconds: f64,
     ) -> PyResult<Bound<'py, PyAny>> {
         let pool = self.pool.clone();
-        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+        crate::async_bridge::future_into_py(py, async move {
             let uuid = uuid::Uuid::parse_str(&callback_id)
                 .map_err(|e| map_awa_error(awa_model::AwaError::Validation(e.to_string())))?;
             let timeout = validate_timeout_seconds(timeout_seconds)?;
@@ -2174,7 +2174,7 @@ impl PyClient {
             .map(|value| Python::attach(|py| py_to_json(py, value.bind(py))))
             .transpose()?;
         let action = parse_default_action(default_action)?;
-        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+        crate::async_bridge::future_into_py(py, async move {
             let uuid = uuid::Uuid::parse_str(&callback_id)
                 .map_err(|e| map_awa_error(awa_model::AwaError::Validation(e.to_string())))?;
             let outcome =
@@ -2247,7 +2247,7 @@ impl PyClient {
             opts.as_deref(),
         )?;
 
-        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+        crate::async_bridge::future_into_py(py, async move {
             let results = awa_model::insert_many_copy_from_pool(&pool, &insert_params)
                 .await
                 .map_err(map_awa_error)?;
@@ -2346,7 +2346,7 @@ impl PyClient {
         )?;
         let queue_counts = enqueue_batch_queue_counts(&insert_params);
 
-        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+        crate::async_bridge::future_into_py(py, async move {
             let schema = QueueStorage::active_schema(&pool)
                 .await
                 .map_err(map_awa_error)?

--- a/awa-python/src/client.rs
+++ b/awa-python/src/client.rs
@@ -628,10 +628,10 @@ impl PyClient {
         lease_slot_count: u32,
         reset: bool,
     ) -> PyResult<Bound<'py, PyAny>> {
-        begin_queue_storage_install(&self.lifecycle)?;
         let pool = self.pool.clone();
         let lifecycle = self.lifecycle.clone();
         crate::async_bridge::future_into_py(py, async move {
+            begin_queue_storage_install(&lifecycle)?;
             let result = async {
                 let store = QueueStorage::new(QueueStorageConfig {
                     schema,
@@ -1917,22 +1917,21 @@ impl PyClient {
             builder = builder.job_kind_descriptor_kind(kind, descriptor);
         }
 
-        begin_runtime_start(&self.lifecycle)?;
-        let runtime = match builder.build() {
-            Ok(runtime) => Arc::new(runtime),
-            Err(err) => {
-                set_runtime_lifecycle(&self.lifecycle, RuntimeLifecycle::Idle);
-                return Err(state_error(err.to_string()));
-            }
-        };
-        let runtime_clone = runtime.clone();
         let runtime_store = self.runtime.clone();
         let lifecycle = self.lifecycle.clone();
-        // Store the runtime BEFORE starting so shutdown() can find it
-        // even if called concurrently. If start() fails, remove it.
-        *runtime_store.lock().expect("runtime mutex poisoned") = Some(runtime);
         crate::async_bridge::future_into_py(py, async move {
-            if let Err(e) = runtime_clone.start().await {
+            begin_runtime_start(&lifecycle)?;
+            let runtime = match builder.build() {
+                Ok(runtime) => Arc::new(runtime),
+                Err(err) => {
+                    set_runtime_lifecycle(&lifecycle, RuntimeLifecycle::Idle);
+                    return Err(state_error(err.to_string()));
+                }
+            };
+            // Publish only after bridge acceptance, before starting so an
+            // accepted concurrent shutdown can find the runtime.
+            *runtime_store.lock().expect("runtime mutex poisoned") = Some(runtime.clone());
+            if let Err(e) = runtime.start().await {
                 runtime_store.lock().expect("runtime mutex poisoned").take();
                 set_runtime_lifecycle(&lifecycle, RuntimeLifecycle::Idle);
                 return Err(map_awa_error(e));
@@ -1943,9 +1942,10 @@ impl PyClient {
 
     #[pyo3(signature = (timeout_ms=2000))]
     fn shutdown<'py>(&self, py: Python<'py>, timeout_ms: u64) -> PyResult<Bound<'py, PyAny>> {
-        let runtime = self.runtime.lock().expect("runtime mutex poisoned").take();
+        let runtime_store = self.runtime.clone();
         let lifecycle = self.lifecycle.clone();
         crate::async_bridge::future_into_py(py, async move {
+            let runtime = runtime_store.lock().expect("runtime mutex poisoned").take();
             if let Some(runtime) = runtime {
                 runtime.shutdown(Duration::from_millis(timeout_ms)).await;
             }

--- a/awa-python/src/job.rs
+++ b/awa-python/src/job.rs
@@ -275,7 +275,7 @@ impl PyJob {
         let run_lease = self.run_lease;
         let queue_storage = self.queue_storage.clone();
 
-        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+        crate::async_bridge::future_into_py(py, async move {
             let (snapshot, target_generation) = {
                 let guard = buffer.lock().expect("progress lock poisoned");
                 match guard.pending_snapshot() {
@@ -430,7 +430,7 @@ impl PyJob {
         let has_expressions =
             filter.is_some() || on_complete.is_some() || on_fail.is_some() || transform.is_some();
 
-        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+        crate::async_bridge::future_into_py(py, async move {
             let timeout = std::time::Duration::from_secs_f64(timeout_seconds);
             let callback_id = if has_expressions {
                 let config = awa_model::admin::CallbackConfig {
@@ -485,7 +485,7 @@ impl PyJob {
             pyo3::exceptions::PyValueError::new_err(format!("invalid callback token UUID: {e}"))
         })?;
 
-        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+        crate::async_bridge::future_into_py(py, async move {
             let entered = enter_callback_wait(&pool, job_id, run_lease, token_uuid)
                 .await
                 .map_err(map_awa_error)?;

--- a/awa-python/src/lib.rs
+++ b/awa-python/src/lib.rs
@@ -1,4 +1,5 @@
 mod args;
+mod async_bridge;
 mod callback_contract;
 mod client;
 mod dlq;
@@ -44,7 +45,7 @@ fn migrate<'py>(py: Python<'py>, database_url: String) -> PyResult<Bound<'py, Py
 
         Ok::<(), PyErr>(())
     });
-    pyo3_async_runtimes::tokio::future_into_py(py, async move {
+    crate::async_bridge::future_into_py(py, async move {
         result?;
         Ok(())
     })
@@ -80,6 +81,7 @@ fn current_migration_version() -> i32 {
 
 #[pymodule]
 fn _awa(m: &Bound<'_, PyModule>) -> PyResult<()> {
+    async_bridge::register_shutdown(m)?;
     // Classes
     m.add_class::<client::PyClient>()?;
     m.add_class::<job::PyJob>()?;

--- a/awa-python/src/transaction.rs
+++ b/awa-python/src/transaction.rs
@@ -25,6 +25,39 @@ impl PyTransaction {
     }
 }
 
+/// Roll back a transaction handle that Python released without committing.
+///
+/// The last Python reference can be dropped by garbage collection on a thread
+/// with no Tokio context, including interpreter finalization. sqlx returns the
+/// pooled connection from a spawned task when the transaction drops, and that
+/// spawn panics outside a runtime. Move the transaction onto the shared runtime
+/// first so the rollback and pool return happen where they are allowed.
+fn release_abandoned(handle: &mut Arc<Mutex<Option<Transaction<'static, Postgres>>>>) {
+    let owned = std::mem::replace(handle, Arc::new(Mutex::new(None)));
+    // A clone held by an in-flight bridge future drops inside that Tokio task.
+    let Ok(mutex) = Arc::try_unwrap(owned) else {
+        return;
+    };
+    let Some(tx) = mutex.into_inner() else {
+        return;
+    };
+    pyo3_async_runtimes::tokio::get_runtime().spawn(async move {
+        let _ = tx.rollback().await;
+    });
+}
+
+impl Drop for PyTransaction {
+    fn drop(&mut self) {
+        release_abandoned(&mut self.tx);
+    }
+}
+
+impl Drop for PySyncTransaction {
+    fn drop(&mut self) {
+        release_abandoned(&mut self.tx);
+    }
+}
+
 #[pymethods]
 impl PyTransaction {
     #[pyo3(signature = (query, *args))]

--- a/awa-python/src/transaction.rs
+++ b/awa-python/src/transaction.rs
@@ -37,7 +37,7 @@ impl PyTransaction {
         let tx = self.tx.clone();
         let json_args = to_json_args(py, args)?;
 
-        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+        crate::async_bridge::future_into_py(py, async move {
             let mut guard = tx.lock().await;
             let tx_ref = tx_ref(&mut guard)?;
             let result = bind_json_args(sqlx::query(&query), &json_args)
@@ -58,7 +58,7 @@ impl PyTransaction {
         let tx = self.tx.clone();
         let json_args = to_json_args(py, args)?;
 
-        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+        crate::async_bridge::future_into_py(py, async move {
             let mut guard = tx.lock().await;
             let tx_ref = tx_ref(&mut guard)?;
             let row = bind_json_args(sqlx::query(&query), &json_args)
@@ -79,7 +79,7 @@ impl PyTransaction {
         let tx = self.tx.clone();
         let json_args = to_json_args(py, args)?;
 
-        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+        crate::async_bridge::future_into_py(py, async move {
             let mut guard = tx.lock().await;
             let tx_ref = tx_ref(&mut guard)?;
             let row = bind_json_args(sqlx::query(&query), &json_args)
@@ -103,7 +103,7 @@ impl PyTransaction {
         let tx = self.tx.clone();
         let json_args = to_json_args(py, args)?;
 
-        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+        crate::async_bridge::future_into_py(py, async move {
             let mut guard = tx.lock().await;
             let tx_ref = tx_ref(&mut guard)?;
             let rows = bind_json_args(sqlx::query(&query), &json_args)
@@ -153,7 +153,7 @@ impl PyTransaction {
                 .transpose()
         })?;
 
-        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+        crate::async_bridge::future_into_py(py, async move {
             let mut guard = tx.lock().await;
             let tx_ref = tx_ref(&mut guard)?;
             let row = insert_raw_job(
@@ -214,7 +214,7 @@ impl PyTransaction {
                 .transpose()
         })?;
 
-        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+        crate::async_bridge::future_into_py(py, async move {
             let mut guard = tx.lock().await;
             let tx_ref = tx_ref(&mut guard)?;
             let mut inserted = Vec::with_capacity(prepared_jobs.len());
@@ -244,7 +244,7 @@ impl PyTransaction {
 
     fn commit<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
         let tx = self.tx.clone();
-        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+        crate::async_bridge::future_into_py(py, async move {
             let mut guard = tx.lock().await;
             let tx = guard
                 .take()
@@ -255,7 +255,7 @@ impl PyTransaction {
     }
 
     fn __aenter__(slf: Py<Self>, py: Python<'_>) -> PyResult<Bound<'_, PyAny>> {
-        pyo3_async_runtimes::tokio::future_into_py(py, async move { Ok(slf) })
+        crate::async_bridge::future_into_py(py, async move { Ok(slf) })
     }
 
     #[pyo3(signature = (exc_type, _exc_val, _exc_tb))]
@@ -268,7 +268,7 @@ impl PyTransaction {
     ) -> PyResult<Bound<'py, PyAny>> {
         let tx = self.tx.clone();
         let has_exception = exc_type.is_some();
-        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+        crate::async_bridge::future_into_py(py, async move {
             let mut guard = tx.lock().await;
             if let Some(tx) = guard.take() {
                 if has_exception {
@@ -283,7 +283,7 @@ impl PyTransaction {
 
     fn rollback<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
         let tx = self.tx.clone();
-        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+        crate::async_bridge::future_into_py(py, async move {
             let mut guard = tx.lock().await;
             let tx = guard
                 .take()

--- a/awa-python/tests/test_interpreter_shutdown.py
+++ b/awa-python/tests/test_interpreter_shutdown.py
@@ -141,3 +141,89 @@ def test_rejected_bridge_operations_preserve_client_lifecycle():
     result = subprocess.run([sys.executable, "-X", "faulthandler", "-c", code],
                             capture_output=True, text=True, timeout=30)
     assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_stalled_shutdown_warns_without_finalizing_live_callback():
+    import os
+    from pathlib import Path
+    import tempfile
+    import time
+
+    code = textwrap.dedent('''
+        import atexit, asyncio, os, threading, time
+        from pathlib import Path
+        released = Path(os.environ["AWA_TEST_RELEASE_CALLBACK"])
+        finished = threading.Event()
+        atexit.register(lambda: print("SAFE_EXIT" if finished.is_set() else "EARLY_EXIT", flush=True))
+        import awa
+        async def main():
+            loop = asyncio.get_running_loop()
+            original = loop._write_to_self
+            def controlled_wakeup():
+                original()
+                if threading.current_thread() is not threading.main_thread():
+                    while not released.exists():
+                        time.sleep(0.01)
+                    finished.set()
+            loop._write_to_self = controlled_wakeup
+            client = awa.AsyncClient(os.environ["DATABASE_URL"])
+            await client.close()
+        asyncio.run(main())
+    ''')
+    with tempfile.TemporaryDirectory() as directory:
+        release = Path(directory) / "release"
+        stderr_path = Path(directory) / "stderr"
+        with stderr_path.open("w") as stderr:
+            child = subprocess.Popen(
+                [sys.executable, "-X", "faulthandler", "-c", code],
+                stdout=subprocess.PIPE, stderr=stderr, text=True,
+                env={**os.environ, "AWA_TEST_RELEASE_CALLBACK": str(release)},
+            )
+            try:
+                deadline = time.monotonic() + 12
+                while "Awa shutdown is still waiting" not in stderr_path.read_text():
+                    assert child.poll() is None, stderr_path.read_text()
+                    assert time.monotonic() < deadline, "stalled shutdown emitted no diagnostic"
+                    time.sleep(0.02)
+                assert child.poll() is None, "shutdown finalized a live callback"
+                release.touch()
+                stdout, _ = child.communicate(timeout=10)
+                assert child.returncode == 0, stdout + stderr_path.read_text()
+                assert "SAFE_EXIT" in stdout, stdout
+            finally:
+                if child.poll() is None:
+                    child.kill()
+                    child.communicate()
+
+
+def test_shutdown_cancels_native_database_wait():
+    # A pending socket/lock wait is cancellable, unlike synchronous Python code.
+    code = textwrap.dedent('''
+        import atexit, asyncio, os
+        atexit.register(lambda: print("DATABASE_WAIT_EXIT", flush=True))
+        import awa
+        retained = []
+        async def main():
+            client = awa.AsyncClient(os.environ["DATABASE_URL"])
+            holder = await client._raw.transaction()
+            waiter = await client._raw.transaction()
+            inspector = await client._raw.transaction()
+            pid = (await waiter.fetch_one("SELECT pg_backend_pid() AS pid"))["pid"]
+            await holder.execute("SELECT pg_advisory_xact_lock(481, $1::int)", pid)
+            pending = waiter.execute("SELECT pg_advisory_xact_lock(481, $1::int)", pid)
+            deadline = asyncio.get_running_loop().time() + 5
+            while True:
+                row = await inspector.fetch_one("SELECT cardinality(pg_blocking_pids($1::int)) AS blockers", pid)
+                if row["blockers"]:
+                    break
+                assert asyncio.get_running_loop().time() < deadline, "query never blocked"
+                await asyncio.sleep(0.01)
+            # Keep the blocking transaction alive until interpreter finalization;
+            # only cancellation can release the bridge's pending task join.
+            retained.extend((client, holder, waiter, inspector, pending))
+        asyncio.run(main())
+    ''')
+    result = subprocess.run([sys.executable, "-X", "faulthandler", "-c", code],
+                            capture_output=True, text=True, timeout=15)
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "DATABASE_WAIT_EXIT" in result.stdout, result.stdout + result.stderr

--- a/awa-python/tests/test_interpreter_shutdown.py
+++ b/awa-python/tests/test_interpreter_shutdown.py
@@ -1,0 +1,58 @@
+"""Native completion callbacks must finish before CPython finalizes objects."""
+
+import subprocess
+import sys
+import textwrap
+
+
+def test_interpreter_exit_joins_native_completion():
+    # Registration order matters: this check runs after awa's shutdown hook.
+    # Hold the Rust completion callback after it wakes asyncio, reproducing the
+    # handoff in the captured 0.6.2 SIGSEGV without depending on scheduler luck.
+    code = textwrap.dedent('''
+        import atexit, asyncio, threading, time, os
+        released = threading.Event()
+        finished = threading.Event()
+        atexit.register(lambda: print("SAFE_EXIT" if finished.is_set() else "EARLY_EXIT", flush=True))
+        import awa
+        atexit.register(released.set)
+        async def main():
+            loop = asyncio.get_running_loop()
+            original = loop._write_to_self
+            def controlled_wakeup():
+                original()
+                if threading.current_thread() is not threading.main_thread():
+                    released.wait()
+                    time.sleep(0.05)
+                    finished.set()
+            loop._write_to_self = controlled_wakeup
+            client = awa.AsyncClient(os.environ["DATABASE_URL"])
+            await client.close()
+        asyncio.run(main())
+    ''')
+    result = subprocess.run([sys.executable, "-X", "faulthandler", "-c", code],
+                            capture_output=True, text=True, timeout=15)
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "SAFE_EXIT" in result.stdout, result.stdout + result.stderr
+
+
+def test_shutdown_fences_new_bridge_calls():
+    code = textwrap.dedent('''
+        import asyncio, os, awa
+        from awa._awa import _shutdown_async_bridge
+        async def main():
+            client = awa.AsyncClient(os.environ["DATABASE_URL"])
+            await client.close()
+            _shutdown_async_bridge()
+            _shutdown_async_bridge()  # idempotent; atexit will call it again
+            try:
+                await client.close()
+            except RuntimeError as error:
+                assert "shutting down" in str(error)
+            else:
+                raise AssertionError("bridge accepted a call after shutdown")
+        asyncio.run(main())
+    ''')
+    result = subprocess.run([sys.executable, "-X", "faulthandler", "-c", code],
+                            capture_output=True, text=True, timeout=15)
+    assert result.returncode == 0, result.stdout + result.stderr

--- a/awa-python/tests/test_interpreter_shutdown.py
+++ b/awa-python/tests/test_interpreter_shutdown.py
@@ -56,3 +56,40 @@ def test_shutdown_fences_new_bridge_calls():
     result = subprocess.run([sys.executable, "-X", "faulthandler", "-c", code],
                             capture_output=True, text=True, timeout=15)
     assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_interpreter_exit_joins_pending_native_future():
+    # Some async bodies themselves acquire the GIL (e.g. argument conversion),
+    # before they reach the completion callback. Fence/join those tasks too.
+    code = textwrap.dedent('''
+        import atexit, asyncio, os, threading, time
+        from dataclasses import dataclass
+        entered = threading.Event()
+        released = threading.Event()
+        finished = threading.Event()
+        atexit.register(lambda: print("SAFE_EXIT" if finished.is_set() else "EARLY_EXIT", flush=True))
+        import awa
+        atexit.register(released.set)
+        @dataclass
+        class Payload:
+            value: str
+            def __getattribute__(self, name):
+                if name == "value":
+                    entered.set()
+                    released.wait()
+                    time.sleep(0.05)
+                    finished.set()
+                return object.__getattribute__(self, name)
+        async def main():
+            client = awa.AsyncClient(os.environ["DATABASE_URL"])
+            pending = client._raw.insert(Payload("pending"), queue="shutdown_probe")
+            assert await asyncio.to_thread(entered.wait, 5)
+            await client.close()
+            # The caller abandons pending work, but native code must not access
+            # Python after interpreter finalization begins.
+        asyncio.run(main())
+    ''')
+    result = subprocess.run([sys.executable, "-X", "faulthandler", "-c", code],
+                            capture_output=True, text=True, timeout=15)
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "SAFE_EXIT" in result.stdout, result.stdout + result.stderr

--- a/awa-python/tests/test_interpreter_shutdown.py
+++ b/awa-python/tests/test_interpreter_shutdown.py
@@ -104,9 +104,9 @@ def test_rejected_bridge_operations_preserve_client_lifecycle():
             starting = awa.AsyncClient(os.environ["DATABASE_URL"])
             running = awa.AsyncClient(os.environ["DATABASE_URL"])
             await running.migrate()
-            tx = await running.transaction()
-            row = await tx.fetch_one("SELECT COALESCE((SELECT schema_name FROM awa.runtime_storage_backends WHERE backend='queue_storage'), 'awa') AS schema")
-            await tx.commit()
+            # Same normalisation as the other runtime suites: the shared database
+            # may carry a custom prepared schema left by an earlier test module.
+            await running.install_queue_storage(reset=True)
             from dataclasses import dataclass
             @dataclass
             class Payload:
@@ -115,7 +115,7 @@ def test_rejected_bridge_operations_preserve_client_lifecycle():
                 return None
             for client in (starting, running):
                 client.worker(Payload, queue="shutdown_lifecycle_probe")(handler)
-            await running.start([("shutdown_lifecycle_probe", 1)], queue_storage_schema=row["schema"])
+            await running.start([("shutdown_lifecycle_probe", 1)])
             _shutdown_async_bridge()
             for operation in (
                 lambda: installing._raw.install_queue_storage("awa", 8, 8, False),
@@ -227,3 +227,40 @@ def test_shutdown_cancels_native_database_wait():
                             capture_output=True, text=True, timeout=15)
     assert result.returncode == 0, result.stdout + result.stderr
     assert "DATABASE_WAIT_EXIT" in result.stdout, result.stdout + result.stderr
+
+
+def test_abandoned_transactions_roll_back_on_the_runtime():
+    # Garbage collection may drop the last transaction handle on a thread with
+    # no Tokio context, including interpreter finalization. The pooled
+    # connection must still return without a native panic.
+    code = textwrap.dedent('''
+        import asyncio, os, sys, awa
+        async def main():
+            client = awa.AsyncClient(os.environ["DATABASE_URL"])
+            leaked = await client.transaction()
+            await leaked.execute("SELECT 1")
+            failing = await client.transaction()
+            try:
+                await failing.fetch_one("SELECT no_such_column FROM awa.schema_version")
+            except awa.DatabaseError:
+                pass
+            else:
+                raise AssertionError("invalid query succeeded")
+            sync_client = awa.Client(os.environ["DATABASE_URL"], max_connections=1)
+            sync_leaked = sync_client.transaction()
+            sync_leaked.execute("SELECT 1")
+            del sync_leaked
+            # A dropped handle releases its connection; a pool of one proves it.
+            sync_client.transaction().commit()
+            sync_client.close()
+            # Keep the async handles alive until finalization.
+            globals().update(client=client, leaked=leaked, failing=failing)
+            print("ABANDONED_OK", flush=True)
+        asyncio.run(main())
+    ''')
+    result = subprocess.run([sys.executable, "-X", "faulthandler", "-c", code],
+                            capture_output=True, text=True, timeout=30)
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "ABANDONED_OK" in result.stdout, result.stdout
+    assert "PanicException" not in result.stderr, result.stderr
+    assert "Tokio context" not in result.stderr, result.stderr

--- a/awa-python/tests/test_interpreter_shutdown.py
+++ b/awa-python/tests/test_interpreter_shutdown.py
@@ -93,3 +93,51 @@ def test_interpreter_exit_joins_pending_native_future():
                             capture_output=True, text=True, timeout=15)
     assert result.returncode == 0, result.stdout + result.stderr
     assert "SAFE_EXIT" in result.stdout, result.stdout + result.stderr
+
+
+def test_rejected_bridge_operations_preserve_client_lifecycle():
+    code = textwrap.dedent('''
+        import asyncio, os, awa
+        from awa._awa import _shutdown_async_bridge
+        async def main():
+            installing = awa.AsyncClient(os.environ["DATABASE_URL"])
+            starting = awa.AsyncClient(os.environ["DATABASE_URL"])
+            running = awa.AsyncClient(os.environ["DATABASE_URL"])
+            await running.migrate()
+            tx = await running.transaction()
+            row = await tx.fetch_one("SELECT COALESCE((SELECT schema_name FROM awa.runtime_storage_backends WHERE backend='queue_storage'), 'awa') AS schema")
+            await tx.commit()
+            from dataclasses import dataclass
+            @dataclass
+            class Payload:
+                value: int
+            async def handler(job):
+                return None
+            for client in (starting, running):
+                client.worker(Payload, queue="shutdown_lifecycle_probe")(handler)
+            await running.start([("shutdown_lifecycle_probe", 1)], queue_storage_schema=row["schema"])
+            _shutdown_async_bridge()
+            for operation in (
+                lambda: installing._raw.install_queue_storage("awa", 8, 8, False),
+                lambda: starting.start([("shutdown_lifecycle_probe", 1)]),
+                lambda: running.shutdown(),
+            ):
+                try:
+                    await operation()
+                except RuntimeError as error:
+                    assert "shutting down" in str(error), str(error)
+                else:
+                    raise AssertionError("bridge accepted operation")
+            for client in (installing, starting):
+                try:
+                    client._raw.install_queue_storage_sync("invalid-schema", 8, 8, False)
+                except Exception as error:
+                    assert "schema" in str(error) and "runtime" not in str(error) and "progress" not in str(error), str(error)
+                else:
+                    raise AssertionError("invalid schema accepted")
+            assert running._raw.health_check_sync().poll_loop_alive, "rejected shutdown lost the runtime"
+        asyncio.run(main())
+    ''')
+    result = subprocess.run([sys.executable, "-X", "faulthandler", "-c", code],
+                            capture_output=True, text=True, timeout=30)
+    assert result.returncode == 0, result.stdout + result.stderr

--- a/awa/tests/cel_callback_test.rs
+++ b/awa/tests/cel_callback_test.rs
@@ -1073,3 +1073,35 @@ async fn test_c19_cel_disabled_resolve_error() {
     let job = client.get_job(job_id).await.unwrap();
     assert_eq!(job.state, JobState::WaitingExternal);
 }
+
+#[sqlx::test(migrations = false)]
+async fn mixed_retry_notifies_only_after_commit(pool: sqlx::PgPool) {
+    let (id, callback) = mixed_callback(&pool).await;
+    let queue: String = sqlx::query_scalar("SELECT queue FROM awa.jobs_hot WHERE id=$1")
+        .bind(id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    let mut listener = sqlx::postgres::PgListener::connect_with(&pool)
+        .await
+        .unwrap();
+    listener.listen(&format!("awa:{queue}")).await.unwrap();
+    let mut tx = pool.begin().await.unwrap();
+    admin::retry_external_in_tx(&mut tx, callback, Some(7))
+        .await
+        .unwrap();
+    tx.rollback().await.unwrap();
+    assert!(
+        tokio::time::timeout(Duration::from_millis(100), listener.recv())
+            .await
+            .is_err()
+    );
+    admin::retry_external(&pool, callback, Some(7))
+        .await
+        .unwrap();
+    let notification = tokio::time::timeout(Duration::from_secs(3), listener.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(notification.channel(), format!("awa:{queue}"));
+}

--- a/awa/tests/cel_callback_test.rs
+++ b/awa/tests/cel_callback_test.rs
@@ -139,6 +139,70 @@ async fn finalized_callback_does_not_fall_back_to_canonical(pool: sqlx::PgPool) 
     ));
 }
 
+#[sqlx::test]
+async fn mixed_resume_delivers_payload_to_waiting_handler(pool: sqlx::PgPool) {
+    let (id, callback) = mixed_callback(&pool).await;
+    admin::resume_external(
+        &pool,
+        callback,
+        Some(serde_json::json!({"answer": 42})),
+        Some(7),
+    )
+    .await
+    .unwrap();
+    match admin::check_callback_state(&pool, id, callback)
+        .await
+        .unwrap()
+    {
+        admin::CallbackPollResult::Resolved(payload) => assert_eq!(payload["answer"], 42),
+        other => panic!("canonical handler lost its callback payload: {other:?}"),
+    }
+    let metadata: serde_json::Value =
+        sqlx::query_scalar("SELECT metadata FROM awa.jobs_hot WHERE id=$1")
+            .bind(id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    assert!(metadata.get("_awa_callback_result").is_none());
+}
+
+#[sqlx::test]
+async fn mixed_running_handler_can_register_wait_and_cancel(pool: sqlx::PgPool) {
+    let (id, _) = mixed_callback(&pool).await;
+    sqlx::query("UPDATE awa.jobs_hot SET state='running',callback_id=NULL WHERE id=$1")
+        .bind(id)
+        .execute(&pool)
+        .await
+        .unwrap();
+    let callback = admin::register_callback(&pool, id, 7, Duration::from_secs(60))
+        .await
+        .unwrap();
+    assert!(!admin::cancel_callback(&pool, id, 6).await.unwrap());
+    assert!(admin::enter_callback_wait(&pool, id, 7, callback)
+        .await
+        .unwrap());
+    assert!(matches!(
+        admin::check_callback_state(&pool, id, callback)
+            .await
+            .unwrap(),
+        admin::CallbackPollResult::Pending
+    ));
+    admin::resume_external(&pool, callback, None, Some(7))
+        .await
+        .unwrap();
+    let next = admin::register_callback_with_config(
+        &pool,
+        id,
+        7,
+        Duration::from_secs(60),
+        &CallbackConfig::default(),
+    )
+    .await
+    .unwrap();
+    assert_ne!(next, callback);
+    assert!(admin::cancel_callback(&pool, id, 7).await.unwrap());
+}
+
 async fn setup() -> TestClient {
     let pool = PgPoolOptions::new()
         .max_connections(5)

--- a/awa/tests/cel_callback_test.rs
+++ b/awa/tests/cel_callback_test.rs
@@ -15,6 +15,130 @@ fn database_url() -> String {
         .unwrap_or_else(|_| "postgres://postgres:test@localhost:15432/awa_test".to_string())
 }
 
+async fn mixed_callback(pool: &sqlx::PgPool) -> (i64, uuid::Uuid) {
+    migrations::run(pool).await.unwrap();
+    let job = awa::insert_with(
+        pool,
+        &WebhookPayment { order_id: 462 },
+        awa::InsertOpts::default(),
+    )
+    .await
+    .unwrap();
+    let callback = uuid::Uuid::new_v4();
+    sqlx::query("UPDATE awa.jobs SET state='waiting_external', attempt=1, run_lease=7, callback_id=$2, callback_timeout_at=now()+interval '1 hour' WHERE id=$1")
+        .bind(job.id).bind(callback).execute(pool).await.unwrap();
+    awa::model::storage::prepare(pool, "queue_storage", serde_json::json!({"schema":"awa"}))
+        .await
+        .unwrap();
+    sqlx::query("INSERT INTO awa.runtime_instances(instance_id,pid,version,started_at,last_seen_at,snapshot_interval_ms,healthy,postgres_connected,poll_loop_alive,heartbeat_alive,maintenance_alive,shutting_down,leader,storage_capability,transition_role) VALUES ($1,1,'0.7.0-alpha.1',now(),now(),1000,true,true,true,true,true,false,false,'queue_storage','queue_storage_target')")
+        .bind(uuid::Uuid::new_v4()).execute(pool).await.unwrap();
+    awa::model::storage::enter_mixed_transition(pool)
+        .await
+        .unwrap();
+    (job.id, callback)
+}
+
+macro_rules! mixed_callback_case {
+    ($name:ident, $action:literal, $state:literal) => {
+        #[sqlx::test]
+        async fn $name(pool: sqlx::PgPool) {
+            let (id, callback) = mixed_callback(&pool).await;
+            match $action {
+                "complete" => { admin::complete_external(&pool, callback, None, Some(7)).await.unwrap(); }
+                "resume" => { admin::resume_external(&pool, callback, Some(serde_json::json!({"answer":42})), Some(7)).await.unwrap(); }
+                "fail" => { admin::fail_external(&pool, callback, "declined", Some(7)).await.unwrap(); }
+                "retry" => { admin::retry_external(&pool, callback, Some(7)).await.unwrap(); }
+                "heartbeat" => { admin::heartbeat_callback(&pool, callback, Duration::from_secs(7200)).await.unwrap(); }
+                "resolve" => { admin::resolve_callback(&pool, callback, Some(serde_json::json!({"answer":42})), DefaultAction::Complete, Some(7)).await.unwrap(); }
+                _ => unreachable!(),
+            }
+            let (state, metadata): (String, serde_json::Value) = sqlx::query_as("SELECT state::text,metadata FROM awa.jobs_hot WHERE id=$1")
+                .bind(id).fetch_one(&pool).await.unwrap();
+            assert_eq!(state, $state);
+            if $action == "resume" { assert_eq!(metadata["_awa_callback_result"]["answer"], 42); }
+        }
+    };
+}
+mixed_callback_case!(
+    mixed_complete_preserves_canonical_callback,
+    "complete",
+    "completed"
+);
+mixed_callback_case!(
+    mixed_resume_preserves_canonical_callback,
+    "resume",
+    "running"
+);
+mixed_callback_case!(mixed_fail_preserves_canonical_callback, "fail", "failed");
+mixed_callback_case!(
+    mixed_retry_preserves_canonical_callback,
+    "retry",
+    "available"
+);
+mixed_callback_case!(
+    mixed_heartbeat_preserves_canonical_callback,
+    "heartbeat",
+    "waiting_external"
+);
+mixed_callback_case!(
+    mixed_resolve_preserves_canonical_callback,
+    "resolve",
+    "completed"
+);
+
+#[sqlx::test]
+async fn mixed_callback_preserves_lease_fence_and_rollback(pool: sqlx::PgPool) {
+    let (id, callback) = mixed_callback(&pool).await;
+    for action in ["complete", "resume", "fail", "retry"] {
+        let result = match action {
+            "complete" => admin::complete_external(&pool, callback, None, Some(6)).await,
+            "resume" => admin::resume_external(&pool, callback, None, Some(6)).await,
+            "fail" => admin::fail_external(&pool, callback, "declined", Some(6)).await,
+            "retry" => admin::retry_external(&pool, callback, Some(6)).await,
+            _ => unreachable!(),
+        };
+        assert!(
+            matches!(result, Err(AwaError::CallbackNotFound { .. })),
+            "{result:?}"
+        );
+    }
+    assert!(matches!(
+        admin::resolve_callback(&pool, callback, None, DefaultAction::Complete, Some(6)).await,
+        Err(AwaError::CallbackNotFound { .. })
+    ));
+    let mut tx = pool.begin().await.unwrap();
+    admin::complete_external_in_tx(&mut tx, callback, None, Some(7))
+        .await
+        .unwrap();
+    tx.rollback().await.unwrap();
+    let state: String = sqlx::query_scalar("SELECT state::text FROM awa.jobs_hot WHERE id=$1")
+        .bind(id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert_eq!(state, "waiting_external");
+    admin::complete_external(&pool, callback, None, Some(7))
+        .await
+        .unwrap();
+    assert!(matches!(
+        admin::complete_external(&pool, callback, None, Some(7)).await,
+        Err(AwaError::CallbackNotFound { .. })
+    ));
+}
+
+#[sqlx::test]
+async fn finalized_callback_does_not_fall_back_to_canonical(pool: sqlx::PgPool) {
+    let (_, callback) = mixed_callback(&pool).await;
+    // Simulate a stale canonical row surviving outside the supported transition
+    // window. Active routing must never make this row authoritative again.
+    sqlx::query("UPDATE awa.storage_transition_state SET state='active',current_engine='queue_storage',prepared_engine=NULL WHERE singleton")
+        .execute(&pool).await.unwrap();
+    assert!(matches!(
+        admin::complete_external(&pool, callback, None, Some(7)).await,
+        Err(AwaError::CallbackNotFound { .. })
+    ));
+}
+
 async fn setup() -> TestClient {
     let pool = PgPoolOptions::new()
         .max_connections(5)

--- a/correctness/run-tlc-suite.sh
+++ b/correctness/run-tlc-suite.sh
@@ -34,6 +34,8 @@ AwaStorageLockOrder.tla        ;; AwaStorageLockOrder.cfg                 ;; pas
 AwaStorageLockOrder.tla        ;; AwaStorageLockOrderDeadlockDemo.cfg     ;; NoDeadlock is violated ;; deadlock detector witness
 AwaDeadTupleContract.tla       ;; AwaDeadTupleContract.cfg                ;; pass ;; architectural reclaim contract
 AwaStorageTransition.tla       ;; -                                       ;; pass ;; transition control plane + #456 reschedule drain
+AwaQuiescedTransition.tla      ;; -                                       ;; pass ;; quiesced routing flip serializes snapshot evidence
+AwaQuiescedTransition.tla      ;; AwaQuiescedTransitionUnlocked.cfg       ;; QuiescedAtFlip is violated ;; unlocked liveness check race
 AwaStorageTransition.tla       ;; AwaStorageTransitionCurrentGate.cfg     ;; MixedHasQueueExecutor is violated ;; pre-v014 capability-gate witness
 AwaStorageTransition.tla       ;; AwaStorageTransitionRescheduleStaysCanonical.cfg ;; MixedTransitionCanReduceCanonicalBacklog is violated ;; pre-#456 canonical re-schedule wedge witness
 AwaMigratedRescheduleUnique.tla ;; -                                      ;; pass ;; migrated re-schedule duplicate cancellation

--- a/correctness/storage/AwaQuiescedTransition.cfg
+++ b/correctness/storage/AwaQuiescedTransition.cfg
@@ -1,0 +1,3 @@
+CONSTANT LockSnapshots = TRUE
+SPECIFICATION Spec
+INVARIANT QuiescedAtFlip

--- a/correctness/storage/AwaQuiescedTransition.tla
+++ b/correctness/storage/AwaQuiescedTransition.tla
@@ -1,0 +1,43 @@
+---- MODULE AwaQuiescedTransition ----
+EXTENDS Naturals, TLC
+CONSTANT LockSnapshots
+VARIABLES state, fresh, snapshotLock, phase, entryWasQuiesced
+vars == <<state, fresh, snapshotLock, phase, entryWasQuiesced>>
+
+\* The operator keeps worker processes stopped throughout this command.
+\* A snapshot writer already in flight may finish before we obtain the table
+\* lock. The model checks that it cannot invalidate the liveness observation
+\* between the check and flip. Stale evidence is not a process fence.
+Init == /\ state = "prepared"
+        /\ fresh = FALSE
+        /\ snapshotLock = FALSE
+        /\ phase = "idle"
+        /\ entryWasQuiesced = TRUE
+Acquire == /\ phase = "idle"
+           /\ snapshotLock' = LockSnapshots
+           /\ phase' = "locked"
+           /\ UNCHANGED <<state, fresh, entryWasQuiesced>>
+Snapshot == /\ ~snapshotLock
+            /\ fresh' = TRUE
+            /\ UNCHANGED <<state, snapshotLock, phase, entryWasQuiesced>>
+Expire == /\ fresh' = FALSE
+          /\ UNCHANGED <<state, snapshotLock, phase, entryWasQuiesced>>
+Check == /\ phase = "locked"
+         /\ ~fresh
+         /\ phase' = "checked"
+         /\ UNCHANGED <<state, fresh, snapshotLock, entryWasQuiesced>>
+Refuse == /\ phase = "locked"
+          /\ fresh
+          /\ phase' = "done"
+          /\ snapshotLock' = FALSE
+          /\ UNCHANGED <<state, fresh, entryWasQuiesced>>
+Flip == /\ phase = "checked"
+        /\ state' = "mixed_transition"
+        /\ entryWasQuiesced' = ~fresh
+        /\ phase' = "done"
+        /\ snapshotLock' = FALSE
+        /\ UNCHANGED fresh
+Next == Acquire \/ Snapshot \/ Expire \/ Check \/ Refuse \/ Flip
+Spec == Init /\ [][Next]_vars
+QuiescedAtFlip == entryWasQuiesced
+====

--- a/correctness/storage/AwaQuiescedTransitionUnlocked.cfg
+++ b/correctness/storage/AwaQuiescedTransitionUnlocked.cfg
@@ -1,0 +1,3 @@
+CONSTANT LockSnapshots = FALSE
+SPECIFICATION Spec
+INVARIANT QuiescedAtFlip

--- a/docs/upgrade-0.5-to-0.6.md
+++ b/docs/upgrade-0.5-to-0.6.md
@@ -152,6 +152,40 @@ awa --database-url "$DATABASE_URL" storage status
 #     post-flip.
 ```
 
+## Quiesced alternative to the witness runtime
+
+A CLI carrying [#457](https://github.com/hardbyte/awa/issues/457) accepts
+`awa storage enter-mixed-transition --quiesced` after `storage prepare`.
+This path runs without a schema migration and replaces Phase 2 steps 6–7.
+It is intended for a stopped fleet, not a live rollout:
+
+1. Stop producers and drain canonical work before stopping workers if you want
+   a fully role-free cutover. Inspect `canonical_live_backlog`, including scheduled
+   work and jobs waiting for external callbacks.
+2. Stop every worker and keep them stopped. Wait for runtime heartbeats to expire
+   (at least 30 seconds, or three snapshot intervals when longer). The command
+   refuses **any** fresh runtime, including unhealthy or shutting-down ones.
+3. Run `awa storage enter-mixed-transition --quiesced`. The liveness check and
+   routing change serialize against runtime snapshot writes. Stale heartbeats
+   do not fence a paused process; preventing old workers from returning during
+   this window remains an operator responsibility.
+4. Run `awa storage finalize --check`, then `awa storage finalize` when ready.
+   Restart workers on 0.6 and resume producers; new auto-role workers resolve
+   queue storage at startup.
+
+The command preserves canonical jobs and does not bypass finalization gates.
+If canonical backlog remains, drain it with canonical drain workers before
+finalizing; restarting only auto-role workers after the flip will not execute
+canonical work. Use the live staged path above when a stop-and-drain window
+is impractical.
+
+Callback APIs carrying [#462](https://github.com/hardbyte/awa/issues/462) resolve
+callbacks left on canonical jobs throughout `mixed_transition`, including
+completion, resume, failure, retry, heartbeat and CEL resolution. Lease checks
+and transaction rollback still apply. Run a 0.6 backport containing this fix
+before flipping a cluster with outstanding callbacks; a fix installed only in
+0.7 arrives too late for an unfinalized cluster.
+
 ## Health checks per step
 
 | After step | Watch for |


### PR DESCRIPTION
Unfinalized 0.6 clusters need these fixes before crossing the 0.7 migration gate. Backport #484 onto the v0.6.7 release line without changing migrations.

- Preserve canonical callback administration and handler registration/wait/cancel/poll during mixed transition, including leases, rollback, payload cleanup and commit-time retry notifications (#462).
- Add `storage enter-mixed-transition --quiesced`: validate the complete target substrate, refuse every fresh runtime with millisecond precision, serialize snapshot writes with the flip, and retain backlog/finalize gates. Operators must keep the fleet stopped (#457 proposal 2).
- Fence new Python bridge work, cancel pending native async tasks, and join tasks/completion callbacks before interpreter finalization. Rejected install/start/shutdown calls preserve client lifecycle state.

The review-correction commit `1a24ee03` passed the following checks: all seven transition tests pass on PostgreSQL 17/18 against released v040 migrations, 28 CEL callback tests pass on PostgreSQL 18, and all 28 Python shutdown/startup tests pass against the rebuilt wheel. Rust fmt/clippy/workspace build and Python clippy/wheel build pass. Current `83372d90` also adds a five-second stalled-exit diagnostic without releasing the safety join; all six shutdown regressions and required build/lint checks pass. [Current CI](https://github.com/hardbyte/awa/actions/runs/34070517034) is running. Previous `330668c4` passed 303 local Python tests; that earlier full-suite result does not certify the latest review corrections. The shared snapshot-lock TLC model is validated in #484.

Native crash evidence and historical-wheel CI configuration remain in #484. Publish a new 0.6 patch before directing unfinalized clusters to these paths. No version bump or release publication is included.
