### PR TITLE
fix(python): roll back abandoned transactions on the Tokio runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,12 @@ Notable changes between releases. Detailed migration notes for storage transitio
 
 ### Fixed
 
+- Python `Transaction`/`SyncTransaction` handles released without commit or
+  rollback now roll back on the shared Tokio runtime. Previously garbage
+  collection on a thread without a runtime, including interpreter exit,
+  panicked inside sqlx's pool return with "this functionality requires a
+  Tokio context".
+
 - Rejected Python bridge operations leave install/start/shutdown lifecycle state
   unchanged. Canonical callback retries retain commit-time dispatcher notifications.
 

--- a/awa-python/src/transaction.rs
+++ b/awa-python/src/transaction.rs
@@ -25,6 +25,39 @@ impl PyTransaction {
     }
 }
 
+/// Roll back a transaction handle that Python released without committing.
+///
+/// The last Python reference can be dropped by garbage collection on a thread
+/// with no Tokio context, including interpreter finalization. sqlx returns the
+/// pooled connection from a spawned task when the transaction drops, and that
+/// spawn panics outside a runtime. Move the transaction onto the shared runtime
+/// first so the rollback and pool return happen where they are allowed.
+fn release_abandoned(handle: &mut Arc<Mutex<Option<Transaction<'static, Postgres>>>>) {
+    let owned = std::mem::replace(handle, Arc::new(Mutex::new(None)));
+    // A clone held by an in-flight bridge future drops inside that Tokio task.
+    let Ok(mutex) = Arc::try_unwrap(owned) else {
+        return;
+    };
+    let Some(tx) = mutex.into_inner() else {
+        return;
+    };
+    pyo3_async_runtimes::tokio::get_runtime().spawn(async move {
+        let _ = tx.rollback().await;
+    });
+}
+
+impl Drop for PyTransaction {
+    fn drop(&mut self) {
+        release_abandoned(&mut self.tx);
+    }
+}
+
+impl Drop for PySyncTransaction {
+    fn drop(&mut self) {
+        release_abandoned(&mut self.tx);
+    }
+}
+
 #[pymethods]
 impl PyTransaction {
     #[pyo3(signature = (query, *args))]

--- a/awa-python/tests/test_interpreter_shutdown.py
+++ b/awa-python/tests/test_interpreter_shutdown.py
@@ -227,3 +227,40 @@ def test_shutdown_cancels_native_database_wait():
                             capture_output=True, text=True, timeout=15)
     assert result.returncode == 0, result.stdout + result.stderr
     assert "DATABASE_WAIT_EXIT" in result.stdout, result.stdout + result.stderr
+
+
+def test_abandoned_transactions_roll_back_on_the_runtime():
+    # Garbage collection may drop the last transaction handle on a thread with
+    # no Tokio context, including interpreter finalization. The pooled
+    # connection must still return without a native panic.
+    code = textwrap.dedent('''
+        import asyncio, os, sys, awa
+        async def main():
+            client = awa.AsyncClient(os.environ["DATABASE_URL"])
+            leaked = await client.transaction()
+            await leaked.execute("SELECT 1")
+            failing = await client.transaction()
+            try:
+                await failing.fetch_one("SELECT no_such_column FROM awa.schema_version")
+            except awa.DatabaseError:
+                pass
+            else:
+                raise AssertionError("invalid query succeeded")
+            sync_client = awa.Client(os.environ["DATABASE_URL"], max_connections=1)
+            sync_leaked = sync_client.transaction()
+            sync_leaked.execute("SELECT 1")
+            del sync_leaked
+            # A dropped handle releases its connection; a pool of one proves it.
+            sync_client.transaction().commit()
+            sync_client.close()
+            # Keep the async handles alive until finalization.
+            globals().update(client=client, leaked=leaked, failing=failing)
+            print("ABANDONED_OK", flush=True)
+        asyncio.run(main())
+    ''')
+    result = subprocess.run([sys.executable, "-X", "faulthandler", "-c", code],
+                            capture_output=True, text=True, timeout=30)
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "ABANDONED_OK" in result.stdout, result.stdout
+    assert "PanicException" not in result.stderr, result.stderr
+    assert "Tokio context" not in result.stderr, result.stderr


### PR DESCRIPTION
Dropping the last Python reference to a `Transaction` or `SyncTransaction` that was never committed or rolled back panics when the drop happens on a thread with no Tokio context, such as garbage collection during interpreter finalization. sqlx returns the pooled connection from a spawned task inside the transaction's `Drop`, and that spawn requires a runtime. Repro on `main`:

```python
import asyncio, os, awa
async def main():
    c = awa.AsyncClient(os.environ["DATABASE_URL"])
    tx = await c.transaction()
    await tx.fetch_one("SELECT no_such_column FROM awa.storage_transition_state")
asyncio.run(main())
```

```
thread '<unnamed>' panicked at sqlx-core-0.9.0/src/pool/connection.rs:208:13:
this functionality requires a Tokio context
pyo3_runtime.PanicException: this functionality requires a Tokio context
```

Both wrappers now implement `Drop`: if this is the last handle and the transaction is still open, it is moved onto the shared runtime and rolled back from a spawned task. A handle still cloned into an in-flight bridge future is left alone, because that future drops inside its own Tokio task. Committed or rolled-back handles are a no-op.

The regression test abandons an async transaction, a transaction whose query failed, and a sync transaction on a pool of one, then proves the sync connection was returned and the interpreter exits cleanly without a panic.

Validation: `cargo fmt`, Python crate clippy with `-D warnings`, wheel build, the repro above exits with only the `DatabaseError`, and `test_interpreter_shutdown.py`, `test_awa.py`, `test_sync.py` pass (66 passed, 1 skipped) on PG17.

Found while landing #484; this behaviour predates it.
