### PR TITLE
fix: widen OpenTelemetry dep range to >=0.30,<0.33

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,9 +65,9 @@ croner = "2"
 # Logging / Observability
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
-opentelemetry = { version = "0.32", features = ["metrics"] }
-opentelemetry_sdk = { version = "0.32", features = ["metrics", "rt-tokio"] }
-tracing-opentelemetry = "0.33"
+opentelemetry = { version = ">=0.30, <0.33", features = ["metrics"] }
+opentelemetry_sdk = { version = ">=0.30, <0.33", features = ["metrics", "rt-tokio"] }
+tracing-opentelemetry = ">=0.31, <0.34"
 
 # CEL expressions (optional)
 cel = { version = "0.13", features = ["json"] }


### PR DESCRIPTION
## Summary

- Widens `opentelemetry`, `opentelemetry_sdk`, and `tracing-opentelemetry` workspace deps from pinned versions to ranges (`>=0.30, <0.33` / `>=0.31, <0.34`)
- Fixes silent no-op metrics for consumers whose workspace resolves to opentelemetry 0.30 (e.g. via `tower-otel-http-metrics 0.16`, which has no 0.31+ release)

## Problem

When a consumer's workspace has `opentelemetry = "0.30"` and AWA pins `"0.32"`, Cargo links both as separate crates — each with its own `static` global meter provider. The consumer calls `set_meter_provider()` on 0.30's global; `AwaMetrics::from_global()` reads 0.32's global and gets a no-op. Queue depth, lag, job duration, and all other AWA metrics silently record into a void.

## Fix

The metric API surface (`Meter`, `Counter`, `Gauge`, `Histogram`, `UpDownCounter`, `KeyValue`, `global::meter`) is identical across 0.30–0.32. Widening the range lets Cargo unify to whatever the consumer already has, so there's a single global and `AwaMetrics` registers on the real provider.

## Test plan

- `cargo check -p awa-metrics -p awa-worker` passes (verified against 0.30 and 0.32)
- Confirmed in a consumer workspace that `cargo tree -i opentelemetry` shows a single version after the change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Broadened compatibility with supported OpenTelemetry crate versions while preserving existing metrics and Tokio runtime features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->